### PR TITLE
Awaitable remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `DOMNode.ancestors_with_self`, which retains the old behaviour of
   `DOMNode.ancestors`.
 - Improved the speed of `DOMQuery.remove`.
+- It is now possible to `await` a `Widget.remove`.
+  https://github.com/Textualize/textual/issues/1094
+- It is now possible to `await` a `DOMQuery.remove`. Note that this changes
+  the return value of `DOMQuery.remove`, which uses to return `self`.
+  https://github.com/Textualize/textual/issues/1094
 
 
 ## [0.4.0] - 2022-11-08

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -1,13 +1,23 @@
+"""Provides the type of an awaitable remove."""
+
 from asyncio import Event
 from typing import Generator
 
 
 class AwaitRemove:
+    """An awaitable returned by App.remove and DOMQuery.remove."""
+
     def __init__(self, finished_flag: Event) -> None:
+        """Initialise the instance of ``AwaitRemove``.
+
+        Args:
+            finished_flag (asyncio.Event): The asyncio event to wait on.
+        """
         self.finished_flag = finished_flag
 
     def __await__(self) -> Generator[None, None, None]:
         async def await_prune() -> None:
+            """Wait for the prune operation to finish."""
             await self.finished_flag.wait()
 
         return await_prune().__await__()

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -1,0 +1,13 @@
+from asyncio import Event
+from typing import Generator
+
+
+class AwaitRemove:
+    def __init__(self, finished_flag: Event) -> None:
+        self.finished_flag = finished_flag
+
+    def __await__(self) -> Generator[None, None, None]:
+        async def await_prune() -> None:
+            await self.finished_flag.wait()
+
+        return await_prune().__await__()

--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -351,7 +351,11 @@ class DOMQuery(Generic[QueryType]):
         return self
 
     def remove(self) -> AwaitRemove:
