### PR TITLE
docs: remove center layout

### DIFF
--- a/docs/styles/layout.md
+++ b/docs/styles/layout.md
@@ -7,7 +7,7 @@ See [layout](../guide/layout.md) guide for more information.
 ## Syntax
 
 ```
-layout: [center|grid|horizontal|vertical];
+layout: [grid|horizontal|vertical];
 ```
 
 ### Values


### PR DESCRIPTION
The docs reference `center` as an allowed value for the `layout` style, but it is not supported and causes CSS parsing to fail.

```
   Invalid value for layout property
   └── The layout property expects a value of 'grid', 'horizontal', or 'vertical'


 CSS parsing failed: 1 error found in stylesheet
```