### PR TITLE
Add missing close quote to height Python example

### DIFF
--- a/docs/styles/height.md
+++ b/docs/styles/height.md
@@ -46,6 +46,6 @@ width: auto
 
 ```python
 self.styles.height = 10
-self.styles.height = "50%
+self.styles.height = "50%"
 self.styles.height = "auto"
 ```


### PR DESCRIPTION
Closing quote was missing off a line in the example of setting `height` from Python code.