### PR TITLE
Harmonise the types of the App's css path declarations

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -11,7 +11,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime
 from pathlib import Path, PurePath
 from time import perf_counter
-from typing import Any, Generic, Iterable, Iterator, Type, TypeVar, cast
+from typing import Any, Generic, Iterable, Iterator, Type, TypeVar, cast, Union
 from weakref import WeakSet, WeakValueDictionary
 
 from ._ansi_sequences import SYNC_END, SYNC_START
@@ -119,7 +119,7 @@ class _NullFile:
         pass
 
 
-CSSPathType = str | PurePath | None
+CSSPathType = Union[str, PurePath, None]
 
 
 @rich.repr.auto

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -119,6 +119,9 @@ class _NullFile:
         pass
 
 
+CSSPathType = str | PurePath | None
+
+
 @rich.repr.auto
 class App(Generic[ReturnType], DOMNode):
     """The base class for Textual Applications.
@@ -145,7 +148,7 @@ class App(Generic[ReturnType], DOMNode):
     SCREENS: dict[str, Screen] = {}
 
     _BASE_PATH: str | None = None
-    CSS_PATH: str | None = None
+    CSS_PATH: CSSPathType = None
 
     focused: Reactive[Widget | None] = Reactive(None)
 
@@ -153,7 +156,7 @@ class App(Generic[ReturnType], DOMNode):
         self,
         driver_class: Type[Driver] | None = None,
         title: str | None = None,
-        css_path: str | PurePath | None = None,
+        css_path: CSSPathType = None,
         watch_css: bool = False,
     ):
         # N.B. This must be done *before* we call the parent constructor, because MessagePump's


### PR DESCRIPTION
The CSS path for an app can be given either as an init parameter, or as a class variable. The declared types for these two declarations didn't match (the class variable didn't allow for a PurePath).

This ensures that the types are the same and any future changes will be made to both routes of declaration.

See #866.