### PR TITLE
[key bindings] Add dynamic "$event.[something]" mini-language to our key bindings management

### DIFF
--- a/sandbox/scroll_to_widget.py
+++ b/sandbox/scroll_to_widget.py
@@ -54,14 +54,19 @@ class MyTestApp(App):
     def on_mount(self):
         self.bind("q", "quit")
         self.bind("t", "tree")
-        for widget_index in range(placeholders_count):
-            self.bind(str(widget_index), f"scroll_to('placeholder_{widget_index}')")
+
+        scroll_to_placeholders_keys_to_bind = ",".join(
+            [str(i) for i in range(placeholders_count)]
+        )
+        self.bind(
+            scroll_to_placeholders_keys_to_bind, "scroll_to_placeholder('$event.key')"
+        )
 
     def action_tree(self):
         self.log(self.tree)
 
-    async def action_scroll_to(self, target_placeholder_id: str):
-        target_placeholder = self.query(f"#{target_placeholder_id}").first()
+    async def action_scroll_to_placeholder(self, key: str):
+        target_placeholder = self.query(f"#placeholder_{key}").first()
         target_placeholder_container = self.query("#root").first()
         target_placeholder_container.scroll_to_widget(target_placeholder, animate=True)
 

--- a/src/textual/_callback.py
+++ b/src/textual/_callback.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 
 @lru_cache(maxsize=2048)
-def count_parameters(func: Callable) -> tuple[int, bool]:
+def analyze_parameters(func: Callable) -> tuple[int, bool]:
     """Count the number of parameters in a callable, and checks if the last positional one is a "capture all"
 
     Args:
@@ -38,7 +38,7 @@ async def invoke(callback: Callable, *params: object) -> Any:
         Any: [description]
     """
     _rich_traceback_guard = True
-    parameter_count, has_capture_all = count_parameters(callback)
+    parameter_count, has_capture_all = analyze_parameters(callback)
     # If the target has a "capture all" argument we simply inject everything,
     # otherwise we only inject the number of arguments expected by the callable:
     parameters = params if has_capture_all else params[:parameter_count]

--- a/src/textual/_callback.py
+++ b/src/textual/_callback.py
@@ -2,14 +2,30 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from inspect import signature, isawaitable
+from inspect import signature, isawaitable, Parameter
 from typing import Any, Callable
 
 
 @lru_cache(maxsize=2048)
-def count_parameters(func: Callable) -> int:
-    """Count the number of parameters in a callable"""
-    return len(signature(func).parameters)
+def count_parameters(func: Callable) -> tuple[int, bool]:
+    """Count the number of parameters in a callable, and checks if the last positional one is a "capture all"
+
+    Args:
+        func (Callable): a callable
+    Returns:
+        tuple[int, bool]: the number of parameters, and a boolean that is `True` only if
+            the last positional parameter is a "capture all" (i.e. `*args`)
+    """
+    callable_signature = signature(func)
+    callable_parameters = callable_signature.parameters
+    parameters_count = len(callable_parameters)
+    has_capture_all = parameters_count > 0 and any(
+        (
+            parameter.kind is Parameter.VAR_POSITIONAL
+            for parameter in callable_parameters.values()
+        )
+    )
+    return parameters_count, has_capture_all
 
 
 async def invoke(callback: Callable, *params: object) -> Any:
