### PR TITLE
fix for escape key processing

### DIFF
--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -47,7 +47,7 @@ class _ReadUntil(Awaitable):
         self.max_bytes = max_bytes
 
 
-class PeekBuffer(Awaitable):
+class _PeekBuffer(Awaitable):
     __slots__: list[str] = []
 
 
@@ -61,7 +61,7 @@ class Parser(Generic[T]):
     read = _Read
     read1 = _Read1
     read_until = _ReadUntil
-    peek_buffer = PeekBuffer
+    peek_buffer = _PeekBuffer
 
     def __init__(self) -> None:
         self._buffer = io.StringIO()
@@ -103,14 +103,14 @@ class Parser(Generic[T]):
         while tokens:
             yield popleft()
 
-        while pos < data_size or isinstance(self._awaiting, PeekBuffer):
+        while pos < data_size or isinstance(self._awaiting, _PeekBuffer):
 
             _awaiting = self._awaiting
             if isinstance(_awaiting, _Read1):
                 self._awaiting = self._gen.send(data[pos : pos + 1])
                 pos += 1
 
-            elif isinstance(_awaiting, PeekBuffer):
+            elif isinstance(_awaiting, _PeekBuffer):
                 self._awaiting = self._gen.send(data[pos:])
 
             elif isinstance(_awaiting, _Read):

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -190,18 +190,21 @@ class LinuxDriver(Driver):
             return False
 
         parser = XTermParser(self._target, more_data)
+        feed = parser.feed
 
         utf8_decoder = getincrementaldecoder("utf-8")().decode
         decode = utf8_decoder
         read = os.read
 
+        EVENT_READ = selectors.EVENT_READ
+
         try:
             while not self.exit_event.is_set():
                 selector_events = selector.select(0.1)
                 for _selector_key, mask in selector_events:
-                    if mask | selectors.EVENT_READ:
+                    if mask | EVENT_READ:
                         unicode_data = decode(read(fileno, 1024))
-                        for event in parser.feed(unicode_data):
+                        for event in feed(unicode_data):
                             self.process_event(event)
         except Exception as error:
             log(error)

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -285,5 +285,6 @@ class EventMonitor(threading.Thread):
 
     def on_size_change(self, width: int, height: int) -> None:
         """Called when terminal size changes."""
-        event = Resize(self.target, Size(width, height))
+        size = Size(width, height)
+        event = Resize(self.target, size, size)
         run_coroutine_threadsafe(self.target.post_message(event), loop=self.loop)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,56 @@
+from textual._parser import Parser
+
+
+def test_read1():
+    class TestParser(Parser[str]):
+        """A simple parser that reads a byte at a time from a stream."""
+
+        def parse(self, on_token):
+            while True:
+                data = yield self.read1()
+                if not data:
+                    break
+                on_token(data)
+
+    test_parser = TestParser()
+
+    test_data = "Where there is a Will there is a way!"
+
+    for size in range(1, len(test_data) + 1):
+        # Feed the parser in pieces, first 1 character at a time, then 2, etc
+        test_parser = TestParser()
+        data = []
+        for offset in range(0, len(test_data), size):
+            for chunk in test_parser.feed(test_data[offset : offset + size]):
+                data.append(chunk)
+        # Check we have received all the data in characters, no matter the fee dsize
+        assert len(data) == len(test_data)
+        assert "".join(data) == test_data
+
+
+def test_read():
+    class TestParser(Parser[str]):
+        """A parser that reads chunks of a given size from the stream."""
+
+        def __init__(self, size):
+            self.size = size
+            super().__init__()
+
+        def parse(self, on_token):
+            while True:
+                data = yield self.read1()
+                if not data:
+                    break
+                on_token(data)
+
+    test_data = "Where there is a Will there is a way!"
+
+    for read_size in range(1, len(test_data) + 1):
+        test_parser = TestParser(read_size)
+        for size in range(1, len(test_data) + 1):
+            test_parser = TestParser(read_size)
+            data = []
+            for offset in range(0, len(test_data), size):
+                for chunk in test_parser.feed(test_data[offset : offset + size]):
+                    data.append(chunk)
+            assert "".join(data) == test_data

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -46,7 +46,6 @@ def test_read():
     test_data = "Where there is a Will there is a way!"
 
     for read_size in range(1, len(test_data) + 1):
-        test_parser = TestParser(read_size)
         for size in range(1, len(test_data) + 1):
             test_parser = TestParser(read_size)
             data = []


### PR DESCRIPTION
FIxes escape key processing. Previously moving the mouse and hitting escape repeatedly could put the parser in a state where it wasn't producing any keys.

Also fixes an error that broke Windows.

Fixes https://github.com/Textualize/textual/issues/387