### PR TITLE
make watchers instant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] - Unreleased
+
+### Changed
+
+- Watchers are now called immediately when setting the attribute if they are synchronous. https://github.com/Textualize/textual/pull/1145
+
 ## [0.4.0] - 2022-11-08
 
 https://textual.textualize.io/blog/2022/11/08/version-040/#version-040

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -165,7 +165,7 @@ class Reactive(Generic[ReactiveType]):
             # Set and return the value
             setattr(obj, self.internal_name, default_value)
             if self._init:
-                self._check_watchers(obj, self.name, default_value, first_set=True)
+                self._check_watchers(obj, self.name, default_value)
             return default_value
         return value
 
@@ -187,15 +187,13 @@ class Reactive(Generic[ReactiveType]):
             # Store the internal value
             setattr(obj, self.internal_name, value)
             # Check all watchers
-            self._check_watchers(obj, name, current_value, first_set=first_set)
+            self._check_watchers(obj, name, current_value)
             # Refresh according to descriptor flags
             if self._layout or self._repaint:
                 obj.refresh(repaint=self._repaint, layout=self._layout)
 
     @classmethod
-    def _check_watchers(
-        cls, obj: Reactable, name: str, old_value: Any, first_set: bool = False
-    ) -> None:
+    def _check_watchers(cls, obj: Reactable, name: str, old_value: Any):
         """Check watchers, and call watch methods / computes
 
         Args:

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -1,0 +1,26 @@
+from textual.app import App, ComposeResult
+from textual.reactive import reactive
+
+
+class WatchApp(App):
+
+    count = reactive(0, init=False)
+
+    test_count = 0
+
+    def watch_count(self, value: int) -> None:
+        self.test_count = value
+
+
+async def test_watch():
+    """Test that changes to a watched reactive attribute happen immediately."""
+    app = WatchApp()
+    async with app.run_test():
+        app.count += 1
+        assert app.test_count == 1
+        app.count += 1
+        assert app.test_count == 2
+        app.count -= 1
+        assert app.test_count == 1
+        app.count -= 1
+        assert app.test_count == 0


### PR DESCRIPTION
- Makes watchers called immediately if the are synchronous. 
- Added `_rich_traceback_omit=True` to a few places, so that the internals between setting an attribute and an exception in the watch method are not visible