@@ -22,9 +38,12 @@ async def invoke(callback: Callable, *params: object) -> Any:
         Any: [description]
     """
     _rich_traceback_guard = True
-    parameter_count = count_parameters(callback)
+    parameter_count, has_capture_all = count_parameters(callback)
+    # If the target has a "capture all" argument we simply inject everything,
+    # otherwise we only inject the number of arguments expected by the callable:
+    parameters = params if has_capture_all else params[:parameter_count]
 
-    result = callback(*params[:parameter_count])
+    result = callback(*parameters)
     if isawaitable(result):
         result = await result
     return result

--- a/src/textual/actions.py
+++ b/src/textual/actions.py
@@ -1,60 +1,154 @@
 from __future__ import annotations
 
 import ast
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import re
 
 if TYPE_CHECKING:
-    from textual.events import Event
+    from typing import Any, Mapping, Optional
 
 
 class ActionError(Exception):
     pass
 
 
+class NotAllowedActionExpression(ActionError):
+    pass
+
+
+class NotAllowedAttributeAccessInActionExpression(NotAllowedActionExpression):
+    def __init__(self, expression: str, data_source: object, attribute: str):
+        self.expression = expression
+        self.data_source = data_source
+        self.attribute = attribute
+
+
+class TooManyLevelsInActionExpression(NotAllowedActionExpression):
+    pass
+
+
 re_action_params = re.compile(r"([\w\.]+)(\(.*?\))")
-# We use our own "mini language" for dynamic event properties injections:
-# e.g. `'$event.key'` will inject the pressed key, `$event.sender` the string representation of the sender, etc.
-re_injected_event = re.compile(r"\$(event[\w.]+)")
 
 
-def parse(action: str, event: Event | None = None) -> tuple[str, tuple[Any, ...]]:
+def parse(
+    action: str, dynamic_data_sources: Mapping[str, Any] = None
+) -> tuple[str, tuple[Any, ...]]:
+    """
+    Parse an action string into a tuple of the action name and the action parameters.
+    Any parameter that is a string starting with a dollar sign is considered a dynamic placeholder,
+    and will be replaced with the data source value for that key.
+
+    For example, the parameter string `"$event.key"` will be parsed into `"c"` if the dynamic data sources
+    dict has an "event" key, for which the value is a class that explicitly allows the usage of its "key"
+    attribute by actions parameters - and the value of its "key" attribute is the string "c".
+    Such explicit attribute access is needed for security reasons, to avoid exposing sensitive data in the
+    action.
+
+    To enable such explicit attribute access, you can add a `__allowed_attributes_for_actions__` attribute
+    on the object.
+    For example, an Event class with the following line in its class definition:
+    ```__allowed_attributes_for_actions__ = ("key", "sender)```
+    ...explicitly allows the use of its "key" and "sender" attributes by actions parameters.
+
+    Only one level of dynamic attribute access is allowed, so `"$event.sender.is_system"` is never allowed
+    even if the "sender" explicitly allow the usage of its "is_system" attribute.
+
+    In order to allow direct access to a direct value of dynamic data sources dict, we can add the
+    string "Self" to the list of allowed attributes.
+    For example, an Event class with the following line in its class definition:
+    ```__allowed_attributes_for_actions__ = ("Self", "key", "sender)```
+    ...explicitly allows the use of the expression `$event` actions parameters if an instance of this class
+    is passed as the "event" key of the dynamic data sources dict.
+
+    Args:
+        action (str): an action expression - e.g. `on_mount("login", "$event.key")`
+        dynamic_data_sources (dict | None): a mapping of dynamic data sources to use in the action expression.
+
+    Returns:
+        tuple[str, tuple[Any, ...]]: the action name and the action parameters, processed according to the
+            dynamic data sources and dynamic parameters pattern.
+
+    Raises:
+        ActionError: if the action expression is invalid
+        NotAllowedActionExpression:, if dynamic attributes resolution rules prevent access to an attribute
+    """
     params_match = re_action_params.match(action)
     if params_match is not None:
         action_name, action_params_str = params_match.groups()
-        if event and "$event" in action_params_str:
-            # Allows things like: `self.bind("1,2,3", "on_digit('$event.key')")`
-            # i.e. the action handler can receive dynamic data from the event
-            action_params_str = _process_dynamic_event_params(action_params_str, event)
         try:
             action_params = ast.literal_eval(action_params_str)
         except Exception:
             raise ActionError(
                 f"unable to parse {action_params_str!r} in action {action!r}"
             )
+        action_params = _process_dynamic_data_source_params(
+            action_params if isinstance(action_params, tuple) else (action_params,),
+            dynamic_data_sources,
+        )
     else:
         action_name = action
         action_params = ()
 
     return (
         action_name,
-        action_params if isinstance(action_params, tuple) else (action_params,),
+        action_params,
     )
 
 
-def _process_dynamic_event_params(action_params_str: str, event: Event) -> str:
-    for dynamic_event_match in re.finditer(re_injected_event, action_params_str):
-        dynamic_event_processed = re.sub(
-            # `$event.sender` becomes `{event.sender}`, ready to be process by `str.format`:
-            re_injected_event,
-            r"{\1}",
-            dynamic_event_match[0],
+def _process_dynamic_data_source_params(
+    action_params: tuple[Any, ...], dynamic_data_sources: Optional[Mapping[str, Any]]
+) -> tuple[Any, ...]:
+    processed_params = []
+
+    for param in action_params:
+        is_dynamic_param = isinstance(param, str) and param.startswith("$")
+
+        if not is_dynamic_param:
+            # We just don't post-process this param at all:
+            processed_params.append(param)
+            continue
+
+        param_components = param[1:].split(".")
+
+        data_source_key = param_components[0]
+        if data_source_key not in dynamic_data_sources:
+            # We're requesting something like `"$event"`, but the dynamic data sources dict doesn't have
+            # an "event" key: that's an error!
+            raise NotAllowedActionExpression(param)
+        data_source = dynamic_data_sources[data_source_key]
+
+        allowed_attributes = getattr(
+            data_source, "__allowed_attributes_for_actions__", None
         )
-        dynamic_event_processed = dynamic_event_processed.format(event=event)
-        action_params_str = action_params_str.replace(
-            dynamic_event_match[0], dynamic_event_processed
-        )
-    return action_params_str
+
+        if len(param_components) == 1:
+            # Simple case: no attributes access, we just replace the placeholder with the value
+            # for this key in our dynamic data sources - e.g. `"$event"` is replaced with sources["event"].
+            # This can be done only if we have the string "Self" amongst the allowed attributes,
+            if not allowed_attributes or "Self" not in allowed_attributes:
+                raise NotAllowedAttributeAccessInActionExpression(
+                    param, data_source, "Self"
+                )
+            processed_params.append(data_source)
+            continue
+
+        if len(param_components) == 2:
+            # There is an attribute access: for security reasons we're going to check that the
+            # data source does allow this attribute to be read by actions
+            attribute = param_components[1]
+            if not allowed_attributes or attribute not in allowed_attributes:
+                raise NotAllowedAttributeAccessInActionExpression(
+                    param, data_source, attribute
+                )
+            processed_params.append(getattr(data_source, attribute))
+            continue
+
+        # For security reasons we only allow one level of attribute access in dynamic action expressions.
+        # Doing otherwise would open a risk of exposing sensitive data in the "sub-objects" of the expression.
+        # (i.e. "$event.sender" can be safe but that may not be the case of "$event.sender.__class__")
+        raise TooManyLevelsInActionExpression(param)
+
+    return tuple(processed_params)
 
 
 if __name__ == "__main__":
@@ -64,3 +158,14 @@ if __name__ == "__main__":
     print(parse("view.toggle('side')"))
 
     print(parse("view.toggle"))
+
+    class Event:
+        __allowed_attributes_for_actions__ = ["Self", "key"]
+        key = "k"
+
+    print(
+        parse(
+            "view.toggle('a', 1, {1: 'a', 2: 'b'}, '$event', '$event.key')",
+            {"event": Event()},
+        )
+    )

--- a/src/textual/actions.py
+++ b/src/textual/actions.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import ast
-from typing import Any, Tuple
+from typing import Any, TYPE_CHECKING
 import re
+
+if TYPE_CHECKING:
+    from textual.events import Event
 
 
 class ActionError(Exception):
@@ -10,12 +13,19 @@ class ActionError(Exception):
 
 
 re_action_params = re.compile(r"([\w\.]+)(\(.*?\))")
+# We use our own "mini language" for dynamic event properties injections:
+# e.g. `'$event.key'` will inject the pressed key, `$event.sender` the string representation of the sender, etc.
+re_injected_event = re.compile(r"\$(event[\w.]+)")
 
 
-def parse(action: str) -> tuple[str, tuple[Any, ...]]:
+def parse(action: str, event: Event | None = None) -> tuple[str, tuple[Any, ...]]:
     params_match = re_action_params.match(action)
     if params_match is not None:
         action_name, action_params_str = params_match.groups()
+        if event and "$event" in action_params_str:
+            # Allows things like: `self.bind("1,2,3", "on_digit('$event.key')")`
+            # i.e. the action handler can receive dynamic data from the event
+            action_params_str = _process_dynamic_event_params(action_params_str, event)
         try:
             action_params = ast.literal_eval(action_params_str)
         except Exception:
@@ -30,6 +40,21 @@ def parse(action: str) -> tuple[str, tuple[Any, ...]]:
         action_name,
         action_params if isinstance(action_params, tuple) else (action_params,),
     )
+
+
+def _process_dynamic_event_params(action_params_str: str, event: Event) -> str:
+    for dynamic_event_match in re.finditer(re_injected_event, action_params_str):
+        dynamic_event_processed = re.sub(
+            # `$event.sender` becomes `{event.sender}`, ready to be process by `str.format`:
+            re_injected_event,
+            r"{\1}",
+            dynamic_event_match[0],
+        )
+        dynamic_event_processed = dynamic_event_processed.format(event=event)
+        action_params_str = action_params_str.replace(
+            dynamic_event_match[0], dynamic_event_processed
+        )
+    return action_params_str
 
 
 if __name__ == "__main__":

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -964,20 +964,20 @@ class App(Generic[ReturnType], DOMNode):
         """Play the console 'bell'."""
         self.console.bell()
 
-    async def press(self, event: events.Key) -> bool:
+    async def press(self, key: str) -> bool:
         """Handle a key press.
 
         Args:
