### PR TITLE
Get rid of string split key display, bug fix for not showing screen-level bindings

### DIFF
--- a/sandbox/darren/just_a_box.py
+++ b/sandbox/darren/just_a_box.py
@@ -14,6 +14,7 @@ class JustABox(App):
             key="o,f,w",
             action="widget_fade_out",
             description="opacity fade out",
+            key_display="o or f or w",
         ),
     ]
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -325,10 +325,10 @@ class App(Generic[ReturnType], DOMNode):
     @property
     def bindings(self) -> Bindings:
         """Get current bindings. If no widget is focused, then the app-level bindings
-        are returned. If a widget is focused, then any bindings present between that widget
-        and the App in the DOM are merged and returned."""
+        are returned. If a widget is focused, then any bindings present in the active
+        screen and app are merged and returned."""
         if self.focused is None:
-            return self._bindings
+            return Bindings.merge([self.screen._bindings, self._bindings])
         else:
             return Bindings.merge(
                 node._bindings for node in reversed(self.focused.ancestors)

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -47,26 +47,14 @@ class Bindings:
             for binding in bindings:
                 if isinstance(binding, Binding):
                     binding_keys = binding.key.split(",")
-
-                    # If there's a key display, split it and associate it with the keys
-                    key_displays = (
-                        binding.key_display.split(",") if binding.key_display else []
-                    )
-                    if len(binding_keys) == len(key_displays):
-                        keys_and_displays = zip(binding_keys, key_displays)
-                    else:
-                        keys_and_displays = [
-                            (key, binding.key_display) for key in binding_keys
-                        ]
-
                     if len(binding_keys) > 1:
-                        for key, display in keys_and_displays:
+                        for key in binding_keys:
                             new_binding = Binding(
                                 key=key,
                                 action=binding.action,
                                 description=binding.description,
                                 show=binding.show,
-                                key_display=display,
+                                key_display=binding.key_display,
                                 allow_forward=binding.allow_forward,
                             )
                             yield new_binding

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from rich.console import RenderableType
-
-from rich.text import Text
 import rich.repr
+from rich.console import RenderableType
+from rich.text import Text
 
 from .. import events
 from ..reactive import Reactive, watch
@@ -95,14 +94,12 @@ class Footer(Widget):
             action_to_bindings[binding.action].append(binding)
 
         for action, bindings in action_to_bindings.items():
-            key_displays = [
+            binding = bindings[0]
+            key_display = (
                 binding.key.upper()
                 if binding.key_display is None
                 else binding.key_display
-                for binding in bindings
-            ]
-            key_display = "·".join(key_displays)
-            binding = bindings[0]
+            )
             hovered = self.highlight_key == binding.key
             key_text = Text.assemble(
                 (f" {key_display} ", highlight_key_style if hovered else key_style),


### PR DESCRIPTION
Removes the string splitting thing and makes it so you can just write what you want to be displayed when multiple keys map to the same action, as suggested the other day.

Also fixes issue where if no widget is focused, then only the app-level bindings were returned (no bindings at the screen level were, even though they're available).