### PR TITLE
Add sensible error to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.2] - Unreleased
+
+### Changed
+
+- DOMQuery now raises InvalidQueryFormat in response to invalid query strings, rather than cryptic CSS error
+
 ## [0.2.1] - 2022-10-23
 
 ### Changed

--- a/examples/calculator.py
+++ b/examples/calculator.py
@@ -28,7 +28,8 @@ class CalculatorApp(App):
         "plus_minus_sign": "plus-minus",
         "percent_sign": "percent",
         "equals_sign": "equals",
-        "enter": "equals",
+        "minus": "minus",
+        "plus": "plus",
     }
 
     def watch_numbers(self, value: str) -> None:
@@ -80,7 +81,6 @@ class CalculatorApp(App):
                 self.query_one(f"#{button_id}", Button).press()
             except NoMatches:
                 pass
-            self.set_focus(None)
 
         key = event.key
         if key.isdecimal():
@@ -89,7 +89,9 @@ class CalculatorApp(App):
             press("c")
             press("ac")
         else:
-            press(self.NAME_MAP.get(key, key))
+            button_id = self.NAME_MAP.get(key)
+            if button_id is not None:
+                press(self.NAME_MAP.get(key, key))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Called when a button is pressed."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,7 @@
+import pytest
+
 from textual.widget import Widget
+from textual.css.query import InvalidQueryFormat
 
 
 def test_query():
@@ -78,3 +81,16 @@ def test_query():
         assert list(app.query("#widget1, #widget2")) == [widget1, widget2]
         assert list(app.query("#widget1 , #widget2")) == [widget1, widget2]
         assert list(app.query("#widget1, #widget2, App")) == [app, widget1, widget2]
+
+
+def test_invalid_query():
+    class App(Widget):
+        pass
+
+    app = App()
+
+    with pytest.raises(InvalidQueryFormat):
+        app.query("#3")
+
+    with pytest.raises(InvalidQueryFormat):
+        app.query("#foo").exclude("#2")


### PR DESCRIPTION
`app.query` would raise an invalid CSS error because it reuses code from CSS parsing. This PR converts those to a more sensibly named error.