### PR TITLE
Improve the speed of `DOMQuery.remove`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `DOMNode.ancestors` no longer includes `self`.
 - Added `DOMNode.ancestors_with_self`, which retains the old behaviour of
   `DOMNode.ancestors`.
+- Improved the speed of `DOMQuery.remove`.
 
 ## [0.4.0] - 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] - Unreleased
+
+### Changed
+
+- `DOMNode.ancestors` no longer includes `self`.
+- Added `DOMNode.ancestors_with_self`, which retains the old behaviour of
+  `DOMNode.ancestors`.
+
 ## [0.4.0] - 2022-11-08
 
 https://textual.textualize.io/blog/2022/11/08/version-040/#version-040

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1859,10 +1859,11 @@ class App(Generic[ReturnType], DOMNode):
         # In other words: find the smallest set of ancestors in the DOM that
         # will remove the widgets requested for removal, and also ensure
         # that all knock-on effects happen too.
+        request_remove = set(event.widgets)
         pruned_remove = [
             widget
             for widget in event.widgets
-            if dedupe_to_remove.isdisjoint(widget.ancestors)
+            if request_remove.isdisjoint(widget.ancestors)
         ]
 
         # Now that we know that minimal set of widgets, we go through them

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1863,13 +1863,17 @@ class App(Generic[ReturnType], DOMNode):
             )
         ]
 
+        # Now that we know that minimal set of widgets, we go through them
+        # and get their parents to forget about them. This has the effect of
+        # snipping each affected branch from the DOM.
         for widget in pruned_remove:
             if widget.parent is not None:
                 widget.parent.children._remove(widget)
 
-        # Now that we have the minimal set of widgets that need to be
-        # removed from the DOM, to get the effect of removing everything
-        # affected, let's go prune them.
+        # Havnig done that, it's now safe for us to start the process of
+        # winding down all of the affected widgets. We do that by pruning
+        # just the roots of each affected branch, and letting the normal
+        # prune process take care of all the offspring.
         for widget in pruned_remove:
             await self._prune_node(widget)
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1652,7 +1652,9 @@ class App(Generic[ReturnType], DOMNode):
                 (self, self._bindings),
             ]
         else:
-            namespace_bindings = [(node, node._bindings) for node in focused.ancestors]
+            namespace_bindings = [
+                (node, node._bindings) for node in focused.ancestors_with_self
+            ]
         return namespace_bindings
 
     async def check_bindings(self, key: str, universal: bool = False) -> bool:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1860,12 +1860,10 @@ class App(Generic[ReturnType], DOMNode):
         # a candidate for removal. Note that we retain the ordering of the
         # original walk at the top as it's depth-first and so should be the
         # order we want to go in from here on.
-        pruned_remove: list[Widget] = [
+        pruned_remove = [
             widget
             for widget in everything_to_remove
-            if not any(
-                ancestor in everything_to_remove for ancestor in widget.ancestors
-            )
+            if dedupe_to_remove.isdisjoint(widget.ancestors)
         ]
 
         # Now that we know that minimal set of widgets, we go through them

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1875,7 +1875,7 @@ class App(Generic[ReturnType], DOMNode):
             if widget.parent is not None:
                 widget.parent.children._remove(widget)
 
-        # Havnig done that, it's now safe for us to start the process of
+        # Having done that, it's now safe for us to start the process of
         # winding down all of the affected widgets. We do that by pruning
         # just the roots of each affected branch, and letting the normal
         # prune process take care of all the offspring.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1853,16 +1853,15 @@ class App(Generic[ReturnType], DOMNode):
                 [to_remove for to_remove in dedupe_to_remove if to_remove.can_focus],
             )
 
-        # Next, we want to go through the full set of everything to remove
-        # and reduce it to the minimal set of things that need removing. In
-        # other words, for any given branch that is going to have things
-        # removed, we need to just keep the topmost node in the DOM that is
-        # a candidate for removal. Note that we retain the ordering of the
-        # original walk at the top as it's depth-first and so should be the
-        # order we want to go in from here on.
+        # Next, we go through the set of widgets we've been asked to remove
+        # and try and find the minimal collection of widgets that will
+        # result in everything else that should be removed, being removed.
+        # In other words: find the smallest set of ancestors in the DOM that
+        # will remove the widgets requested for removal, and also ensure
+        # that all knock-on effects happen too.
         pruned_remove = [
             widget
-            for widget in everything_to_remove
+            for widget in event.widgets
             if dedupe_to_remove.isdisjoint(widget.ancestors)
         ]
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1822,7 +1822,7 @@ class App(Generic[ReturnType], DOMNode):
         await self.screen.post_message(event)
 
     async def _on_remove(self, event: events.Remove) -> None:
