### PR TITLE
Fix unclosed loop error

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -185,7 +185,11 @@ class App(MessagePump):
             app = cls(console=console, screen=screen, driver_class=driver, **kwargs)
             await app.process_messages()
 
-        asyncio.run(run_app())
+        loop = asyncio.get_event_loop()
+        try:
+            asyncio.run(run_app())
+        finally:
+            loop.close()
 
     async def push_view(self, view: ViewType) -> ViewType:
         self.register(view, self)


### PR DESCRIPTION
Closes #127

Based on the conference talk @lllama provided I tried this and it cleared up the error. I tried several of the examples with this change in place and they all still worked and closed without error.

@willmcgugan not knowing the architecture of Textual as well as you, can you think of a time that the app would not be able to get a running loop and therefore error because of that?