### PR TITLE
Allow parentheses in action parameter string

### DIFF
--- a/src/textual/actions.py
+++ b/src/textual/actions.py
@@ -9,7 +9,7 @@ class ActionError(Exception):
     pass
 
 
-re_action_params = re.compile(r"([\w\.]+)(\(.*?\))")
+re_action_params = re.compile(r"([\w\.]+)(\(.*\))")
 
 
 def parse(action: str) -> tuple[str, tuple[Any, ...]]:


### PR DESCRIPTION
Removing this `?` converts this `.*` regular expression from non-greedy to greedy. Without this change, action parameters cannot contain a right parenthesis (an `ActionError` exception is raised).