### PR TITLE
Style error improvements

### DIFF
--- a/sandbox/uber.css
+++ b/sandbox/uber.css
@@ -10,5 +10,5 @@
   height: 8;
   min-width: 80;
   background: dark_blue;
-  margin-bottom: 4;
+  padding: 1 2;
 }

--- a/sandbox/uber.css
+++ b/sandbox/uber.css
@@ -2,7 +2,7 @@
   layout: vertical;
 
   background: dark_green;
-  overflow: hidden auto;
+  overflow: auto auto;
   border: heavy white;
 }
 
@@ -10,4 +10,5 @@
   height: 8;
   min-width: 80;
   background: dark_blue;
+  margin-bottom: 4;
 }

--- a/sandbox/uber.py
+++ b/sandbox/uber.py
@@ -87,8 +87,8 @@ class BasicApp(App):
 
     def action_increase_margin(self):
         old_margin = self.focused.styles.margin
-        new_margin = old_margin + Spacing.all(1)
-        self.focused.styles.margin = new_margin
+        # new_margin = old_margin + (1,1,1)
+        self.focused.styles.padding = (1, 1, 1)
 
 
 BasicApp.run(css_file="uber.css", log="textual.log", log_verbosity=1)

--- a/sandbox/uber.py
+++ b/sandbox/uber.py
@@ -30,9 +30,9 @@ class BasicApp(App):
             Widget(id="uber2-child1"),
             Widget(id="uber2-child2"),
         )
-        self.first_child = Placeholder(id="child1", classes={"list-item"})
+        first_child = Placeholder(id="child1", classes={"list-item"})
         uber1 = Widget(
-            self.first_child,
+            first_child,
             Placeholder(id="child2", classes={"list-item"}),
             Placeholder(id="child3", classes={"list-item"}),
             Placeholder(classes={"list-item"}),
@@ -40,7 +40,7 @@ class BasicApp(App):
             Placeholder(classes={"list-item"}),
         )
         self.mount(uber1=uber1)
-        await self.first_child.focus()
+        await first_child.focus()
 
     async def on_key(self, event: events.Key) -> None:
         await self.dispatch_key(event)

--- a/sandbox/uber.py
+++ b/sandbox/uber.py
@@ -1,7 +1,9 @@
+import random
 import sys
 
 from textual import events
 from textual.app import App
+from textual.geometry import Spacing
 from textual.widget import Widget
 from textual.widgets import Placeholder
 
@@ -14,8 +16,13 @@ class BasicApp(App):
         self.bind("d", "dump")
         self.bind("t", "log_tree")
         self.bind("p", "print")
+        self.bind("o", "toggle_visibility")
+        self.bind("p", "toggle_display")
+        self.bind("f", "modify_first_child")
+        self.bind("b", "toggle_border")
+        self.bind("m", "increase_margin")
 
-    def on_mount(self):
+    async def on_mount(self):
         """Build layout here."""
 
         uber2 = Widget()
@@ -23,8 +30,9 @@ class BasicApp(App):
             Widget(id="uber2-child1"),
             Widget(id="uber2-child2"),
         )
+        self.first_child = Placeholder(id="child1", classes={"list-item"})
         uber1 = Widget(
-            Placeholder(id="child1", classes={"list-item"}),
+            self.first_child,
             Placeholder(id="child2", classes={"list-item"}),
             Placeholder(id="child3", classes={"list-item"}),
             Placeholder(classes={"list-item"}),
@@ -32,6 +40,7 @@ class BasicApp(App):
             Placeholder(classes={"list-item"}),
         )
         self.mount(uber1=uber1)
+        await self.first_child.focus()
 
     async def on_key(self, event: events.Key) -> None:
         await self.dispatch_key(event)
@@ -54,6 +63,32 @@ class BasicApp(App):
         print(1234, 5678)
 
         sys.stdout.write("abcdef")
