### PR TITLE
Updated the README.md file, fixing the incorrect example link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can see some of these examples in action in the [Developer Video Log](#devel
 - [animation.py](https://github.com/willmcgugan/textual/tree/main/examples/animation.py) Demonstration of 60fps animation easing function
 - [calculator.py](https://github.com/willmcgugan/textual/tree/main/examples/calculator.py) A "clone" of the MacOS calculator using Grid layout
 - [code_viewer.py](https://github.com/willmcgugan/textual/tree/main/examples/code_viewer.py) A demonstration of a tree view which loads syntax highlighted code
-- [grid.py](https://github.com/willmcgugan/textual/tree/main/examples/calculator.py) A simple demonstration of adding widgets in a Grid layout
+- [grid.py](https://github.com/aitoehigie/textual/blob/main/examples/grid.py) A simple demonstration of adding widgets in a Grid layout
 - [grid_auto.py](https://github.com/willmcgugan/textual/tree/main/examples/grid_auto.py) A demonstration of automatic Grid layout
 - [simple.py](https://github.com/willmcgugan/textual/tree/main/examples/simple.py) A very simple Textual app with scrolling Markdown view
 


### PR DESCRIPTION
I updated the README.md file. 
The link to the grid example was incorrectly pointing to the calculator example.
This PR fixes this little error. 