### PR TITLE
Add conversion to/from the CIE-L*ab color space.

### DIFF
--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -378,7 +378,10 @@ class ColorPair(NamedTuple):
 def rgb_to_lab(rgb: Color) -> Lab:
     """Convert an RGB color to the CIE-L*ab format.
 
-    See https://stackoverflow.com/a/8433985/2828287."""
+    Uses the standard RGB color space with a D65/2⁰ standard illuminant.
+    Conversion passes through the XYZ color space.
+    Cf. http://www.easyrgb.com/en/math.php.
+    """
 
     r, g, b = rgb.r / 255, rgb.g / 255, rgb.b / 255
 
@@ -401,7 +404,9 @@ def rgb_to_lab(rgb: Color) -> Lab:
 def lab_to_rgb(lab: Lab) -> Color:
     """Convert a CIE-L*ab color to RGB.
 
-    See https://stackoverflow.com/a/8433985/2828287
+    Uses the standard RGB color space with a D65/2⁰ standard illuminant.
+    Conversion passes through the XYZ color space.
+    Cf. http://www.easyrgb.com/en/math.php.
     """
 
     y = (lab.L + 16) / 116

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -3,7 +3,7 @@ import pytest
 from rich.color import Color as RichColor
 from rich.text import Text
 
-from textual.color import Color, ColorPair
+from textual.color import Color, ColorPair, Lab, rgb_to_lab
 
 
 @pytest.mark.parametrize(
@@ -76,3 +76,12 @@ def test_hls():
     assert red.hls == pytest.approx(
         (0.9888888888888889, 0.43137254901960786, 0.818181818181818)
     )
+
+
+def test_rgb_to_lab():
+    r, g, b = 10, 23, 73
+    rgb = Color(r, g, b)
+    lab = rgb_to_lab(rgb)
+    assert lab.L == pytest.approx(10.245)
+    assert lab.a == pytest.approx(15.913)
+    assert lab.b == pytest.approx(-32.672)


### PR DESCRIPTION
This adds a simple `Lab` class to represent colours in the CIE-L*ab colour space and adds two functions to allow for RGB conversion to and from that space.
Tests are still being written.

Formulas as seen in https://stackoverflow.com/a/8433985/2828287.

Tests use the calculator available in http://www.easyrgb.com/en/convert.php.