### PR TITLE
Switch the dark mode toggle to Ctrl+D

### DIFF
--- a/examples/five_by_five.py
+++ b/examples/five_by_five.py
@@ -315,7 +315,7 @@ class FiveByFive(App[None]):
     SCREENS = {"help": Help()}
 
     #: App-level bindings.
-    BINDINGS = [("D", "toggle_dark", "Toggle Dark Mode")]
+    BINDINGS = [("ctrl+d", "toggle_dark", "Toggle Dark Mode")]
 
     def __init__(self) -> None:
         """Constructor."""


### PR DESCRIPTION
It was on D (as in uppercase D, or shift-d), but I feel this was going to be confusing given that there is still this slight mixup with the display of letters in the footer, and what was bound, etc.

So... make it obvious what to press.

Remember, 'd' can't be used because it's a movement key in this game.