### PR TITLE
Grid cell margin

### DIFF
--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -150,7 +150,7 @@ class GridLayout(Layout):
                 fraction_unit,
             )
             region = (
-                Region(x, y, int(width), int(height))
+                Region(x, y, int(width + margin.width), int(height + margin.height))
                 .shrink(margin)
                 .clip_size(cell_size)
             )


### PR DESCRIPTION
Fixes #771 

When the height and width of a widget inside a grid cell were being calculated, the margin was not factored in.
The height and width of the Region of the grid cell should take into account the margin of the widget contained within.

## After:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/5740731/190186889-23b6870f-67dd-4906-9d6f-8e2525913c90.png">


## Before:

<img width="747" alt="image" src="https://user-images.githubusercontent.com/5740731/190187584-b556c2ab-9764-4a4d-9b73-25a3b999db64.png">