-            key (events.Key): A key event
+            key (str): A key
 
         Returns:
             bool: True if the key was handled by a binding, otherwise False
         """
         try:
-            binding = self.bindings.get_key(event.key)
+            binding = self.bindings.get_key(key)
         except NoBinding:
             return False
-        await self.action(binding.action, event=event)
+        await self.action(binding.action, event=events.Key(self, key))
         return True
 
     async def on_event(self, event: events.Event) -> None:
@@ -1020,11 +1020,11 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             action (str): Action encoded in a string.
         """
-        target, params = actions.parse(action, event=event)
+        target, params = actions.parse(action, {"event": event})
         if "." in target:
             destination, action_name = target.split(".", 1)
             if destination not in self._action_targets:
-                raise ActionError("Action namespace {destination} is not known")
+                raise ActionError(f"Action namespace {destination} is not known")
             action_target = getattr(self, destination)
         else:
             action_target = default_namespace or self

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -20,6 +20,17 @@ if TYPE_CHECKING:
 
 @rich.repr.auto
 class Event(Message):
+    __allowed_attributes_for_actions__ = (
+        "Self",  # Allow access to the event object itself, via `"$event"` expressions
+        "sender",  # allows `"$event.sender"` usage in action expressions
+        "name",  # etc.
+        "time",
+        "bubble",
+        "verbosity",
+        "system",
+        "is_forwarded",
+    )
+
     def __rich_repr__(self) -> rich.repr.Result:
         return
         yield
