### PR TITLE
Fix textual run path bug on Windows

### DIFF
--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -31,9 +31,9 @@ def import_app(import_name: str) -> App:
     import importlib
     import sys
 
-    from textual.app import App
+    from textual.app import App, WINDOWS
 
-    import_name, *argv = shlex.split(import_name)
+    import_name, *argv = shlex.split(import_name, posix=not WINDOWS)
     lib, _colon, name = import_name.partition(":")
 
     if lib.endswith(".py"):


### PR DESCRIPTION
`textual run` didn't work with a Windows style path (which gets used automatically when you tab complete in the terminal).