### PR TITLE
fixes for variable css errors

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1017,11 +1017,11 @@ class App(Generic[ReturnType], DOMNode):
         ), "Can only call panic with strings or Rich renderables"
 
         def render(renderable: RenderableType) -> list[Segment]:
+            """Render a panic renderables."""
             segments = list(self.console.render(renderable, self.console.options))
             return segments
 
         pre_rendered = [Segments(render(renderable)) for renderable in renderables]
-
         self._exit_renderables.extend(pre_rendered)
         self._close_messages_no_wait()
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -28,7 +28,7 @@ import rich.repr
 from rich.console import Console, RenderableType
 from rich.measure import Measurement
 from rich.protocol import is_renderable
-from rich.segment import Segments
+from rich.segment import Segment, Segments
 from rich.traceback import Traceback
 
 from . import (
@@ -1016,10 +1016,11 @@ class App(Generic[ReturnType], DOMNode):
             is_renderable(renderable) for renderable in renderables
         ), "Can only call panic with strings or Rich renderables"
 
-        pre_rendered = [
-            Segments(self.console.render(renderable, self.console.options))
-            for renderable in renderables
-        ]
+        def render(renderable: RenderableType) -> list[Segment]:
+            segments = list(self.console.render(renderable, self.console.options))
+            return segments
+
+        pre_rendered = [Segments(render(renderable)) for renderable in renderables]
 
         self._exit_renderables.extend(pre_rendered)
         self._close_messages_no_wait()

--- a/src/textual/cli/previews/borders.py
+++ b/src/textual/cli/previews/borders.py
@@ -53,7 +53,7 @@ class BorderApp(App):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.text.styles.border = (
             event.button.id,
-            self.stylesheet.variables["secondary"],
+            self.stylesheet._variables["secondary"],
         )
         self.bell()
 

--- a/src/textual/css/_help_renderables.py
+++ b/src/textual/css/_help_renderables.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
+import rich.repr
 from rich.console import Console, ConsoleOptions, RenderResult
-
 from rich.highlighter import ReprHighlighter
 from rich.markup import render
 from rich.text import Text
@@ -42,6 +42,7 @@ class Example:
         yield _markup_and_highlight(f"  [dim]e.g. [/][i]{self.markup}[/]")
 
 
