### PR TITLE
Adding space key to ansi sequences allows binding

### DIFF
--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -5,6 +5,7 @@ from .keys import Keys
 # Mapping of vt100 escape codes to Keys.
 ANSI_SEQUENCES: Dict[str, Tuple[Keys, ...]] = {
     # Control keys.
+    " ": (Keys.Space,),
     "\r": (Keys.Enter,),
     "\x00": (Keys.ControlAt,),  # Control-At (Also for Ctrl-Space)
     "\x01": (Keys.ControlA,),  # Control-A (home)

--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -189,6 +189,7 @@ class Keys(str, Enum):
     # Some 'Key' aliases (for backwardshift+compatibility).
     ControlSpace = "ctrl-at"
     Tab = "tab"
+    Space = "space"
     Enter = "enter"
     Backspace = "backspace"
 


### PR DESCRIPTION
So you can define space binding like this:
```
        await self.bind("space", "quit", "Quit")
```
I think this is a better fix than #143 and should be more easily accepted.