### PR TITLE
Refresh scrollbars on style changes.

### DIFF
--- a/sandbox/file_search.scss
+++ b/sandbox/file_search.scss
@@ -5,8 +5,8 @@ Screen {
 
 #file_table_wrapper {
   dock: bottom;
-  height: auto;
-  overflow: auto auto;
+  height: 20;
+  overflow: auto scroll;
   scrollbar-color: $accent-darken-1;
 }
 

--- a/sandbox/file_search.scss
+++ b/sandbox/file_search.scss
@@ -5,8 +5,8 @@ Screen {
 
 #file_table_wrapper {
   dock: bottom;
-  height: 20;
-  overflow: auto scroll;
+  height: auto;
+  overflow: auto auto;
   scrollbar-color: $accent-darken-1;
 }
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -386,15 +386,15 @@ if __name__ == "__main__":
     from rich.traceback import install
 
     install(show_locals=True)
-    #
-    # class Widget(DOMNode):
-    #     pass
-    #
-    # class View(DOMNode):
-    #     pass
-    #
-    # class App(DOMNode):
-    #     pass
+
+    class Widget(DOMNode):
+        pass
+
+    class View(DOMNode):
+        pass
+
+    class App(DOMNode):
+        pass
 
     app = App()
     main_view = View(id="main")

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -15,6 +15,7 @@ from rich.style import Style
 from rich.syntax import Syntax
 from rich.text import Text
 
+from textual.widget import Widget
 from .errors import StylesheetError
 from .match import _check_selectors
 from .model import RuleSet
@@ -304,6 +305,8 @@ class Stylesheet:
             },
         )
         self.replace_rules(node, node_rules, animate=animate)
+        if isinstance(node, Widget):
+            node._refresh_scrollbars()
 
     @classmethod
     def replace_rules(
@@ -383,15 +386,15 @@ if __name__ == "__main__":
     from rich.traceback import install
 
     install(show_locals=True)
-
-    class Widget(DOMNode):
-        pass
-
-    class View(DOMNode):
-        pass
-
-    class App(DOMNode):
-        pass
+    #
+    # class Widget(DOMNode):
+    #     pass
+    #
+    # class View(DOMNode):
+    #     pass
+    #
+    # class App(DOMNode):
+    #     pass
 
     app = App()
     main_view = View(id="main")

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -343,6 +343,7 @@ class DOMNode(MessagePump):
         return ()
 
     def reset_styles(self) -> None:
+        """Reset styles back to their initial state"""
         from .widget import Widget
 
         for node in self.walk_children():

--- a/src/textual/widgets/text_input.py
+++ b/src/textual/widgets/text_input.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from typing import Callable
 
 from rich.cells import cell_len
@@ -135,7 +134,7 @@ class TextInput(TextWidgetBase, can_focus=True):
         super().__init__(name=name, id=id, classes=classes)
         self.placeholder = placeholder
         self._editor = TextEditorBackend(initial, 0)
-        self.visible_range: tuple[int, int] | None = None
+        self.visible_range: tuple[int, int] = (0, 0)
         self.autocompleter = autocompleter
         self._suggestion_suffix = ""
 
@@ -282,18 +281,6 @@ class TextInput(TextWidgetBase, can_focus=True):
             if visible_content_to_cursor_cell_len + key_cell_len >= available_width:
                 self.visible_range = start + key_cell_len, end + key_cell_len
             self._update_suggestion(event)
-        elif (
-            key == "ctrl+x"
-        ):  # TODO: This allows us to query and print the text input state
-            self.log(start=start)
-            self.log(end=end)
-            self.log(visible_content=visible_content)
-            self.log(visible_content_cell_len=visible_content_cell_len)
-            self.log(
-                visible_content_to_cursor_cell_len=visible_content_to_cursor_cell_len
-            )
-            self.log(available_width=available_width)
-            self.log(cursor_index=self._editor.cursor_index)
         elif key == "enter" and self._editor.content:
             self.post_message_no_wait(TextInput.Submitted(self, self._editor.content))
         elif key == "right":


### PR DESCRIPTION
Previously scrollbar visibility was only refreshed when the size of a widget changes.

However, when you modify the CSS with "watch_css" enabled, scrollbar visibility may change despite the size staying the same.

I suspect (but didn't confirm) that scrollbars wouldn't appear if you toggled overflow_x/y using Python at runtime too.

- Refresh scrollbars on style changes.
- Instantiate text input visible range to (0,0) by default.
- Remove debug code.