### PR TITLE
App log

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -197,7 +197,7 @@ class App(Generic[ReturnType], DOMNode):
         else:
             self._title = title
 
-        self._logger = Logger()
+        self._logger = Logger(self._log)
 
         self._bindings.bind("ctrl+c", "quit", show=False, allow_forward=False)
         self._refresh_required = False

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -220,11 +220,9 @@ class EventMonitor(threading.Thread):
         self.target = target
         self.exit_event = exit_event
         self.process_event = process_event
-        self.app.log("event monitor constructed")
         super().__init__()
 
     def run(self) -> None:
-        self.app.log("event monitor thread started")
         exit_requested = self.exit_event.is_set
         parser = XTermParser(self.target, lambda: False)
 
@@ -280,8 +278,7 @@ class EventMonitor(threading.Thread):
                     self.on_size_change(*new_size)
 
         except Exception as error:
-            self.app.log("EVENT MONITOR ERROR", error)
-        self.app.log("event monitor thread finished")
+            self.app.log.error("EVENT MONITOR ERROR", error)
 
     def on_size_change(self, width: int, height: int) -> None:
         """Called when terminal size changes."""


### PR DESCRIPTION
Allows logging to work outside of app context.

Adds a log callable to loggers. When a callable isn't provided it will detect the active app. If there is not callable it will fall back to print.

Will probably fix https://github.com/Textualize/textual/issues/752 on Windows, although I haven't tried.