@@ -88,6 +99,11 @@ class Resize(Event, verbosity=2, bubble=False):
     """Sent when the app or widget has been resized."""
 
     __slots__ = ["size"]
+    __allowed_attributes_for_actions__ = (
+        *Event.__allowed_attributes_for_actions__,
+        "size",
+    )
+
     size: Size
 
     def __init__(
@@ -148,6 +164,11 @@ class MouseCapture(Event, bubble=False):
 
     """
 
+    __allowed_attributes_for_actions__ = (
+        *Event.__allowed_attributes_for_actions__,
+        "mouse_position",
+    )
+
     def __init__(self, sender: MessageTarget, mouse_position: Offset) -> None:
         """
 
@@ -165,6 +186,11 @@ class MouseCapture(Event, bubble=False):
 @rich.repr.auto
 class MouseRelease(Event, bubble=False):
     """Mouse has been released."""
+
+    __allowed_attributes_for_actions__ = (
+        *Event.__allowed_attributes_for_actions__,
+        "mouse_position",
+    )
 
     def __init__(self, sender: MessageTarget, mouse_position: Offset) -> None:
         """
@@ -188,6 +214,10 @@ class Key(InputEvent):
     """Sent when the user hits a key on the keyboard"""
 
     __slots__ = ["key"]
+    __allowed_attributes_for_actions__ = (
+        *Event.__allowed_attributes_for_actions__,
+        "key",
+    )
 
     def __init__(self, sender: MessageTarget, key: str) -> None:
         """
@@ -230,6 +260,10 @@ class MouseEvent(InputEvent, bubble=True, verbosity=2):
         "screen_y",
         "_style",
     ]
