### PR TITLE
Remove codecov from Textual

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -43,11 +43,3 @@ jobs:
         run: |
           source $VENV
           python e2e_tests/sandbox_basic_test.py basic 2.0
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v1.0.10
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          name: rich
-          flags: unittests
-          env_vars: OS,PYTHON


### PR DESCRIPTION
Should be easy enough to add back in the future, but right now it's causing a lot of issues.