### PR TITLE
Use the `layout` as specified in CSS 

### DIFF
--- a/examples/basic.css
+++ b/examples/basic.css
@@ -1,6 +1,7 @@
 /* CSS file for basic.py */
 
 App > View {
+  layout: dock;
   docks: side=left/1;
   text: on #20639b;
 }

--- a/examples/basic.css
+++ b/examples/basic.css
@@ -1,7 +1,6 @@
 /* CSS file for basic.py */
 
 App > View {
-  layout: dock;
   docks: side=left/1;
   text: on #20639b;
 }

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1,49 +1,43 @@
 from __future__ import annotations
-import os
 
+import os
 import asyncio
 
-from typing import Any, Callable, ClassVar, Iterable, Type, TypeVar
 import warnings
-
-from rich.control import Control
+from typing import Any, Callable, Iterable, Type, TypeVar
 
 import rich.repr
-from rich.screen import Screen
 from rich.console import Console, RenderableType
+from rich.control import Control
 from rich.measure import Measurement
-
+from rich.screen import Screen
 from rich.traceback import Traceback
 
-
-from . import events
 from . import actions
-from .dom import DOMNode
-from ._animator import Animator
-from .binding import Bindings, NoBinding
-from .geometry import Offset, Region, Size
+from . import events
 from . import log
+from . import messages
+from ._animator import Animator
 from ._callback import invoke
 from ._context import active_app
-from .css.stylesheet import Stylesheet, StylesheetParseError, StylesheetError
 from ._event_broker import extract_handler_actions, NoHandler
+from ._linux_driver import LinuxDriver
+from ._profile import timer
+from .binding import Bindings, NoBinding
+from .css.stylesheet import Stylesheet, StylesheetParseError, StylesheetError
+from .dom import DOMNode
 from .driver import Driver
 from .file_monitor import FileMonitor
-
+from .geometry import Offset, Region, Size
 from .layouts.dock import DockLayout, Dock
-from ._linux_driver import LinuxDriver
-from ._types import MessageTarget
-from . import messages
 from .message_pump import MessagePump
-from ._profile import timer
+from .reactive import Reactive
 from .view import View
 from .views import DockView
-from .widget import Widget, Reactive
-
+from .widget import Widget
 
 # asyncio will warn against resources not being cleared
 warnings.simplefilter("always", ResourceWarning)
-
 
 LayoutDefinition = "dict[str, Any]"
 
@@ -638,17 +632,11 @@ class App(DOMNode):
 
 if __name__ == "__main__":
     import asyncio
-    from logging import FileHandler
-
-    from rich.panel import Panel
 
     from .widgets import Header
     from .widgets import Footer
 
     from .widgets import Placeholder
-    from .scrollbar import ScrollBar
-
-    from rich.markdown import Markdown
 
     # from .widgets.scroll_view import ScrollView
 
@@ -672,7 +660,6 @@ if __name__ == "__main__":
             self.show_bar = not self.show_bar
 
         async def on_mount(self, event: events.Mount) -> None:
-
             view = await self.push_view(DockView())
 
             header = Header()

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -510,7 +510,7 @@ class App(DOMNode):
         # Handle input events that haven't been forwarded
         # If the event has been forwarded it may have bubbled up back to the App
         if isinstance(event, events.Mount):
-            view = View()
+            view = View(id="_root")
             self.register(self, view)
             await self.push_view(view)
             await super().on_event(event)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -503,7 +503,7 @@ class App(DOMNode):
         # Handle input events that haven't been forwarded
         # If the event has been forwarded it may have bubbled up back to the App
         if isinstance(event, events.Mount):
-            view = View(id="_root")
+            view = View()
             self.register(self, view)
             await self.push_view(view)
             await super().on_event(event)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -90,7 +90,6 @@ class App(DOMNode):
         self._screen = screen
         self.driver_class = driver_class or LinuxDriver
         self._title = title
-        self._layout = DockLayout()
         self._view_stack: list[View] = []
 
         self.focused: Widget | None = None

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -30,9 +30,9 @@ from .transition import Transition
 from ..geometry import Spacing, SpacingDimensions
 
 if TYPE_CHECKING:
