### PR TITLE
Change `edit_uri` base path to `main` branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Textual
 site_url: https://textual.textualize.io/
 repo_url: https://github.com/textualize/textual/
-edit_uri: edit/css/docs/
+edit_uri: edit/main/docs/
 
 nav:
   - Introduction:


### PR DESCRIPTION
The existing path points to a `css` branch, which no longer exists.

I'm assuming that the docs are being built from the `main` branch, so have suggested that as an alternative.

However, if it should link to a non-`main` branch, that should be substituted instead. The existing link (e.g. `https://github.com/textualize/textual/edit/css/docs/getting_started.md`) goes to a 404.

I'm not very familiar with Mkdocs, but I tested this change locally, and it appears to have the desired effect of setting the edit link to point to files on the `main` branch.