### PR TITLE
README has 'development development'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Textual is a Python framework for creating interactive applications that run in 
 
 ## About
 
-Textual adds interactivity to [Rich](https://github.com/Textualize/rich) with a Python API inspired by modern development development.
+Textual adds interactivity to [Rich](https://github.com/Textualize/rich) with a Python API inspired by modern web development.
 
 On modern terminal software (installed by default on most systems), Textual apps can use **16.7 million** colors with mouse support and smooth flicker-free animation. A powerful layout engine and re-usable components makes it possible to build apps that rival the desktop and web experience. 
 


### PR DESCRIPTION
Quick documentation fix, I was just reading the `About` section of the readme and noticed this. Looking at the blame it looks like it used to be "web development" but was accidentally switched in the last merge.