+@rich.repr.auto
 class Bullet:
     """Renderable for a single 'bullet point' containing information and optionally some examples
         pertaining to that information.
@@ -59,10 +60,11 @@ class Bullet:
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        yield _markup_and_highlight(f"{self.markup}")
+        yield _markup_and_highlight(self.markup)
         yield from self.examples
 
 
+@rich.repr.auto
 class HelpText:
     """Renderable for help text - the user is shown this when they
     encounter a style-related error (e.g. setting a style property to an invalid

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import cast, Iterable, NoReturn, Sequence
+from typing import Iterable, NoReturn, Sequence, cast
 
 import rich.repr
 
+from .._border import BorderValue, normalize_border_value
+from .._duration import _duration_as_seconds
+from .._easing import EASING
+from ..color import Color, ColorParseError
+from ..geometry import Spacing, SpacingDimensions, clamp
+from ..suggestions import get_suggestion
 from ._error_tools import friendly_list
 from ._help_renderables import HelpText
 from ._help_text import (
@@ -33,34 +39,28 @@ from .constants import (
     VALID_ALIGN_VERTICAL,
     VALID_BORDER,
     VALID_BOX_SIZING,
-    VALID_EDGE,
     VALID_DISPLAY,
+    VALID_EDGE,
     VALID_OVERFLOW,
-    VALID_VISIBILITY,
-    VALID_STYLE_FLAGS,
     VALID_SCROLLBAR_GUTTER,
+    VALID_STYLE_FLAGS,
     VALID_TEXT_ALIGN,
+    VALID_VISIBILITY,
 )
 from .errors import DeclarationError, StyleValueError
 from .model import Declaration
 from .scalar import (
     Scalar,
-    ScalarOffset,
-    Unit,
     ScalarError,
+    ScalarOffset,
     ScalarParseError,
+    Unit,
     percentage_string_to_float,
 )
-from .styles import DockGroup, Styles
+from .styles import Styles
 from .tokenize import Token
 from .transition import Transition
-from .types import BoxSizing, Edge, Display, Overflow, Visibility, EdgeType
-from .._border import normalize_border_value, BorderValue
-from ..color import Color, ColorParseError
-from .._duration import _duration_as_seconds
-from .._easing import EASING
-from ..geometry import Spacing, SpacingDimensions, clamp
-from ..suggestions import get_suggestion
+from .types import BoxSizing, Display, Edge, EdgeType, Overflow, Visibility
 
 
 def _join_tokens(tokens: Iterable[Token], joiner: str = "") -> str:
@@ -434,6 +434,7 @@ class StylesBuilder:
     process_padding_left = _process_space_partial
 
     def _parse_border(self, name: str, tokens: list[Token]) -> BorderValue:
+
         border_type: EdgeType = "solid"
         border_color = Color(0, 255, 0)
 
@@ -553,7 +554,7 @@ class StylesBuilder:
             self.styles._rules["offset"] = ScalarOffset(x, y)
 
     def process_layout(self, name: str, tokens: list[Token]) -> None:
-        from ..layouts.factory import get_layout, MissingLayout
+        from ..layouts.factory import MissingLayout, get_layout
 
         if tokens:
             if len(tokens) != 1:
@@ -602,7 +603,6 @@ class StylesBuilder:
 
         if color is not None or alpha is not None:
             if alpha is not None:
-
                 color = (color or Color(255, 255, 255)).with_alpha(alpha)
             self.styles._rules[name] = color
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -46,7 +46,7 @@ class StylesheetErrors:
     def _get_snippet(cls, code: str, line_no: int) -> RenderableType:
         syntax = Syntax(
             code,
-            lexer="sass",
+            lexer="scss",
             theme="ansi_light",
             line_numbers=True,
             indent_guides=True,

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -4,7 +4,7 @@ import os
 from collections import defaultdict
 from operator import itemgetter
 from pathlib import Path, PurePath
-from typing import Iterable, NamedTuple, Sequence, cast
+from typing import Iterable, NamedTuple, cast
 
 import rich.repr
 from rich.console import Console, ConsoleOptions, RenderableType, RenderResult

--- a/src/textual/css/tokenizer.py
+++ b/src/textual/css/tokenizer.py
@@ -118,6 +118,7 @@ class ReferencedBy(NamedTuple):
     name: str
     location: tuple[int, int]
     length: int
+    code: str
 
 
 @rich.repr.auto
@@ -209,6 +210,7 @@ class Tokenizer:
                 message,
             )
         iter_groups = iter(match.groups())
+
         next(iter_groups)
 
         for name, value in zip(expect.names, iter_groups):

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1059,7 +1059,9 @@ class Widget(DOMNode):
 
         while isinstance(widget.parent, Widget) and widget is not self:
             container = widget.parent
-            scroll_offset = container.scroll_to_region(region, animate=animate)
+            scroll_offset = container.scroll_to_region(
+                region, spacing=widget.parent.gutter, animate=animate
+            )
             if scroll_offset:
                 scrolled = True
 
@@ -1096,6 +1098,10 @@ class Widget(DOMNode):
         window = self.content_region.at_offset(self.scroll_offset)
         if spacing is not None:
             window = window.shrink(spacing)
+
+        if window in region:
+            return Offset()
+
         delta_x, delta_y = Region.get_scroll_to_visible(window, region)
         scroll_x, scroll_y = self.scroll_offset
         delta = Offset(

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -36,7 +36,7 @@ class Button(Widget, can_focus=True):
         height: 3;
         background: $panel;
         color: $text;      
-        border: none;
+        border: none;        
         border-top: tall $panel-lighten-2;
         border-bottom: tall $panel-darken-3;
         content-align: center middle;        

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -557,7 +557,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
     def _scroll_cursor_in_to_view(self, animate: bool = False) -> None:
         region = self._get_cell_region(self.cursor_row, self.cursor_column)
-        spacing = self._get_cell_border()
+        spacing = self._get_cell_border() + self.scrollbar_gutter
         self.scroll_to_region(region, animate=animate, spacing=spacing)
 
     def on_click(self, event: events.Click) -> None:

--- a/tests/css/test_parse.py
+++ b/tests/css/test_parse.py
@@ -97,7 +97,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 4),
-                referenced_by=ReferencedBy(name="x", location=(0, 28), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(0, 28), length=2, code=css
+                ),
             ),
             Token(
                 name="declaration_end",
@@ -191,7 +193,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 3),
-                referenced_by=ReferencedBy(name="x", location=(0, 27), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(0, 27), length=2, code=css
+                ),
             ),
             Token(
                 name="declaration_end",
@@ -273,7 +277,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 4),
-                referenced_by=ReferencedBy(name="x", location=(1, 4), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(1, 4), length=2, code=css
+                ),
             ),
             Token(
                 name="variable_value_end",
@@ -337,7 +343,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 4),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -446,7 +454,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 4),
-                referenced_by=ReferencedBy(name="x", location=(1, 6), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(1, 6), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -454,7 +464,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 5),
-                referenced_by=ReferencedBy(name="x", location=(1, 6), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(1, 6), length=2, code=css
+                ),
             ),
             Token(
                 name="number",
@@ -462,7 +474,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 6),
-                referenced_by=ReferencedBy(name="x", location=(1, 6), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(1, 6), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -542,7 +556,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(1, 4),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -550,7 +566,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(1, 5),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="number",
@@ -558,7 +576,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 4),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -566,7 +586,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 5),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="number",
@@ -574,7 +596,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 6),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -582,7 +606,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(1, 8),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="number",
@@ -590,7 +616,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(1, 9),
-                referenced_by=ReferencedBy(name="y", location=(2, 17), length=2),
+                referenced_by=ReferencedBy(
+                    name="y", location=(2, 17), length=2, code=css
+                ),
             ),
             Token(
                 name="whitespace",
@@ -715,7 +743,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 4),
-                referenced_by=ReferencedBy(name="x", location=(1, 20), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(1, 20), length=2, code=css
+                ),
             ),
             Token(
                 name="declaration_end",
@@ -845,7 +875,9 @@ class TestVariableReferenceSubstitution:
                 path="",
                 code=css,
                 location=(0, 7),
-                referenced_by=ReferencedBy(name="x", location=(0, 26), length=2),
+                referenced_by=ReferencedBy(
+                    name="x", location=(0, 26), length=2, code=css
+                ),
             ),
             Token(
                 name="declaration_set_end",
@@ -1134,7 +1166,9 @@ class TestParsePadding:
 
 
 class TestParseTextAlign:
-    @pytest.mark.parametrize("valid_align", ["left", "start", "center", "right", "end", "justify"])
+    @pytest.mark.parametrize(
+        "valid_align", ["left", "start", "center", "right", "end", "justify"]
+    )
     def test_text_align(self, valid_align):
         css = f"#foo {{ text-align: {valid_align} }}"
         stylesheet = Stylesheet()


### PR DESCRIPTION
- Fixes issue where an error occurs at a reference token and breaks the pretty errors. Essentially the code was the variable, but the line number was the outer CSS.
- Cached tokenizing variables which was done multiple times.
- Fix for scrolling in to view when the region was larger than the window