### PR TITLE
Add highlighting for id="timers" line in tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -430,7 +430,7 @@ The Stopwatch app creates widgets when it starts via the `compose` method. We wi
 
 Let's use these methods to implement adding and removing stopwatches to our app.
 
-```python title="stopwatch.py" hl_lines="78-79 88-92 94-98"
+```python title="stopwatch.py" hl_lines="78-79 86 88-92 94-98"
 --8<-- "docs/examples/tutorial/stopwatch.py"
 ```
 


### PR DESCRIPTION
It appears the tutorial is missing a line of highlighting when adding the `timers` id to the timer container. This PR adds highlighting for that line.

Rendered:
<img width="775" alt="highlighting" src="https://user-images.githubusercontent.com/1581856/197407983-6549d3d1-2a97-4ebf-92f3-380c09a771eb.png">