+    from ..layout import Layout
     from .styles import Styles
     from .styles import DockGroup
-    from ..layout import Layout
     from ..layouts.factory import LayoutName
 
 
@@ -313,7 +313,7 @@ class LayoutProperty:
             layout (LayoutName | Layout): The layout to use. You can supply a ``LayoutName``
                 (a string literal such as ``"dock"``) or a ``Layout`` object.
         """
-        from ..layouts.factory import get_layout  # Prevents circular import
+        from ..layouts.factory import get_layout, Layout  # Prevents circular import
 
         obj.refresh(True)
         if isinstance(layout, Layout):

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -28,6 +28,7 @@ from .constants import NULL_SPACING
 from .errors import StyleTypeError, StyleValueError
 from .transition import Transition
 from ._error_tools import friendly_list
+from ..layouts.factory import get_layout
 
 if TYPE_CHECKING:
     from .styles import Styles
@@ -288,6 +289,22 @@ class DockProperty:
         obj.refresh(True)
         obj._rule_dock = spacing
         return spacing
+
+
+class LayoutProperty:
+    def __set_name__(self, owner: Styles, name: str) -> None:
+        self._internal_name = f"_rule_{name}"
+
+    def __get__(self, obj: Styles, objtype: type[Styles] | None = None) -> str:
+        return getattr(obj, self._internal_name) or ""
+
+    def __set__(self, obj: Styles, layout: str | Styles):
+        obj.refresh(True)
+        if isinstance(layout, str):
+            new_layout = get_layout(layout)
+        else:
+            new_layout = layout
+        self._layout = new_layout
 
 
 class OffsetProperty:

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -257,7 +257,7 @@ class SpacingProperty:
         return getattr(obj, self._internal_name) or NULL_SPACING
 
     def __set__(self, obj: Styles, spacing: SpacingDimensions) -> Spacing:
-        obj.refresh(True)
+        obj.refresh(layout=True)
         spacing = Spacing.unpack(spacing)
         setattr(obj, self._internal_name, spacing)
         return spacing
@@ -272,7 +272,7 @@ class DocksProperty:
     def __set__(
         self, obj: Styles, docks: Iterable[DockGroup] | None
     ) -> Iterable[DockGroup] | None:
-        obj.refresh(True)
+        obj.refresh(layout=True)
         if docks is None:
             obj._rule_docks = None
         else:
@@ -285,7 +285,7 @@ class DockProperty:
         return obj._rule_dock or ""
 
     def __set__(self, obj: Styles, spacing: str | None) -> str | None:
-        obj.refresh(True)
+        obj.refresh(layout=True)
         obj._rule_dock = spacing
         return spacing
 
@@ -315,7 +315,7 @@ class LayoutProperty:
         """
         from ..layouts.factory import get_layout, Layout  # Prevents circular import
 
-        obj.refresh(True)
+        obj.refresh(layout=True)
         if isinstance(layout, Layout):
             new_layout = layout
         else:
@@ -335,7 +335,7 @@ class OffsetProperty:
     def __set__(
         self, obj: Styles, offset: tuple[int | str, int | str] | ScalarOffset
     ) -> tuple[int | str, int | str] | ScalarOffset:
-        obj.refresh(True)
+        obj.refresh(layout=True)
         if isinstance(offset, ScalarOffset):
             setattr(obj, self._internal_name, offset)
             return offset
@@ -403,7 +403,7 @@ class NameProperty:
         return getattr(obj, self._internal_name) or ""
 
     def __set__(self, obj: Styles, name: str | None) -> str | None:
-        obj.refresh(True)
+        obj.refresh(layout=True)
         if not isinstance(name, str):
             raise StyleTypeError(f"{self._name} must be a str")
         setattr(obj, self._internal_name, name)
@@ -423,7 +423,7 @@ class NameListProperty:
     def __set__(
         self, obj: Styles, names: str | tuple[str] | None = None
     ) -> str | tuple[str] | None:
