### PR TITLE
exclude invisible widgets

### DIFF
--- a/sandbox/will/spacing.css
+++ b/sandbox/will/spacing.css
@@ -9,4 +9,5 @@ Static {
     height: 100%;
     margin: 2 4;
     min-width: 30;
+    visibility: hidden;
 }

--- a/sandbox/will/spacing.py
+++ b/sandbox/will/spacing.py
@@ -2,9 +2,14 @@ from textual.app import App
 from textual.widgets import Static
 
 
+class Clickable(Static):
+    def on_click(self):
+        self.app.bell()
+
+
 class SpacingApp(App):
     def compose(self):
-        yield Static()
+        yield Clickable()
 
 
 app = SpacingApp(css_path="spacing.css")

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -487,7 +487,7 @@ class Compositor:
         # TODO: Optimize with some line based lookup
         contains = Region.contains
         for widget, cropped_region, region, *_ in self:
-            if contains(cropped_region, x, y):
+            if contains(cropped_region, x, y) and widget.visible:
                 return widget, region
         raise errors.NoWidget(f"No widget under screen coordinate ({x}, {y})")
 


### PR DESCRIPTION
Make invisible widgets non-clickable. 

Fixes https://github.com/Textualize/textual/issues/697

Will we ever need widgets that don't render but capture clicks? Seems unlikely.