### PR TITLE
[css branch] Update _style_properties.py

### DIFF
--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -642,7 +642,7 @@ class NameListProperty:
     def __get__(
         self, obj: StylesBase, objtype: type[StylesBase] | None = None
     ) -> tuple[str, ...]:
-        return cast(tuple[str, ...], obj.get_rule(self.name, ()))
+        return cast("tuple[str, ...]", obj.get_rule(self.name, ()))
 
     def __set__(self, obj: StylesBase, names: str | tuple[str] | None = None):
 


### PR DESCRIPTION
Uses the string version of the argument to `cast` to work with python 3.8 and lower.