### PR TITLE
Fix broken `overflow` CSS rule

### DIFF
--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -127,7 +127,7 @@ class StylesBuilder:
         """
         return [attr[8:] for attr in dir(self) if attr.startswith("process_")]
 
-    def _get_process_enum_multiple(
+    def _process_enum_multiple(
         self, name: str, tokens: list[Token], valid_values: set[str], count: int
     ) -> tuple[str, ...]:
         """Generic code to process a declaration with two enumerations, like overflow: auto auto"""

--- a/tests/css/test_parse.py
+++ b/tests/css/test_parse.py
@@ -983,6 +983,18 @@ class TestParseOffset:
         assert styles.offset.y == parsed_y
 
 
+class TestParseOverflow:
+    def test_multiple_enum(self):
+        css = "#some-widget { overflow: hidden auto; }"
+        stylesheet = Stylesheet()
+        stylesheet.add_source(css)
+
+        styles = stylesheet.rules[0].styles
+
+        assert len(stylesheet.rules) == 1
+        assert styles.overflow_x == "hidden"
+        assert styles.overflow_y == "auto"
+
 class TestParseTransition:
     @pytest.mark.parametrize(
         "duration, parsed_duration",


### PR DESCRIPTION
Seems like it was just a typo, but there was no test for this. I've added one which catches this issue.