### PR TITLE
fix: pylint no-name-in-module for widgets

### DIFF
--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -4,11 +4,25 @@ import typing
 
 from ..case import camel_to_snake
 
+# ⚠️For any new built-in Widget we create, not only do we have to import them here and add them to `__all__`,
+# but also to the `__init__.pyi` file in this same folder - otherwise text editors and type checkers won't
+# be able to "see" them.
 if typing.TYPE_CHECKING:
     from ..widget import Widget
+    from ._button import Button
+    from ._checkbox import Checkbox
+    from ._data_table import DataTable
+    from ._directory_tree import DirectoryTree
+    from ._footer import Footer
+    from ._header import Header
+    from ._placeholder import Placeholder
+    from ._pretty import Pretty
+    from ._static import Static
+    from ._input import Input
+    from ._text_log import TextLog
+    from ._tree_control import TreeControl
+    from ._welcome import Welcome
 
-# ⚠️For any new built-in Widget we create, not only we have to add them to the following list, but also to the
-# `__init__.pyi` file in this same folder - otherwise text editors and type checkers won't be able to "see" them.
 __all__ = [
     "Button",
     "Checkbox",


### PR DESCRIPTION
For #1107, we can import Widgets under `if typing.TYPE_CHECKING:` to avoid `no-name-in-module` errors from `pylint` when importing from `textual.widgets`. I also updated and moved the comment to reflect the additional step needed for new built-in Widgets.