### PR TITLE
Support for key aliases, key handling tests

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -241,7 +241,6 @@ class XTermParser(Parser[events.Event]):
             Iterable[events.Key]: keys
 
         """
-
         keys = ANSI_SEQUENCES_KEYS.get(sequence)
         if keys is not None:
             for key in keys:

--- a/src/textual/errors.py
+++ b/src/textual/errors.py
@@ -11,3 +11,7 @@ class NoWidget(TextualError):
 
 class RenderError(TextualError):
     """An object could not be rendered."""
+
+
+class DuplicateKeyHandlers(TextualError):
+    """More than one handler for a single key press. E.g. key_ctrl_i and key_tab handlers both found on one object."""

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Awaitable, Callable, Type, TypeVar
+from typing import TYPE_CHECKING, Awaitable, Callable, Type, TypeVar, Iterable
 
 import rich.repr
 from rich.style import Style
 
 from ._types import MessageTarget
 from .geometry import Offset, Size
+from .keys import _get_key_aliases
 from .message import Message
 
 MouseEventT = TypeVar("MouseEventT", bound="MouseEvent")
@@ -209,7 +210,13 @@ class Key(InputEvent):
     @property
     def key_name(self) -> str | None:
         """Name of a key suitable for use as a Python identifier."""
-        return self.key.replace("+", "_")
+        return _normalize_key(self.key)
+
+    @property
+    def key_aliases(self) -> Iterable[str]:
+        """Get the aliases for the key, including the key itself"""
+        for alias in _get_key_aliases(self.key):
+            yield _normalize_key(alias)
 
     @property
     def is_printable(self) -> bool:
@@ -220,6 +227,11 @@ class Key(InputEvent):
             bool: True if the key is printable.
         """
         return False if self.char is None else self.char.isprintable()
+
+
+def _normalize_key(key: str) -> str:
+    """Convert the key string to a name suitable for use as a Python identifier."""
+    return key.replace("+", "_")
 
 
 @rich.repr.auto

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Awaitable, Callable, Type, TypeVar, Iterable
+from typing import TYPE_CHECKING, Awaitable, Callable, Type, TypeVar
 
 import rich.repr
 from rich.style import Style
@@ -202,6 +202,7 @@ class Key(InputEvent):
         super().__init__(sender)
         self.key = key
         self.char = (key if len(key) == 1 else None) if char is None else char
+        self._key_aliases = [_normalize_key(alias) for alias in _get_key_aliases(key)]
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "key", self.key
@@ -213,10 +214,9 @@ class Key(InputEvent):
         return _normalize_key(self.key)
 
     @property
-    def key_aliases(self) -> Iterable[str]:
+    def key_aliases(self) -> list[str]:
         """Get the aliases for the key, including the key itself"""
-        for alias in _get_key_aliases(self.key):
-            yield _normalize_key(alias)
+        return self._key_aliases
 
     @property
     def is_printable(self) -> bool:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -194,6 +194,9 @@ class Key(InputEvent):
         sender (MessageTarget): The sender of the event (the App).
         key (str): A key name (textual.keys.Keys).
         char (str | None, optional): A printable character or None if it is not printable.
