### PR TITLE
Use screen offset instead of offset

### DIFF
--- a/sandbox/darren/focus_keybinds.css
+++ b/sandbox/darren/focus_keybinds.css
@@ -1,0 +1,52 @@
+*:focus {
+  tint: red 20%;
+}
+
+#info {
+  background: $primary;
+  dock: top;
+  height: 3;
+  padding: 1;
+}
+
+#body {
+  dock: top;
+}
+
+#left_list {
+  width: 50%;
+}
+
+#right_list {
+  width: 50%;
+}
+
+#footer {
+  height: 1;
+  background: $secondary;
+  padding: 0 1;
+  dock: bottom;
+}
+
+.list:focus-within {
+  background: $panel-lighten-1;
+  outline-top:  $accent-lighten-1;
+  outline-bottom:  $accent-lighten-1;
+}
+
+.list {
+  background: $surface;
+  border-top: hkey $surface-darken-1;
+}
+
+.list-item {
+  background: $surface;
+  height: auto;
+  border: $surface-darken-1 tall;
+  padding: 0 1;
+}
+
+.list-item:focus {
+  background: $surface-darken-1;
+  outline: $accent tall;
+}

--- a/sandbox/darren/focus_keybinds.py
+++ b/sandbox/darren/focus_keybinds.py
@@ -1,0 +1,60 @@
+from textual import containers as layout
+from textual.app import App, ComposeResult
+from textual.widgets import Static, Input
+
+
+class Label(Static, can_focus=True):
+    pass
+
+
+class FocusKeybindsApp(App):
+    dark = True
+
+    def on_load(self) -> None:
+        self.bind("1", "focus('widget1')")
+        self.bind("2", "focus('widget2')")
+        self.bind("3", "focus('widget3')")
+        self.bind("4", "focus('widget4')")
+        self.bind("q", "focus('widgetq')")
+        self.bind("w", "focus('widgetw')")
+        self.bind("e", "focus('widgete')")
+        self.bind("r", "focus('widgetr')")
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Use keybinds to shift focus between the widgets in the lists below",
+            id="info",
+        )
+        yield layout.Horizontal(
+            layout.Vertical(
+                Label("Press 1 to focus", id="widget1", classes="list-item"),
+                Label("Press 2 to focus", id="widget2", classes="list-item"),
+                Input(placeholder="Enter some text..."),
+                Label("Press 3 to focus", id="widget3", classes="list-item"),
+                Label("Press 4 to focus", id="widget4", classes="list-item"),
+                classes="list",
+                id="left_list",
+            ),
+            layout.Vertical(
+                Label("Press Q to focus", id="widgetq", classes="list-item"),
+                Label("Press W to focus", id="widgetw", classes="list-item"),
+                Label("Press E to focus", id="widgete", classes="list-item"),
+                Label("Press R to focus", id="widgetr", classes="list-item"),
+                classes="list",
+                id="right_list",
+            ),
+        )
+        yield Static("No widget focused", id="footer")
+
+    def on_descendant_focus(self):
+        self.get_child("footer").update(
+            f"Focused: {self.focused.id}" or "No widget focused"
+        )
+
+    def key_p(self):
+        print(self.app.focused.parent)
+        print(self.app.focused)
+
+
+app = FocusKeybindsApp(css_path="focus_keybinds.css", watch_css=True)
+app.run()

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -373,7 +373,7 @@ class MouseEvent(InputEvent, bubble=True):
         Returns:
             Offset | None: An offset where the origin is at the top left of the content area.
         """
-        if self.offset not in widget.content_region:
+        if self.screen_offset not in widget.content_region:
             return None
         return self.offset - widget.gutter.top_left
 


### PR DESCRIPTION
1-liner.

There was a check put in a couple of weeks ago which checked if the event offset was inside `content_region`. However, the event offset is in widget-space and the `content_region` is screen space. I've updated that check to ensure both use screen-space coordinates and functionality is restored.