### PR TITLE
fix deadlock on tests

### DIFF
--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -189,9 +189,12 @@ class Animator:
     async def stop(self) -> None:
         """Stop the animator task."""
         try:
-            await self._timer.stop()
-        except asyncio.CancelledError:
-            pass
+            try:
+                await self._timer.stop()
+            except asyncio.CancelledError:
+                pass
+        finally:
+            self._idle_event.set()
 
     def bind(self, obj: object) -> BoundAnimator:
         """Bind the animator to a given objects."""

--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -189,10 +189,9 @@ class Animator:
     async def stop(self) -> None:
         """Stop the animator task."""
         try:
-            try:
-                await self._timer.stop()
-            except asyncio.CancelledError:
-                pass
+            await self._timer.stop()
+        except asyncio.CancelledError:
+            pass
         finally:
             self._idle_event.set()
 


### PR DESCRIPTION
Fixed an issue where a failed snapshot test caused a deadlock. Highlighted by https://github.com/Textualize/textual/pull/1165

Essentially `animator.wait_for_idle()` was awaiting an event which never occurred.