### PR TITLE
Focus order

### DIFF
--- a/sandbox/darren/just_a_box.css
+++ b/sandbox/darren/just_a_box.css
@@ -26,7 +26,7 @@ Screen {
 }
 
 #middle_pane:focus {
-    outline: #8bc34a;
+    tint: cyan 40%;
 }
 
 #right_pane {
@@ -35,7 +35,7 @@ Screen {
 }
 
 .box:focus {
-    outline: #8bc34a;
+    tint: cyan 40%;
 }
 
 #box1 {

--- a/sandbox/darren/just_a_box.css
+++ b/sandbox/darren/just_a_box.css
@@ -1,6 +1,61 @@
-#box {
-    height: 50%;
-    width: 50%;
-    align: center middle;
+Screen {
+    height: 100vh;
+    width: 100%;
+    background: red;
+}
+
+#horizontal {
+    width: 100%;
+}
+
+.box {
+    height: 5;
+    width: 5;
+    margin: 1 10;
+}
+
+#left_pane {
+    width: 1fr;
+    background: $background;
+}
+
+#middle_pane {
+    margin-top: 4;
+    width: 1fr;
+    background: #173f5f;
+}
+
+#middle_pane:focus {
+    outline: #8bc34a;
+}
+
+#right_pane {
+    width: 1fr;
+    background: #f6d55c;
+}
+
+.box:focus {
+    outline: #8bc34a;
+}
+
+#box1 {
     background: green;
+}
+
+#box2 {
+    offset-y: 3;
+    background: hotpink;
+}
+
+#box3 {
+    background: red;
+}
+
+
+#box4 {
+    background: blue;
+}
+
+#box5 {
+    background: darkviolet;
 }

--- a/sandbox/darren/just_a_box.py
+++ b/sandbox/darren/just_a_box.py
@@ -4,10 +4,11 @@ from rich.console import RenderableType
 from rich.panel import Panel
 
 from textual.app import App, ComposeResult
+from textual.layout import Horizontal, Vertical
 from textual.widget import Widget
 
 
