### PR TITLE
tests for auto refresh

### DIFF
--- a/docs/examples/introduction/clock.py
+++ b/docs/examples/introduction/clock.py
@@ -7,7 +7,7 @@ from textual.widget import Widget
 class Clock(Widget):
     def on_mount(self):
         self.styles.content_align = ("center", "middle")
-        self.set_interval(1, self.refresh)
+        self.auto_refresh = 1.0
 
     def render(self):
         return datetime.now().strftime("%c")

--- a/docs/examples/introduction/clock01.py
+++ b/docs/examples/introduction/clock01.py
@@ -7,15 +7,15 @@ from textual.widget import Widget
 class Clock(Widget):
     def on_mount(self):
         self.styles.content_align = ("center", "middle")
-        self.set_interval(1, self.refresh)
+        self.auto_refresh = 1.0
 
     def render(self):
-        return datetime.now().strftime("%c")
+        return datetime.now().strftime("%X")
 
 
 class ClockApp(App):
-    def on_mount(self):
-        self.mount(Clock())
+    def compose(self):
+        yield Clock()
 
 
 app = ClockApp()

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -557,7 +557,7 @@ class App(Generic[ReturnType], DOMNode):
 
         if headless:
             self.features = cast(
-                frozenset[FeatureFlag], self.features.union({"headless"})
+                "frozenset[FeatureFlag]", self.features.union({"headless"})
             )
 
         async def run_app() -> None:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -14,13 +14,13 @@ from time import perf_counter
 from typing import (
     TYPE_CHECKING,
     Any,
-    cast,
     Generic,
     Iterable,
     Iterator,
     TextIO,
     Type,
     TypeVar,
+    cast,
 )
 from weakref import WeakSet, WeakValueDictionary
 
@@ -48,12 +48,12 @@ from ._event_broker import NoHandler, extract_handler_actions
 from .binding import Bindings, NoBinding
 from .css.query import NoMatchingNodesError
 from .css.stylesheet import Stylesheet
-from .drivers.headless_driver import HeadlessDriver
 from .design import ColorSystem
 from .devtools.client import DevtoolsClient, DevtoolsConnectionError, DevtoolsLog
 from .devtools.redirect_output import StdoutRedirector
 from .dom import DOMNode
 from .driver import Driver
