### PR TITLE
Change the way that `textual run` does the argv monkey-patch

### DIFF
--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import runpy
 import shlex
 from pathlib import Path
@@ -30,7 +31,6 @@ def import_app(import_name: str) -> App:
 
     import inspect
     import importlib
-    import sys
 
     from textual.app import App, WINDOWS
 
@@ -45,8 +45,7 @@ def import_app(import_name: str) -> App:
         except Exception as error:
             raise AppFail(str(error))
 
-        if "sys" in global_vars:
-            global_vars["sys"].argv = [path, *argv]
+        sys.argv = [path, *argv]
 
         if name:
             # User has given a name, use that

--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -45,7 +45,7 @@ def import_app(import_name: str) -> App:
         except Exception as error:
             raise AppFail(str(error))
 
-        sys.argv = [path, *argv]
+        sys.argv[:] = [path, *argv]
 
         if name:
             # User has given a name, use that


### PR DESCRIPTION
A `textual run` already made an attempt to monkey-patch `argv` so that the application being run would not see an `argv` any differently to how it would if it had been run "vanilla". However, it could be caught out by code like:

    from sys import argv

    ...

    do_something_with( argv )

beforehand it was okay with:

    import sys

    ...

    do_something_with( sys.argv )

With this change it should work both ways.

Somewhat related to #1064.