### PR TITLE
XTerm parsing improvements

### DIFF
--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -166,7 +166,6 @@ if __name__ == "__main__":
         def parse(
             self, on_token: Callable[[str], None]
         ) -> Generator[Awaitable, str, None]:
-            data = yield self.read1()
             while True:
                 data = yield self.read1()
                 if not data:

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 
 import re
-from collections import deque
 from typing import Any, Callable, Generator, Iterable
 
 from . import messages
@@ -36,11 +35,11 @@ class XTermParser(Parser[events.Event]):
         self.last_x = 0
         self.last_y = 0
 
-        self._debug_log_file = open("keys.log", "wt")
+        self._debug_log_file = open("keys.log", "wt") if debug else None
 
         super().__init__()
 
-    def debug_log(self, *args: Any) -> None:
+    def debug_log(self, *args: Any) -> None:  # pragma: no cover
         if self._debug_log_file is not None:
             self._debug_log_file.write(" ".join(args) + "\n")
             self._debug_log_file.flush()
@@ -187,12 +186,13 @@ class XTermParser(Parser[events.Event]):
                         mouse_match = _re_mouse_event.match(sequence)
                         if mouse_match is not None:
                             mouse_code = mouse_match.group(0)
-                            print(mouse_code)
                             event = self.parse_mouse_code(mouse_code, self.sender)
                             if event:
                                 on_token(event)
                             break
-                        # Or a mode report? (i.e. the terminal telling us if it supports a mode we requested)
+
+                        # Or a mode report?
+                        # (i.e. the terminal saying it supports a mode we requested)
                         mode_report_match = _re_terminal_mode_response.match(sequence)
                         if mode_report_match is not None:
                             if (

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -148,7 +148,7 @@ class XTermParser(Parser[events.Event]):
                     # to find a match, and should issue everything we've seen within
                     # the suspected sequence as Key events instead.
                     sequence_character = yield read1()
-                    next_sequence = sequence + sequence_character
+                    new_sequence = sequence + sequence_character
 
                     threshold_exceeded = len(sequence) > _MAX_SEQUENCE_SEARCH_THRESHOLD
                     found_escape = sequence_character and sequence_character == ESC
@@ -156,7 +156,7 @@ class XTermParser(Parser[events.Event]):
                     if threshold_exceeded:
                         # We exceeded the sequence length threshold, so reissue all the
                         # characters in that sequence as key-presses.
-                        reissue_sequence_as_keys(next_sequence)
+                        reissue_sequence_as_keys(new_sequence)
                         break
 
                     if found_escape:
@@ -167,7 +167,7 @@ class XTermParser(Parser[events.Event]):
                         reissue_sequence_as_keys(sequence)
                         break
 
-                    sequence = next_sequence
+                    sequence = new_sequence
 
                     self.debug_log(f"sequence={sequence!r}")
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -127,6 +127,16 @@ class XTermParser(Parser[events.Event]):
                 # Could be the escape key was pressed OR the start of an escape sequence
                 sequence: str = character
                 if not bracketed_paste:
+                    # TODO: There's nothing left in the buffer at the moment,
+                    #  but since we're on an escape, how can we be sure that the
+                    #  data that next gets fed to the parser isn't an escape sequence?
+
+                    #  This problem arises when an ESC falls at the end of a chunk.
+                    #  We'll be at an escape, but peek_buffer will return an empty
+                    #  string because there's nothing in the buffer yet.
+
+                    #  This code makes an assumption that an escape sequence will never be
+                    #  "chopped up", so buffers would never contain partial escape sequences.
                     peek_buffer = yield self.peek_buffer()
                     if not peek_buffer:
                         # An escape arrived without any following characters

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -90,7 +90,7 @@ class XTermParser(Parser[events.Event]):
 
         ESC = "\x1b"
         read1 = self.read1
-        get_key_ansi_sequence = ANSI_SEQUENCES_KEYS.get
+        sequence_to_key_events = self._sequence_to_key_events
         more_data = self.more_data
         paste_buffer: list[str] = []
         bracketed_paste = False
@@ -144,7 +144,7 @@ class XTermParser(Parser[events.Event]):
                         or len(sequence) > _MAX_SEQUENCE_SEARCH_THRESHOLD
                     ):
                         for character in sequence:
-                            key_events = self._sequence_to_key_events(character)
+                            key_events = sequence_to_key_events(character)
                             for event in key_events:
                                 if event.key == "escape":
                                     event = events.Key(event.sender, key="^")
@@ -170,7 +170,7 @@ class XTermParser(Parser[events.Event]):
 
                     if not bracketed_paste:
                         # Was it a pressed key event that we received?
-                        key_events = list(self._sequence_to_key_events(sequence))
+                        key_events = list(sequence_to_key_events(sequence))
                         for event in key_events:
                             on_token(event)
                         if key_events:
@@ -200,7 +200,7 @@ class XTermParser(Parser[events.Event]):
                             break
             else:
                 if not bracketed_paste:
-                    for event in self._sequence_to_key_events(character):
+                    for event in sequence_to_key_events(character):
                         on_token(event)
 
     def _sequence_to_key_events(self, sequence: str) -> Iterable[events.Key]:

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -94,7 +94,7 @@ class XTermParser(Parser[events.Event]):
         more_data = self.more_data
         paste_buffer: list[str] = []
         bracketed_paste = False
-        reuse_escape = False
+        use_prior_escape = False
 
         def reissue_sequence_as_keys(reissue_sequence: str) -> None:
             for character in reissue_sequence:
@@ -116,8 +116,8 @@ class XTermParser(Parser[events.Event]):
                 on_token(events.Paste(self.sender, text=pasted_text))
                 paste_buffer.clear()
 
-            character = ESC if reuse_escape else (yield read1())
-            reuse_escape = False
+            character = ESC if use_prior_escape else (yield read1())
+            use_prior_escape = False
 
             if bracketed_paste:
                 paste_buffer.append(character)
@@ -163,7 +163,7 @@ class XTermParser(Parser[events.Event]):
                         # We've hit an escape, so we need to reissue all the keys
                         # up to but not including it, since this escape could be
                         # part of an upcoming control sequence.
-                        reuse_escape = True
+                        use_prior_escape = True
                         reissue_sequence_as_keys(sequence)
                         break
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,12 +13,10 @@ def test_read1():
                 on_token(data)
 
     test_parser = TestParser()
-
     test_data = "Where there is a Will there is a way!"
 
     for size in range(1, len(test_data) + 1):
         # Feed the parser in pieces, first 1 character at a time, then 2, etc
-        test_parser = TestParser()
         data = []
         for offset in range(0, len(test_data), size):
             for chunk in test_parser.feed(test_data[offset : offset + size]):

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -3,8 +3,15 @@ from unittest import mock
 import pytest
 
 from textual._xterm_parser import XTermParser
-from textual.events import Paste, Key, MouseDown, MouseUp, MouseMove, MouseScrollDown, \
-    MouseScrollUp
+from textual.events import (
+    Paste,
+    Key,
+    MouseDown,
+    MouseUp,
+    MouseMove,
+    MouseScrollDown,
+    MouseScrollUp,
+)
 from textual.messages import TerminalSupportsSynchronizedOutput
 
 
@@ -205,6 +212,13 @@ def test_mouse_scroll_up(parser, sequence, shift, meta):
     assert isinstance(event, MouseScrollUp)
     assert event.x == 17
     assert event.y == 24
