### PR TITLE
Default css

### DIFF
--- a/docs/examples/guide/structure.py
+++ b/docs/examples/guide/structure.py
@@ -7,7 +7,7 @@ from textual.widget import Widget
 class Clock(Widget):
     """A clock app."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Clock {
         content-align: center middle;
     }

--- a/docs/examples/light_dark.py
+++ b/docs/examples/light_dark.py
@@ -4,7 +4,7 @@ from textual.widgets import Button
 
 class ButtonApp(App):
 
-    CSS = """
+    DEFAULT_CSS = """
     Button {
         width: 100%;
     }

--- a/sandbox/borders.py
+++ b/sandbox/borders.py
@@ -8,7 +8,7 @@ from textual.widgets import Placeholder
 
 
 class VerticalContainer(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     VerticalContainer {
         layout: vertical;
         overflow: hidden auto;
@@ -24,7 +24,7 @@ class VerticalContainer(Widget):
 
 
 class Introduction(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     Introduction {
         background: indigo;
         color: white;

--- a/sandbox/color_names.py
+++ b/sandbox/color_names.py
@@ -23,7 +23,7 @@ class ColorDisplay(Widget, can_focus=True):
 
 
 class ColorNames(App):
-    CSS = """
+    DEFAULT_CSS = """
     ColorDisplay {
         height: 1;
     }

--- a/sandbox/fifty.py
+++ b/sandbox/fifty.py
@@ -5,7 +5,7 @@ from textual.widget import Widget
 
 class FiftyApp(App):
 
-    CSS = """
+    DEFAULT_CSS = """
     Screen {
         layout: vertical;
     }
@@ -23,6 +23,7 @@ class FiftyApp(App):
     def compose(self):
         yield layout.Horizontal(Widget(), Widget())
         yield layout.Horizontal(Widget(), Widget())
+
 
 app = FiftyApp()
 if __name__ == "__main__":

--- a/sandbox/scroll_to_widget.py
+++ b/sandbox/scroll_to_widget.py
@@ -9,7 +9,7 @@ placeholders_count = 12
 
 
 class VerticalContainer(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     VerticalContainer {
         layout: vertical;
         overflow: hidden auto;
@@ -26,7 +26,7 @@ class VerticalContainer(Widget):
 
 
 class Introduction(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     Introduction {
         background: indigo;
         color: white;

--- a/sandbox/vertical_container.py
+++ b/sandbox/vertical_container.py
@@ -10,7 +10,7 @@ initial_placeholders_count = 4
 
 
 class VerticalContainer(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     VerticalContainer {
         layout: vertical;
         overflow: hidden auto;
@@ -30,7 +30,7 @@ class VerticalContainer(Widget):
 
 
 class Introduction(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     Introduction {
         background: indigo;
         color: white;

--- a/sandbox/will/add_remove.py
+++ b/sandbox/will/add_remove.py
@@ -11,7 +11,7 @@ class Thing(Static):
 
 
 class AddRemoveApp(App):
-    CSS = """
+    DEFAULT_CSS = """
     #buttons {
         dock: top;
         height: auto;       

--- a/sandbox/will/center.py
+++ b/sandbox/will/center.py
@@ -3,7 +3,7 @@ from textual.widgets import Static
 
 
 class CenterApp(App):
-    CSS = """
+    DEFAULT_CSS = """
     
     CenterApp Screen {
         layout: center;

--- a/sandbox/will/center2.py
+++ b/sandbox/will/center2.py
@@ -4,7 +4,7 @@ from textual.widgets import Static
 
 
 class CenterApp(App):
-    CSS = """
+    DEFAULT_CSS = """
 
     #sidebar {
         dock: left;

--- a/sandbox/will/just_a_box.py
+++ b/sandbox/will/just_a_box.py
@@ -10,7 +10,7 @@ from textual.widget import Widget
 
 
 class Box(Widget, can_focus=True):
-    CSS = "#box {background: blue;}"
+    DEFAULT_CSS = "#box {background: blue;}"
 
     def render(self) -> RenderableType:
         return Panel("Box")

--- a/sandbox/will/screens.py
+++ b/sandbox/will/screens.py
@@ -21,7 +21,7 @@ class NewScreen(Screen):
 
 
 class ScreenApp(App):
-    CSS = """
+    DEFAULT_CSS = """
     ScreenApp Screen {
         background: #111144;
         color: white;

--- a/sandbox/will/spacing.css
+++ b/sandbox/will/spacing.css
@@ -8,5 +8,6 @@ Static {
     background: blue 20%;
     height: 100%;
     margin: 2 4;
-    min-width: 30;
+    min-width: 80;
+    min-height: 40;
 }

--- a/sandbox/will/tree.py
+++ b/sandbox/will/tree.py
@@ -5,7 +5,7 @@ from textual.widgets import DirectoryTree
 
 
 class TreeApp(App):
-    CSS = """
+    DEFAULT_CSS = """
     Screen {
         overflow: auto;
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -142,7 +142,11 @@ class App(Generic[ReturnType], DOMNode):
 
     """
 