-        """Remove matched nodes from the DOM"""
+        """Remove matched nodes from the DOM.
+
+        Returns:
+            AwaitRemove: An awaitable object that waits for the widget to be removed.
+        """
         prune_finished_event = asyncio.Event()
         app = active_app.get()
         app.post_message_no_wait(

--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -17,11 +17,13 @@ a method which evaluates the query, such as first() and last().
 from __future__ import annotations
 
 from typing import cast, Generic, TYPE_CHECKING, Iterator, TypeVar, overload
+import asyncio
 
 import rich.repr
 
 from .. import events
 from .._context import active_app
+from ..await_remove import AwaitRemove
 from .errors import DeclarationError, TokenError
 from .match import match
 from .model import SelectorSet
@@ -348,11 +350,18 @@ class DOMQuery(Generic[QueryType]):
             node.toggle_class(*class_names)
         return self
 
-    def remove(self) -> DOMQuery[QueryType]:
+    def remove(self) -> AwaitRemove:
         """Remove matched nodes from the DOM"""
+        prune_finished_event = asyncio.Event()
         app = active_app.get()
-        app.post_message_no_wait(events.Remove(app, widgets=list(self)))
-        return self
+        app.post_message_no_wait(
+            events.Prune(
+                app,
+                widgets=app._detach_from_dom(list(self)),
+                finished_flag=prune_finished_event,
+            )
+        )
+        return AwaitRemove(prune_finished_event)
 
     def set_styles(
         self, css: str | None = None, **update_styles

--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -354,7 +354,7 @@ class DOMQuery(Generic[QueryType]):
         """Remove matched nodes from the DOM.
 
         Returns:
-            AwaitRemove: An awaitable object that waits for the widget to be removed.
+            AwaitRemove: An awaitable object that waits for the widgets to be removed.
         """
         prune_finished_event = asyncio.Event()
         app = active_app.get()

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from .timer import Timer as TimerClass
     from .timer import TimerCallback
     from .widget import Widget
+    import asyncio
 
 
 @rich.repr.auto
@@ -126,12 +127,21 @@ class Unmount(Mount, bubble=False, verbose=False):
     """Sent when a widget is unmounted and may not longer receive messages."""
 
 
-class Remove(Event, bubble=False):
-    """Sent to the app to ask it to remove one or more widgets from the DOM."""
+class Prune(Event, bubble=False):
+    """Sent to the app to ask it to prune one or more widgets from the DOM."""
 
-    def __init__(self, sender: MessageTarget, widgets: list[Widget]) -> None:
-        self.widgets = widgets
+    def __init__(
+        self, sender: MessageTarget, widgets: list[Widget], finished_flag: asyncio.Event
+    ) -> None:
+        """Initialise the event.
+
+        Args:
+            widgets (list[Widgets]): The list of widgets to prune.
+            finished_flag (asyncio.Event): An asyncio Event to that will be flagged when the prune is done.
+        """
         super().__init__(sender)
+        self.finished_flag = finished_flag
+        self.widgets = widgets
 
 
 class Show(Event, bubble=False):

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -128,7 +128,12 @@ class Unmount(Mount, bubble=False, verbose=False):
 
 
 class Prune(Event, bubble=False):
-    """Sent to the app to ask it to prune one or more widgets from the DOM."""
+    """Sent to the app to ask it to prune one or more widgets from the DOM.
+
+    Attributes:
+        widgets (list[Widgets]): The list of widgets to prune.
+        finished_flag (asyncio.Event): An asyncio Event to that will be flagged when the prune is done.
+    """
 
     def __init__(
         self, sender: MessageTarget, widgets: list[Widget], finished_flag: asyncio.Event

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1992,7 +1992,11 @@ class Widget(DOMNode):
         self.check_idle()
 
     def remove(self) -> AwaitRemove:
-        """Remove the Widget from the DOM (effectively deleting it)"""
+        """Remove the Widget from the DOM (effectively deleting it)
+
+        Returns:
+            AwaitRemove: An awaitable object that waits for the widget to be removed.
+        """
         prune_finished_event = AsyncEvent()
         self.app.post_message_no_wait(
             events.Prune(

--- a/tests/test_widget_removing.py
+++ b/tests/test_widget_removing.py
@@ -109,8 +109,8 @@ async def test_remove_move_focus():
         assert pilot.app.focused is not None
         assert pilot.app.focused == buttons[9]
 
-async def test_remove_order():
-    """The removal of a top-level widget should cause bottom-first removal."""
+async def test_widget_remove_order():
+    """A Widget.remove of a top-level widget should cause bottom-first removal."""
 
     removals: list[str] = []
 
@@ -123,4 +123,20 @@ async def test_remove_order():
             Removable(Removable(Removable(id="grandchild"), id="child"), id="parent")
         )
         await pilot.app.screen.children[0].remove()
+        assert removals == ["grandchild", "child", "parent"]
+
+async def test_query_remove_order():
+    """A DOMQuery.remove of a top-level widget should cause bottom-first removal."""
+
+    removals: list[str] = []
+
+    class Removable(Container):
+        def on_unmount( self, _ ):
+            removals.append(self.id if self.id is not None else "unknown")
+
+    async with App().run_test() as pilot:
+        await pilot.app.mount(
+            Removable(Removable(Removable(id="grandchild"), id="child"), id="parent")
+        )
+        await pilot.app.query(Removable).remove()
         assert removals == ["grandchild", "child", "parent"]

--- a/tests/test_widget_removing.py
+++ b/tests/test_widget_removing.py
@@ -108,3 +108,19 @@ async def test_remove_move_focus():
         assert len(pilot.app.screen.walk_children(with_self=False)) == 6
         assert pilot.app.focused is not None
         assert pilot.app.focused == buttons[9]
+
+async def test_remove_order():
+    """The removal of a top-level widget should cause bottom-first removal."""
+
+    removals: list[str] = []
+
+    class Removable(Container):
+        def on_unmount( self, _ ):
+            removals.append(self.id if self.id is not None else "unknown")
+
+    async with App().run_test() as pilot:
+        await pilot.app.mount(
+            Removable(Removable(Removable(id="grandchild"), id="child"), id="parent")
+        )
+        await pilot.app.screen.children[0].remove()
+        assert removals == ["grandchild", "child", "parent"]

--- a/tests/test_widget_removing.py
+++ b/tests/test_widget_removing.py
@@ -122,7 +122,9 @@ async def test_widget_remove_order():
         await pilot.app.mount(
             Removable(Removable(Removable(id="grandchild"), id="child"), id="parent")
         )
+        assert len(pilot.app.screen.walk_children(with_self=False)) == 3
         await pilot.app.screen.children[0].remove()
+        assert len(pilot.app.screen.walk_children(with_self=False)) == 0
         assert removals == ["grandchild", "child", "parent"]
 
 async def test_query_remove_order():
@@ -138,5 +140,7 @@ async def test_query_remove_order():
         await pilot.app.mount(
             Removable(Removable(Removable(id="grandchild"), id="child"), id="parent")
         )
+        assert len(pilot.app.screen.walk_children(with_self=False)) == 3
         await pilot.app.query(Removable).remove()
+        assert len(pilot.app.screen.walk_children(with_self=False)) == 0
         assert removals == ["grandchild", "child", "parent"]

--- a/tests/test_widget_removing.py
+++ b/tests/test_widget_removing.py
@@ -4,24 +4,12 @@ from textual.widget import Widget
 from textual.widgets import Static, Button
 from textual.containers import Container
 
-async def await_remove_standin():
-    """Standin function for awaiting removal.
-
-    These tests are being written so that we can go on and make remove
-    awaitable, but it would be good to have some tests in place *before* we
-    make that change, but the tests need to await remove to be useful tests.
-    So to get around that bootstrap issue, we just use this function as a
-    standin until we can swap over.
-    """
-    await asyncio.sleep(0) # Until we can await remove.
-
 async def test_remove_single_widget():
     """It should be possible to the only widget on a screen."""
     async with App().run_test() as pilot:
         await pilot.app.mount(Static())
         assert len(pilot.app.screen.children) == 1
-        pilot.app.query_one(Static).remove()
-        await await_remove_standin()
+        await pilot.app.query_one(Static).remove()
         assert len(pilot.app.screen.children) == 0
 
 async def test_many_remove_all_widgets():
@@ -29,8 +17,7 @@ async def test_many_remove_all_widgets():
     async with App().run_test() as pilot:
         await pilot.app.mount(*[Static() for _ in range(1000)])
         assert len(pilot.app.screen.children) == 1000
-        pilot.app.query(Static).remove()
-        await await_remove_standin()
+        await pilot.app.query(Static).remove()
         assert len(pilot.app.screen.children) == 0
 
 async def test_many_remove_some_widgets():
@@ -38,8 +25,7 @@ async def test_many_remove_some_widgets():
     async with App().run_test() as pilot:
         await pilot.app.mount(*[Static(id=f"is-{n%2}") for n in range(1000)])
         assert len(pilot.app.screen.children) == 1000
-        pilot.app.query("#is-0").remove()
-        await await_remove_standin()
+        await pilot.app.query("#is-0").remove()
         assert len(pilot.app.screen.children) == 500
 
 async def test_remove_branch():
@@ -71,8 +57,7 @@ async def test_remove_branch():
             ),
         )
         assert len(pilot.app.screen.walk_children(with_self=False)) == 13
-        pilot.app.screen.children[0].remove()
-        await await_remove_standin()
+        await pilot.app.screen.children[0].remove()
         assert len(pilot.app.screen.walk_children(with_self=False)) == 7
 
 async def test_remove_overlap():
@@ -104,8 +89,7 @@ async def test_remove_overlap():
             ),
         )
         assert len(pilot.app.screen.walk_children(with_self=False)) == 13
-        pilot.app.query(Container).remove()
-        await await_remove_standin()
+        await pilot.app.query(Container).remove()
         assert len(pilot.app.screen.walk_children(with_self=False)) == 1
 
 async def test_remove_move_focus():
@@ -119,8 +103,7 @@ async def test_remove_move_focus():
         await pilot.press( "tab" )
         assert pilot.app.focused is not None
         assert pilot.app.focused == buttons[0]
-        pilot.app.screen.children[0].remove()
-        await await_remove_standin()
+        await pilot.app.screen.children[0].remove()
         assert len(pilot.app.screen.children) == 1
         assert len(pilot.app.screen.walk_children(with_self=False)) == 6
         assert pilot.app.focused is not None


### PR DESCRIPTION
This adds the ability to `await` a `Widget.remove` or a `DOMQuery.remove`. Doing this adds a new type -- `AwaitRemove` -- and also changes the return type of `DOMQuery.remove` (which used to return `self` but now returns an awaitable object).