### PR TITLE
writer thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `DOMNode.query_one` now raises a `TooManyMatches` exception if there is
   more than one matching node.
   https://github.com/Textualize/textual/issues/1096
+- `App.mount` and `Widget.mount` have new `before` and `after` parameters https://github.com/Textualize/textual/issues/778
 
 ### Added
 
 - Added `init` param to reactive.watch
 - `CSS_PATH` can now be a list of CSS files https://github.com/Textualize/textual/pull/1079
 - Added `DOMQuery.only_one` https://github.com/Textualize/textual/issues/1096
+- Writes to stdout are now done in a thread, for smoother animation. https://github.com/Textualize/textual/pull/1104
 
 ## [0.3.0] - 2022-10-31
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -162,12 +162,13 @@ class _WriterThread(threading.Thread):
         get = self._queue.get
         qsize = self._queue.qsize
         while True:
-            if not qsize():
-                flush()
             text: str | None = get()
+            empty = qsize() == 0
             if text is None:
                 break
             write(text)
+            if empty:
+                flush()
 
     def stop(self) -> None:
         self._queue.put(None)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -143,7 +143,7 @@ class _WriterThread(threading.Thread):
 
     def __init__(self) -> None:
         super().__init__(daemon=True)
-        self._queue: Queue[str | None | threading.Event] = Queue(10)
+        self._queue: Queue[str | None | threading.Event] = Queue(16)
         self._file = sys.__stdout__
 
     def write(self, text: str) -> None:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -6,27 +6,25 @@ import io
 import os
 import platform
 import sys
+import threading
 import unicodedata
 import warnings
 from asyncio import Task
-from contextlib import asynccontextmanager
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import asynccontextmanager, redirect_stderr, redirect_stdout
 from datetime import datetime
 from pathlib import Path, PurePath
 from queue import Queue
-from ._profile import timer
-import threading
 from time import perf_counter
 from typing import (
+    TYPE_CHECKING,
     Any,
     Generic,
     Iterable,
-    Type,
-    TYPE_CHECKING,
-    TypeVar,
-    cast,
-    Union,
     List,
+    Type,
+    TypeVar,
+    Union,
+    cast,
 )
 from weakref import WeakSet, WeakValueDictionary
 
@@ -39,7 +37,7 @@ from rich.segment import Segment, Segments
 from rich.traceback import Traceback
 
 from . import Logger, LogGroup, LogVerbosity, actions, events, log, messages
-from ._animator import Animator, DEFAULT_EASING, Animatable, EasingFunction
+from ._animator import DEFAULT_EASING, Animatable, Animator, EasingFunction
 from ._ansi_sequences import SYNC_END, SYNC_START
 from ._callback import invoke
 from ._context import active_app

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -129,6 +129,8 @@ ReturnType = TypeVar("ReturnType")
 
 
 class _NullFile:
+    """A file-like where writes go nowhere."""
+
     def write(self, text: str) -> None:
         pass
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -162,12 +162,14 @@ class _WriterThread(threading.Thread):
         write = self._file.write
         flush = self._file.flush
         get = self._queue.get
+        qsize = self._queue.qsize
         while True:
+            if not qsize():
+                flush()
             text: str | None = get()
             if text is None:
                 break
             write(text)
-            flush()
 
     def stop(self) -> None:
         self._queue.put(None)

--- a/src/textual/demo.css
+++ b/src/textual/demo.css
@@ -1,5 +1,5 @@
  *  {
-    transition: background 250ms linear, color 250ms linear;
+    transition: background 500ms in_out_cubic, color 500ms in_out_cubic;
 }
 
 Screen {

--- a/src/textual/demo.py
+++ b/src/textual/demo.py
@@ -219,7 +219,7 @@ class Welcome(Container):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.app.add_note("[b magenta]Start!")
-        self.app.query_one(".location-first").scroll_visible(speed=50, top=True)
+        self.app.query_one(".location-first").scroll_visible(duration=0.5, top=True)
 
 
 class OptionGroup(Container):
@@ -272,7 +272,7 @@ class LocationLink(Static):
         self.reveal = reveal
 
     def on_click(self) -> None:
-        self.app.query_one(self.reveal).scroll_visible(top=True)
+        self.app.query_one(self.reveal).scroll_visible(top=True, duration=0.5)
         self.app.add_note(f"Scrolling to [b]{self.reveal}[/b]")
 
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -18,7 +18,7 @@ from .renderables.blank import Blank
 from .widget import Widget
 
 
-# Screen updates will be batched so that they don't happen more often than 60 times per second:
+# Screen updates will be batched so that they don't happen more often than 120 times per second:
 UPDATE_PERIOD: Final[float] = 1 / 120
 
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -19,7 +19,7 @@ from .widget import Widget
 
 
 # Screen updates will be batched so that they don't happen more often than 60 times per second:
-UPDATE_PERIOD: Final = 1 / 60
+UPDATE_PERIOD: Final[float] = 1 / 120
 
 
 @rich.repr.auto


### PR DESCRIPTION
An experiment that uses a thread to write to stdout.

I discovered that writing to stdout was surprisingly slow. Some writes were in the order of 20ms. I suspect because it includes the time the terminal took to update the display.

Doing the writes in a thread makes them non-blocking, and allows us to work on the next frame at the same time.