### PR TITLE
Skip CI-based MacOS devtools tests

### DIFF
--- a/tests/devtools/__init__.py
+++ b/tests/devtools/__init__.py
@@ -9,5 +9,5 @@ import pytest
 # teardown code has finished running. These are very rare, but are much more of an issue on
 # CI since they can delay builds that have passed locally.
 pytestmark = pytest.mark.skipif(
-    sys.platform == "darwin" and os.getenv("CI"), reason="Issue #411"
+    sys.platform == "darwin" and os.getenv("CI", "0") != "0", reason="Issue #411"
 )

--- a/tests/devtools/__init__.py
+++ b/tests/devtools/__init__.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+import pytest
+
+# TODO - this needs to be revisited - perhaps when aiohttp 4.0 is released?
+# We get occasional test failures relating to devtools. These *appear* to be limited to MacOS,
+# and the error messages suggest the event loop is being shutdown before async fixture
+# teardown code has finished running. These are very rare, but are much more of an issue on
+# CI since they can delay builds that have passed locally.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "darwin" and os.getenv("CI"), reason="Issue #411"
+)

--- a/tests/devtools/test_devtools.py
+++ b/tests/devtools/test_devtools.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from datetime import datetime, timezone
 
 import pytest

--- a/tests/devtools/test_devtools.py
+++ b/tests/devtools/test_devtools.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from datetime import datetime, timezone
 
 import pytest


### PR DESCRIPTION
Devtools tests fail on MacOS sometimes (although very rare, maybe less than 5% of the time?).

The tracebacks suggest the event loop is being shutdown before our async fixture teardown code has complete (a CancellationError is sometimes raised during the shutdown process which occurs inside this teardown).

I can't find the source of this cancellation (i.e. where the event loop is being shut down from), and it's extremely hard to reproduce since it occurs so rarely.

Given my investigation didn't yield a solution, I've created this PR to skip devtools tests on CI on MacOS only.

This is a short-term "solution" to work around the annoyance of arbitrarily failing CI builds - we can track this issue on our project board and revisit it in the future. Hopefully with this in place we will be able to avoid these failures, but still have confidence in the devtools tests given they're run on Ubuntu on CI, and ran very frequently on MacOS machines locally.