### PR TITLE
Add `auto_refresh` property to DOMNode/Widget

### DIFF
--- a/docs/examples/introduction/clock.py
+++ b/docs/examples/introduction/clock.py
@@ -5,9 +5,9 @@ from textual.widget import Widget
 
 
 class Clock(Widget):
-    def on_mount(self):
+    def on_mount(self, event):
         self.styles.content_align = ("center", "middle")
-        self.set_interval(1, self.refresh)
+        self.auto_refresh = 1
 
     def render(self):
         return datetime.now().strftime("%c")

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from .app import App
     from .css.styles import StylesBase
     from .css.query import DOMQuery
+    from ._timer import Timer
     from .screen import Screen
     from .widget import Widget
 
@@ -69,6 +70,8 @@ class DOMNode(MessagePump):
         self.styles = RenderStyles(self, self._css_styles, self._inline_styles)
         # A mapping of class names to Styles set in COMPONENT_CLASSES
         self.component_styles: dict[str, StylesBase] = {}
+
+        self._auto_refresh_timer: Timer | None = None
 
         super().__init__()
 
@@ -592,3 +595,20 @@ class DOMNode(MessagePump):
 
     def refresh(self, *, repaint: bool = True, layout: bool = False) -> None:
         pass
+
+    @property
+    def auto_refresh(self) -> float | None:
+        if self._auto_refresh_timer:
+            return self._auto_refresh_timer._interval
+        else:
+            return None
+
+    @auto_refresh.setter
+    def auto_refresh(self, interval: float | None) -> None:
+        if self._auto_refresh_timer:
+            self._auto_refresh_timer.stop_no_wait()
+
+        if interval is None:
+            self._auto_refresh_timer = None
+        else:
+            self._auto_refresh_timer = self.set_interval(interval, self.refresh)

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -598,6 +598,11 @@ class DOMNode(MessagePump):
 
     @property
     def auto_refresh(self) -> float | None:
+        """Return the currently set auto-refresh interval.
+
+        Returns:
+            the auto-refresh interval or None if not set
+        """
         if self._auto_refresh_timer:
             return self._auto_refresh_timer._interval
         else:
@@ -605,6 +610,14 @@ class DOMNode(MessagePump):
 
     @auto_refresh.setter
     def auto_refresh(self, interval: float | None) -> None:
+        """Set the auto-refresh interval.
+
+        Assigning a float value will set (or reset) the auto-refresh behaviour with the
+        provided interval value. Assigning None will disable the auto-refresh behaviour.
+
+        Args:
+            interval: the auto-refresh interval or None to disable auto-refresh
+        """
         if self._auto_refresh_timer:
             self._auto_refresh_timer.stop_no_wait()
 

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -220,7 +220,8 @@ class MessagePump:
         self._closing = True
         await self._message_queue.put(MessagePriority(None))
         for task in self._child_tasks:
-            task.cancel()
+            if not task.cancelled():
+                task.cancel()
             await task
         self._child_tasks.clear()
         if self._task is not None:


### PR DESCRIPTION
This PR adds an `auto_refresh` property to `DOMNode` (and thus `Widget`) to implement the common case of setting an interval timer on `refresh()`. The `auto_refresh` property can be set to a a float value (interval) or `None` to stop the auto-refresh behaviour. It can be read to check the current refresh value.

Side changes:
- fixed missing `event` parameter for `Clock.on_mount()`
- added a test on cancelled status in `MessagePump.close_messages()`

TODO/TBD:
- `Timer` doesn't have an API to access the currently set interval. I'm using `Timer._interval` for the time being, which is obviously bad. (Suggestion: rename `_interval` to `interval` to make it public.)
- Repeatedly setting/changing/cancelling the `auto_refresh` value likely leaks asyncio tasks (and possibly Timer objects). In particular, I had to add the test on cancelled status in the `close_messages()` function such as to avoid a `CancelledError` upon app close (with ctrl-C).
- Missing tests.