-    CSS = """
+    # Inline CSS for quick scripts (generally css_path should be preferred.)
+    CSS = ""
+
+    # Default (lowest priority) CSS
+    DEFAULT_CSS = """
     App {
         background: $background;
         color: $text-background;
@@ -683,7 +687,6 @@ class App(Generic[ReturnType], DOMNode):
     async def _on_css_change(self) -> None:
         """Called when the CSS changes (if watch_css is True)."""
         if self.css_path is not None:
-
             try:
                 time = perf_counter()
                 stylesheet = self.stylesheet.copy()
@@ -1059,6 +1062,16 @@ class App(Generic[ReturnType], DOMNode):
             for path, css, tie_breaker in self.get_default_css():
                 self.stylesheet.add_source(
                     css, path=path, is_default_css=True, tie_breaker=tie_breaker
+                )
+            if self.CSS:
+                try:
+                    app_css_path = (
+                        f"{inspect.getfile(self.__class__)}:{self.__class__.__name__}"
+                    )
+                except TypeError:
+                    app_css_path = f"{self.__class__.__name__}"
+                self.stylesheet.add_source(
+                    self.CSS, path=app_css_path, is_default_css=False
                 )
         except Exception as error:
             self.on_exception(error)

--- a/src/textual/css/parse.py
+++ b/src/textual/css/parse.py
@@ -347,7 +347,7 @@ def parse(
         path (str): Path to the CSS
         variables (dict[str, str]): Substitution variables to substitute tokens for.
         is_default_rules (bool): True if the rules we're extracting are
-            default (i.e. in Widget.CSS) rules. False if they're from user defined CSS.
+            default (i.e. in Widget.DEFAULT_CSS) rules. False if they're from user defined CSS.
     """
     variable_tokens = tokenize_values(variables or {})
     tokens = iter(substitute_references(tokenize(css, path), variable_tokens))

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -571,7 +571,7 @@ class Styles(StylesBase):
         Args:
             specificity (Specificity3): A node specificity.
             is_default_rules (bool): True if the rules we're extracting are
-                default (i.e. in Widget.CSS) rules. False if they're from user defined CSS.
+                default (i.e. in Widget.DEFAULT_CSS) rules. False if they're from user defined CSS.
 
         Returns:
             list[tuple[str, Specificity5, Any]]]: A list containing a tuple of <RULE NAME>, <SPECIFICITY> <RULE VALUE>.

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -209,7 +209,7 @@ class Stylesheet:
             css (str): String containing Textual CSS.
             path (str | PurePath): Path to CSS or unique identifier
             is_default_rules (bool): True if the rules we're extracting are
-                default (i.e. in Widget.CSS) rules. False if they're from user defined CSS.
+                default (i.e. in Widget.DEFAULT_CSS) rules. False if they're from user defined CSS.
 
         Raises:
             StylesheetError: If the CSS is invalid.

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -555,7 +555,7 @@ if __name__ == "__main__":
     print(app.tree)
     print()
 
-    CSS = """
+    DEFAULT_CSS = """
     App > View {
         layout: dock;
         docks: sidebar=left | widgets=top;

--- a/src/textual/devtools/borders.py
+++ b/src/textual/devtools/borders.py
@@ -14,7 +14,7 @@ Where the fear has gone there will be nothing. Only I will remain."""
 
 
 class BorderButtons(layout.Vertical):
-    CSS = """
+    DEFAULT_CSS = """
     BorderButtons {
         dock: left;
         width: 24;
@@ -34,7 +34,7 @@ class BorderButtons(layout.Vertical):
 class BorderApp(App):
     """Demonstrates the border styles."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Static {
         margin: 2 4;
         padding: 2 4;

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -54,8 +54,8 @@ class NoParent(Exception):
 class DOMNode(MessagePump):
     """The base class for object that can be in the Textual DOM (App and Widget)"""
 
-    # Custom CSS
-    CSS: ClassVar[str] = ""
+    # CSS defaults
+    DEFAULT_CSS: ClassVar[str] = ""
 
     # Default classes argument if not supplied
     DEFAULT_CLASSES: str = ""
@@ -198,7 +198,7 @@ class DOMNode(MessagePump):
                 return f"{base.__name__}"
 
         for tie_breaker, base in enumerate(self._node_bases):
-            css = base.CSS.strip()
+            css = base.DEFAULT_CSS.strip()
             if css:
                 css_stack.append((get_path(base), css, -tie_breaker))
 

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -4,7 +4,7 @@ from .widget import Widget
 class Container(Widget):
     """Simple container widget, with vertical layout."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Container {
         layout: vertical;       
         overflow: auto;
@@ -16,13 +16,13 @@ class Vertical(Container):
     """A container widget to align children vertically."""
 
     # Blank CSS is important, otherwise you get a clone of Container
-    CSS = ""
+    DEFAULT_CSS = ""
 
 
 class Horizontal(Container):
     """A container widget to align children horizontally."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Horizontal {
         layout: horizontal;        
     }    
@@ -32,7 +32,7 @@ class Horizontal(Container):
 class Center(Container):
     """A container widget to align children in the center."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Center {
         layout: center;        
     }

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -29,7 +29,7 @@ UPDATE_PERIOD: Final = 1 / 60
 class Screen(Widget):
     """A widget for the root of the app."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Screen {
         layout: vertical;
         overflow-y: auto;

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -16,7 +16,7 @@ class ScrollView(Widget):
 
     """
 
-    CSS = """
+    DEFAULT_CSS = """
     
     ScrollView {     
         overflow-y: auto;

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -87,15 +87,19 @@ class ScrollView(Widget):
             width, height = self.container_size
             if self.show_vertical_scrollbar:
                 self.vertical_scrollbar.window_virtual_size = virtual_size.height
-                self.vertical_scrollbar.window_size = height
+                self.vertical_scrollbar.window_size = (
+                    height - self.scrollbar_size_horizontal
+                )
             if self.show_horizontal_scrollbar:
                 self.horizontal_scrollbar.window_virtual_size = virtual_size.width
-                self.horizontal_scrollbar.window_size = width
+                self.horizontal_scrollbar.window_size = (
+                    width - self.scrollbar_size_vertical
+                )
 
             self.scroll_x = self.validate_scroll_x(self.scroll_x)
             self.scroll_y = self.validate_scroll_y(self.scroll_y)
             self.refresh(layout=False)
-            self.call_later(self.scroll_to, self.scroll_x, self.scroll_y)
+            self.scroll_to(self.scroll_x, self.scroll_y)
 
     def render(self) -> RenderableType:
         """Render the scrollable region (if `render_lines` is not implemented).

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -93,9 +93,9 @@ class ScrollBarRender:
     ) -> Segments:
 
         if vertical:
-            bars = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
+            bars = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", " "]
         else:
-            bars = ["█", "▉", "▊", "▋", "▌", "▍", "▎", "▏", " "]
+            bars = ["▉", "▊", "▋", "▌", "▍", "▎", "▏", " "]
 
         back = back_color
         bar = bar_color
@@ -110,11 +110,11 @@ class ScrollBarRender:
         if window_size and size and virtual_size and size != virtual_size:
             step_size = virtual_size / size
 
-            start = int(position / step_size * 9)
-            end = start + max(9, int(ceil(window_size / step_size * 9)))
+            start = int(position / step_size * 8)
+            end = start + max(8, int(ceil(window_size / step_size * 8)))
 
-            start_index, start_bar = divmod(start, 9)
-            end_index, end_bar = divmod(end, 9)
+            start_index, start_bar = divmod(start, 8)
+            end_index, end_bar = divmod(end, 8)
 
             upper = {"@click": "scroll_up"}
             lower = {"@click": "scroll_down"}
@@ -130,19 +130,23 @@ class ScrollBarRender:
             ] * (end_index - start_index)
 
             if start_index < len(segments):
-                segments[start_index] = _Segment(
-                    bars[8 - start_bar] * width_thickness,
-                    _Style(bgcolor=back, color=bar, meta=foreground_meta)
-                    if vertical
-                    else _Style(bgcolor=bar, color=back, meta=foreground_meta),
-                )
+                bar_character = bars[7 - start_bar]
+                if bar_character != " ":
+                    segments[start_index] = _Segment(
+                        bar_character * width_thickness,
+                        _Style(bgcolor=back, color=bar, meta=foreground_meta)
+                        if vertical
+                        else _Style(bgcolor=bar, color=back, meta=foreground_meta),
+                    )
             if end_index < len(segments):
-                segments[end_index] = _Segment(
-                    bars[8 - end_bar] * width_thickness,
-                    _Style(bgcolor=bar, color=back, meta=foreground_meta)
-                    if vertical
-                    else _Style(bgcolor=back, color=bar, meta=foreground_meta),
-                )
+                bar_character = bars[7 - end_bar]
+                if bar_character != " ":
+                    segments[end_index] = _Segment(
+                        bar_character * width_thickness,
+                        _Style(bgcolor=bar, color=back, meta=foreground_meta)
+                        if vertical
+                        else _Style(bgcolor=back, color=bar, meta=foreground_meta),
+                    )
         else:
             style = _Style(bgcolor=back)
             segments = [_Segment(blank, style=style)] * int(size)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -468,7 +468,7 @@ class Widget(DOMNode):
         self.app.start_widget(self, scroll_bar)
         return scroll_bar
 
-    def _refresh_scrollbars(self) -> tuple[bool, bool]:
+    def _refresh_scrollbars(self) -> None:
         """Refresh scrollbar visibility."""
         if not self.is_scrollable:
             return
@@ -498,8 +498,6 @@ class Widget(DOMNode):
         self.show_vertical_scrollbar = show_vertical
         self.horizontal_scrollbar.display = show_horizontal
         self.vertical_scrollbar.display = show_vertical
-
-        return show_horizontal, show_vertical
 
     @property
     def scrollbars_enabled(self) -> tuple[bool, bool]:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -72,7 +72,7 @@ class Widget(DOMNode):
 
     """
 
-    CSS = """
+    DEFAULT_CSS = """
     Widget{
         scrollbar-background: $panel-darken-1;
         scrollbar-background-hover: $panel-darken-2;

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -468,7 +468,7 @@ class Widget(DOMNode):
         self.app.start_widget(self, scroll_bar)
         return scroll_bar
 
-    def _refresh_scrollbars(self) -> None:
+    def _refresh_scrollbars(self) -> tuple[bool, bool]:
         """Refresh scrollbar visibility."""
         if not self.is_scrollable:
             return
@@ -498,6 +498,8 @@ class Widget(DOMNode):
         self.show_vertical_scrollbar = show_vertical
         self.horizontal_scrollbar.display = show_horizontal
         self.vertical_scrollbar.display = show_vertical
+
+        return show_horizontal, show_vertical
 
     @property
     def scrollbars_enabled(self) -> tuple[bool, bool]:
@@ -1248,16 +1250,19 @@ class Widget(DOMNode):
                 width, height = self.container_size
                 if self.show_vertical_scrollbar:
                     self.vertical_scrollbar.window_virtual_size = virtual_size.height
-                    self.vertical_scrollbar.window_size = height
+                    self.vertical_scrollbar.window_size = (
+                        height - self.scrollbar_size_horizontal
+                    )
                 if self.show_horizontal_scrollbar:
                     self.horizontal_scrollbar.window_virtual_size = virtual_size.width
-                    self.horizontal_scrollbar.window_size = width
+                    self.horizontal_scrollbar.window_size = (
+                        width - self.scrollbar_size_vertical
+                    )
 
                 self.scroll_x = self.validate_scroll_x(self.scroll_x)
                 self.scroll_y = self.validate_scroll_y(self.scroll_y)
                 self.refresh(layout=True)
                 self.scroll_to(self.scroll_x, self.scroll_y)
-                # self.call_later(self.scroll_to, self.scroll_x, self.scroll_y)
             else:
                 self.refresh()
 

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -29,7 +29,7 @@ class InvalidButtonVariant(Exception):
 class Button(Widget, can_focus=True):
     """A simple clickable button."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Button {
         width: auto;
         min-width: 10;

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -106,7 +106,7 @@ class Coord(NamedTuple):
 
 class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
-    CSS = """
+    DEFAULT_CSS = """
     DataTable {
         background: $surface;
         color: $text-surface;       

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -13,7 +13,7 @@ from ..widget import Widget
 @rich.repr.auto
 class Footer(Widget):
 
-    CSS = """
+    DEFAULT_CSS = """
     Footer {
         background: $accent;
         color: $text-accent;

--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -11,7 +11,7 @@ from ..reactive import Reactive, watch
 class HeaderIcon(Widget):
     """Display an 'icon' on the left of the header."""
 
-    CSS = """
+    DEFAULT_CSS = """
     HeaderIcon {
         dock: left;
         padding: 0 1;
@@ -28,7 +28,7 @@ class HeaderIcon(Widget):
 class HeaderClock(Widget):
     """Display a clock on the right of the header."""
 
-    CSS = """
+    DEFAULT_CSS = """
     HeaderClock {
         dock: right;
         width: auto;
@@ -50,7 +50,7 @@ class HeaderClock(Widget):
 class HeaderTitle(Widget):
     """Display the title / subtitle in the header."""
 
-    CSS = """
+    DEFAULT_CSS = """
     HeaderTitle {
         content-align: center middle;
         width: 100%;
@@ -70,7 +70,7 @@ class HeaderTitle(Widget):
 class Header(Widget):
     """A header widget with icon and clock."""
 
-    CSS = """
+    DEFAULT_CSS = """
     Header {
         dock: top;
         width: 100%;

--- a/src/textual/widgets/_pretty.py
+++ b/src/textual/widgets/_pretty.py
@@ -7,7 +7,7 @@ from ..widget import Widget
 
 
 class Pretty(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     Static {
         height: auto;
     }

--- a/src/textual/widgets/_static.py
+++ b/src/textual/widgets/_static.py
@@ -25,7 +25,7 @@ def _check_renderable(renderable: object):
 
 
 class Static(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     Static {
         height: auto;
     }

--- a/src/textual/widgets/_tree_control.py
+++ b/src/textual/widgets/_tree_control.py
@@ -169,7 +169,7 @@ class TreeClick(Generic[NodeDataType], Message, bubble=True):
 
 
 class TreeControl(Generic[NodeDataType], Widget, can_focus=True):
-    CSS = """
+    DEFAULT_CSS = """
     TreeControl {
         background: $panel;
         color: $text-panel;

--- a/src/textual/widgets/text_input.py
+++ b/src/textual/widgets/text_input.py
@@ -112,7 +112,7 @@ class TextInput(TextWidgetBase, can_focus=True):
             suggestion will be displayed as dim text similar to suggestion text in the zsh or fish shells.
     """
 
-    CSS = """
+    DEFAULT_CSS = """
     TextInput {
         width: auto;
         background: $surface;
@@ -417,7 +417,7 @@ class TextInput(TextWidgetBase, can_focus=True):
 
 
 class TextArea(Widget):
-    CSS = """
+    DEFAULT_CSS = """
     TextArea { overflow: auto auto; height: 5; background: $primary-darken-1; }
 """
 
@@ -428,7 +428,7 @@ class TextArea(Widget):
 class TextAreaChild(TextWidgetBase, can_focus=True):
     # TODO: Not nearly ready for prime-time, but it exists to help
     #  model the superclass.
-    CSS = "TextAreaChild { height: auto; background: $primary-darken-1; }"
+    DEFAULT_CSS = "TextAreaChild { height: auto; background: $primary-darken-1; }"
     STOP_PROPAGATE = {"tab", "shift+tab"}
 
     def render(self) -> RenderableType:

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -106,7 +106,7 @@ def test_stylesheet_apply_user_css_over_widget_css():
     user_css = ".a {color: red; tint: yellow;}"
 
     class MyWidget(Widget):
-        CSS = ".a {color: blue !important; background: lime;}"
+        DEFAULT_CSS = ".a {color: blue !important; background: lime;}"
 
     node = MyWidget()
     node.add_class("a")

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -112,10 +112,12 @@ def test_stylesheet_apply_user_css_over_widget_css():
     node.add_class("a")
 
     stylesheet = _make_user_stylesheet(user_css)
-    stylesheet.add_source(MyWidget.CSS, "widget.py:MyWidget", is_default_css=True)
+    stylesheet.add_source(
+        MyWidget.DEFAULT_CSS, "widget.py:MyWidget", is_default_css=True
+    )
     stylesheet.apply(node)
 
-    # The node is red because user CSS overrides Widget.CSS
+    # The node is red because user CSS overrides Widget.DEFAULT_CSS
     assert node.styles.color == Color(255, 0, 0)
     # The background colour defined in the Widget still applies, since user CSS doesn't override it
     assert node.styles.background == Color(0, 255, 0)

--- a/tests/test_integration_layout.py
+++ b/tests/test_integration_layout.py
@@ -110,7 +110,7 @@ async def test_composition_of_vertical_container_with_children(
     expected_placeholders_offset_x: int,
 ):
     class VerticalContainer(Widget):
-        CSS = (
+        DEFAULT_CSS = (
             """
         VerticalContainer {
             layout: vertical;
@@ -304,7 +304,7 @@ async def test_scrollbar_size_impact_on_the_layout(
     class LargeWidgetContainer(Widget):
         # TODO: Once textual#581 ("Default versus User CSS") is solved the following CSS should just use the
         #  "LargeWidgetContainer" selector, without having to use a more specific one to be able to override Widget's CSS:
-        CSS = """
+        DEFAULT_CSS = """
         #large-widget-container {
             width: 20;
             height: 20;

--- a/tests/test_integration_scrolling.py
+++ b/tests/test_integration_scrolling.py
@@ -48,7 +48,7 @@ async def test_scroll_to_widget(
     last_screen_expected_placeholder_ids: Sequence[int],
 ):
     class VerticalContainer(Widget):
-        CSS = """
+        DEFAULT_CSS = """
         VerticalContainer {
             layout: vertical;
             overflow: hidden auto;
@@ -60,7 +60,7 @@ async def test_scroll_to_widget(
         """
 
     class MyTestApp(AppTest):
-        CSS = """
+        DEFAULT_CSS = """
         Placeholder {
             height: 5; /* minimal height to see the name of a Placeholder */
         }


### PR DESCRIPTION
Renames `CSS` to `DEFAULT_CSS` which sets the low specificity CSS.

Adds `CSS` with regular specificity to just App

This is because it is tempting to set CSS on App to knock up a quick app, but the results are sometimes surprising because you have to take in to account the specificity of all the widgets.

I still want to push external CSS which offers a number of benefits, but this seems like a reasonable convenience.

Fixes https://github.com/Textualize/textual/issues/688