### PR TITLE
Adds the debounce decorator

### DIFF
--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -1,6 +1,11 @@
 import asyncio
 from functools import wraps
-from typing import Any, Callable, Optional, ParamSpec
+from typing import Any, Callable, Optional
+
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
 
 from .app import App
 from .timer import Timer as TimerClass

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -32,9 +32,9 @@ def debounce(timeout: float) -> Callable[[Callable[P, Any]], Callable[P, None]]:
         async def wrapper(self: App, *args: P.args, **kwargs: P.kwargs) -> None:
             nonlocal timer
             if timer:
-                timer.reset()
-            else:
-                timer = self.set_timer(timeout, lambda: f(self, *args, **kwargs))
+                timer.stop_no_wait()
+
+            timer = self.set_timer(timeout, lambda: f(self, *args, **kwargs))
 
         return wrapper
 

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -1,12 +1,14 @@
 import asyncio
 from functools import wraps
-from typing import Callable, Optional
+from typing import Any, Callable, Optional, ParamSpec
 
 from .app import App
 from .timer import Timer as TimerClass
 
+P = ParamSpec("P")
 
-def debounce(timeout: float) -> Callable:
+
+def debounce(timeout: float) -> Callable[[Callable[P, Any]], Callable[P, None]]:
     """Debounce repeated events.
 
     If event handlers perform expensive operations, then it is sometimes desirable to
@@ -18,11 +20,11 @@ def debounce(timeout: float) -> Callable:
         timeout (float): the number of seconds to wait for repeated events.
     """
 
-    def decorator(f: Callable) -> Callable:
+    def decorator(f: Callable[P, Any]) -> Callable[P, None]:
         timer: Optional[TimerClass] = None
 
         @wraps(f)
-        async def wrapper(self: App, *args, **kwargs) -> None:
+        async def wrapper(self: App, *args: P.args, **kwargs: P.kwargs) -> None:
             nonlocal timer
             if timer:
                 timer.reset()

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -34,9 +34,7 @@ def debounce(timeout: float) -> Callable[[Callable[P, Any]], Callable[P, None]]:
             if timer:
                 timer.reset()
             else:
-                timer = self.set_timer(
-                    timeout, lambda: asyncio.create_task(f(self, *args, *kwargs))
-                )
+                timer = self.set_timer(timeout, lambda: f(self, *args, **kwargs))
 
         return wrapper
 

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -1,0 +1,24 @@
+import asyncio
+from functools import wraps
+from typing import Callable, Optional
+
+from .app import App
+from .timer import Timer as TimerClass
+
+
+def debounce(timeout: float) -> Callable:
+    def decorator(f: Callable) -> Callable:
+        timer: Optional[TimerClass] = None
+
+        @wraps(f)
+        async def wrapper(self: App, *args, **kwargs) -> None:
+            nonlocal timer
+            if timer:
+                timer.stop_no_wait()
+            timer = self.set_timer(
+                timeout, lambda: asyncio.create_task(f(self, *args, *kwargs))
+            )
+
+        return wrapper
+
+    return decorator

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -7,6 +7,17 @@ from .timer import Timer as TimerClass
 
 
 def debounce(timeout: float) -> Callable:
+    """Debounce repeated events.
+
+    If event handlers perform expensive operations, then it is sometimes desirable to
+    limit the number of calls to the handler. The debounce decorartor will (re)start
+    a timer for every event received and only call the handler if no events have occured
+    in the time period provided.
+
+    Args:
+        timeout (float): the number of seconds to wait for repeated events.
+    """
+
     def decorator(f: Callable) -> Callable:
         timer: Optional[TimerClass] = None
 
@@ -14,10 +25,11 @@ def debounce(timeout: float) -> Callable:
         async def wrapper(self: App, *args, **kwargs) -> None:
             nonlocal timer
             if timer:
-                timer.stop_no_wait()
-            timer = self.set_timer(
-                timeout, lambda: asyncio.create_task(f(self, *args, *kwargs))
-            )
+                timer.reset()
+            else:
+                timer = self.set_timer(
+                    timeout, lambda: asyncio.create_task(f(self, *args, *kwargs))
+                )
 
         return wrapper
 

--- a/src/textual/debounce.py
+++ b/src/textual/debounce.py
@@ -17,7 +17,7 @@ def debounce(timeout: float) -> Callable[[Callable[P, Any]], Callable[P, None]]:
     """Debounce repeated events.
 
     If event handlers perform expensive operations, then it is sometimes desirable to
-    limit the number of calls to the handler. The debounce decorartor will (re)start
+    limit the number of calls to the handler. The debounce decorator will (re)start
     a timer for every event received and only call the handler if no events have occured
     in the time period provided.
 


### PR DESCRIPTION
We add the debounce decorator. It can be used to ensure an event handler does not get overwhelmed with events, or that expensive operations (e.g. network requests) do not happen too frequently.