-        obj.refresh(True)
+        obj.refresh(layout=True)
         names_value: tuple[str, ...] | None = None
         if isinstance(names, str):
             names_value = tuple(name.strip().lower() for name in names.split(" "))

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -297,10 +297,23 @@ class LayoutProperty:
         self._internal_name = f"_rule_{name}"
 
     def __get__(self, obj: Styles, objtype: type[Styles] | None = None) -> Layout:
+        """
+        Args:
+            obj (Styles): The Styles object
+            objtype (type[Styles]): The Styles class
+        Returns:
+            The ``Layout`` object.
+        """
         return getattr(obj, self._internal_name)
 
     def __set__(self, obj: Styles, layout: LayoutName | Layout):
-        from ..layouts.factory import get_layout
+        """
+        Args:
+            obj (Styles): The Styles object.
+            layout (LayoutName | Layout): The layout to use. You can supply a ``LayoutName``
+                (a string literal such as ``"dock"``) or a ``Layout`` object.
+        """
+        from ..layouts.factory import get_layout  # Prevents circular import
 
         obj.refresh(True)
         if isinstance(layout, Layout):

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -28,7 +28,6 @@ from .constants import NULL_SPACING
 from .errors import StyleTypeError, StyleValueError
 from .transition import Transition
 from ._error_tools import friendly_list
-from ..layouts.factory import get_layout
 
 if TYPE_CHECKING:
     from .styles import Styles
@@ -299,6 +298,8 @@ class LayoutProperty:
         return getattr(obj, self._internal_name) or ""
 
     def __set__(self, obj: Styles, layout: str | Styles):
+        from ..layouts.factory import get_layout
+
         obj.refresh(True)
         if isinstance(layout, str):
             new_layout = get_layout(layout)

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -18,6 +18,7 @@ from .styles import DockGroup, Styles
 from .types import Edge, Display, Visibility
 from .tokenize import Token
 from .transition import Transition
+from ..layouts.factory import get_layout
 
 
 class StylesBuilder:
@@ -288,7 +289,7 @@ class StylesBuilder:
             if len(tokens) != 1:
                 self.error(name, tokens[0], "unexpected tokens in declaration")
             else:
-                self.styles._rule_layout = tokens[0].value
+                self.styles._rule_layout = get_layout(tokens[0].value)
 
     def process_text(self, name: str, tokens: list[Token], important: bool) -> None:
         style_definition = " ".join(token.value for token in tokens)

--- a/src/textual/css/model.py
+++ b/src/textual/css/model.py
@@ -5,13 +5,14 @@ import rich.repr
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
-from .. import log
-from ..dom import DOMNode
 from .styles import Styles
 from .tokenize import Token
 from .types import Specificity3
+
+if TYPE_CHECKING:
+    from ..dom import DOMNode
 
 
 class SelectorType(Enum):

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -39,11 +39,6 @@ from .. import log
 from .._animator import Animation, EasingFunction
 from ..geometry import Spacing
 
-if sys.version_info >= (3, 8):
-    pass
-else:
-    pass
-
 
 if TYPE_CHECKING:
     from ..layout import Layout

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -1,32 +1,14 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from functools import lru_cache
-import sys
 from typing import Any, Iterable, NamedTuple, TYPE_CHECKING
 
-from rich import print
-from rich.color import Color
 import rich.repr
+from rich.color import Color
 from rich.style import Style
 
