### PR TITLE
Document requirements for example apps

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains example Textual applications.
 
-To run them, navigate to the examples directory and enter `python` followed buy the name of the Python file.
+To run them, navigate to the examples directory and enter `python` followed by the name of the Python file.
 
 ```
 cd textual/examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,17 +10,15 @@ If you have them installed globally already, you can follow the run instructions
 You can install the required dependencies globally, using `pip install -r requirements.txt`.
 
 If you're comfortable with [virtual environments](https://docs.python.org/3/tutorial/venv.html) for managing dependencies,
-it's recommended to use these instead. There is a built-in Python 
+it's recommended to use these instead. There is a built-in Python
 library called ["venv"](https://docs.python.org/3/library/venv.html)
 which can be used to create virtual environments.
-
 
 ## Running the examples
 
 To run them, navigate to the examples directory and enter `python` followed by the name of the Python file. If you're using a virtual environment to manage dependencies, make sure to activate it first.
 
-```
+```sh
 cd textual/examples
 python pride.py
 ```
-

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,25 @@
 
 This directory contains example Textual applications.
 
-To run them, navigate to the examples directory and enter `python` followed by the name of the Python file.
+## Dependencies
+
+Running these examples requires you to have Textual installed. Some of them also require [httpx](https://www.python-httpx.org/).
+If you have them installed globally already, you can follow the run instructions below.
+
+You can install the required dependencies globally, using `pip install -r requirements.txt`.
+
+If you're comfortable with [virtual environments](https://docs.python.org/3/tutorial/venv.html) for managing dependencies,
+it's recommended to use these instead. There is a built-in Python 
+library called ["venv"](https://docs.python.org/3/library/venv.html)
+which can be used to create virtual environments.
+
+
+## Running the examples
+
+To run them, navigate to the examples directory and enter `python` followed by the name of the Python file. If you're using a virtual environment to manage dependencies, make sure to activate it first.
 
 ```
 cd textual/examples
 python pride.py
 ```
+

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,15 @@
+anyio==3.6.2
+certifi==2022.9.24
+commonmark==0.9.1
+h11==0.12.0
+httpcore==0.15.0
+httpx==0.23.0
+idna==3.4
+importlib-metadata==4.13.0
+nanoid==2.0.0
+Pygments==2.13.0
+rfc3986==1.5.0
+rich==12.6.0
+sniffio==1.3.0
+textual==0.3.0
+zipp==3.10.0


### PR DESCRIPTION
Adds a `requirements.txt` file in `./examples/`, and some documentation of dependencies in the README.

Specifically, the direct dependencies at the time of writing are Textual (for all of the example apps) and httpx (for `dictionary.py`) the file includes both of these, plus their dependencies, according to `pip freeze`. The `requirements.txt` file in this PR is the output of:

```sh
python -m venv venv
venv bin activate
pip install textual
pip install httpx
pip freeze -r requirements.txt
```

See #1090 