### PR TITLE
Win slow

### DIFF
--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -43,30 +43,15 @@ class Logger:
         self._group = group
         self._verbosity = verbosity
 
-    @property
-    def app(self) -> App:
-        try:
-            app = active_app.get()
-        except LookupError:
-            raise LoggerError("Unable to log without an active app.") from None
-        return app
-
-    @property
-    def log(self) -> LogCallable:
-        if self._log is None:
-            try:
-                app = active_app.get()
-            except LookupError:
-                raise LoggerError("Unable to log without an active app.") from None
-            return app._log
-        return self._log
-
     def __rich_repr__(self) -> rich.repr.Result:
         yield self._group, LogGroup.INFO
         yield self._verbosity, LogVerbosity.NORMAL
 
     def __call__(self, *args: object, **kwargs) -> None:
-        app = self.app
+        try:
+            app = active_app.get()
+        except LookupError:
+            raise LoggerError("Unable to log without an active app.") from None
         if not app.devtools.is_connected:
             return
         caller = inspect.stack(0)[1]
@@ -75,7 +60,7 @@ class Logger:
             _log(
                 self._group,
                 self._verbosity,
-                _textual_calling_frame=caller,
+                caller,
                 *args,
                 **kwargs,
             )

--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -75,8 +75,8 @@ class Logger:
             _log(
                 self._group,
                 self._verbosity,
-                *args,
                 _textual_calling_frame=caller,
+                *args,
                 **kwargs,
             )
         except LoggerError:

--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -54,7 +54,10 @@ class Logger:
             raise LoggerError("Unable to log without an active app.") from None
         if not app.devtools.is_connected:
             return