-from .. import log
-from .._animator import SimpleAnimation, Animation, EasingFunction
-from .._types import MessageTarget
-from .errors import StyleValueError
-from .. import events
-from ._error_tools import friendly_list
-from .types import Specificity3, Specificity4
-from .constants import (
-    VALID_DISPLAY,
-    VALID_VISIBILITY,
-    VALID_LAYOUT,
-    NULL_SPACING,
-)
-from .scalar_animation import ScalarAnimation
-from ..geometry import NULL_OFFSET, Offset, Spacing
-from .scalar import Scalar, ScalarOffset, Unit
-from .transition import Transition
 from ._style_properties import (
     BorderProperty,
     BoxProperty,
@@ -44,16 +26,27 @@ from ._style_properties import (
     TransitionsProperty,
     LayoutProperty,
 )
+from .constants import (
+    VALID_DISPLAY,
+    VALID_VISIBILITY,
+)
+from .scalar import Scalar, ScalarOffset, Unit
+from .scalar_animation import ScalarAnimation
+from .transition import Transition
 from .types import Display, Edge, Visibility
-
+from .types import Specificity3, Specificity4
+from .. import log
+from .._animator import Animation, EasingFunction
+from ..geometry import Spacing
 
 if sys.version_info >= (3, 8):
-    from typing import Literal
+    pass
 else:
-    from typing_extensions import Literal
+    pass
 
 
 if TYPE_CHECKING:
+    from ..layout import Layout
     from ..dom import DOMNode
 
 
@@ -71,7 +64,7 @@ class Styles:
 
     _rule_display: Display | None = None
     _rule_visibility: Visibility | None = None
-    _rule_layout: str | None = None
+    _rule_layout: "Layout" | None = None
 
     _rule_text_color: Color | None = None
     _rule_text_background: Color | None = None
@@ -434,7 +427,7 @@ if __name__ == "__main__":
     styles.dock = "bar"
     styles.layers = "foo bar"
 
-    from rich import inspect, print
+    from rich import print
 
     print(styles.text_style)
     print(styles.text)

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -42,6 +42,7 @@ from ._style_properties import (
     StyleProperty,
     StyleFlagsProperty,
     TransitionsProperty,
+    LayoutProperty,
 )
 from .types import Display, Edge, Visibility
 
@@ -110,7 +111,7 @@ class Styles:
 
     display = StringProperty(VALID_DISPLAY, "block")
     visibility = StringProperty(VALID_VISIBILITY, "visible")
-    layout = StringProperty(VALID_LAYOUT, "dock")
+    layout = LayoutProperty()
 
     text = StyleProperty()
     text_color = ColorProperty()
@@ -279,6 +280,10 @@ class Styles:
                         )
                 else:
                     setattr(styles, f"_rule_{key}", value)
+
+        if self.node.id == "_root":
+            log("_root.styles.layout =", self.node.styles.layout)
+
         if self.node is not None:
             self.node.on_style_change()
 

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -269,9 +269,6 @@ class Styles:
                 else:
                     setattr(styles, f"_rule_{key}", value)
 
-        if self.node.id == "_root":
-            log("_root.styles.layout =", self.node.styles.layout)
-
         if self.node is not None:
             self.node.on_style_change()
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -108,6 +108,18 @@ class Stylesheet:
                 yield selector_set.specificity
 
     def apply(self, node: DOMNode) -> None:
+        """
+        Args:
+            node (DOMNode): The ``DOMNode`` to apply the stylesheet to.
+                Applies the styles defined in this ``Stylesheet`` to the node.
+                If the same rule is defined multiple times for the node (e.g. multiple
+                classes modifying the same CSS property), then only the most specific
+                rule will be applied.
+
+        Returns:
+            None
+        """
+
         # Dictionary of rule attribute names e.g. "text_background" to list of tuples.
         # The tuples contain the rule specificity, and the value for that rule.
         # We can use this to determine, for a given rule, whether we should apply it

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -140,7 +140,6 @@ class Stylesheet:
             for name, specificity_rules in rule_attributes.items()
         ]
 
-        log(node.id, node_rules)
         node.styles.apply_rules(node_rules)
 
     def update(self, root: DOMNode) -> None:

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -108,7 +108,8 @@ class Stylesheet:
                 yield selector_set.specificity
 
     def apply(self, node: DOMNode) -> None:
-        """
+        """Apply the stylesheet to a DOM node.
+
         Args:
             node (DOMNode): The ``DOMNode`` to apply the stylesheet to.
                 Applies the styles defined in this ``Stylesheet`` to the node.

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1,24 +1,22 @@
 from __future__ import annotations
 
-from typing import Any, cast, Iterable, Iterator, TYPE_CHECKING
+from typing import Iterable, Iterator, TYPE_CHECKING
 
