### PR TITLE
Add links to CHANGELOG and fix date for v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.1.18] - 2022-03-30
+## [0.1.18] - 2022-04-30
 
 ### Changed
 
@@ -115,3 +115,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Scrollview now shows scrollbars automatically
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
+
+
+[0.1.18]: https://github.com/Textualize/textual/compare/v0.1.17...v0.1.18
+[0.1.17]: https://github.com/Textualize/textual/compare/v0.1.16...v0.1.17
+[0.1.16]: https://github.com/Textualize/textual/compare/v0.1.15...v0.1.16
+[0.1.15]: https://github.com/Textualize/textual/compare/v0.1.14...v0.1.15
+[0.1.14]: https://github.com/Textualize/textual/compare/v0.1.13...v0.1.14
+[0.1.13]: https://github.com/Textualize/textual/compare/v0.1.12...v0.1.13
+[0.1.12]: https://github.com/Textualize/textual/compare/v0.1.11...v0.1.12
+[0.1.11]: https://github.com/Textualize/textual/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/Textualize/textual/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/Textualize/textual/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/Textualize/textual/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/Textualize/textual/releases/tag/v0.1.7


### PR DESCRIPTION
The CHANGELOG now conforms to conventions set by [Keep a Changelog](http://keepachangelog.com/). Many of these new links are broken ATM, but that is only because git tags have only been added for some (not all) releases. These tags would need to be added by a maintainer (not something I can do in a PR).

I would also recommend adding an "Unreleased" section to the top (so contributors can add changelog bullets as they work), but that is not something I have done in this PR.

Awesome project btw @willmcgugan. I'm super excited to see what this looks like once it has matured a bit!