### PR TITLE
Adds the debounce decorator

### DIFF
--- a/examples/dictionary.py
+++ b/examples/dictionary.py
@@ -12,6 +12,7 @@ from rich.markdown import Markdown
 from textual.app import App, ComposeResult
 from textual.containers import Content
 from textual.widgets import Static, Input
+from textual.debounce import debounce
 
 
 class DictionaryApp(App):
@@ -28,6 +29,7 @@ class DictionaryApp(App):
         # Give the input focus, so we can start typing straight away
         self.query_one(Input).focus()
 
+    @debounce(0.250)
     async def on_input_changed(self, message: Input.Changed) -> None:
         """A coroutine to handle a text changed message."""
         if message.value:

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -1,0 +1,24 @@
+import asyncio
+from functools import wraps
+from typing import Callable, Optional
+
+from .app import App
+from .timer import Timer as TimerClass
+
+
+def debounce(timeout: float) -> Callable:
+    def decorator(f: Callable) -> Callable:
+        timer: Optional[TimerClass] = None
+
+        @wraps(f)
+        async def wrapper(self: App, *args, **kwargs) -> None:
+            nonlocal timer
+            if timer:
+                timer.stop_no_wait()
+            timer = self.set_timer(
+                timeout, lambda: asyncio.create_task(f(self, *args, *kwargs))
+            )
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
The debounce decorator can be used to debounce calls to a method. In the below example, the decorator is used to debounce calls to `on_text_input_changed` in the dictionary example app, which means that unnecessary network calls are not made.

```python
    @debounce(0.250)
    async def on_text_input_changed(self, message: TextInput.Changed) -> None:
        """A coroutine to handle a text changed message."""
        if message.value:
            # Look up the word in the background
            asyncio.create_task(self.lookup_word(message.value))
        else:
            # Clear the results
            self.query_one("#results", Static).update()

    async def lookup_word(self, word: str) -> None:
        """Looks up a word."""
        url = f"https://api.dictionaryapi.dev/api/v2/entries/en/{word}"
        async with httpx.AsyncClient() as client:
            results = (await client.get(url)).json()

        if word == self.query_one(TextInput).value:
            markdown = self.make_word_markdown(results)
            self.query_one("#results", Static).update(Markdown(markdown))
```

I don't know if this is the right file to put this but it seemed appropriate.