+
+    def action_modify_first_child(self):
+        """Increment height of first child widget, randomise border and bg color"""
+        previous_height = self.focused.styles.height.value
+        new_height = previous_height + 1
+        self.focused.styles.height = self.focused.styles.height.copy_with(
+            value=new_height
+        )
+        color = random.choice(["red", "green", "blue"])
+        self.focused.styles.background = color
+        self.focused.styles.border = ("dashed", color)
+
+    def action_toggle_visibility(self):
+        self.focused.visible = not self.focused.visible
+
+    def action_toggle_display(self):
+        # TODO: Doesn't work
+        self.focused.display = not self.focused.display
+
+    def action_toggle_border(self):
+        self.focused.styles.border = [("solid", "red"), ("solid", "white")]
+
+    def action_increase_margin(self):
+        old_margin = self.focused.styles.margin
+        new_margin = old_margin + Spacing.all(1)
+        self.focused.styles.margin = new_margin
 
 
 BasicApp.run(css_file="uber.css", log="textual.log", log_verbosity=1)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -439,7 +439,7 @@ class App(DOMNode):
             await widget.post_message(events.MouseCapture(self, self.mouse_position))
 
     def panic(self, *renderables: RenderableType) -> None:
-        """Exits the app after displaying a message.
+        """Exits the app then displays a message.
 
         Args:
             *renderables (RenderableType, optional): Rich renderables to display on exit.

--- a/src/textual/css/_error_tools.py
+++ b/src/textual/css/_error_tools.py
@@ -16,7 +16,7 @@ def friendly_list(words: Iterable[str], joiner: str = "or") -> str:
     Returns:
         str: List as prose.
     """
-    words = [repr(word) for word in sorted(words, key=str.lower)]
+    words = [repr(word) for word in sorted(words, key=str.lower) if word]
     if len(words) == 1:
         return words[0]
     elif len(words) == 2:

--- a/src/textual/css/_help_text.py
+++ b/src/textual/css/_help_text.py
@@ -1,0 +1,31 @@
+from textual.css._error_tools import friendly_list
+from textual.css.scalar import SYMBOL_UNIT
+
+
+def _inline_name(property_name: str) -> str:
+    return property_name.replace("-", "_")
+
+
+def spacing_help_text(property_name: str, num_values_supplied: int) -> str:
+    return f"""\
+• You supplied {num_values_supplied} values for the '{property_name}' property
+• Spacing properties like 'margin' and 'padding' require either 1, 2 or 4 integer values
+• In Textual CSS, supply 1, 2 or 4 values separated by a space
+    [dim]e.g. [/][i]{property_name}: 1 2 3 4;[/]
+• In Python, you can set it to a tuple to assign spacing to each edge
+    [dim]e.g. [/][i]widget.styles.{_inline_name(property_name)} = (1, 2, 3, 4)[/]
+• Or to an integer to assign to all edges at once
+    [dim]e.g. [/][i]widget.styles.{_inline_name(property_name)} = 2[/]"""
+
+
+def scalar_help_text(property_name: str) -> str:
+    return f"""\
+• Invalid value for the '{property_name}' property
+• Scalar properties like '{property_name}' require numerical values and an optional unit
+• Valid units are {friendly_list(SYMBOL_UNIT)}
+• Here's an example of how you'd set a scalar property in Textual CSS
+    [dim]e.g. [/][i]{property_name}: 50%;[/]
+• In Python, you can assign a string, int or Scalar object itself
+    [dim]e.g. [/][i]widget.styles.{_inline_name(property_name)} = "50%"[/]
+    [dim]e.g. [/][i]widget.styles.{_inline_name(property_name)} = 10[/]
+    [dim]e.g. [/][i]widget.styles.{_inline_name(property_name)} = Scalar(...)[/]"""

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -9,11 +9,13 @@ when setting and getting.
 
 from __future__ import annotations
 
+import inspect
 from typing import Iterable, NamedTuple, TYPE_CHECKING, cast
 
 import rich.repr
 from rich.style import Style
 
+from ._help_text import spacing_help_text, scalar_help_text
 from ..color import Color, ColorPair
 from ._error_tools import friendly_list
 from .constants import NULL_SPACING
@@ -98,7 +100,10 @@ class ScalarProperty:
             try:
                 new_value = Scalar.parse(value)
             except ScalarParseError:
-                raise StyleValueError("unable to parse scalar from {value!r}")
+                raise StyleValueError(
+                    "unable to parse scalar from {value!r}",
+                    help_text=scalar_help_text(property_name=self.name),
+                )
         else:
             raise StyleValueError("expected float, int, Scalar, or None")
         if new_value is not None and new_value.unit not in self.units:
@@ -368,7 +373,16 @@ class SpacingProperty:
             if obj.clear_rule(self.name):
                 obj.refresh(layout=True)
         else:
-            if obj.set_rule(self.name, Spacing.unpack(spacing)):
+            try:
+                unpacked_spacing = Spacing.unpack(spacing)
+            except ValueError as error:
+                raise StyleValueError(
+                    str(error),
+                    help_text=spacing_help_text(
+                        property_name=self.name, num_values_supplied=len(spacing)
+                    ),
+                )
+            if obj.set_rule(self.name, unpacked_spacing):
                 obj.refresh(layout=True)
 
 

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -282,10 +282,12 @@ class StylesBuilder:
                 except ValueError:
                     self.error(name, token, f"expected a number here; found {value!r}")
             else:
-                self.error(name, token, f"unexpected token {value!r} in declaration")
+                self.error(name, token, f"expected a number here; found {value!r}")
         if len(space) not in (1, 2, 4):
             self.error(
-                name, tokens[0], f"1, 2, or 4 values expected; received {len(space)}"
+                name,
+                tokens[0],
+                f"1, 2, or 4 values expected; received {len(space)} values",
             )
         self.styles._rules[name] = Spacing.unpack(cast(SpacingDimensions, tuple(space)))
 

--- a/src/textual/css/constants.py
+++ b/src/textual/css/constants.py
@@ -31,4 +31,4 @@ VALID_BOX_SIZING: Final = {"border-box", "content-box"}
 VALID_OVERFLOW: Final = {"scroll", "hidden", "auto"}
 
 
-NULL_SPACING: Final = Spacing(0, 0, 0, 0)
+NULL_SPACING: Final = Spacing.all(0)

--- a/src/textual/css/errors.py
+++ b/src/textual/css/errors.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+from rich.console import ConsoleOptions, Console
+from rich.padding import Padding
+from rich.traceback import Traceback
+
 from .tokenize import Token
 
 
@@ -18,7 +24,13 @@ class StyleTypeError(TypeError):
 
 
 class StyleValueError(ValueError):
-    pass
+    def __init__(self, *args, help_text: str | None = None):
+        super().__init__(*args)
+        self.help_text = help_text
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions):
+        yield Traceback.from_exception(type(self), self, self.__traceback__)
+        yield Padding(self.help_text, pad=(1, 0, 0, 1))
 
 
 class StylesheetError(Exception):

--- a/src/textual/css/scalar.py
+++ b/src/textual/css/scalar.py
@@ -156,6 +156,25 @@ class Scalar(NamedTuple):
             raise ScalarResolveError(f"expected dimensions; found {str(self)!r}")
         return dimension
 
+    def copy_with(
+        self,
+        value: float | None = None,
+        unit: Unit | None = None,
+        percent_unit: Unit | None = None,
+    ) -> Scalar:
+        """Get a copy of this Scalar, with values optionally modified
+
+        Args:
+            value (float | None): The new value, or None to keep the same value
+            unit (Unit | None): The new unit, or None to keep the same unit
+            percent_unit (Unit | None): The new percent_unit, or None to keep the same unit
+        """
+        return Scalar(
+            value if value is not None else self.value,
+            unit if unit is not None else self.unit,
+            percent_unit if percent_unit is not None else self.percent_unit,
+        )
+
 
 @rich.repr.auto(angular=True)
 class ScalarOffset(NamedTuple):

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -59,10 +59,9 @@ if TYPE_CHECKING:
 class RulesMap(TypedDict, total=False):
     """A typed dict for CSS rules.
 
