### PR TITLE
set argv when importing app

### DIFF
--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -101,6 +101,8 @@ def import_app(import_name: str) -> App:
         except AttributeError:
             raise AppFail(f"Unable to find {name!r} in {module!r}")
 
+        sys.argv[:] = [import_name, *argv]
+
     if inspect.isclass(app) and issubclass(app, App):
         app = app()
 


### PR DESCRIPTION
The fix for #1064 covered only when debugging a script ending in `.py`, this ensures the correct arguments are passed through to the application when imported.

Example.  Using sample/sample.py:

```
from textual.app import App, ComposeResult
from textual.widgets import Static
from sys import argv

class app(App):
    def __init__(self) -> None:
        self.args = argv
        print(argv)
        super().__init__()

    def compose(self) -> ComposeResult:
        yield Static(f"{self.args}")

if __name__ == "__main__":
    app().run()
```

Before - it works correctly with scripts ending in `.py`,  but when importing the app the `textual` path and `run` command are incorrectly passed to the app:

``` 
$ textual run "sample/sample.py arg1 arg2"
['/home/pi/src/sample/sample.py', 'arg1', 'arg2']

$ textual run "sample.sample arg1 arg2"
['/home/pi/.cache/pypoetry/virtualenvs/spotbot-VA7g20E_-py3.10/bin/textual', 'run', 'sample.sample arg1 arg2']
```

After - just the indicated arguments are passed and argv[0] is set to import_name.  

```
$ textual run "sample/sample.py arg1 arg2"
['/home/pi/src/sample/sample.py', 'arg1', 'arg2']

$ textual run "sample.sample arg1 arg2"
['sample.sample', 'arg1', 'arg2']
```