### PR TITLE
Post-PR #954 tidy up

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1448,8 +1448,8 @@ class App(Generic[ReturnType], DOMNode):
         widget = event.widget
         parent = widget.parent
 
-        remove_widgets = list(
-            widget.walk_children(Widget, with_self=True, method="depth", reverse=True)
+        remove_widgets = widget.walk_children(
+            Widget, with_self=True, method="depth", reverse=True
         )
 
         if self.screen.focused in remove_widgets:

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -263,7 +263,7 @@ class Screen(Widget):
         for candidate in reversed(
             focusable_widgets[widget_index + 1 :] + focusable_widgets[:widget_index]
         ):
-            if candidate not in avoiding and candidate.can_focus:
+            if candidate not in avoiding:
                 chosen = candidate
                 break
 


### PR DESCRIPTION
Addresses one observation by @willmcgugan and also removes a `cast` on `walk_children` that isn't required any more now that #952 is merged.