+
+    Attributes:
+        key_aliases (list[str]): The aliases for the key, including the key itself
     """
 
     __slots__ = ["key", "char"]
@@ -202,7 +205,7 @@ class Key(InputEvent):
         super().__init__(sender)
         self.key = key
         self.char = (key if len(key) == 1 else None) if char is None else char
-        self._key_aliases = [_normalize_key(alias) for alias in _get_key_aliases(key)]
+        self.key_aliases = [_normalize_key(alias) for alias in _get_key_aliases(key)]
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "key", self.key
@@ -212,11 +215,6 @@ class Key(InputEvent):
     def key_name(self) -> str | None:
         """Name of a key suitable for use as a Python identifier."""
         return _normalize_key(self.key)
-
-    @property
-    def key_aliases(self) -> list[str]:
-        """Get the aliases for the key, including the key itself"""
-        return self._key_aliases
 
     @property
     def is_printable(self) -> bool:

--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -178,10 +178,6 @@ class Keys(str, Enum):
     ScrollUp = "<scroll-up>"
     ScrollDown = "<scroll-down>"
 
-    CPRResponse = "<cursor-position-response>"
-    Vt100MouseEvent = "<vt100-mouse-event>"
-    WindowsMouseEvent = "<windowshift+mouse-event>"
-
     # For internal use: key which is ignored.
     # (The key binding for this key should not do anything.)
     Ignore = "<ignore>"
@@ -205,6 +201,7 @@ class Keys(str, Enum):
 KEY_NAME_REPLACEMENTS = {
     "solidus": "slash",
     "reverse_solidus": "backslash",
+    "commercial_at": "at",
 }
 
 # Some keys have aliases. For example, if you press `ctrl+m` on your keyboard,
@@ -213,8 +210,8 @@ KEY_NAME_REPLACEMENTS = {
 KEY_ALIASES = {
     "tab": ["ctrl+i"],
     "enter": ["ctrl+m"],
-    "escape": ["ctrl+["],
-    "ctrl+@": ["ctrl+space"],
+    "escape": ["ctrl+left_square_brace"],
+    "ctrl+at": ["ctrl+space"],
     "ctrl+j": ["newline"],
 }
 

--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
 from enum import Enum
 
+
 # Adapted from prompt toolkit https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/prompt_toolkit/keys.py
-
-
 class Keys(str, Enum):
     """
     List of keys for use in key bindings.
@@ -206,3 +206,19 @@ KEY_NAME_REPLACEMENTS = {
     "solidus": "slash",
     "reverse_solidus": "backslash",
 }
+
+# Some keys have aliases. For example, if you press `ctrl+m` on your keyboard,
+# it's treated the same way as if you press `enter`. Key handlers `key_ctrl_m` and
+# `key_enter` are both valid in this case.
+KEY_ALIASES = {
+    "tab": ["ctrl+i"],
+    "enter": ["ctrl+m"],
+    "escape": ["ctrl+["],
+    "ctrl+@": ["ctrl+space"],
+    "ctrl+j": ["newline"],
+}
+
+
+def _get_key_aliases(key: str) -> list[str]:
+    """Return all aliases for the given key, including the key itself"""
+    return [key] + KEY_ALIASES.get(key, [])

--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -10,6 +10,7 @@ from ._types import MessageTarget as MessageTarget
 
 if TYPE_CHECKING:
     from .widget import Widget
+    from .message_pump import MessagePump
 
 
 @rich.repr.auto
@@ -113,7 +114,7 @@ class Message:
         self._stop_propagation = stop
         return self
 
-    async def _bubble_to(self, widget: Widget) -> None:
+    async def bubble_to(self, widget: MessagePump) -> None:
         """Bubble to a widget (typically the parent).
 
         Args:

--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -114,7 +114,7 @@ class Message:
         self._stop_propagation = stop
         return self
 
-    async def bubble_to(self, widget: MessagePump) -> None:
+    async def _bubble_to(self, widget: MessagePump) -> None:
         """Bubble to a widget (typically the parent).
 
         Args:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -558,7 +558,7 @@ class MessagePump(metaclass=MessagePumpMeta):
         invoked_method = None
         key_name = event.key_name
         if not key_name:
-            return invoked_method is not None
+            return False
 
         key_aliases = _get_key_aliases(event.key)
         for key_alias in key_aliases:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -588,7 +588,7 @@ class MessagePump(metaclass=MessagePumpMeta):
 def _raise_duplicate_key_handlers_error(
     key_name: str, first_handler: str, second_handler: str
 ) -> None:
