### PR TITLE
Provide extra hinting for App.query

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -691,7 +691,9 @@ class DOMNode(MessagePump):
     def query(self, selector: type[ExpectType]) -> DOMQuery[ExpectType]:
         ...
 
-    def query(self, selector: str | type[ExpectType] | None = None) -> DOMQuery[Widget] | DOMQuery[ExpectType]:
+    def query(
+        self, selector: str | type[ExpectType] | None = None
+    ) -> DOMQuery[Widget] | DOMQuery[ExpectType]:
         """Get a DOM query matching a selector.
 
         Args:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -684,14 +684,14 @@ class DOMNode(MessagePump):
     ExpectType = TypeVar("ExpectType", bound="Widget")
 
     @overload
-    def query(self, selector: str | None) -> DOMQuery:
+    def query(self, selector: str | None) -> DOMQuery[Widget]:
         ...
 
     @overload
     def query(self, selector: type[ExpectType]) -> DOMQuery[ExpectType]:
         ...
 
-    def query(self, selector: str | type | None = None) -> DOMQuery:
+    def query(self, selector: str | type[ExpectType] | None = None) -> DOMQuery[Widget] | DOMQuery[ExpectType]:
         """Get a DOM query matching a selector.
 
         Args:


### PR DESCRIPTION
This change seeks to help silence some warnings that were appearing with pylance/pyright when type checking was in strict mode. See #867.