### PR TITLE
fix `examples/simple.py` Windows compatibility

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -28,7 +28,7 @@ class MyApp(App):
         await self.view.dock(body, edge="right")
 
         async def get_markdown(filename: str) -> None:
-            with open(filename, "rt") as fh:
+            with open(filename, "r", encoding="utf8") as fh:
                 readme = Markdown(fh.read(), hyperlinks=True)
             await body.update(readme)
 


### PR DESCRIPTION
On Windows, the default encoding used by Python sadly is cp1252. We want to force UTF-8 here (as it is the default on macOS/Linux), otherwise the README cannot be read.