### PR TITLE
Tabbed Widget

### DIFF
--- a/examples/tabs.py
+++ b/examples/tabs.py
@@ -1,0 +1,22 @@
+from textual.app import App
+from textual import events
+from textual.widgets import Placeholder, Tabs, Tab
+
+
+class TabTest(App):
+    async def on_load(self, event: events.Load) -> None:
+        await self.bind("q", "quit", "Quit")
+
+    async def on_mount(self, event: events.Mount) -> None:
+        """Make a simple tab arrangement."""
+        tab1 = Tab("First Tab Label")
+        await tab1.view.dock(Placeholder())
+
+        tab2 = Tab("Second Tab Label")
+        await tab2.view.dock(Placeholder())
+
+        tabs = Tabs([tab1, tab2])
+        await self.view.dock(tabs)
+
+
+TabTest.run(title="Tab Test", log="textual.log")

--- a/examples/tabs.py
+++ b/examples/tabs.py
@@ -10,13 +10,15 @@ from textual.widgets import (
     ScrollView,
     Header,
     Footer,
-    Placeholder,
 )
 
 
 class TabTest(App):
     async def on_load(self, event: events.Load) -> None:
         await self.bind("q", "quit", "Quit")
+        await self.bind("1", "switch('0')", "Switch to tab #1")
+        await self.bind("2", "switch('1')", "Switch to tab #2")
+        await self.bind("3", "switch('2')", "Switch to tab #3")
 
     async def on_mount(self, event: events.Mount) -> None:
         """Make a simple tab arrangement."""
@@ -28,16 +30,16 @@ class TabTest(App):
             await tab1.view.dock(ScrollView(Markdown(f.read())))
 
         tab2 = Tab("Demo Code")
-        await tab2.view.dock(ScrollView(Syntax.from_path("tabs.py")))
+        await tab2.view.dock(ScrollView(Syntax.from_path(__file__)))
 
         tab3 = Tab("Directory")
         await tab3.view.dock(ScrollView(DirectoryTree("..")))
 
-        tab4 = Tab("Placeholder")
-        await tab4.view.dock(Placeholder())
+        self.tabs = Tabs([tab1, tab2, tab3])
+        await self.view.dock(self.tabs)
 
-        tabs = Tabs([tab1, tab2, tab3, tab4])
-        await self.view.dock(tabs)
+    async def action_switch(self, tab_idx: str) -> None:
+        self.tabs.current = int(tab_idx)
 
 
 TabTest.run(title="Tab Test", log="textual.log")

--- a/examples/tabs.py
+++ b/examples/tabs.py
@@ -1,6 +1,9 @@
+from rich.markdown import Markdown
+from rich.syntax import Syntax
+
 from textual.app import App
 from textual import events
-from textual.widgets import Placeholder, Tabs, Tab
+from textual.widgets import DirectoryTree, Tabs, Tab, ScrollView, Header, Footer
 
 
 class TabTest(App):
@@ -9,13 +12,20 @@ class TabTest(App):
 
     async def on_mount(self, event: events.Mount) -> None:
         """Make a simple tab arrangement."""
-        tab1 = Tab("First Tab Label")
-        await tab1.view.dock(Placeholder())
+        await self.view.dock(Header())
+        await self.view.dock(Footer(), edge="bottom")
 
-        tab2 = Tab("Second Tab Label")
-        await tab2.view.dock(Placeholder())
+        tab1 = Tab("Rich Readme")
+        with open("richreadme.md", "r") as f:
+            await tab1.view.dock(ScrollView(Markdown(f.read())))
 
-        tabs = Tabs([tab1, tab2])
+        tab2 = Tab("Demo Code")
+        await tab2.view.dock(ScrollView(Syntax.from_path("tabs.py")))
+
+        tab3 = Tab("Directory")
+        await tab3.view.dock(ScrollView(DirectoryTree("..")))
+
+        tabs = Tabs([tab1, tab2, tab3])
         await self.view.dock(tabs)
 
 

--- a/examples/tabs.py
+++ b/examples/tabs.py
@@ -3,7 +3,15 @@ from rich.syntax import Syntax
 
 from textual.app import App
 from textual import events
-from textual.widgets import DirectoryTree, Tabs, Tab, ScrollView, Header, Footer
+from textual.widgets import (
+    DirectoryTree,
+    Tabs,
+    Tab,
+    ScrollView,
+    Header,
+    Footer,
+    Placeholder,
+)
 
 
 class TabTest(App):