-from rich.highlighter import ReprHighlighter
 import rich.repr
+from rich.highlighter import ReprHighlighter
 from rich.pretty import Pretty
 from rich.style import Style
 from rich.tree import Tree
 
+from ._node_list import NodeList
 from .css._error_tools import friendly_list
 from .css.constants import VALID_DISPLAY
 from .css.errors import StyleValueError
 from .css.styles import Styles
 from .message_pump import MessagePump
-from ._node_list import NodeList
-
 
 if TYPE_CHECKING:
     from .css.query import DOMQuery
-    from .widget import Widget
 
 
 class NoParent(Exception):

--- a/src/textual/layouts/dock.py
+++ b/src/textual/layouts/dock.py
@@ -5,14 +5,10 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable, TYPE_CHECKING, NamedTuple, Sequence
 
-
-from .. import log
-from ..dom import DOMNode
 from .._layout_resolve import layout_resolve
+from ..css.types import Edge
 from ..geometry import Offset, Region, Size
 from ..layout import Layout, WidgetPlacement
-from ..layout_map import LayoutMap
-from ..css.types import Edge
 from ..widget import Widget
 
 if sys.version_info >= (3, 8):
@@ -20,11 +16,8 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-
 if TYPE_CHECKING:
-    from ..widget import Widget
     from ..view import View
-
 
 DockEdge = Literal["top", "right", "bottom", "left"]
 

--- a/src/textual/layouts/factory.py
+++ b/src/textual/layouts/factory.py
@@ -1,9 +1,14 @@
-from typing import Literal
+import sys
 
 from ..layout import Layout
 from ..layouts.dock import DockLayout
 from ..layouts.grid import GridLayout
 from ..layouts.vertical import VerticalLayout
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 LayoutName = Literal["dock", "grid", "vertical"]
 LAYOUT_MAP = {"dock": DockLayout, "grid": GridLayout, "vertical": VerticalLayout}

--- a/src/textual/layouts/factory.py
+++ b/src/textual/layouts/factory.py
@@ -28,5 +28,5 @@ def get_layout(name: LayoutName) -> Layout:
 
     layout_class = LAYOUT_MAP.get(name)
     if layout_class is None:
-        raise MissingLayout("no layout called {name!r}")
+        raise MissingLayout(f"no layout called {name!r}, valid layouts")
     return layout_class()

--- a/src/textual/layouts/factory.py
+++ b/src/textual/layouts/factory.py
@@ -1,19 +1,15 @@
-from __future__ import annotations
+from ..layouts.dock import DockLayout
+from ..layouts.grid import GridLayout
+from ..layouts.vertical import VerticalLayout
 
-from ..layout import Layout
-from .dock import DockLayout
-from .grid import GridLayout
-from .vertical import VerticalLayout
+LAYOUT_MAP = {"dock": DockLayout, "grid": GridLayout, "vertical": VerticalLayout}
 
 
 class MissingLayout(Exception):
     pass
 
 
-LAYOUT_MAP = {"dock": DockLayout, "grid": GridLayout, "vertical": VerticalLayout}
-
-
-def get_layout(name: str) -> Layout:
+def get_layout(name: str):
     """Get a named layout object.
 
     Args:
@@ -25,6 +21,7 @@ def get_layout(name: str) -> Layout:
     Returns:
         Layout: A layout object.
     """
+
     layout_class = LAYOUT_MAP.get(name)
     if layout_class is None:
         raise MissingLayout("no layout called {name!r}")

--- a/src/textual/layouts/factory.py
+++ b/src/textual/layouts/factory.py
@@ -1,7 +1,11 @@
+from typing import Literal
+
+from ..layout import Layout
 from ..layouts.dock import DockLayout
 from ..layouts.grid import GridLayout
 from ..layouts.vertical import VerticalLayout
 
+LayoutName = Literal["dock", "grid", "vertical"]
 LAYOUT_MAP = {"dock": DockLayout, "grid": GridLayout, "vertical": VerticalLayout}
 
 