-    """Raises exception if user presses a key and there are multiple candidate key handler methods for it."""
+    """Raise exception for case where user presses a key and there are multiple candidate key handler methods for it."""
     raise DuplicateKeyHandlers(
         f"Multiple handlers for key press {key_name!r}.\n"
         f"We found both {first_handler!r} and {second_handler!r}, "

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -418,7 +418,7 @@ class MessagePump(metaclass=MessagePumpMeta):
                 # parent is sender, so we stop propagation after parent
                 message.stop()
             if self.is_parent_active and not self._parent._closing:
-                await message.bubble_to(self._parent)
+                await message._bubble_to(self._parent)
 
     def check_idle(self) -> None:
         """Prompt the message pump to call idle if the queue is empty."""

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -548,11 +548,6 @@ class MessagePump(metaclass=MessagePumpMeta):
             private_handler_name = f"_key_{key}"
             private_handler = getattr(pump, private_handler_name, None)
 
-            if public_handler and private_handler:
-                _raise_duplicate_key_handlers_error(
-                    key, public_handler_name, private_handler_name
-                )
-
             return public_handler or private_handler
 
         invoked_method = None
@@ -560,9 +555,8 @@ class MessagePump(metaclass=MessagePumpMeta):
         if not key_name:
             return False
 
-        key_aliases = _get_key_aliases(event.key)
-        for key_alias in key_aliases:
-            key_method = get_key_handler(self, key_alias.replace("+", "_"))
+        for key_alias in event.key_aliases:
+            key_method = get_key_handler(self, key_alias)
             if key_method is not None:
                 if invoked_method:
                     _raise_duplicate_key_handlers_error(

--- a/tests/test_message_pump.py
+++ b/tests/test_message_pump.py
@@ -47,14 +47,6 @@ class DuplicateHandlersWidget(Widget):
         self.called_by = self.key_ctrl_i
 
 
-async def test_dispatch_key_raises_when_public_and_private_handlers():
-    """When both a public and private handler exists for one key, we fail fast via exception."""
-    widget = DuplicateHandlersWidget()
-    with pytest.raises(DuplicateKeyHandlers):
-        await widget.dispatch_key(Key(widget, key="x", char="x"))
-    assert widget.called_by is None
-
-
 async def test_dispatch_key_raises_when_conflicting_handler_aliases():
     """If you've got a handler for e.g. ctrl+i and a handler for tab, that's probably a mistake.
     In the terminal, they're the same thing, so we fail fast via exception here."""

--- a/tests/test_message_pump.py
+++ b/tests/test_message_pump.py
@@ -1,0 +1,64 @@
+import pytest
+
+from textual.errors import DuplicateKeyHandlers
+from textual.events import Key
+from textual.widget import Widget
+
+
+class ValidWidget(Widget):
+    called_by = None
+
+    def key_x(self):
+        self.called_by = self.key_x
+
+    def key_ctrl_i(self):
+        self.called_by = self.key_ctrl_i
+
+
+async def test_dispatch_key_valid_key():
+    widget = ValidWidget()
+    result = await widget.dispatch_key(Key(widget, key="x", char="x"))
+    assert result is True
+    assert widget.called_by == widget.key_x
+
+
+async def test_dispatch_key_valid_key_alias():
+    """When you press tab or ctrl+i, it comes through as a tab key event, but handlers for
+    tab and ctrl+i are both considered valid."""
+    widget = ValidWidget()
+    result = await widget.dispatch_key(Key(widget, key="tab", char="\t"))
+    assert result is True
+    assert widget.called_by == widget.key_ctrl_i
+
+
+class DuplicateHandlersWidget(Widget):
+    called_by = None
+
+    def key_x(self):
+        self.called_by = self.key_x
+
+    def _key_x(self):
+        self.called_by = self._key_x
+
+    def key_tab(self):
+        self.called_by = self.key_tab
+
+    def key_ctrl_i(self):
+        self.called_by = self.key_ctrl_i
+
+
+async def test_dispatch_key_raises_when_public_and_private_handlers():
+    """When both a public and private handler exists for one key, we fail fast via exception."""
+    widget = DuplicateHandlersWidget()
+    with pytest.raises(DuplicateKeyHandlers):
+        await widget.dispatch_key(Key(widget, key="x", char="x"))
+    assert widget.called_by is None
+
+
+async def test_dispatch_key_raises_when_conflicting_handler_aliases():
+    """If you've got a handler for e.g. ctrl+i and a handler for tab, that's probably a mistake.
+    In the terminal, they're the same thing, so we fail fast via exception here."""
+    widget = DuplicateHandlersWidget()
+    with pytest.raises(DuplicateKeyHandlers):
+        await widget.dispatch_key(Key(widget, key="tab", char="\t"))
+    assert widget.called_by == widget.key_tab


### PR DESCRIPTION
- Adds support for key aliases.
- Adds message pump unit tests for dispatching keys and ensuring handlers are called as expected.

If multiple handlers exist for a single key, an exception is raised since we can't know which one the author meant.

Also adds the exception logic to the case where public and private handlers exist for the same key press.

Example output for conflicting handlers:

<img width="611" alt="image" src="https://user-images.githubusercontent.com/5740731/194534204-6457d8c4-d676-4fc2-827b-5f91ec6b1d3f.png">
