### PR TITLE
key bindings refactor

### DIFF
--- a/sandbox/will/screen_actions.py
+++ b/sandbox/will/screen_actions.py
@@ -1,0 +1,24 @@
+from textual.app import App, ComposeResult
+from textual.screen import Screen
+from textual.widgets import Footer
+
+
+class DefaultScreen(Screen):
+
+    BINDINGS = [("f", "foo", "FOO")]
+
+    def compose(self) -> ComposeResult:
+        yield Footer()
+
+    def action_foo(self) -> None:
+        self.app.bell()
+
+
+class ScreenApp(App):
+    def on_mount(self) -> None:
+        self.push_screen(DefaultScreen())
+
+
+app = ScreenApp()
+if __name__ == "__main__":
+    app.run()

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -327,7 +327,7 @@ class App(Generic[ReturnType], DOMNode):
         screen and app are merged and returned."""
 
         namespace_binding_map: dict[str, tuple[DOMNode, Binding]] = {}
-        for namespace, bindings in self._binding_chain:
+        for namespace, bindings in reversed(self._binding_chain):
             for key, binding in bindings.keys.items():
                 namespace_binding_map[key] = (namespace, binding)
 
@@ -1265,8 +1265,8 @@ class App(Generic[ReturnType], DOMNode):
 
     @property
     def _binding_chain(self) -> list[tuple[DOMNode, Bindings]]:
-        """Get a chain of nodes and bindings to consider. Goes from app to focused
-        widget, or app to screen.
+        """Get a chain of nodes and bindings to consider. Goes from focused widget to app, or
+        screen to app.
 
         Returns:
             list[tuple[DOMNode, Bindings]]: List of DOM nodes and their bindings.
@@ -1275,13 +1275,11 @@ class App(Generic[ReturnType], DOMNode):
         namespace_bindings: list[tuple[DOMNode, Bindings]]
         if focused is None:
             namespace_bindings = [
-                (self, self._bindings),
                 (self.screen, self.screen._bindings),
+                (self, self._bindings),
             ]
         else:
-            namespace_bindings = [
-                (node, node._bindings) for node in reversed(focused.ancestors)
-            ]
+            namespace_bindings = [(node, node._bindings) for node in focused.ancestors]
         return namespace_bindings
 
     async def check_bindings(self, key: str) -> bool:
@@ -1294,7 +1292,7 @@ class App(Generic[ReturnType], DOMNode):
             bool: True if the key was handled by a binding, otherwise False
         """
 
-        for namespace, bindings in reversed(self._binding_chain):
+        for namespace, bindings in self._binding_chain:
             binding = bindings.keys.get(key)
             if binding is not None:
                 await self.action(binding.action, default_namespace=namespace)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1265,8 +1265,7 @@ class App(Generic[ReturnType], DOMNode):
 
     @property
     def _binding_chain(self) -> list[tuple[DOMNode, Bindings]]:
-        """Get a chain of nodes and bindings to consider. Goes from focused widget to app, or
-        screen to app.
+        """Get a chain of nodes and bindings to consider. If no widget is focused, returns the bindings from both the screen and the app level bindings. Otherwise, combines all the bindings from the currently focused node up the DOM to the root App.
 
         Returns:
             list[tuple[DOMNode, Bindings]]: List of DOM nodes and their bindings.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -321,12 +321,12 @@ class App(Generic[ReturnType], DOMNode):
         return self.screen.focused
 
     @property
-    def namespace_bindings(self) -> dict[str, tuple[object, Binding]]:
+    def namespace_bindings(self) -> dict[str, tuple[DOMNode, Binding]]:
         """Get current bindings. If no widget is focused, then the app-level bindings
         are returned. If a widget is focused, then any bindings present in the active
         screen and app are merged and returned."""
 
-        namespace_binding_map: dict[str, tuple[object, Binding]] = {}
+        namespace_binding_map: dict[str, tuple[DOMNode, Binding]] = {}
         for namespace, bindings in self._binding_chain:
             for key, binding in bindings.keys.items():
                 namespace_binding_map[key] = (namespace, binding)
@@ -1265,7 +1265,8 @@ class App(Generic[ReturnType], DOMNode):
 
     @property
     def _binding_chain(self) -> list[tuple[DOMNode, Bindings]]:
-        """Get a chain of nodes and bindings to consider.
+        """Get a chain of nodes and bindings to consider. Goes from app to focused
+        widget, or app to screen.
 
         Returns:
             list[tuple[DOMNode, Bindings]]: List of DOM nodes and their bindings.

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -34,7 +34,7 @@ class Binding:
     """Show the action in Footer, or False to hide."""
     key_display: str | None = None
     """How the key should be shown in footer."""
-    allow_forward: bool = True
+    universal: bool = False
     """Allow forwarding from app to focused widget."""
 
 
@@ -55,7 +55,7 @@ class Bindings:
                                 description=binding.description,
                                 show=binding.show,
                                 key_display=binding.key_display,