+
+
+def test_mouse_event_detected_but_info_not_parsed(parser):
+    # I don't know if this can actually happen in reality, but
+    # there's a branch in the code that allows for the possibility.
+    events = list(parser.feed("\x1b[<65;18;20;25M"))
+    assert len(events) == 0
 
 
 def test_escape_sequence_resulting_in_multiple_keypresses(parser):

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -15,6 +15,15 @@ from textual.events import (
 from textual.messages import TerminalSupportsSynchronizedOutput
 
 
+def chunks(data, size):
+    chunk_start = 0
+    chunk_end = size
+    while chunk_end <= len(data):
+        yield data[chunk_start:chunk_end]
+        chunk_start = chunk_end
+        chunk_end += size
+
+
 @pytest.fixture
 def parser():
     return XTermParser(sender=mock.sentinel, more_data=lambda: False)

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -1,0 +1,160 @@
+from unittest import mock
+
+import pytest
+
+from textual._xterm_parser import XTermParser
+from textual.events import Paste, Key, MouseDown, MouseUp, MouseMove
+
+
+@pytest.fixture
+def parser():
+    return XTermParser(sender=mock.sentinel, more_data=lambda: False)
+
+
+def test_bracketed_paste(parser):
+    """ When bracketed paste mode is enabled in the terminal emulator and
+    the user pastes in some text, it will surround the pasted input
+    with the escape codes "\x1b[200~" and "\x1b[201~". The text between
+    these codes corresponds to a single `Paste` event in Textual.
+    """
+    pasted_text = "PASTED"
+    events = list(parser.feed(f"\x1b[200~{pasted_text}\x1b[201~"))
+
+    assert len(events) == 1
+    assert isinstance(events[0], Paste)
+    assert events[0].text == pasted_text
+    assert events[0].sender == mock.sentinel
+
+
+def test_bracketed_paste_content_contains_escape_codes(parser):
+    """When performing a bracketed paste, if the pasted content contains
+    supported ANSI escape sequences, it should not interfere with the paste,
+    and no escape sequences within the bracketed paste should be converted
+    into Textual events.
+    """
+    pasted_text = "PAS\x0fTED"
+    events = list(parser.feed(f"\x1b[200~{pasted_text}\x1b[201~"))
+    assert len(events) == 1
+    assert events[0].text == pasted_text
+
+
+def test_cant_match_escape_sequence_too_long(parser):
+    """ The sequence did not match, and we hit the maximum sequence search
+    length threshold, so each character should be issued as a key-press instead.
+    """
+    sequence = "\x1b[123456789123456789123"
+    events = list(parser.feed(sequence))
+
+    # Every character in the sequence is converted to a key press
+    assert len(events) == len(sequence)
+    assert all(isinstance(event, Key) for event in events)
+
+    # '\x1b' is translated to 'escape'
+    assert events[0].key == "escape"
+
+    # The rest of the characters correspond to the expected key presses
+    events = events[1:]
+    for index, character in enumerate(sequence[1:]):
+        assert events[index].key == character
+
+
+def test_unknown_sequence_followed_by_known_sequence(parser):
+    """ When we feed the parser an unknown sequence followed by a known
+    sequence. The characters in the unknown sequence are delivered as keys,
+    and the known escape sequence that follows is delivered as expected.
+    """
+    unknown_sequence = "\x1b[?"
+    known_sequence = "\x1b[8~"  # key = 'end'
+
+    sequence = unknown_sequence + known_sequence
+    events = parser.feed(sequence)
+
+    assert next(events).key == "escape"
+    assert next(events).key == "["
+    assert next(events).key == "?"
+    assert next(events).key == "end"
+
+    with pytest.raises(StopIteration):
+        next(events)
+
+
+def test_simple_key_presses_all_delivered_correct_order(parser):
+    sequence = "123abc"
+    events = parser.feed(sequence)
+    assert "".join(event.key for event in events) == sequence
+
+
+def test_key_presses_and_escape_sequence_mixed(parser):
+    sequence = "abc\x1b[13~123"
+    events = list(parser.feed(sequence))
+
+    assert len(events) == 7
+    assert "".join(event.key for event in events) == "abcf3123"
+
+
+def test_single_escape(parser):
+    """A single \x1b should be interpreted as a single press of the Escape key"""
+    events = parser.feed("\x1b")
+    assert [event.key for event in events] == ["escape"]
+
+
+def test_double_escape(parser):
+    """Windows Terminal writes double ESC when the user presses the Escape key once."""
+    events = parser.feed("\x1b\x1b")
+    assert [event.key for event in events] == ["escape"]
+
+
+@pytest.mark.parametrize("sequence, event_type, shift, meta", [
+    # Mouse down, with and without modifiers
+    ("\x1b[<0;50;25M", MouseDown, False, False),
+    ("\x1b[<4;50;25M", MouseDown, True, False),
+    ("\x1b[<8;50;25M", MouseDown, False, True),
+    # Mouse up, with and without modifiers
+    ("\x1b[<0;50;25m", MouseUp, False, False),
+    ("\x1b[<4;50;25m", MouseUp, True, False),
+    ("\x1b[<8;50;25m", MouseUp, False, True),
+])
+def test_mouse_click(parser, sequence, event_type, shift, meta):
+    """ANSI codes for mouse should be converted to Textual events"""
+    events = list(parser.feed(sequence))
+
+    assert len(events) == 1
+
+    event = events[0]
+
+    assert isinstance(event, event_type)
+    assert event.x == 49
+    assert event.y == 24
+    assert event.screen_x == 49
+    assert event.screen_y == 24
+    assert event.meta is meta
+    assert event.shift is shift
+
+
+@pytest.mark.parametrize("sequence, shift, meta, button", [
+    ("\x1b[<32;15;38M", False, False, 1),  # Click and drag
+    ("\x1b[<35;15;38M", False, False, 0),  # Basic cursor movement
+    ("\x1b[<39;15;38M", True, False, 0),   # Shift held down
+    ("\x1b[<43;15;38M", False, True, 0),   # Meta held down
+])
+def test_mouse_move(parser, sequence, shift, meta, button):
+    events = list(parser.feed(sequence))
+
+    assert len(events) == 1
+
+    event = events[0]
+
+    assert isinstance(event, MouseMove)
+    assert event.x == 14
+    assert event.y == 37
+    assert event.shift is shift
+    assert event.meta is meta
+    assert event.button == button
+
+
+def test_escape_sequence_resulting_in_multiple_keypresses(parser):
+    """Some sequences are interpreted as more than 1 keypress"""
+    events = list(parser.feed("\x1b[2;4~"))
+    assert len(events) == 2
+    assert events[0].key == "escape"
+    assert events[1].key == "shift+insert"

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -67,8 +67,8 @@ def test_cant_match_escape_sequence_too_long(parser):
     assert len(events) == len(sequence)
     assert all(isinstance(event, Key) for event in events)
 
-    # '\x1b' is translated to 'escape'
-    assert events[0].key == "escape"
+    # When we backtrack '\x1b' is translated to '^'
+    assert events[0].key == "^"
 
     # The rest of the characters correspond to the expected key presses
     events = events[1:]
@@ -87,7 +87,7 @@ def test_unknown_sequence_followed_by_known_sequence(parser):
     sequence = unknown_sequence + known_sequence
     events = parser.feed(sequence)
 
-    assert next(events).key == "escape"
+    assert next(events).key == "^"
     assert next(events).key == "["
     assert next(events).key == "?"
     assert next(events).key == "end"

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -95,6 +95,13 @@ def test_simple_key_presses_all_delivered_correct_order(parser):
     assert "".join(event.key for event in events) == sequence
 
 
+def test_simple_keypress_non_character_key(parser):
+    sequence = "\x09"
+    events = list(parser.feed(sequence))
+    assert len(events) == 1
+    assert events[0].key == "tab"
+
+
 def test_key_presses_and_escape_sequence_mixed(parser):
     sequence = "abc\x1b[13~123"
     events = list(parser.feed(sequence))


### PR DESCRIPTION
- Added a unit test suite covering the XTermParser code
- Fixes freeze/hanging issue: When a candidate escape sequence grows in length to exceed a threshold, or when another \x1b is found, it'll backtrack and treat the characters until that point as keypresses (and escape codes that follow the non-matched sequence won't be lost).