### PR TITLE
Added 'title' attribute to Placeholder class

### DIFF
--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -19,26 +19,31 @@ log = getLogger("rich")
 @rich.repr.auto(angular=False)
 class Placeholder(Widget, can_focus=True):
 
+    title: str
     has_focus: Reactive[bool] = Reactive(False)
     mouse_over: Reactive[bool] = Reactive(False)
     style: Reactive[str] = Reactive("")
     height: Reactive[int | None] = Reactive(None)
 
-    def __init__(self, *, name: str | None = None, height: int | None = None) -> None:
+    def __init__(self, *, title: str | None = None,
+                 name: str | None = None, height: int | None = None) -> None:
         super().__init__(name=name)
         self.height = height
+        self.title = title
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "name", self.name
+        yield "title", self.title
         yield "has_focus", self.has_focus, False
         yield "mouse_over", self.mouse_over, False
 
     def render(self) -> RenderableType:
         return Panel(
             Align.center(
-                Pretty(self, no_wrap=True, overflow="ellipsis"), vertical="middle"
+                Pretty(self, no_wrap=True, overflow="ellipsis"),
+                vertical="middle"
             ),
-            title=self.__class__.__name__,
+            title=self.title,
             border_style="green" if self.mouse_over else "blue",
             box=box.HEAVY if self.has_focus else box.ROUNDED,
             style=self.style,


### PR DESCRIPTION
A new attribute which allows one to change the title of a placeholder independently of the internal name of the window or the class.

This introduces a feature I felt was lacking, so I implemented it myself.

Example: 
await self.view.dock(Placeholder(title='Output'), Placeholder(title='Data'), edge="top")

<img width="938" alt="image" src="https://user-images.githubusercontent.com/4507152/137029691-44ad7fde-7e1e-45c3-92f6-6099a3303909.png">

The results can be seen in the image above.