-                                allow_forward=binding.allow_forward,
+                                universal=binding.universal,
                             )
                             yield new_binding
                     else:
@@ -103,7 +103,7 @@ class Bindings:
         description: str = "",
         show: bool = True,
         key_display: str | None = None,
-        allow_forward: bool = True,
+        universal: bool = False,
     ) -> None:
         all_keys = [key.strip() for key in keys.split(",")]
         for key in all_keys:
@@ -113,7 +113,7 @@ class Bindings:
                 description,
                 show=show,
                 key_display=key_display,
-                allow_forward=allow_forward,
+                universal=universal,
             )
 
     def get_key(self, key: str) -> Binding:
@@ -126,4 +126,4 @@ class Bindings:
         binding = self.keys.get(key, None)
         if binding is None:
             return True
-        return binding.allow_forward
+        return not binding.universal

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -121,9 +121,3 @@ class Bindings:
             return self.keys[key]
         except KeyError:
             raise NoBinding(f"No binding for {key}") from None
-
-    def allow_forward(self, key: str) -> bool:
-        binding = self.keys.get(key, None)
-        if binding is None:
-            return True
-        return not binding.universal

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -584,7 +584,9 @@ class MessagePump(metaclass=MessagePumpMeta):
                     _raise_duplicate_key_handlers_error(
                         key_name, invoked_method.__name__, key_method.__name__
                     )
-                handled = await invoke(key_method, event)
+                # If key handlers return False, then they are not considered handled
+                # This allows key handlers to do some conditional logic
+                handled = (await invoke(key_method, event)) != False
                 invoked_method = key_method
 
         return handled

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -571,6 +571,7 @@ class MessagePump(metaclass=MessagePumpMeta):
 
             return public_handler or private_handler
 
+        handled = False
         invoked_method = None
         key_name = event.key_name
         if not key_name:
@@ -583,10 +584,10 @@ class MessagePump(metaclass=MessagePumpMeta):
                     _raise_duplicate_key_handlers_error(
                         key_name, invoked_method.__name__, key_method.__name__
                     )
-                await invoke(key_method, event)
+                handled = await invoke(key_method, event)
                 invoked_method = key_method
 
-        return invoked_method is not None
+        return handled
 
     async def on_timer(self, event: events.Timer) -> None:
         event.prevent_default()

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1900,12 +1900,7 @@ class Widget(DOMNode):
         await self.handle_key(event)
 
     async def handle_key(self, event: events.Key) -> bool:
-        try:
-            binding = self._bindings.get_key(event.key)
-        except NoBinding:
-            return await self.dispatch_key(event)
-        await self.action(binding.action)
-        return True
+        return await self.dispatch_key(event)
 
     async def _on_compose(self, event: events.Compose) -> None:
         widgets = list(self.compose())

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -112,7 +112,7 @@ class Footer(Widget):
                     highlight_style if hovered else base_style,
                 ),
                 meta={
-                    "@click": f"app.check_binding('{binding.key}')",
+                    "@click": f"app.check_bindings('{binding.key}')",
                     "key": binding.key,
                 },
             )

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -87,7 +87,11 @@ class Footer(Widget):
         highlight_key_style = self.get_component_rich_style("footer--highlight-key")
         key_style = self.get_component_rich_style("footer--key")
 
-        bindings = self.app.bindings.shown_keys
+        bindings = [
+            binding
+            for (_namespace, binding) in self.app.namespace_bindings.values()
+            if binding.show
+        ]
 
         action_to_bindings = defaultdict(list)
         for binding in bindings:
@@ -107,7 +111,10 @@ class Footer(Widget):
                     f" {binding.description} ",
                     highlight_style if hovered else base_style,
                 ),
-                meta={"@click": f"app.press('{binding.key}')", "key": binding.key},
+                meta={
+                    "@click": f"app.check_binding('{binding.key}')",
+                    "key": binding.key,
+                },
             )
             text.append_text(key_text)
         return text

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -239,12 +239,10 @@ class Input(Widget, can_focus=True):
 
         # Do key bindings first
         if await self.handle_key(event):
-            print("HANDLE KEY STOPPED")
             event.prevent_default()
             event.stop()
             return
         elif event.is_printable:
-            print("PRINTABLE STOPPED")
             event.stop()
             assert event.char is not None
             self.insert_text_at_cursor(event.char)

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -239,10 +239,12 @@ class Input(Widget, can_focus=True):
 
         # Do key bindings first
         if await self.handle_key(event):
+            print("HANDLE KEY STOPPED")
             event.prevent_default()
             event.stop()
             return
         elif event.is_printable:
+            print("PRINTABLE STOPPED")
             event.stop()
             assert event.char is not None
             self.insert_text_at_cursor(event.char)


### PR DESCRIPTION
- Fixed footer click to run binding
- Takes in to account a widget's namespace when invoking bindings
- Adds "universal" keys which are processed first, but never sent to the focused widgert