@@ -9,7 +13,7 @@ class MissingLayout(Exception):
     pass
 
 
-def get_layout(name: str):
+def get_layout(name: LayoutName) -> Layout:
     """Get a named layout object.
 
     Args:

--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
-from operator import itemgetter
-from logging import getLogger
 from itertools import cycle, product
-import sys
+from logging import getLogger
+from operator import itemgetter
 from typing import Iterable, NamedTuple, TYPE_CHECKING
 
 from .._layout_resolve import layout_resolve
 from ..geometry import Size, Offset, Region
 from ..layout import Layout, WidgetPlacement
-from ..widget import Widget
-
 
 if TYPE_CHECKING:
     from ..widget import Widget

--- a/src/textual/layouts/vertical.py
+++ b/src/textual/layouts/vertical.py
@@ -4,7 +4,6 @@ from typing import Iterable, TYPE_CHECKING
 
 from ..geometry import Offset, Region, Size, Spacing, SpacingDimensions
 from ..layout import Layout, WidgetPlacement
-from ..widget import Widget
 from .._loop import loop_last
 
 if TYPE_CHECKING:

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-
 import rich.repr
 from rich.color import Color
-from rich.console import Console, ConsoleOptions, RenderResult, RenderableType
-from rich.segment import Segment, Segments
+from rich.console import ConsoleOptions, RenderResult, RenderableType
+from rich.segment import Segment
 from rich.style import Style, StyleType
 
+from textual.reactive import Reactive
 from . import events
-from .geometry import Offset
 from ._types import MessageTarget
+from .geometry import Offset
 from .message import Message
-from .widget import Reactive, Widget
+from .widget import Widget
 
 
 @rich.repr.auto

--- a/src/textual/view.py
+++ b/src/textual/view.py
@@ -64,7 +64,7 @@ class View(Widget):
             new_value:
 
         Returns:
-
+            None
         """
         self.styles.layout = new_value
 

--- a/src/textual/view.py
+++ b/src/textual/view.py
@@ -16,8 +16,8 @@ from .widget import Widget
 @rich.repr.auto
 class View(Widget):
     STYLES = """
+        layout: dock;
         docks: main=top;
-
     """
 
     def __init__(self, name: str | None = None, id: str | None = None) -> None:

--- a/src/textual/view.py
+++ b/src/textual/view.py
@@ -12,7 +12,6 @@ from . import errors
 from . import log
 from . import messages
 from .layout import Layout, NoWidget, WidgetPlacement
-from .layouts.factory import get_layout
 from .geometry import Size, Offset, Region
 from .reactive import Reactive, watch
 

--- a/src/textual/view.py
+++ b/src/textual/view.py
@@ -16,24 +16,11 @@ from .layouts.factory import get_layout
 from .geometry import Size, Offset, Region
 from .reactive import Reactive, watch
 
-from .widget import Widget, Widget
+from .widget import Widget
 
 
 if TYPE_CHECKING:
     from .app import App
-
-
-class LayoutProperty:
-    def __get__(self, obj: View, objtype: type[View] | None = None) -> str:
-        return obj._layout.name
-
-    def __set__(self, obj: View, layout: str | Layout) -> str:
-        if isinstance(layout, str):
-            new_layout = get_layout(layout)
-        else:
-            new_layout = layout
-        self._layout = new_layout
-        return self._layout.name
 
 
 @rich.repr.auto