+    __allowed_attributes_for_actions__ = (
+        *Event.__allowed_attributes_for_actions__,
+        *__slots__,
+    )
 
     def __init__(
         self,

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -15,7 +15,7 @@ from typing import (
 
 from . import events
 
-from ._callback import count_parameters, invoke
+from ._callback import analyze_parameters, invoke
 from ._types import MessageTarget
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class Reactive(Generic[ReactiveType]):
             obj: Reactable, watch_function: Callable, old_value: Any, value: Any
         ) -> None:
             _rich_traceback_guard = True
-            if count_parameters(watch_function)[0] == 2:
+            if analyze_parameters(watch_function)[0] == 2:
                 watch_result = watch_function(old_value, value)
             else:
                 watch_result = watch_function(value)

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -94,7 +94,7 @@ class Reactive(Generic[ReactiveType]):
             obj: Reactable, watch_function: Callable, old_value: Any, value: Any
         ) -> None:
             _rich_traceback_guard = True
-            if count_parameters(watch_function) == 2:
+            if count_parameters(watch_function)[0] == 2:
                 watch_result = watch_function(old_value, value)
             else:
                 watch_result = watch_function(value)

--- a/tests/test_integration_key_binding.py
+++ b/tests/test_integration_key_binding.py
@@ -1,11 +1,14 @@
+from unittest import mock
+
 import pytest
 
 from tests.utilities.test_app import AppTest
+from textual import actions
 from textual.events import Key
 
 
 @pytest.mark.asyncio
-async def test_key_binding_expressions():
+async def test_valid_key_binding_expressions():
     # N.B. This test would have been a bit more elegant modelised as a parameterised test,
     # but as it takes a few milliseconds to boot an instance of AppTest let's be pragmatic
     # and boot it only once - and then, test our various cases against this one instance.
@@ -18,13 +21,13 @@ async def test_key_binding_expressions():
                 "h": "no_params",
                 "s": "static_param('this is a static param')",
                 "m": "multiple_static_params('correct horse', 'battery staple')",
+                "d": "multiple_static_params('Huey', 'Dewey', 'Louie - should not be passed')",
                 "c": "multiple_static_params_with_capture_all_args(1, 'a', {0: 1e5}, True, [2, 3])",
                 "a": "multiple_with_only_capture_all_args(-1, 3.14, None)",
-                "0,1,2": "dynamic_param('$event.key')",
-                "5,6": "dynamic_and_static_params('$event.key', {'key': 'static value'})",
-                # Note that for this example some of our dynamic params will be resolved with single quotes in
-                # their string-ified representation, so we'd better use double quotes to wrap them:
-                "8,9": """multiple_with_only_capture_all_args("$event.sender", $event.is_forwarded, 'static', "$event.key", '$event.__module__', "$event.__class__.__mro__")""",
+                "0": "dynamic_param_is_object('$event')",
+                "2,3": "dynamic_param('$event.key')",
+                "5,6": "dynamic_and_static_params('$event.key', {'key': 'static value'}, '$event.verbosity')",
+                "8,9": """multiple_with_only_capture_all_args("$event.sender", "$event.is_forwarded", "static", "$event.key", 3)""",
             }
             for key, action in bindings.items():
                 self.bind(key, action)
@@ -49,15 +52,20 @@ async def test_key_binding_expressions():
         def action_dynamic_param(self, key: str):
             self.key_binding_result = f"key pressed: {key}"
 
-        def action_dynamic_and_static_params(self, key: str, static: str):
-            self.key_binding_result = (f"key pressed: {key}", static)
+        def action_dynamic_param_is_object(self, object: object):
+            self.key_binding_result = object
 
-    app = MyApp(test_name="key_binding_expressions")
+        def action_dynamic_and_static_params(
+            self, key: str, static: str, event_verbosity: int
+        ):
+            self.key_binding_result = (f"key pressed: {key}", static, event_verbosity)
+
+    app = MyApp(test_name="valid_key_binding_expressions")
 
     async with app.in_running_state() as clock_mock:
 
         async def press_key(key: str) -> None:
