### PR TITLE
Fix issue with binding space key

### DIFF
--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -36,7 +36,7 @@ class Bindings:
         key_display: str | None = None,
         allow_forward: bool = True,
     ) -> None:
-        all_keys = [key.strip() for key in keys.split(",")]
+        all_keys = [key.strip() or ' ' for key in keys.split(",")]
         for key in all_keys:
             self.keys[key] = Binding(
                 key,


### PR DESCRIPTION
This fixes the issue with binding the space key to an action. The use of `key.strip()` will create an empty string when a space is passed as key parameter.