### PR TITLE
fix: allow downstream projects to use mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Typing :: Typed",
 ]
 
 


### PR DESCRIPTION
Downstream projects get a message `error: Skipping analyzing "textual": module is installed, but missing library stubs or py.typed marker` when trying to use mypy. This adds the missing marker, copied from rich. `tool.poetry.include` is not required, though - poetry (now?) picks this up from VCS, like other files.

Tested with:

```console
$ pip run build
...
$ unzip -l dist/textual-0.1.15-py3-none-any.whl | grep py.typed
        0  01-01-1980 00:00   textual/py.typed
```