### PR TITLE
Fix the hover text for the docs dark mode switch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,7 +166,7 @@ theme:
     accent: purple
     toggle:
       icon: material/weather-sunny
-      name: Switch to dark modeTask was destroyed but it is pending!
+      name: Switch to dark mode
   - media: "(prefers-color-scheme: dark)"
     scheme: slate
     primary: black


### PR DESCRIPTION
While looking at how the docs are done... stumbled on the cause of that odd hover text I reported the other week!