### PR TITLE
Extend set of handled reserved characters for screenshots

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -535,7 +535,8 @@ class App(Generic[ReturnType], DOMNode):
             svg_filename = (
                 f"{self.title.lower()} {datetime.now().strftime(time_format)}.svg"
             )
-            svg_filename = svg_filename.replace("/", "_").replace("\\", "_")
+            for reserved in '<>:"/\\|?*':
+                svg_filename = svg_filename.replace(reserved, "_")
         else:
             svg_filename = filename
         svg_path = os.path.expanduser(os.path.join(path, svg_filename))

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -541,7 +541,7 @@ class App(Generic[ReturnType], DOMNode):
             svg_filename = filename
         svg_path = os.path.expanduser(os.path.join(path, svg_filename))
         screenshot_svg = self.export_screenshot()
-        with open(svg_path, "w") as svg_file:
+        with open(svg_path, "w", encoding="utf-8") as svg_file:
             svg_file.write(screenshot_svg)
         return svg_path
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -518,7 +518,7 @@ class App(Generic[ReturnType], DOMNode):
         self,
         filename: str | None = None,
         path: str = "./",
-        time_format: str = "%Y-%m-%d %X %f",
+        time_format: str = "%Y%m%d %H%M%S %f",
     ) -> str:
         """Save an SVG screenshot of the current screen.
 


### PR DESCRIPTION
This extends the set of reserved characters that are guarded against when auto-generating a screenshot filename. The extension covers the most likely candidates taken from:

   https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions

This could be spun out into a more general filename cleaning function, which takes OS and filesystem into account and covers every single reserved character, but for the purposes of this bit of code this should be more than enough.

Addresses #993.