### PR TITLE
Add README to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "textual"
 version = "0.1.15"
 homepage = "https://github.com/willmcgugan/textual"
 description = "Text User Interface using Rich"
+readme = README.md
 authors = ["Will McGugan <willmcgugan@gmail.com>"]
 license = "MIT"
 classifiers = [


### PR DESCRIPTION
Currently, when you go to https://pypi.org/project/textual/ it looks like this:

![image](https://user-images.githubusercontent.com/1658117/152685182-c814af78-ef3c-4c47-9c81-c26d15247649.png)

With this PR (+ a new version added to PyPI with those changes), there should be the README.

I'm not 100% certain, but the following indicates it might work: https://github.com/python-poetry/poetry/issues/1979