### PR TITLE
add max_idle for screen

### DIFF
--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -51,6 +51,7 @@ class Screen(Widget):
         self._dirty_widgets: set[Widget] = set()
         self._update_timer: Timer | None = None
         self._callbacks: list[CallbackType] = []
+        self._max_idle = UPDATE_PERIOD
 
     @property
     def is_transparent(self) -> bool:


### PR DESCRIPTION
Adds a "_max_idle" which is the maximum period between idle events.

The screen refreshes on idle events to allow the app finished updating its state. If a message queue is congested, it can prevent the screen from updating. In practice this meant that scrolling sometimes missed a few frames of animation.

This update calls on_idle if a maximum period has elapsed, even if there are messages on the queue. For smoother scrolling.