-    Any key may be absent, indiciating that rule has not been set.
+    Any key may be absent, indicating that rule has not been set.
 
     Does not define composite rules, that is a rule that is made of a combination of other rules.
-
     """
 
     display: Display
@@ -150,7 +149,7 @@ class StylesBase(ABC):
         "scrollbar_background_active",
     }
 
-    display = StringEnumProperty(VALID_DISPLAY, "block")
+    display = StringEnumProperty(VALID_DISPLAY, "block", layout=True)
     visibility = StringEnumProperty(VALID_VISIBILITY, "visible")
     layout = LayoutProperty()
 
@@ -164,19 +163,19 @@ class StylesBase(ABC):
     margin = SpacingProperty()
     offset = OffsetProperty()
 
-    border = BorderProperty()
+    border = BorderProperty(layout=True)
     border_top = BoxProperty(Color(0, 255, 0))
     border_right = BoxProperty(Color(0, 255, 0))
     border_bottom = BoxProperty(Color(0, 255, 0))
     border_left = BoxProperty(Color(0, 255, 0))
 
-    outline = BorderProperty()
+    outline = BorderProperty(layout=False)
     outline_top = BoxProperty(Color(0, 255, 0))
     outline_right = BoxProperty(Color(0, 255, 0))
     outline_bottom = BoxProperty(Color(0, 255, 0))
     outline_left = BoxProperty(Color(0, 255, 0))
 
-    box_sizing = StringEnumProperty(VALID_BOX_SIZING, "border-box")
+    box_sizing = StringEnumProperty(VALID_BOX_SIZING, "border-box", layout=True)
     width = ScalarProperty(percent_unit=Unit.WIDTH)
     height = ScalarProperty(percent_unit=Unit.HEIGHT)
     min_width = ScalarProperty(percent_unit=Unit.WIDTH)

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -10,6 +10,7 @@ from typing import cast, Iterable
 import rich.repr
 from rich.console import Group, RenderableType
 from rich.highlighter import ReprHighlighter
+from rich.markup import render
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.syntax import Syntax
@@ -88,13 +89,7 @@ class StylesheetErrors:
                     )
                     append(self._get_snippet(token.code, line_no))
 
-                final_message = ""
-                for is_last, message_part in loop_last(message.split(";")):
-                    end = "" if is_last else "\n"
-                    final_message += f"• {message_part.strip()};{end}"
-
-                append(Padding(highlighter(Text(final_message, "red")), pad=(0, 1)))
-                append("")
+                append(Padding(highlighter(render(message)), pad=(0, 1)))
         return Group(*errors)
 
 

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -4,15 +4,12 @@ Functions and classes to manage terminal geometry (anything involving coordinate
 
 """
 
