### PR TITLE
Wrap an open call in the simple example in a try block.

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -28,9 +28,12 @@ class MyApp(App):
         await self.view.dock(body, edge="right")
 
         async def get_markdown(filename: str) -> None:
-            with open(filename, "rt") as fh:
-                readme = Markdown(fh.read(), hyperlinks=True)
-            await body.update(readme)
+            try:
+                with open(filename, "rt") as fh:
+                    readme = Markdown(fh.read(), hyperlinks=True)
+                    await body.update(readme)
+            except OSError as e:
+                self.log("Couldn't open markdown file: {}".format(e))
 
         await self.call_later(get_markdown, "richreadme.md")
 


### PR DESCRIPTION
The simple.py example was failing if it was called from a different directory.

This fix lets it keep working if the richreadme.md file isn't found and logs the file open exception.

You might want to instead fail with a simple error message.

Thanks for the great project.