### PR TITLE
Tests around CSS specificity, and fix ordering in case of specificity clash

### DIFF
--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -288,7 +288,7 @@ class Stylesheet:
             rule_attributes[key].append((default_specificity, value))
 
         # Collect the rules defined in the stylesheet
-        for rule in self.rules:
+        for rule in reversed(self.rules):
             for specificity in _check_rule(rule, node):
                 for key, rule_specificity, value in rule.styles.extract_rules(
                     specificity
@@ -297,15 +297,13 @@ class Stylesheet:
 
         # For each rule declared for this node, keep only the most specific one
         get_first_item = itemgetter(0)
-        node_rules: RulesMap = cast(RulesMap, {})
-        for name, specificity_rules in rule_attributes.items():
-            highest_specificity = max(specificity_rules, key=get_first_item)[0]
-            rules_with_highest_specificity = [
-                rule for rule in specificity_rules if rule[0] == highest_specificity
-            ]
-            # In the event of two rules having the same specificity, we take the
-            # rule that was declared last and use that.
-            node_rules[name] = rules_with_highest_specificity[-1][1]
+        node_rules: RulesMap = cast(
+            RulesMap,
+            {
+                name: max(specificity_rules, key=get_first_item)[1]
+                for name, specificity_rules in rule_attributes.items()
+            },
+        )
 
         self.replace_rules(node, node_rules, animate=animate)
         if isinstance(node, Widget):

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -303,6 +303,8 @@ class Stylesheet:
             rules_with_highest_specificity = [
                 rule for rule in specificity_rules if rule[0] == highest_specificity
             ]
+            # In the event of two rules having the same specificity, we take the
+            # rule that was declared last and use that.
             node_rules[name] = rules_with_highest_specificity[-1][1]
 
         self.replace_rules(node, node_rules, animate=animate)

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -296,13 +296,15 @@ class Stylesheet:
                     rule_attributes[key].append((rule_specificity, value))
 
         # For each rule declared for this node, keep only the most specific one
-        node_rules: RulesMap = cast(
-            RulesMap,
-            {
-                name: specificity_rules[-1][1]
-                for name, specificity_rules in rule_attributes.items()
-            },
-        )
+        get_first_item = itemgetter(0)
+        node_rules: RulesMap = cast(RulesMap, {})
+        for name, specificity_rules in rule_attributes.items():
+            highest_specificity = max(specificity_rules, key=get_first_item)[0]
+            rules_with_highest_specificity = [
+                rule for rule in specificity_rules if rule[0] == highest_specificity
+            ]
+            node_rules[name] = rules_with_highest_specificity[-1][1]
+
         self.replace_rules(node, node_rules, animate=animate)
         if isinstance(node, Widget):
             node._refresh_scrollbars()

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -296,11 +296,10 @@ class Stylesheet:
                     rule_attributes[key].append((rule_specificity, value))
 
         # For each rule declared for this node, keep only the most specific one
-        get_first_item = itemgetter(0)
         node_rules: RulesMap = cast(
             RulesMap,
             {
-                name: max(specificity_rules, key=get_first_item)[1]
+                name: specificity_rules[-1][1]
                 for name, specificity_rules in rule_attributes.items()
             },
         )

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -8,6 +8,7 @@ from textual.css._help_renderables import HelpText
 from textual.css.stylesheet import Stylesheet, StylesheetParseError
 from textual.css.tokenizer import TokenizeError
 from textual.dom import DOMNode
+from textual.geometry import Spacing
 
 
 def _make_stylesheet(css: str) -> Stylesheet:
@@ -25,6 +26,16 @@ def test_stylesheet_apply_highest_specificity_wins():
     stylesheet.apply(node)
 
     assert node.styles.color == Color(255, 0, 0)
+
+
+def test_stylesheet_apply_doesnt_override_defaults():
+    css = "#id {color: red;}"
+    stylesheet = _make_stylesheet(css)
+    node = DOMNode(id="id")
+    stylesheet.apply(node)
+
+    assert node.styles.margin == Spacing.all(0)
+    assert node.styles.box_sizing == "border-box"
 
 
 def test_stylesheet_apply_highest_specificity_wins_multiple_classes():

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -7,6 +7,20 @@ from textual.color import Color
 from textual.css._help_renderables import HelpText
 from textual.css.stylesheet import Stylesheet, StylesheetParseError
 from textual.css.tokenizer import TokenizeError
+from textual.dom import DOMNode
+
+
+def test_stylesheet_apply_takes_final_rule_in_specificity_clash():
+    css = ".a {background: red; color: lime} .b {background:blue}"
+    stylesheet = Stylesheet()
+    stylesheet.source["test.css"] = css
+    stylesheet.parse()
+
+    node = DOMNode(classes="a b")
+    stylesheet.apply(node)
+
+    assert node.styles.color == Color(0, 255, 0)  # color: lime
+    assert node.styles.background == Color(0, 0, 255)  # background: blue
 
 
 @pytest.mark.parametrize(

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -23,6 +23,17 @@ def test_stylesheet_apply_takes_final_rule_in_specificity_clash():
     assert node.styles.background == Color(0, 0, 255)  # background: blue
 
 
+def test_stylesheet_apply_empty_rules():
+    css = ".a {} .b {}"
+
+    stylesheet = Stylesheet()
+    stylesheet.source["test.css"] = css
+    stylesheet.parse()
+
+    node = DOMNode(classes="a b")
+    stylesheet.apply(node)
+
+
 @pytest.mark.parametrize(
     "css_value,expectation,expected_color",
     [

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -11,12 +11,12 @@ from textual.dom import DOMNode
 
 
 def test_stylesheet_apply_takes_final_rule_in_specificity_clash():
-    css = ".a {background: red; color: lime} .b {background:blue}"
+    css = ".a {background: red; color: lime} .b {background: blue}"
     stylesheet = Stylesheet()
     stylesheet.source["test.css"] = css
     stylesheet.parse()
 
-    node = DOMNode(classes="a b")
+    node = DOMNode(classes="a b", id="c")
     stylesheet.apply(node)
 
     assert node.styles.color == Color(0, 255, 0)  # color: lime


### PR DESCRIPTION
When 2 rules have matching specificity, take the final one, not the first.