-
 from __future__ import annotations
 
 from math import sqrt
 from typing import Any, cast, NamedTuple, Tuple, Union, TypeVar
 
-
 SpacingDimensions = Union[int, Tuple[int], Tuple[int, int], Tuple[int, int, int, int]]
-
 
 T = TypeVar("T", int, float)
 
@@ -632,11 +629,11 @@ class Spacing(NamedTuple):
     def unpack(cls, pad: SpacingDimensions) -> Spacing:
         """Unpack padding specified in CSS style."""
         if isinstance(pad, int):
-            return cls(pad, pad, pad, pad)
+            return Spacing.all(pad)
         pad_len = len(pad)
         if pad_len == 1:
             _pad = pad[0]
-            return cls(_pad, _pad, _pad, _pad)
+            return Spacing.all(_pad)
         if pad_len == 2:
             pad_top, pad_right = cast(Tuple[int, int], pad)
             return cls(pad_top, pad_right, pad_top, pad_right)
@@ -644,6 +641,18 @@ class Spacing(NamedTuple):
             top, right, bottom, left = cast(Tuple[int, int, int, int], pad)
             return cls(top, right, bottom, left)
         raise ValueError(f"1, 2 or 4 integers required for spacing; {pad_len} given")
+
+    @classmethod
+    def vertical(cls, amount: int) -> Spacing:
+        return Spacing(amount, 0, amount, 0)
+
+    @classmethod
+    def horizontal(cls, amount: int) -> Spacing:
+        return Spacing(0, amount, 0, amount)
+
+    @classmethod
+    def all(cls, amount: int) -> Spacing:
+        return Spacing(amount, amount, amount, amount)
 
     def __add__(self, other: object) -> Spacing:
         if isinstance(other, tuple):

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -640,7 +640,9 @@ class Spacing(NamedTuple):
         if pad_len == 4:
             top, right, bottom, left = cast(Tuple[int, int, int, int], pad)
             return cls(top, right, bottom, left)
-        raise ValueError(f"1, 2 or 4 integers required for spacing; {pad_len} given")
+        raise ValueError(
+            f"1, 2 or 4 integers required for spacing properties; {pad_len} given"
+        )
 
     @classmethod
     def vertical(cls, amount: int) -> Spacing:


### PR DESCRIPTION
## Goals
- [ ] Extract styling/CSS error related help text into a common location
- [ ] Contextual error messaging - errors for inline vs CSS should be specific to that use case
- [ ] Abstract error messages into an object structure to ensure consistent help text printing

<img width="877" alt="image" src="https://user-images.githubusercontent.com/5740731/164420325-45735466-ba4c-4e3c-b751-500c61c50b65.png">
