### PR TITLE
Fix project description not being shown on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "textual"
 version = "0.1.12"
 homepage = "https://github.com/willmcgugan/textual"
 description = "Text User Interface using Rich"
+readme = "README.md"
 authors = ["Will McGugan <willmcgugan@gmail.com>"]
 license = "MIT"
 classifiers = [


### PR DESCRIPTION
Adds the [readme parameter](https://python-poetry.org/docs/pyproject/#readme) to [`pyproject.toml`](https://github.com/willmcgugan/textual/blob/main/pyproject.toml)

The readme parameter is used to provide the full description of the project (i.e. the README). For more info see [this](https://www.python.org/dev/peps/pep-0621/#readme)

Fixes https://github.com/willmcgugan/textual/issues/147