### PR TITLE
Remove a type-checking error for the result of _find_mount_point

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -422,7 +422,7 @@ class Widget(DOMNode):
         # children. We should be able to go looking for the widget's
         # location amongst its parent's children.
         try:
-            return spot.parent, spot.parent.children.index(spot)
+            return cast("Widget", spot.parent), spot.parent.children.index(spot)
         except ValueError:
             raise self.MountError(f"{spot!r} is not a child of {self!r}") from None
 


### PR DESCRIPTION
Just removing a very small annoyance -- tells a type checker that it can trust the type of the parent.