-        widget = event.widget
+        widget = event.widgets[0]
         parent = widget.parent
 
         remove_widgets = widget.walk_children(

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1824,6 +1824,11 @@ class App(Generic[ReturnType], DOMNode):
         await self.screen.post_message(event)
 
     async def _on_remove(self, event: events.Remove) -> None:
+        """Handle a remove event.
+
+        Args:
+            event (events.Remove): The remove event.
+        """
 
         # We've been given a list of widgets to remove, but removing those
         # will also result in other (descendent) widgets being removed. So

--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -20,6 +20,8 @@ from typing import cast, Generic, TYPE_CHECKING, Iterator, TypeVar, overload
 
 import rich.repr
 
+from .. import events
+from .._context import active_app
 from .errors import DeclarationError, TokenError
 from .match import match
 from .model import SelectorSet
@@ -348,8 +350,8 @@ class DOMQuery(Generic[QueryType]):
 
     def remove(self) -> DOMQuery[QueryType]:
         """Remove matched nodes from the DOM"""
-        for node in self:
-            node.remove()
+        app = active_app.get()
+        app.post_message_no_wait(events.Remove(app, widgets=list(self)))
         return self
 
     def set_styles(

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -567,8 +567,7 @@ class DOMNode(MessagePump):
     @property
     def ancestors(self) -> list[DOMNode]:
         """list[DOMNode]: A list of ancestor nodes Nodes by tracing ancestors all the way back to App."""
-        nodes = self.ancestors_with_self
-        return nodes[1:] if nodes else nodes
+        return self.ancestors_with_self[1:]
 
     @property
     def displayed_children(self) -> list[Widget]:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -127,10 +127,10 @@ class Unmount(Mount, bubble=False, verbose=False):
 
 
 class Remove(Event, bubble=False):
-    """Sent to a widget to ask it to remove itself from the DOM."""
+    """Sent to the app to ask it to remove one or more widgets from the DOM."""
 
-    def __init__(self, sender: MessageTarget, widget: Widget) -> None:
-        self.widget = widget
+    def __init__(self, sender: MessageTarget, widgets: list[Widget]) -> None:
+        self.widgets = widgets
         super().__init__(sender)
 
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1054,7 +1054,7 @@ class Widget(DOMNode):
         Returns:
             tuple[str, ...]: Tuple of layer names.
         """
-        for node in self.ancestors:
+        for node in self.ancestors_with_self:
             if not isinstance(node, Widget):
                 break
             if node.styles.has_rule("layers"):
@@ -2059,14 +2059,14 @@ class Widget(DOMNode):
         self.mouse_over = True
 
     def _on_focus(self, event: events.Focus) -> None:
-        for node in self.ancestors:
+        for node in self.ancestors_with_self:
             if node._has_focus_within:
                 self.app.update_styles(node)
         self.has_focus = True
         self.refresh()
 
     def _on_blur(self, event: events.Blur) -> None:
-        if any(node._has_focus_within for node in self.ancestors):
+        if any(node._has_focus_within for node in self.ancestors_with_self):
             self.app.update_styles(self)
         self.has_focus = False
         self.refresh()

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1910,7 +1910,7 @@ class Widget(DOMNode):
 
     def remove(self) -> None:
         """Remove the Widget from the DOM (effectively deleting it)"""
-        self.app.post_message_no_wait(events.Remove(self, widget=self))
+        self.app.post_message_no_wait(events.Remove(self, widgets=[self]))
 
     def render(self) -> RenderableType:
         """Get renderable for widget.

--- a/tests/test_unmount.py
+++ b/tests/test_unmount.py
@@ -10,7 +10,7 @@ async def test_unmount():
 
     class UnmountWidget(Container):
         def on_unmount(self, event: events.Unmount):
-            unmount_ids.append(f"{self.__class__.__name__}#{self.id}")
+            unmount_ids.append(f"{self.__class__.__name__}#{self.id}-{self.parent is not None}-{len(self.children)}")
 
     class MyScreen(Screen):
         def compose(self) -> ComposeResult:
@@ -36,13 +36,13 @@ async def test_unmount():
         await pilot.exit(None)
 
     expected = [
-        "UnmountWidget#bar1",
-        "UnmountWidget#bar2",
-        "UnmountWidget#baz1",
-        "UnmountWidget#baz2",
-        "UnmountWidget#bar",
-        "UnmountWidget#baz",
-        "UnmountWidget#top",
+        "UnmountWidget#bar1-True-0",
+        "UnmountWidget#bar2-True-0",
+        "UnmountWidget#baz1-True-0",
+        "UnmountWidget#baz2-True-0",
+        "UnmountWidget#bar-True-0",
+        "UnmountWidget#baz-True-0",
+        "UnmountWidget#top-True-0",
         "MyScreen#main",
     ]
 


### PR DESCRIPTION
See https://github.com/Textualize/textual/discussions/1110 for some context. In short, this changes the `Remove` event so that it can take a collection of widgets to remove, rather than a single widget. The way that removal is done is then changed to dismantle the relevant parts of the DOM first, perform the closedown of the widgets involved, and then finally do a single refresh operation.

Note that, along the way, what was `DOMNode.ancestors` has become `DOMNode.ancestors_with_self` and `DOMNode.ancestors` now no longer contains `self`.