+from .drivers.headless_driver import HeadlessDriver
 from .features import FeatureFlag, parse_features
 from .file_monitor import FileMonitor
 from .geometry import Offset, Region, Size

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -14,6 +14,7 @@ from time import perf_counter
 from typing import (
     TYPE_CHECKING,
     Any,
+    cast,
     Generic,
     Iterable,
     Iterator,
@@ -163,7 +164,7 @@ class App(Generic[ReturnType], DOMNode):
         _init_uvloop()
 
         super().__init__()
-        self.features: set[FeatureFlag] = parse_features(os.getenv("TEXTUAL", ""))
+        self.features: frozenset[FeatureFlag] = parse_features(os.getenv("TEXTUAL", ""))
 
         self.console = Console(
             file=(open(os.devnull, "wt") if self.is_headless else sys.__stdout__),
@@ -555,7 +556,9 @@ class App(Generic[ReturnType], DOMNode):
         """
 
         if headless:
-            self.features.add("headless")
+            self.features = cast(
+                frozenset[FeatureFlag], self.features.union({"headless"})
+            )
 
         async def run_app() -> None:
             if quit_after is not None:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -963,10 +963,11 @@ class App(Generic[ReturnType], DOMNode):
             await self.dispatch_message(load_event)
 
             driver: Driver
-            if self.is_headless:
-                driver = self._driver = HeadlessDriver(self.console, self)
-            else:
-                driver = self._driver = self.driver_class(self.console, self)
+            driver_class = cast(
+                "type[Driver]",
+                HeadlessDriver if self.is_headless else self.driver_class,
+            )
+            driver = self._driver = driver_class(self.console, self)
 
             driver.start_application_mode()
             try:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -552,7 +552,7 @@ class App(Generic[ReturnType], DOMNode):
             headless (bool, optional): Run in "headless" mode (don't write to stdout).
 
         Returns:
-            ReturnType | None: _description_
+            ReturnType | None: The return value specified in `App.exit` or None if exit wasn't called.
         """
 
         if headless:

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -41,18 +41,6 @@ class Driver(ABC):
             click_event = events.Click.from_event(event)
             self.send_event(click_event)
 
-    def enable_bracketed_paste(self) -> None:
-        """Write the ANSI escape code `ESC[?2004h`, which
-        enables bracketed paste mode."""
-        self.console.file.write("\x1b[?2004h")
-        self.console.file.flush()
-
-    def disable_bracketed_paste(self) -> None:
-        """Write the ANSI escape code `ESC[?2004l`, which
-        disables bracketed paste mode."""
-        self.console.file.write("\x1b[?2004l")
-        self.console.file.flush()
-
     @abstractmethod
     def start_application_mode(self) -> None:
         ...

--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+from ..driver import Driver
+
+
+class HeadlessDriver(Driver):
+    """A do-nothing driver for testing."""
+
+    def start_application_mode(self) -> None:
+        pass
+
+    def disable_input(self) -> None:
+        pass
+
+    def stop_application_mode(self) -> None:
+        pass

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -75,7 +75,7 @@ class LinuxDriver(Driver):
         self.console.file.write("\x1b[?2004h")
 
     def _disable_bracketed_paste(self) -> None:
-        """Disable bracketed pasgte mode."""
+        """Disable bracketed paste mode."""
         self.console.file.write("\x1b[?2004l")
 
     def _disable_mouse_support(self) -> None:

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -70,6 +70,14 @@ class LinuxDriver(Driver):
         # Note: E.g. lxterminal understands 1000h, but not the urxvt or sgr
         #       extensions.
 
+    def _enable_bracketed_paste(self) -> None:
+        """Enable bracketed paste mode."""
+        self.console.file.write("\x1b[?2004h")
+
+    def _disable_bracketed_paste(self) -> None:
+        """Disable bracketed pasgte mode."""
+        self.console.file.write("\x1b[?2004l")
+
     def _disable_mouse_support(self) -> None:
         write = self.console.file.write
         write("\x1b[?1000l")  #
@@ -130,6 +138,7 @@ class LinuxDriver(Driver):
         send_size_event()
         self._key_thread.start()
         self._request_terminal_sync_mode_support()
+        self._enable_bracketed_paste()
 
     def _request_terminal_sync_mode_support(self):
         self.console.file.write("\033[?2026$p")
@@ -168,6 +177,7 @@ class LinuxDriver(Driver):
             pass
 
     def stop_application_mode(self) -> None:
+        self._disable_bracketed_paste()
         self.disable_input()
 
         if self.attrs_before is not None:

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -1,4 +1,4 @@
-    from __future__ import annotations
+from __future__ import annotations
 
 import asyncio
 import sys

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -49,7 +49,7 @@ class WindowsDriver(Driver):
         self.console.file.write("\x1b[?2004h")
 
     def _disable_bracketed_paste(self) -> None:
-        """Disable bracketed pasgte mode."""
+        """Disable bracketed paste mode."""
         self.console.file.write("\x1b[?2004l")
 
     def start_application_mode(self) -> None:

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+    from __future__ import annotations
 
 import asyncio
 import sys
@@ -44,6 +44,14 @@ class WindowsDriver(Driver):
         write("\x1b[?1006l")
         self.console.file.flush()
 
+    def _enable_bracketed_paste(self) -> None:
+        """Enable bracketed paste mode."""
+        self.console.file.write("\x1b[?2004h")
+
+    def _disable_bracketed_paste(self) -> None:
+        """Disable bracketed pasgte mode."""
+        self.console.file.write("\x1b[?2004l")
+
     def start_application_mode(self) -> None:
 
         loop = asyncio.get_running_loop()
@@ -54,6 +62,7 @@ class WindowsDriver(Driver):
         self._enable_mouse_support()
         self.console.show_cursor(False)
         self.console.file.write("\033[?1003h\n")
+        self._enable_bracketed_paste()
 
         app = active_app.get()
 
@@ -75,6 +84,7 @@ class WindowsDriver(Driver):
             pass
 
     def stop_application_mode(self) -> None:
+        self._disable_bracketed_paste()
         self.disable_input()
         if self._restore_console:
             self._restore_console()

--- a/src/textual/features.py
+++ b/src/textual/features.py
@@ -14,7 +14,7 @@ FEATURES: Final = {"devtools", "debug", "headless"}
 FeatureFlag = Literal["devtools", "debug", "headless"]
 
 
-def parse_features(features: str) -> frozenset[FeatureFlag]:
+def parse_features(features: str) -> set[FeatureFlag]:
     """Parse features env var
 
     Args:
@@ -24,11 +24,8 @@ def parse_features(features: str) -> frozenset[FeatureFlag]:
         frozenset[FeatureFlag]: A frozen set of known features.
     """
 
-    features_set = frozenset(
-        set(
-            feature.strip().lower()
-            for feature in features.split(",")
-            if feature.strip()
-        ).intersection(FEATURES)
-    )
-    return cast("frozenset[FeatureFlag]", features_set)
+    features_set = set(
+        feature.strip().lower() for feature in features.split(",") if feature.strip()
+    ).intersection(FEATURES)
+
+    return cast("set[FeatureFlag]", features_set)

--- a/src/textual/features.py
+++ b/src/textual/features.py
@@ -14,7 +14,7 @@ FEATURES: Final = {"devtools", "debug", "headless"}
 FeatureFlag = Literal["devtools", "debug", "headless"]
 
 
-def parse_features(features: str) -> set[FeatureFlag]:
+def parse_features(features: str) -> frozenset[FeatureFlag]:
     """Parse features env var
 
     Args:
@@ -24,8 +24,8 @@ def parse_features(features: str) -> set[FeatureFlag]:
         frozenset[FeatureFlag]: A frozen set of known features.
     """
 
-    features_set = set(
+    features_set = frozenset(
         feature.strip().lower() for feature in features.split(",") if feature.strip()
     ).intersection(FEATURES)
 
-    return cast("set[FeatureFlag]", features_set)
+    return cast("frozenset[FeatureFlag]", features_set)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -36,7 +36,8 @@ from .dom import DOMNode
 from .geometry import Offset, Region, Size, Spacing, clamp
 from .layouts.vertical import VerticalLayout
 from .message import Message
-from .reactive import Reactive, watch
+from .reactive import Reactive
+from ._timer import Timer
 
 
 if TYPE_CHECKING:

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -25,4 +25,4 @@ def test_auto_refresh():
     elapsed = app.run(quit_after=1, headless=True)
     assert elapsed is not None
     # CI can run slower, so we need to give this a bit of margin
-    assert elapsed >= 0.3 and elapsed < 0.5
+    assert elapsed >= 0.3 and elapsed < 0.6

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -1,0 +1,30 @@
+from time import time
+
+from textual.app import App
+
+
+class RefreshApp(App[float]):
+    def __init__(self):
+        self.count = 0
+        super().__init__()
+
+    def on_mount(self):
+        self.start = time()
+        self.auto_refresh = 0.1
+
+    def _automatic_refresh(self):
+        self.count += 1
+        super()._automatic_refresh()
+
+    def refresh(self, *, repaint: bool = True, layout: bool = False) -> None:
+        super().refresh(repaint=repaint, layout=layout)
+        if self.count == 3:
+            self.exit(time() - self.start)
+
+
+def test_auto_refresh():
+    app = RefreshApp()
+
+    elapsed = app.run(quit_after=0.5, headless=True)
+    assert elapsed is not None
+    assert elapsed >= 0.3 and elapsed < 0.31

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -14,12 +14,9 @@ class RefreshApp(App[float]):
 
     def _automatic_refresh(self):
         self.count += 1
-        super()._automatic_refresh()
-
-    def refresh(self, *, repaint: bool = True, layout: bool = False) -> None:
-        super().refresh(repaint=repaint, layout=layout)
         if self.count == 3:
             self.exit(time() - self.start)
+        super()._automatic_refresh()
 
 
 def test_auto_refresh():

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -24,4 +24,5 @@ def test_auto_refresh():
 
     elapsed = app.run(quit_after=0.5, headless=True)
     assert elapsed is not None
-    assert elapsed >= 0.3 and elapsed < 0.35
+    # CI can run slower, so we need to give this a bit of margin
+    assert elapsed >= 0.3 and elapsed < 0.5

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -22,7 +22,7 @@ class RefreshApp(App[float]):
 def test_auto_refresh():
     app = RefreshApp()
 
-    elapsed = app.run(quit_after=0.5, headless=True)
+    elapsed = app.run(quit_after=1, headless=True)
     assert elapsed is not None
     # CI can run slower, so we need to give this a bit of margin
     assert elapsed >= 0.3 and elapsed < 0.5

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -27,4 +27,4 @@ def test_auto_refresh():
 
     elapsed = app.run(quit_after=0.5, headless=True)
     assert elapsed is not None
-    assert elapsed >= 0.3 and elapsed < 0.31
+    assert elapsed >= 0.3 and elapsed < 0.35


### PR DESCRIPTION
Implements an `auto_refresh` property to refresh a DOM node at regular intervals (syntactical sugar for `self.set_interval(self.refresh, 1)`

Also adds an option to App.run to run in "headless" mode. This is probably how we should run tests where a running app is required. Doesn't quite replace integration tests, but it should reduce the need for them dramatically.