### PR TITLE
fix for showing scrollbars

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -253,7 +253,7 @@ class App(DOMNode):
                     key_values = " ".join(
                         f"{key}={value}" for key, value in kwargs.items()
                     )
-                    output = " ".join((output, key_values))
+                    output = f"{output} {key_values}" if output else key_values
                 if self._log_console is not None:
                     self._log_console.print(output, soft_wrap=True)
                 if self.devtools.is_connected:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -527,6 +527,7 @@ class Widget(DOMNode):
             self._container_size = container_size
 
             if self.is_container:
+                self._refresh_scrollbars()
                 width, height = self.container_size
                 if self.show_vertical_scrollbar:
                     self.vertical_scrollbar.window_virtual_size = virtual_size.height
@@ -537,7 +538,7 @@ class Widget(DOMNode):
 
                 self.refresh(layout=True)
                 self.call_later(self.scroll_to, self.scroll_x, self.scroll_y)
-                self._refresh_scrollbars()
+
             else:
                 self.refresh()
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -538,7 +538,6 @@ class Widget(DOMNode):
 
                 self.refresh(layout=True)
                 self.call_later(self.scroll_to, self.scroll_x, self.scroll_y)
-
             else:
                 self.refresh()
 


### PR DESCRIPTION
Fix for scrollbars not being enabled on first refresh.

The issue was that scrollbars weren't enabled prior to changing the sizes.