-            await app.press(Key(..., key))
+            await app.press(key)
 
         async def wait_for_key_processing() -> None:
             await clock_mock.advance_clock(0.001)
@@ -79,6 +87,12 @@ async def test_key_binding_expressions():
         await wait_for_key_processing()
         assert app.key_binding_result == ("correct horse", "battery staple")
 
+        # Binding with multiple static params, the event handler accept less than we pass:
+        await press_key("d")
+        await wait_for_key_processing()
+        # The 3rd param should not be passed - sorry Louie!
+        assert app.key_binding_result == ("Huey", "Dewey")
+
         # Binding with multiple static params, with a "capture all" param:
         await press_key("c")
         await wait_for_key_processing()
@@ -89,8 +103,16 @@ async def test_key_binding_expressions():
         await wait_for_key_processing()
         assert app.key_binding_result == (-1, 3.14, None)
 
+        # Binding with dynamic event object param:
+        await press_key("0")
+        await wait_for_key_processing()
+        assert (
+            isinstance(app.key_binding_result, Key)
+            and app.key_binding_result.key == "0"
+        )
+
         # Dynamic parameters binding:
-        for i in range(3):
+        for i in range(2, 4):
             await press_key(str(i))
             await wait_for_key_processing()
             assert app.key_binding_result == f"key pressed: {i}"
@@ -102,19 +124,61 @@ async def test_key_binding_expressions():
             assert app.key_binding_result == (
                 f"key pressed: {i}",
                 {"key": "static value"},
+                1,  # event verbosity
             )
 
         # Various more advanced dynamic parameters binding:
         for i in range(8, 10):
             await press_key(str(i))
             await wait_for_key_processing()
-            assert app.key_binding_result == (
-                (
-                    "Ellipsis",
-                    False,
-                    "static",
-                    str(i),
-                    "textual.events",
-                    "(<class 'textual.events.Key'>, <class 'textual.events.InputEvent'>, <class 'textual.events.Event'>, <class 'textual.message.Message'>, <class 'object'>)",
-                )
-            )
+            expected = (app, False, "static", str(i), 3)
+            assert app.key_binding_result == expected
+
+
+@pytest.mark.asyncio
+async def test_invalid_key_binding_expressions():
+    # ditto: would have been elegant if parametrised
+
+    class MyApp(AppTest):
+        def on_mount(self) -> None:
+            bindings = {
+                "a": "should_not_be_triggered('$unknown')",
+                # We mock `__allowed_attributes_for_actions__` so the Key event class no longer
+                # allow access to itself via the key "Self", so this should fail:
+                "b": "should_not_be_triggered('$event')",
+                "c": "should_not_be_triggered('$event._forwarded')",
+                "d": "should_not_be_triggered('$event.__class__')",
+                "e": "should_not_be_triggered('$event.key.lower')",
+                "f": "should_not_be_triggered($syntax_error')",
+            }
+            for key, action in bindings.items():
+                self.bind(key, action)
+
+        def action_should_not_be_triggered(self) -> None:
+            raise RuntimeError
+
+    app = MyApp(test_name="invalid_key_binding_expressions")
+
+    async with app.in_running_state() as clock_mock:
+
+        async def press_key(key: str) -> None:
+            await app.press(key)
+
+        async def wait_for_key_processing() -> None:
+            await clock_mock.advance_clock(0.001)
+
+        with mock.patch(
+            "textual.events.Key.__allowed_attributes_for_actions__", new=["key"]
+        ):
+            # Simplest binding, no params:
+            for key, expected_error in [
+                ("a", actions.NotAllowedActionExpression),
+                ("b", actions.NotAllowedAttributeAccessInActionExpression),
+                ("c", actions.NotAllowedAttributeAccessInActionExpression),
+                ("d", actions.NotAllowedAttributeAccessInActionExpression),
+                ("e", actions.TooManyLevelsInActionExpression),
+                ("f", actions.ActionError),
+            ]:
+                with pytest.raises(expected_error):
+                    await press_key(key)
+                    await wait_for_key_processing()

