### PR TITLE
Populate character on simulated key presses

### DIFF
--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -11,7 +11,7 @@ The example below shows how you might create a simple form using two `Input` wid
 
 === "Output"
 
-    ```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n,at,space,D,a"}
+    ```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n"}
     ```
 
 === "input.py"

--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -11,7 +11,7 @@ The example below shows how you might create a simple form using two `Input` wid
 
 === "Output"
 
-    ```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n"}
+    ```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n,at,space,D,a"}
     ```
 
 === "input.py"

--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -206,6 +206,7 @@ KEY_NAME_REPLACEMENTS = {
     "plus_sign": "plus",
     "low_line": "underscore",
 }
+REPLACED_KEYS = {value: key for key, value in KEY_NAME_REPLACEMENTS.items()}
 
 # Some keys have aliases. For example, if you press `ctrl+m` on your keyboard,
 # it's treated the same way as if you press `enter`. Key handlers `key_ctrl_m` and


### PR DESCRIPTION
`char` is now populated when you simulate key presses in the docs and snapshot tests.

```
    ```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n,at,space,D,a"}
    ```
```

<img width="738" alt="image" src="https://user-images.githubusercontent.com/5740731/196719294-78d92bf6-992d-4322-a771-f8adcc7d8005.png">
