### PR TITLE
Let `textual run` run files that don't end in .py

### DIFF
--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -28,9 +28,9 @@ def shebang_python(candidate: Path) -> bool:
     try:
         with candidate.open("rb") as source:
             first_line = source.readline()
-        return first_line.startswith(b"#!") and b"python" in first_line
     except IOError:
         return False
+    return first_line.startswith(b"#!") and b"python" in first_line
 
 
 def import_app(import_name: str) -> App:

--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -16,7 +16,7 @@ class AppFail(Exception):
     pass
 
 
-def shebang_python(candidate: Path):
+def shebang_python(candidate: Path) -> bool:
     """Does the given file look like it's run with Python?
 
     Args:

--- a/src/textual/_import_app.py
+++ b/src/textual/_import_app.py
@@ -16,6 +16,23 @@ class AppFail(Exception):
     pass
 
 
+def shebang_python(candidate: Path):
+    """Does the given file look like it's run with Python?
+
+    Args:
+        candidate (Path): The candidate file to check.
+
+    Returns:
+        bool: ``True`` if it looks to #! python, ``False`` if not.
+    """
+    try:
+        with candidate.open("rb") as source:
+            first_line = source.readline()
+        return first_line.startswith(b"#!") and b"python" in first_line
+    except IOError:
+        return False
+
+
 def import_app(import_name: str) -> App:
     """Import an app from a path or import name.
 
@@ -42,7 +59,7 @@ def import_app(import_name: str) -> App:
     if drive:
         lib = os.path.join(drive, os.sep, lib)
 
-    if lib.endswith(".py"):
+    if lib.endswith(".py") or shebang_python(Path(lib)):
         path = os.path.abspath(lib)
         sys.path.append(str(Path(path).parent))
         try:


### PR DESCRIPTION
It's not uncommon to create "standalone" commands in Python that don't end in a .py and which:

  `#!/usr/bin/env python`

or a variation on that theme. This commit makes it so that `textual run` will treat a file that's named and set to run like that as if it were a file that ends in .py.

See #1106.