--- a/tests/test_integration_key_binding.py
+++ b/tests/test_integration_key_binding.py
@@ -1,0 +1,120 @@
+import pytest
+
+from tests.utilities.test_app import AppTest
+from textual.events import Key
+
+
+@pytest.mark.asyncio
+async def test_key_binding_expressions():
+    # N.B. This test would have been a bit more elegant modelised as a parameterised test,
+    # but as it takes a few milliseconds to boot an instance of AppTest let's be pragmatic
+    # and boot it only once - and then, test our various cases against this one instance.
+
+    class MyApp(AppTest):
+        key_binding_result = None
+
+        def on_mount(self) -> None:
+            bindings = {
+                "h": "no_params",
+                "s": "static_param('this is a static param')",
+                "m": "multiple_static_params('correct horse', 'battery staple')",
+                "c": "multiple_static_params_with_capture_all_args(1, 'a', {0: 1e5}, True, [2, 3])",
+                "a": "multiple_with_only_capture_all_args(-1, 3.14, None)",
+                "0,1,2": "dynamic_param('$event.key')",
+                "5,6": "dynamic_and_static_params('$event.key', {'key': 'static value'})",
+                # Note that for this example some of our dynamic params will be resolved with single quotes in
+                # their string-ified representation, so we'd better use double quotes to wrap them:
+                "8,9": """multiple_with_only_capture_all_args("$event.sender", $event.is_forwarded, 'static', "$event.key", '$event.__module__', "$event.__class__.__mro__")""",
+            }
+            for key, action in bindings.items():
+                self.bind(key, action)
+
+        def action_no_params(self) -> None:
+            self.key_binding_result = "hello_world"
+
+        def action_static_param(self, received_static_param: str) -> None:
+            self.key_binding_result = received_static_param
+
+        def action_multiple_static_params(self, arg_a, arg_b) -> None:
+            self.key_binding_result = (arg_a, arg_b)
+
+        def action_multiple_static_params_with_capture_all_args(
+            self, arg_a, *args
+        ) -> None:
+            self.key_binding_result = (arg_a, args)
+
+        def action_multiple_with_only_capture_all_args(self, *args) -> None:
+            self.key_binding_result = args
+
+        def action_dynamic_param(self, key: str):
+            self.key_binding_result = f"key pressed: {key}"
+
+        def action_dynamic_and_static_params(self, key: str, static: str):
+            self.key_binding_result = (f"key pressed: {key}", static)
+
+    app = MyApp(test_name="key_binding_expressions")
+
+    async with app.in_running_state() as clock_mock:
+
+        async def press_key(key: str) -> None:
+            await app.press(Key(..., key))
+
+        async def wait_for_key_processing() -> None:
+            await clock_mock.advance_clock(0.001)
+
+        assert app.key_binding_result is None
+
+        # Simplest binding, no params:
+        await press_key("h")
+        await wait_for_key_processing()
+        assert app.key_binding_result == "hello_world"
+
+        # Binding with static params:
+        await press_key("s")
+        await wait_for_key_processing()
+        assert app.key_binding_result == "this is a static param"
+
+        # Binding with multiple static params:
+        await press_key("m")
+        await wait_for_key_processing()
+        assert app.key_binding_result == ("correct horse", "battery staple")
+
+        # Binding with multiple static params, with a "capture all" param:
+        await press_key("c")
+        await wait_for_key_processing()
+        assert app.key_binding_result == (1, ("a", {0: 1e5}, True, [2, 3]))
+
+        # Binding with multiple static params, with _only_ a "capture all" param:
+        await press_key("a")
+        await wait_for_key_processing()
+        assert app.key_binding_result == (-1, 3.14, None)
+
+        # Dynamic parameters binding:
+        for i in range(3):
+            await press_key(str(i))
+            await wait_for_key_processing()
+            assert app.key_binding_result == f"key pressed: {i}"
+
+        # Dynamic and static parameters binding:
+        for i in range(5, 7):
+            await press_key(str(i))
+            await wait_for_key_processing()
+            assert app.key_binding_result == (
+                f"key pressed: {i}",
+                {"key": "static value"},
+            )
+
+        # Various more advanced dynamic parameters binding:
+        for i in range(8, 10):
+            await press_key(str(i))
+            await wait_for_key_processing()
+            assert app.key_binding_result == (
+                (
+                    "Ellipsis",
+                    False,
+                    "static",
+                    str(i),
+                    "textual.events",
+                    "(<class 'textual.events.Key'>, <class 'textual.events.InputEvent'>, <class 'textual.events.Event'>, <class 'textual.message.Message'>, <class 'object'>)",
+                )
+            )