@@ -45,7 +32,7 @@ class View(Widget):
     """
 
     def __init__(self, name: str | None = None, id: str | None = None) -> None:
-
+        # TODO: Get rid of this, replace usages with layout from Styles object
         from .layouts.dock import DockLayout
 
         self._layout: Layout = DockLayout()
@@ -68,8 +55,6 @@ class View(Widget):
         if layout is not None:
             cls.layout_factory = layout
         super().__init_subclass__(**kwargs)
-
-    layout = LayoutProperty()
 
     background: Reactive[str] = Reactive("")
     scroll_x: Reactive[int] = Reactive(0)

--- a/src/textual/views/_dock_view.py
+++ b/src/textual/views/_dock_view.py
@@ -29,8 +29,8 @@ class DockView(View):
     ) -> None:
 
         dock = Dock(edge, widgets, z)
-        assert isinstance(self._layout, DockLayout)
-        self._layout.docks.append(dock)
+        assert isinstance(self.layout, DockLayout)
+        self.layout.docks.append(dock)
         for widget in widgets:
             if id is not None:
                 widget._id = id
@@ -60,8 +60,8 @@ class DockView(View):
         grid = GridLayout(gap=gap, gutter=gutter, align=align)
         view = View(layout=grid, id=id, name=name)
         dock = Dock(edge, (view,), z)
-        assert isinstance(self._layout, DockLayout)
-        self._layout.docks.append(dock)
+        assert isinstance(self.layout, DockLayout)
+        self.layout.docks.append(dock)
         if size is not do_not_set:
             view.layout_size = cast(Optional[int], size)
         if name is None:

--- a/src/textual/views/_window_view.py
+++ b/src/textual/views/_window_view.py
@@ -32,7 +32,7 @@ class WindowView(View, layout=VerticalLayout):
         super().__init__(name=name, layout=layout)
 
     async def update(self, widget: Widget | RenderableType) -> None:
-        layout = self._layout
+        layout = self.layout
         assert isinstance(layout, VerticalLayout)
         layout.clear()
         self.widget = widget if isinstance(widget, Widget) else Static(widget)
@@ -46,7 +46,7 @@ class WindowView(View, layout=VerticalLayout):
         await self.emit(WindowChange(self))
 
     async def handle_layout(self, message: messages.Layout) -> None:
-        self._layout.require_update()
+        self.layout.require_update()
         message.stop()
         self.refresh()
 
@@ -54,11 +54,11 @@ class WindowView(View, layout=VerticalLayout):
         await self.emit(WindowChange(self))
 
     async def watch_scroll_x(self, value: int) -> None:
-        self._layout.require_update()
+        self.layout.require_update()
         self.refresh()
 
     async def watch_scroll_y(self, value: int) -> None:
-        self._layout.require_update()
+        self.layout.require_update()
         self.refresh()
 
     async def on_resize(self, event: events.Resize) -> None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from logging import PercentStyle, getLogger
+from logging import getLogger
 from typing import (
     Any,
     Awaitable,
@@ -11,35 +11,30 @@ from typing import (
     NamedTuple,
     cast,
 )
-import rich.repr
-from rich import box
-from rich.align import Align
-from rich.console import Console, RenderableType, ConsoleOptions
-from rich.measure import Measurement
-from rich.panel import Panel
-from rich.padding import Padding
-from rich.pretty import Pretty
-from rich.segment import Segment
-from rich.style import Style, StyleType
-from rich.styled import Styled
-from rich.text import Text, TextType
 
-from . import events
+import rich.repr
+from rich.align import Align
+from rich.console import Console, RenderableType
+from rich.padding import Padding
+from rich.style import Style
+from rich.styled import Styled
+from rich.text import Text
+
 from . import errors
+from . import events
 from ._animator import BoundAnimator
-from ._border import Border, BORDER_STYLES
+from ._border import Border
 from ._callback import invoke
+from ._context import active_app
+from ._types import Lines
 from .blank import Blank
 from .dom import DOMNode
-from ._context import active_app
-from .geometry import Size, Spacing, SpacingDimensions
+from .geometry import Size, Spacing
 from .message import Message
 from .messages import Layout, Update
-from .reactive import Reactive, watch
-from ._types import Lines
+from .reactive import watch
 
 if TYPE_CHECKING:
-    from .app import App
     from .view import View
 
 log = getLogger("rich")

--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -10,7 +10,8 @@ import rich.repr
 from logging import getLogger
 
 from .. import events
-from ..widget import Reactive, Widget
+from ..reactive import Reactive
+from ..widget import Widget
 
 log = getLogger("rich")
 

--- a/src/textual/widgets/_scroll_view.py
+++ b/src/textual/widgets/_scroll_view.py
@@ -93,13 +93,13 @@ class ScrollView(View):
         await self.window.update(renderable)
 
     async def on_mount(self, event: events.Mount) -> None:
-        assert isinstance(self._layout, GridLayout)
-        self._layout.place(
+        assert isinstance(self.layout, GridLayout)
+        self.layout.place(
             content=self.window,
             vscroll=self.vscroll,
             hscroll=self.hscroll,
         )
-        await self._layout.mount_all(self)
+        await self.layout.mount_all(self)
 
     def home(self) -> None:
         self.x = self.y = 0
@@ -215,10 +215,10 @@ class ScrollView(View):
         self.vscroll.virtual_size = virtual_height
         self.vscroll.window_size = height
 
-        assert isinstance(self._layout, GridLayout)
+        assert isinstance(self.layout, GridLayout)
 
-        vscroll_change = self._layout.show_column("vscroll", virtual_height > height)
-        hscroll_change = self._layout.show_row("hscroll", virtual_width > width)
+        vscroll_change = self.layout.show_column("vscroll", virtual_height > height)
+        hscroll_change = self.layout.show_row("hscroll", virtual_width > width)
         if hscroll_change or vscroll_change:
             self.refresh(layout=True)
 

--- a/tests/layouts/test_factory.py
+++ b/tests/layouts/test_factory.py
@@ -1,0 +1,14 @@
+import pytest
+
+from textual.layouts.dock import DockLayout
+from textual.layouts.factory import get_layout, MissingLayout
+
+
+def test_get_layout_valid_layout():
+    layout_class = get_layout("dock")
+    assert type(layout_class) is DockLayout
+
+
+def test_get_layout_invalid_layout():
+    with pytest.raises(MissingLayout):
+        get_layout("invalid")

--- a/tests/layouts/test_factory.py
+++ b/tests/layouts/test_factory.py
@@ -5,8 +5,8 @@ from textual.layouts.factory import get_layout, MissingLayout
 
 
 def test_get_layout_valid_layout():
-    layout_class = get_layout("dock")
-    assert type(layout_class) is DockLayout
+    layout = get_layout("dock")
+    assert type(layout) is DockLayout
 
 
 def test_get_layout_invalid_layout():

--- a/tests/test_css_parse.py
+++ b/tests/test_css_parse.py
@@ -4,6 +4,27 @@ from rich.color import Color, ColorType
 from textual.css.scalar import Scalar, Unit
 from textual.css.stylesheet import Stylesheet, StylesheetParseError
 from textual.css.transition import Transition
+from textual.layouts.dock import DockLayout
+
+
+class TestParseLayout:
+    def test_valid_layout_name(self):
+        css = "#some-widget { layout: dock; }"
+
+        stylesheet = Stylesheet()
+        stylesheet.parse(css)
+
+        styles = stylesheet.rules[0].styles
+        assert isinstance(styles.layout, DockLayout)
+
+    def test_invalid_layout_name(self):
+        css = "#some-widget { layout: invalidlayout; }"
+
+        stylesheet = Stylesheet()
+        with pytest.raises(StylesheetParseError) as ex:
+            stylesheet.parse(css)
+
+        assert ex.value.errors is not None
 
 
 class TestParseText:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,0 +1,18 @@
+import pytest
+
+from textual.layouts.dock import DockLayout
+from textual.layouts.grid import GridLayout
+from textual.layouts.vertical import VerticalLayout
+from textual.view import View
+
+
+@pytest.mark.parametrize("layout_name, layout_type", [
+    ["dock", DockLayout],
+    ["grid", GridLayout],
+    ["vertical", VerticalLayout],
+])
+def test_view_layout_get_and_set(layout_name, layout_type):
+    view = View()
+    view.layout = layout_name
+    assert type(view.layout) is layout_type
+    assert view.styles.layout is view.layout


### PR DESCRIPTION
We no longer create a `DockLayout()` in the code, and instead use the value specified in CSS.

I've added a new rule to the View-level CSS to add `layout: dock` so that it's used by default without you having to specify it in the CSS (and so `basic.css` works without changes).