### PR TITLE
restore missing callback

### DIFF
--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -398,6 +398,9 @@ class MessagePump:
             return False
         return self.post_message_no_wait(message)
 
+    async def on_callback(self, event: events.Callback) -> None:
+        await invoke(event.callback)
+
     def emit_no_wait(self, message: Message) -> bool:
         if self._parent:
             return self._parent.post_message_from_child_no_wait(message)


### PR DESCRIPTION
Scrolling was broken in [this commit](https://github.com/Textualize/textual/commit/a166d84eef2d66211aca9359422cd6bed59c7926)

A handler for `events.Callback` was remove, which was required by the watcher system (which update the screen when scroll_x / scroll_y was changed).