@@ -25,7 +33,10 @@ class TabTest(App):
         tab3 = Tab("Directory")
         await tab3.view.dock(ScrollView(DirectoryTree("..")))
 
-        tabs = Tabs([tab1, tab2, tab3])
+        tab4 = Tab("Placeholder")
+        await tab4.view.dock(Placeholder())
+
+        tabs = Tabs([tab1, tab2, tab3, tab4])
         await self.view.dock(tabs)
 
 

--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -4,6 +4,7 @@ from ._button import Button, ButtonPressed
 from ._placeholder import Placeholder
 from ._scroll_view import ScrollView
 from ._static import Static
+from ._tabs import Tabs, Tab
 from ._tree_control import TreeControl, TreeClick, TreeNode, NodeID
 from ._directory_tree import DirectoryTree, FileClick
 
@@ -17,6 +18,8 @@ __all__ = [
     "Placeholder",
     "ScrollView",
     "Static",
+    "Tab",
+    "Tabs",
     "TreeClick",
     "TreeControl",
     "TreeNode",

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, InitVar
+from logging import getLogger
+from typing import Generic, Literal, TypeVar, TypedDict, cast
+
+from rich.console import RenderableType
+from rich.style import StyleType
+import rich.repr
+
+from ._button import ButtonRenderable
+from .. import events, views
+from ..widget import Reactive, Widget
+from ..view import View
+
+log = getLogger("rich")
+
+ViewType = TypeVar("ViewType", bound=View)
+
+
+class HandleStyle(TypedDict):
+    default: StyleType
+    default_hover: StyleType
+    selected: StyleType
+    selected_hover: StyleType
+
+
+StyleMode = Literal["default", "default_hover", "selected", "selected_hover"]
+
+
+class TabHandle(Widget):
+    def __init__(
+        self,
+        label: str,
+        name: str | None = None,
+        styles: HandleStyle | None = None,
+    ) -> None:
+        self.label = label
+        self.styles: HandleStyle = styles or cast(
+            HandleStyle,
+            {
+                "default": "default",
+                "default_hover": "bold",
+                "selected": "reverse",
+                "selected_hover": "bold reverse",
+            },
+        )
+        super().__init__(name=name)
+
+    @property
+    def container(self) -> Tabs:
+        if not hasattr(self, "_container"):
+            raise RuntimeError("Tab handle must be bound to container before use.")
+        return self._container
+
+    @container.setter
+    def container(self, new: Tabs):
+        if hasattr(self, "_container"):
+            raise RuntimeError("Can only bind tab handle to one container.")
+        self._container = new
+
+    selected: Reactive[bool] = Reactive(False)
+    current_style: Reactive[StyleMode] = Reactive("default")
+
+    def render(self) -> RenderableType:
+        return ButtonRenderable(self.label, style=self.styles[self.current_style])
+
+    async def on_click(self, event: events.Click) -> None:
+        self._container.current = self.label
+
+    async def on_enter(self, event: events.Enter) -> None:
+        self.current_style = "selected_hover" if self.selected else "default_hover"
+
+    async def on_leave(self, event: events.Leave) -> None:
+        self.current_style = "selected" if self.selected else "default"
+
+    async def watch_selected(self, selected: bool):
+        self.current_style = "selected" if selected else "default"
+
+
+class _InitTabType(str):
+    """Simple sentinel for an uninitialized tab selection."""
+
+
+INIT_TAB = _InitTabType()
+
+
+@dataclass
+class Tab(Generic[ViewType]):
+    name: str
+    view_type: InitVar[type[ViewType]] = views.DockView
+    handle_styles: InitVar[HandleStyle | None] = None
+    view: ViewType = field(init=False)
+    handle: TabHandle = field(init=False)
+    _selected: bool = field(init=False, default=False)
+
+    def __post_init__(
+        self, view_type: type[ViewType], handle_styles: HandleStyle | None
+    ):
+        if not self.name:
+            raise ValueError("A Tabs name must be at least one character long.")
+        self.view = view_type()
+        self.handle = TabHandle(self.name, styles=handle_styles)
+
+    def bind(self, container: Tabs):
+        self.handle.container = container
+
+    @property
+    def selected(self) -> bool:
+        return self._selected
+
+    @selected.setter
+    def selected(self, new: bool):
+        self.view.visible = new
+        self.handle.selected = new
+
+
+@rich.repr.auto(angular=False)
+class Tabs(views.GridView, can_focus=True):
+    _tabs: dict[str, Tab]
+
+    def __init__(
+        self,
+        tabs: list[Tab],
+        initial_selection: str | None = None,
+        name: str | None = None,
+    ) -> None:
+        if not tabs:
+            raise ValueError("Tabs requires at least on Tab to function.")
+        self._tabs = {tab.name: tab for tab in tabs}
+        self._init = initial_selection or tabs[0].name
+        super().__init__(name=name)
+
+    async def on_mount(self, event: events.Mount) -> None:
+        for tab in self._tabs.values():
+            tab.bind(self)
+
+        self.grid.set_gap(1, 2)
+        self.grid.set_gutter(1)
+
+        max_column = len(self._tabs)
+        self.grid.add_column("col", fraction=1, repeat=max_column)
+        self.grid.add_row("labels", max_size=1)
+        self.grid.place(*(tab.handle for tab in self._tabs.values()))
+
+        self.grid.add_row("content", fraction=1)
+        self.grid.add_areas(content=f"col1-start|col{max_column}-end,content")
+        for tab in self._tabs.values():
+            self.grid.place(content=tab.view)
+
+        await super().on_mount(event)
+
+        self.current = self._init
+
+    current: Reactive[str] = Reactive(INIT_TAB)
+
+    def validate_current(self, val: str) -> str:
+        if val not in self._tabs:
+            raise RuntimeError(f"Unknown tab with name: {val}.")
+        return val
+
+    async def watch_current(self, old: str, new: str) -> None:
+        if old is not INIT_TAB:
+            self._tabs[old].selected = False
+        self._tabs[new].selected = True

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -99,9 +99,6 @@ class Tab(Generic[ViewType]):
         self.view = view_type()
         self.handle = TabHandle(self.name, styles=handle_styles)
 
-    def bind(self, container: Tabs, idx: int):
-        self.handle.bind(container, idx)
-
     @property
     def selected(self) -> bool:
         return self._selected
@@ -134,7 +131,7 @@ class Tabs(views.DockView):
         grid.add_row("content")
         grid.add_areas(content=f"col1-start|col{max_column}-end,content")
         for i, tab in enumerate(self._tabs):
-            tab.bind(self, i)
+            tab.handle.bind(self, i)
             grid.place(tab.handle, content=tab.view)
         await super().on_mount(event)
         self.current = self._init

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -137,7 +137,7 @@ class Tabs(views.DockView):
         max_column = len(self._tabs)
         grid = await self.dock_grid()
         grid.add_column("col", repeat=max_column)
-        grid.add_row("bar", max_size=3)
+        grid.add_row("bar", size=3)
         grid.add_row("content")
         grid.add_areas(content=f"col1-start|col{max_column}-end,content")
         for tab in self._tabs:

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -134,16 +134,14 @@ class Tabs(views.DockView):
         super().__init__(name=name)
 
     async def on_mount(self, event: events.Mount) -> None:
-        for tab in self._tabs:
-            tab.bind(self)
-
         max_column = len(self._tabs)
-        grid = await self.dock_grid(align=("center", "center"))
+        grid = await self.dock_grid()
         grid.add_column("col", repeat=max_column)
         grid.add_row("bar", max_size=3)
         grid.add_row("content")
         grid.add_areas(content=f"col1-start|col{max_column}-end,content")
         for tab in self._tabs:
+            tab.bind(self)
             grid.place(tab.handle, content=tab.view)
         await super().on_mount(event)
         self.current = self._init


### PR DESCRIPTION
### What?
This PR adds a widget that enables the user to define multiple views as so called tabs and receive a automagically generated bar of tab handles to switch between said views.

### 🖼 Some Pictures
The example code introduced in this PR produces the following:
![Screenshot 2021-08-11 at 19 09 04](https://user-images.githubusercontent.com/30415153/129072925-6997bc3f-d11f-4dcb-b513-8762b33bd3ca.png)
![Screenshot 2021-08-11 at 19 09 08](https://user-images.githubusercontent.com/30415153/129072922-c91d497c-27ff-4afa-bb88-0fc6394870a3.png)
![Screenshot 2021-08-11 at 19 09 11](https://user-images.githubusercontent.com/30415153/129072915-b773805d-b86b-4dd6-91ee-d177c18feb12.png)

### Some additional info
- All _4_ modes a tab handle can be in are "user-stylable". Those being default, hover, selected, and hover+selected.
- The type of view a tab uses can be given by the user upon tab creation. Though this is not strictly necessary thanks to `DockView.dock_grid()`.
  