-class Box(Widget):
+class Box(Widget, can_focus=True):
     CSS = "#box {background: blue;}"
 
     def __init__(
@@ -20,8 +21,25 @@ class Box(Widget):
 
 
 class JustABox(App):
+    dark = True
+
     def compose(self) -> ComposeResult:
-        yield Box(id="box")
+        yield Horizontal(
+            Vertical(
+                Box(id="box1", classes="box"),
+                Box(id="box2", classes="box"),
+                Box(id="box3", classes="box"),
+                id="left_pane",
+            ),
+            Box(id="middle_pane"),
+            Vertical(
+                Box(id="box", classes="box"),
+                Box(id="box4", classes="box"),
+                Box(id="box5", classes="box"),
+                id="right_pane",
+            ),
+            id="horizontal",
+        )
 
 
 if __name__ == "__main__":

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -19,7 +19,9 @@ from .css.errors import StyleValueError
 from .css.parse import parse_declarations
 from .css.styles import Styles, RenderStyles
 from .css.query import NoMatchingNodesError
+from .geometry import Region
 from .message_pump import MessagePump
+from .widget import Widget
 
 if TYPE_CHECKING:
     from .app import App
@@ -429,7 +431,10 @@ class DOMNode(MessagePump):
     def focusable_children(self) -> list[DOMNode]:
         """Get the children which may be focused."""
         # TODO: This may be the place to define order, other focus related rules
-        return [child for child in self.children if child.display and child.visible]
+        focusable = [
+            child for child in self.children if child.display and child.visible
+        ]
+        return sorted(focusable, key=_focus_sort_key)
 
     def get_pseudo_classes(self) -> Iterable[str]:
         """Get any pseudo classes applicable to this Node, e.g. hover, focus.
@@ -596,3 +601,8 @@ class DOMNode(MessagePump):
 
     def refresh(self, *, repaint: bool = True, layout: bool = False) -> None:
         pass
+
+
+def _focus_sort_key(widget: Widget) -> tuple[int, int]:
+    x, y = widget.content_offset
+    return y, x

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from inspect import getfile
+from operator import attrgetter
 from typing import ClassVar, Iterable, Iterator, Type, TYPE_CHECKING
 
 import rich.repr
@@ -426,15 +427,6 @@ class DOMNode(MessagePump):
         """The children which don't have display: none set."""
         return [child for child in self.children if child.display]
 
-    @property
-    def focusable_children(self) -> list[DOMNode]:
-        """Get the children which may be focused."""
-        focusable = [
-            child for child in self.children if child.display and child.visible
-        ]
-        sorted_focusable = sorted(focusable, key=_focus_sort_key)
-        return sorted_focusable
-
     def get_pseudo_classes(self) -> Iterable[str]:
         """Get any pseudo classes applicable to this Node, e.g. hover, focus.
 
@@ -600,8 +592,3 @@ class DOMNode(MessagePump):
 
     def refresh(self, *, repaint: bool = True, layout: bool = False) -> None:
         pass
-
-
-def _focus_sort_key(widget: Widget) -> tuple[int, int]:
-    x, y, _, _ = widget.region_with_margin
-    return y, x

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -19,15 +19,14 @@ from .css.errors import StyleValueError
 from .css.parse import parse_declarations
 from .css.styles import Styles, RenderStyles
 from .css.query import NoMatchingNodesError
-from .geometry import Region
 from .message_pump import MessagePump
-from .widget import Widget
 
 if TYPE_CHECKING:
     from .app import App
     from .css.styles import StylesBase
     from .css.query import DOMQuery
     from .screen import Screen
+    from .widget import Widget
 
 
 class NoParent(Exception):
@@ -430,11 +429,11 @@ class DOMNode(MessagePump):
     @property
     def focusable_children(self) -> list[DOMNode]:
         """Get the children which may be focused."""
-        # TODO: This may be the place to define order, other focus related rules
         focusable = [
             child for child in self.children if child.display and child.visible
         ]
-        return sorted(focusable, key=_focus_sort_key)
+        sorted_focusable = sorted(focusable, key=_focus_sort_key)
+        return sorted_focusable
 
     def get_pseudo_classes(self) -> Iterable[str]:
         """Get any pseudo classes applicable to this Node, e.g. hover, focus.
@@ -604,5 +603,5 @@ class DOMNode(MessagePump):
 
 
 def _focus_sort_key(widget: Widget) -> tuple[int, int]:
-    x, y = widget.content_offset
+    x, y, _, _ = widget.region_with_margin
     return y, x

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -495,7 +496,7 @@ class Widget(DOMNode):
         return window_region
 
     @property
-    def region_with_margin(self) -> Region:
+    def virtual_region_with_margin(self) -> Region:
         """The widget region relative to its container (*including margin*), which may not be visible,
         depending on the scroll offset.
 
@@ -503,6 +504,20 @@ class Widget(DOMNode):
             Region: The virtual region of the Widget, inclusive of its margin.
         """
         return self.virtual_region.grow(self.styles.margin)
+
+    @property
+    def focusable_children(self) -> list[Widget]:
+        """Get the children which may be focused."""
+        focusable = [
+            child for child in self.children if child.display and child.visible
+        ]
+        return sorted(focusable, key=attrgetter("_focus_sort_key"))
+
+    @property
+    def _focus_sort_key(self) -> tuple[int, int]:
+        x, y, _, _ = self.virtual_region
+        top, _, _, left = self.styles.margin
+        return y - top, x - left
 
     @property
     def scroll_offset(self) -> Offset:
@@ -746,7 +761,7 @@ class Widget(DOMNode):
         """
 
         # Grow the region by the margin so to keep the margin in view.
-        region = widget.region_with_margin
+        region = widget.virtual_region_with_margin
         scrolled = False
 
         while isinstance(widget.parent, Widget) and widget is not self:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -495,6 +495,16 @@ class Widget(DOMNode):
         return window_region
 
     @property
+    def region_with_margin(self) -> Region:
+        """The widget region relative to its container (*including margin*), which may not be visible,
+        depending on the scroll offset.
+
+        Returns:
+            Region: The virtual region of the Widget, inclusive of its margin.
+        """
+        return self.virtual_region.grow(self.styles.margin)
+
+    @property
     def scroll_offset(self) -> Offset:
         return Offset(int(self.scroll_x), int(self.scroll_y))
 
@@ -736,7 +746,7 @@ class Widget(DOMNode):
         """
 
         # Grow the region by the margin so to keep the margin in view.
-        region = widget.virtual_region.grow(widget.styles.margin)
+        region = widget.region_with_margin
         scrolled = False
 
         while isinstance(widget.parent, Widget) and widget is not self:


### PR DESCRIPTION
Updates focus order to work in left to right then top to bottom order.
Anchor point is top left corner of the widget region **including** the margin spacing of the widget.