### PR TITLE
fix for layout bug

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -87,7 +87,8 @@ class DOMNode(MessagePump):
         Returns:
             Iterator[Type[DOMNode]]: An iterable of DOMNode classes.
         """
-        return self._css_bases(self.__class__)
+        # Node bases are in reversed order so that the base class is lower priority
+        return reversed(list(self._css_bases(self.__class__)))
 
     @classmethod
     def _css_bases(cls, base: Type[DOMNode]) -> Iterator[Type[DOMNode]]:

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -33,5 +33,4 @@ class Center(Container):
     Center {
         layout: center;        
     }
-    
     """


### PR DESCRIPTION
Fixes layout issue where a Horizontal layout rendered things vertically.

This was due to the CSS on base classes taking precedence, which was not what we want. The fix was to reverse the order the CSS attributes was parsed.

Forgive the lack of regression test for now.