### PR TITLE
Remove unused import

### DIFF
--- a/examples/animation.py
+++ b/examples/animation.py
@@ -1,4 +1,3 @@
-from textual import events
 from textual.app import App
 from textual.reactive import Reactive
 from textual.widgets import Footer, Placeholder


### PR DESCRIPTION
`from textual import events` is not used. The demo runs successfully without it.