--- a/tests/utilities/test_app.py
+++ b/tests/utilities/test_app.py
@@ -23,13 +23,15 @@ from textual.geometry import Size, Region
 # N.B. These classes would better be named TestApp/TestConsole/TestDriver/etc,
 # but it makes pytest emit warning as it will try to collect them as classes containing test cases :-/
 
+_DEFAULT_SIZE = Size(20, 10)
+
 
 class AppTest(App):
     def __init__(
         self,
         *,
         test_name: str,
-        size: Size,
+        size: Size = _DEFAULT_SIZE,
         log_verbosity: int = 2,
     ):
         # Tests will log in "/tests/test.[test name].log":
@@ -101,7 +103,6 @@ class AppTest(App):
                 await self.force_full_screen_update()
 
             # End of simulated time: we just shut down ourselves:
-            assert not run_task.done()
             await self.shutdown()
 
         return get_running_state_context_manager()

--- a/tests/utilities/test_app.py
+++ b/tests/utilities/test_app.py
@@ -59,11 +59,6 @@ class AppTest(App):
         """Handy shortcut when testing stuff"""
         self.log(self.tree)
 
-    def compose(self) -> ComposeResult:
-        raise NotImplementedError(
-            "Create a subclass of TestApp and override its `compose()` method, rather than using TestApp directly"
-        )
-
     def in_running_state(
         self,
         *,


### PR DESCRIPTION
With this PR we can now use a "mini-language" to inject event-related data into the key bindings' handlers
e.g. `self.bind("1,2,3", "digit_pressed('$event.key')")`

- My first implementation was using the Python "Format Specification Mini-Language", so the syntax was the following:
   ```py
    self.bind("1,2,3", "digit_pressed('{event.key}')") # <-- uses curly brackets for interpolation
    ```
    But as I was writing some integration tests with various kinds of Python primitives passed to the key bindings handlers I realised that using this syntax was causing an issue: as it's based on curly brackets we could not use Python dicts or sets in the parameters we inject.
- This is why I ended up opting for a dedicated SDL that doesn't conflict with Python syntax for dicts or set literals. As I don't want to create fancy SDLs out of thin air that users have to learn, I simply based it on the Python [Template strings](https://docs.python.org/3/library/string.html#template-strings)' one.  
    So our previous expression becomes this:
   ```py
    self.bind("1,2,3", "digit_pressed('$event.key')") # <-- uses a "dollar" syntax for interpolation

    # ...which enables this kind of things:
    self.bind("1,2,3", "digit_pressed('$event.key', {'sender_name': 'sidebar'})") # <-- injects a Python dict
    ```

### Limits of this "action binding mini-language" 

As explained in one of my comments on the GitHub diff, I also realised that this "action binding mini-language" has some strong limits, which can be a good thing for security but also has limits.
We can pass `$event.key` to the action method for example, but we cannot pass the instance of the Event itself, or the sender instance - because this SDL is based on `ast.literal_eval`, which intentionally doesn't allow using custom objects.

I guess that time and dog-fooding will tell us if expressions such as `$event.sender` (which is _the string representation of the sender_, rather than the sender instance) is enough, or if we should rather start thinking of something else? :slightly_smiling_face: 

### Potential future improvements: dependency injection?

One potential way to solve this would be to use "a la Pytest" / "a la FastAPI" dependency injection...
So if the action method declares a param named `event` for example we detect that and inject the Event instance for this parameter. Same with a param named `sender`, etc. :slightly_smiling_face: 

Dependency injection would also allow users to not use error-prone "Python-syntax-in-a-string expressions" - i.e. it's easy to miss the syntax error in something like this:
```py
self.bind("1,2,3", "digit_pressed('$event.key', {'sender_name: 'sidebar'})")
```
(a closing single quote is missing)

closes #496 