### PR TITLE
[perf] Widget classes in `textual.widget.__init__.py` are now lazy-loaded

### DIFF
--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -1,21 +1,45 @@
-from ._footer import Footer
-from ._header import Header
-from ._button import Button
-from ._placeholder import Placeholder
-from ._static import Static
-from ._tree_control import TreeControl, TreeClick, TreeNode, NodeID
-from ._directory_tree import DirectoryTree, FileClick
+from __future__ import annotations
+from importlib import import_module
+import typing
 
-__all__ = [
-    "Button",
-    "DirectoryTree",
-    "FileClick",
-    "Footer",
-    "Header",
-    "Placeholder",
-    "Static",
-    "TreeClick",
-    "TreeControl",
-    "TreeNode",
-    "NodeID",
-]
+if typing.TYPE_CHECKING:
+    from ..widget import Widget
+
+# Let's decrease startup time by lazy loading our Widgets:
+# ⚠ For any new built-in Widget we create, not only we have to add them to the following dictionary, but also to the
+# `__init__.pyi` file in this same folder - otherwise text editors and type checkers won't be able to "see" them.
+_WIDGETS_LAZY_LOADING_MAPPING: dict[str, str] = {
+    "Footer": "._footer:Footer",
+    "Header": "._header:Header",
+    "Button": "._button:Button",
+    "Placeholder": "._placeholder:Placeholder",
+    "Static": "._static:Static",
+    "TreeControl": "._tree_control:TreeControl",
+    "TreeClick": "._tree_control:TreeClick",
+    "TreeNode": "._tree_control:TreeNode",
+    "NodeID": "._tree_control:NodeID",
+    "DirectoryTree": "._directory_tree:DirectoryTree",
+    "FileClick": "._directory_tree:FileClick",
+}
+
+_WIDGETS_LAZY_LOADING_CACHE: dict[str, type[Widget]] = {}
+
+
+def __getattr__(widget_name: str) -> type[Widget]:
+    try:
+        return _WIDGETS_LAZY_LOADING_CACHE[widget_name]
+    except KeyError:
+        pass
+
+    if widget_name not in _WIDGETS_LAZY_LOADING_MAPPING:
+        raise ImportError(f"Widget {widget_name} not found")
+
+    module_name, class_name = _WIDGETS_LAZY_LOADING_MAPPING[widget_name].split(":")
+    module = import_module(module_name, package="textual.widgets")
+    class_ = getattr(module, class_name)
+
+    _WIDGETS_LAZY_LOADING_CACHE[widget_name] = class_
+    return class_
+
+
+__all__ = tuple(_WIDGETS_LAZY_LOADING_MAPPING.keys())

--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -2,44 +2,40 @@ from __future__ import annotations
 from importlib import import_module
 import typing
 
+from ..case import camel_to_snake
+
 if typing.TYPE_CHECKING:
     from ..widget import Widget
 
-# Let's decrease startup time by lazy loading our Widgets:
-# ⚠ For any new built-in Widget we create, not only we have to add them to the following dictionary, but also to the
+
+# ⚠️For any new built-in Widget we create, not only we have to add them to the following list, but also to the
 # `__init__.pyi` file in this same folder - otherwise text editors and type checkers won't be able to "see" them.
-_WIDGETS_LAZY_LOADING_MAPPING: dict[str, str] = {
-    "Footer": "._footer:Footer",
-    "Header": "._header:Header",
-    "Button": "._button:Button",
-    "Placeholder": "._placeholder:Placeholder",
-    "Static": "._static:Static",
-    "TreeControl": "._tree_control:TreeControl",
-    "TreeClick": "._tree_control:TreeClick",
-    "TreeNode": "._tree_control:TreeNode",
-    "NodeID": "._tree_control:NodeID",
-    "DirectoryTree": "._directory_tree:DirectoryTree",
-    "FileClick": "._directory_tree:FileClick",
-}
+__all__ = [
+    "Button",
+    "DirectoryTree",
+    "Footer",
+    "Header",
+    "Placeholder",
+    "Static",
+    "TreeControl",
+]
+
 
 _WIDGETS_LAZY_LOADING_CACHE: dict[str, type[Widget]] = {}
 
-
-def __getattr__(widget_name: str) -> type[Widget]:
+# Let's decrease startup time by lazy loading our Widgets:
+def __getattr__(widget_class: str) -> type[Widget]:
     try:
-        return _WIDGETS_LAZY_LOADING_CACHE[widget_name]
+        return _WIDGETS_LAZY_LOADING_CACHE[widget_class]
     except KeyError:
         pass
 
-    if widget_name not in _WIDGETS_LAZY_LOADING_MAPPING:
-        raise ImportError(f"Widget {widget_name} not found")
+    if widget_class not in __all__:
+        raise ImportError(f"Package 'textual.widgets' has no class '{widget_class}'")
 
-    module_name, class_name = _WIDGETS_LAZY_LOADING_MAPPING[widget_name].split(":")
-    module = import_module(module_name, package="textual.widgets")
-    class_ = getattr(module, class_name)
+    widget_module_path = f"._{camel_to_snake(widget_class)}"
+    module = import_module(widget_module_path, package="textual.widgets")
+    class_ = getattr(module, widget_class)
 
-    _WIDGETS_LAZY_LOADING_CACHE[widget_name] = class_
+    _WIDGETS_LAZY_LOADING_CACHE[widget_class] = class_
     return class_
-
-
-__all__ = tuple(_WIDGETS_LAZY_LOADING_MAPPING.keys())

--- a/src/textual/widgets/__init__.pyi
+++ b/src/textual/widgets/__init__.pyi
@@ -1,12 +1,8 @@
+# This stub file must re-export every classes exposed in the __init__.py's `__all__` list:
+from ._button import Button as Button
+from ._directory_tree import DirectoryTree as DirectoryTree
 from ._footer import Footer as Footer
 from ._header import Header as Header
-from ._button import Button as Button
 from ._placeholder import Placeholder as Placeholder
 from ._static import Static as Static
-from ._tree_control import (
-    TreeControl as TreeControl,
-    TreeClick as TreeClick,
-    TreeNode as TreeNode,
-    NodeID as NodeID,
-)
-from ._directory_tree import DirectoryTree as DirectoryTree, FileClick as FileClick
+from ._tree_control import TreeControl as TreeControl

--- a/src/textual/widgets/__init__.pyi
+++ b/src/textual/widgets/__init__.pyi
@@ -1,0 +1,12 @@
+from ._footer import Footer as Footer
+from ._header import Header as Header
+from ._button import Button as Button
+from ._placeholder import Placeholder as Placeholder
+from ._static import Static as Static
+from ._tree_control import (
+    TreeControl as TreeControl,
+    TreeClick as TreeClick,
+    TreeNode as TreeNode,
+    NodeID as NodeID,
+)
+from ._directory_tree import DirectoryTree as DirectoryTree, FileClick as FileClick


### PR DESCRIPTION
Thanks to the `textual.widget.__init__.pyi` file we keep the benefits of having the assistance of code editors and type checkers despite the lazy-loading:
![Screenshot from 2022-06-17 10-57-09](https://user-images.githubusercontent.com/722388/174282200-08abd0eb-d18c-4f23-9617-4a7f7deac9b8.png)

fixes #578 
