### PR TITLE
Improved Windows Driver

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -4,6 +4,7 @@ import os
 
 WINDOWS = os.name == "nt"
 if WINDOWS:
+    """Code from https://stackoverflow.com/questions/5174810/how-to-turn-off-blinking-cursor-in-command-window"""
     import msvcrt
     import ctypes
     class Cursor(ctypes.Structure):

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -4,22 +4,22 @@ import os
 
 WINDOWS = os.name == "nt"
 if WINDOWS:
-    """Code from https://stackoverflow.com/questions/5174810/how-to-turn-off-blinking-cursor-in-command-window"""
     import msvcrt
     import ctypes
-    class Cursor(ctypes.Structure):
-        _fields_ = [("size", ctypes.c_int), ("visible", ctypes.c_byte)]
-    cursorHandle = Cursor()
-    handle = ctypes.windll.kernel32.GetStdHandle(-11)
-    ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(cursorHandle))
-    cursorHandle.visible = False
-    ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(cursorHandle))
+    """Docs: https://docs.microsoft.com/en-us/windows/console/setconsolecursorinfo and https://docs.microsoft.com/en-us/windows/console/console-cursor-info-str"""
+    class CONSOLE_CURSOR_INFO(ctypes.Structure):
+        _fields_ = [("dwSize", ctypes.c_int), ("bVisible", ctypes.c_bool)]
+    hConsoleOutput = ctypes.windll.kernel32.GetStdHandle(-11)
+    lpConsoleCursorInfo = CONSOLE_CURSOR_INFO()
+    ctypes.windll.kernel32.GetConsoleCursorInfo(hConsoleOutput, ctypes.byref(lpConsoleCursorInfo))
+    lpConsoleCursorInfo.bVisible = False
+    ctypes.windll.kernel32.SetConsoleCursorInfo(hConsoleOutput, ctypes.byref(lpConsoleCursorInfo))
     def showCursorWindows():
-        cursorHandle = Cursor()
-        handle = ctypes.windll.kernel32.GetStdHandle(-11)
-        ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(cursorHandle))
-        cursorHandle.visible = True
-        ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(cursorHandle))
+        hConsoleOutput = ctypes.windll.kernel32.GetStdHandle(-11)
+        lpConsoleCursorInfo = CONSOLE_CURSOR_INFO()
+        ctypes.windll.kernel32.GetConsoleCursorInfo(hConsoleOutput, ctypes.byref(lpConsoleCursorInfo))
+        lpConsoleCursorInfo.bVisible = True
+        ctypes.windll.kernel32.SetConsoleCursorInfo(hConsoleOutput, ctypes.byref(lpConsoleCursorInfo))
 
 import asyncio
 from functools import partial

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import sys
 import os
 
-if os.name == 'nt':
+WINDOWS = os.name == "nt"
+if WINDOWS:
     import msvcrt
     import ctypes
     class Cursor(ctypes.Structure):
@@ -362,14 +363,14 @@ class App(MessagePump):
         await self.close_messages()
 
     def refresh(self, repaint: bool = True, layout: bool = False) -> None:
-        sync_available = os.environ.get("TERM_PROGRAM", "") != "Apple_Terminal"
+        sync_available = os.environ.get("TERM_PROGRAM", "") != "Apple_Terminal" and not WINDOWS
         if not self._closed:
             console = self.console
             try:
-                if sync_available and os.name != "nt":
+                if sync_available:
                     console.file.write("\x1bP=1s\x1b\\")
                 console.print(Screen(Control.home(), self.view, Control.home()))
-                if sync_available and os.name != "nt":
+                if sync_available:
                     console.file.write("\x1bP=2s\x1b\\")
                 console.file.flush()
             except Exception:
@@ -517,7 +518,7 @@ class App(MessagePump):
         await self.press(key)
 
     async def action_quit(self) -> None:
-        if os.name == 'nt':
+        if WINDOWS:
             showCursorWindows()
             os.system("cls")
         await self.shutdown()


### PR DESCRIPTION
Fixes the cursor problem on `Powershell` and printing problem on all consoles. Now works (without glitches) on `Powershell`, `Cygwin`, and `Windows Terminal`. Note: `VSCode/Atom Terminals` only send key presses to python, not cursor positions, scrolling, etc.