-        caller = inspect.stack(0)[1]
+
+        previous_frame = inspect.currentframe().f_back
+        caller = inspect.getframeinfo(previous_frame)
+
         _log = self._log or app._log
         try:
             _log(

--- a/src/textual/_clock.py
+++ b/src/textual/_clock.py
@@ -24,7 +24,6 @@ class _Clock:
         await asyncio.sleep(seconds)
 
 
-# That's our target for mocking time! :-)
 _clock = _Clock()
 
 

--- a/src/textual/_clock.py
+++ b/src/textual/_clock.py
@@ -1,5 +1,6 @@
 import asyncio
-from time import monotonic
+
+from ._time import time
 
 
 """
@@ -14,10 +15,10 @@ by mocking the few functions exposed by this module.
 # (so mocking public APIs such as `get_time` wouldn't affect direct references to then that were done during imports)
 class _Clock:
     async def get_time(self) -> float:
-        return self.get_time_no_wait()
+        return time()
 
     def get_time_no_wait(self) -> float:
-        return monotonic()
+        return time()
 
     async def sleep(self, seconds: float) -> None:
         await asyncio.sleep(seconds)

--- a/src/textual/_profile.py
+++ b/src/textual/_profile.py
@@ -3,10 +3,9 @@ Timer context manager, only used in debug.
 
 """
 
-from ._time import time
-
 import contextlib
 from typing import Generator
+from time import perf_counter
 
 from . import log
 
@@ -14,8 +13,8 @@ from . import log
 @contextlib.contextmanager
 def timer(subject: str = "time") -> Generator[None, None, None]:
     """print the elapsed time. (only used in debugging)"""
-    start = time()
+    start = perf_counter()
     yield
-    elapsed = time() - start
+    elapsed = perf_counter() - start
     elapsed_ms = elapsed * 1000
     log(f"{subject} elapsed {elapsed_ms:.2f}ms")

--- a/src/textual/_profile.py
+++ b/src/textual/_profile.py
@@ -3,7 +3,7 @@ Timer context manager, only used in debug.
 
 """
 
-from time import time
+from ._time import time
 
 import contextlib
 from typing import Generator

--- a/src/textual/_time.py
+++ b/src/textual/_time.py
@@ -1,4 +1,5 @@
 import platform
+
 from time import monotonic, perf_counter
 
 PLATFORM = platform.system()
@@ -9,5 +10,3 @@ if WINDOWS:
     time = perf_counter
 else:
     time = monotonic
-
-time = monotonic

--- a/src/textual/_time.py
+++ b/src/textual/_time.py
@@ -9,3 +9,5 @@ if WINDOWS:
     time = perf_counter
 else:
     time = monotonic
+
+time = monotonic

--- a/src/textual/_time.py
+++ b/src/textual/_time.py
@@ -1,4 +1,11 @@
-from time import perf_counter
+import platform
+from time import monotonic, perf_counter
+
+PLATFORM = platform.system()
+WINDOWS = PLATFORM == "Windows"
 
 
-time = perf_counter
+if WINDOWS:
+    time = perf_counter
+else:
+    time = monotonic

--- a/src/textual/_time.py
+++ b/src/textual/_time.py
@@ -1,0 +1,4 @@
+from time import perf_counter
+
+
+time = perf_counter

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -540,7 +540,7 @@ class App(Generic[ReturnType], DOMNode):
             return
 
         if not _textual_calling_frame:
-            _textual_calling_frame = inspect.stack()[1]
+            _textual_calling_frame = inspect.stack(0)[1]
 
         try:
             if len(objects) == 1 and not kwargs:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -513,8 +513,8 @@ class App(Generic[ReturnType], DOMNode):
         self,
         group: LogGroup,
         verbosity: LogVerbosity,
+        _textual_calling_frame: inspect.FrameInfo,
         *objects: Any,
-        _textual_calling_frame: inspect.FrameInfo | None = None,
         **kwargs,
     ) -> None:
         """Write to logs or devtools.
@@ -538,9 +538,6 @@ class App(Generic[ReturnType], DOMNode):
 
         if verbosity.value > LogVerbosity.NORMAL.value and not self.devtools.verbose:
             return
-
-        if not _textual_calling_frame:
-            _textual_calling_frame = inspect.stack(0)[1]
 
         try:
             if len(objects) == 1 and not kwargs:

--- a/src/textual/devtools/client.py
+++ b/src/textual/devtools/client.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-
 import pickle
-from asyncio import Queue, Task, QueueFull
+from asyncio import Queue, QueueFull, Task
 from io import StringIO
-from typing import Type, Any, NamedTuple
+from time import time
+from typing import Any, NamedTuple, Type
 
 from rich.console import Console
 from rich.segment import Segment
 
-from .._time import time
 from .._log import LogGroup, LogVerbosity
 
 
@@ -22,12 +21,12 @@ class DevtoolsDependenciesMissingError(Exception):
 
 try:
     import aiohttp
+    import msgpack
     from aiohttp import (
-        ClientResponseError,
         ClientConnectorError,
+        ClientResponseError,
         ClientWebSocketResponse,
     )
-    import msgpack
 except ImportError:
     # TODO: Add link to documentation on how to install devtools
     raise DevtoolsDependenciesMissingError(

--- a/src/textual/devtools/client.py
+++ b/src/textual/devtools/client.py
@@ -5,7 +5,6 @@ import inspect
 import json
 
 import pickle
-from time import time
 from asyncio import Queue, Task, QueueFull
 from io import StringIO
 from typing import Type, Any, NamedTuple
@@ -13,6 +12,7 @@ from typing import Type, Any, NamedTuple
 from rich.console import Console
 from rich.segment import Segment
 
+from .._time import time
 from .._log import LogGroup, LogVerbosity
 
 

--- a/src/textual/devtools/redirect_output.py
+++ b/src/textual/devtools/redirect_output.py
@@ -39,7 +39,7 @@ class StdoutRedirector:
         if not self.devtools.is_connected:
             return
 
-        caller = inspect.stack()[1]
+        caller = inspect.stack(0)[1]
         self._buffer.append(DevtoolsLog(string, caller=caller))
 
         # By default, `print` adds a "\n" suffix which results in a buffer

--- a/src/textual/devtools/redirect_output.py
+++ b/src/textual/devtools/redirect_output.py
@@ -39,7 +39,9 @@ class StdoutRedirector:
         if not self.devtools.is_connected:
             return
 
-        caller = inspect.stack(0)[1]
+        previous_frame = inspect.currentframe().f_back
+        caller = inspect.getframeinfo(previous_frame)
+
         self._buffer.append(DevtoolsLog(string, caller=caller))
 
         # By default, `print` adds a "\n" suffix which results in a buffer

--- a/src/textual/devtools/service.py
+++ b/src/textual/devtools/service.py
@@ -6,7 +6,6 @@ import base64
 import json
 import pickle
 from json import JSONDecodeError
-from time import time
 from typing import cast
 
 from aiohttp import WSMessage, WSMsgType
@@ -17,6 +16,7 @@ from rich.markup import escape
 import msgpack
 
 from textual._log import LogGroup
+from textual._time import time
 from textual.devtools.renderables import (
     DevConsoleLog,
     DevConsoleNotice,

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from time import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from . import events
+from ._time import time
 from ._types import MessageTarget
 
 if TYPE_CHECKING:

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -4,8 +4,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from . import events
-from ._time import time
+from . import _clock, events
 from ._types import MessageTarget
 
 if TYPE_CHECKING:
@@ -20,7 +19,7 @@ class Driver(ABC):
         self._target = target
         self._debug = debug
         self._loop = asyncio.get_running_loop()
-        self._mouse_down_time = time()
+        self._mouse_down_time = _clock.get_time_no_wait()
 
     def send_event(self, event: events.Event) -> None:
         asyncio.run_coroutine_threadsafe(

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -263,6 +263,11 @@ class EventMonitor(threading.Thread):
                         key_event = input_record.Event.KeyEvent
                         key = key_event.uChar.UnicodeChar
                         if key_event.bKeyDown or key == "\x1b":
+                            if (
+                                key_event.dwControlKeyState
+                                and key_event.wVirtualKeyCode == 0
+                            ):
+                                continue
                             append_key(key)
                     elif event_type == WINDOW_BUFFER_SIZE_EVENT:
                         # Window size changed, store size

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -14,16 +14,16 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable
 from weakref import WeakSet
 
-from . import events, log, messages, Logger
+from . import Logger, events, log, messages
 from ._callback import invoke
 from ._context import NoActiveAppError, active_app
 from ._time import time
-from .errors import DuplicateKeyHandlers
-from .timer import Timer, TimerCallback
 from .case import camel_to_snake
+from .errors import DuplicateKeyHandlers
 from .events import Event
 from .message import Message
 from .reactive import Reactive
+from .timer import Timer, TimerCallback
 
 if TYPE_CHECKING:
     from .app import App

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 from asyncio import CancelledError, Queue, QueueEmpty, Task
-from time import time
 from functools import partial
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable
 from weakref import WeakSet
@@ -18,6 +17,7 @@ from weakref import WeakSet
 from . import events, log, messages, Logger
 from ._callback import invoke
 from ._context import NoActiveAppError, active_app
+from ._time import time
 from .errors import DuplicateKeyHandlers
 from .keys import _get_key_aliases
 from .timer import Timer, TimerCallback

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -19,7 +19,6 @@ from ._callback import invoke
 from ._context import NoActiveAppError, active_app
 from ._time import time
 from .errors import DuplicateKeyHandlers
-from .keys import _get_key_aliases
 from .timer import Timer, TimerCallback
 from .case import camel_to_snake
 from .events import Event

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -469,8 +469,8 @@ class Widget(DOMNode):
     def watch_scroll_y(self, new_value: float) -> None:
         if self.show_vertical_scrollbar:
             self.vertical_scrollbar.position = int(new_value)
-            self.refresh(layout=True)
             self.vertical_scrollbar.refresh()
+            self.refresh(layout=True)
 
     def validate_scroll_x(self, value: float) -> float:
         return clamp(value, 0, self.max_scroll_x)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -461,14 +461,16 @@ class Widget(DOMNode):
             self.highlight_link_id = hover_style.link_id
 
     def watch_scroll_x(self, new_value: float) -> None:
-        self.horizontal_scrollbar.position = int(new_value)
-        self.refresh(layout=True)
-        self.horizontal_scrollbar.refresh()
+        if self.show_horizontal_scrollbar:
+            self.horizontal_scrollbar.position = int(new_value)
+            self.horizontal_scrollbar.refresh()
+            self.refresh(layout=True)
 
     def watch_scroll_y(self, new_value: float) -> None:
-        self.vertical_scrollbar.position = int(new_value)
-        self.refresh(layout=True)
-        self.vertical_scrollbar.refresh()
+        if self.show_vertical_scrollbar:
+            self.vertical_scrollbar.position = int(new_value)
+            self.refresh(layout=True)
+            self.vertical_scrollbar.refresh()
 
     def validate_scroll_x(self, value: float) -> float:
         return clamp(value, 0, self.max_scroll_x)


### PR DESCRIPTION
FIx for Windows pauses

- Turns out stack.frame is slow. `stack.frame(0)` is a little faster. Changed so that we only call it when devtools is enabled.
- User perf_counter on Windows for better accuracy