### PR TITLE
Fix docstring for some widget optional arguments.

### DIFF
--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -168,9 +168,9 @@ class Button(Static, can_focus=True):
         """Create a Button widget.
 
         Args:
-            label (str): The text that appears within the button.
-            disabled (bool): Whether the button is disabled or not.
-            variant (ButtonVariant): The variant of the button.
+            label (str, optional): The text that appears within the button.
+            disabled (bool, optional): Whether the button is disabled or not.
+            variant (ButtonVariant, optional): The variant of the button.
             name (str | None, optional): The name of the button.
             id (str | None, optional): The ID of the button in the DOM.
             classes (str | None, optional): The CSS classes of the button.
@@ -267,8 +267,8 @@ class Button(Static, can_focus=True):
         """Utility constructor for creating a success Button variant.
 
         Args:
-            label (str): The text that appears within the button.
-            disabled (bool): Whether the button is disabled or not.
+            label (str, optional): The text that appears within the button.
+            disabled (bool, optional): Whether the button is disabled or not.
             name (str | None, optional): The name of the button.
             id (str | None, optional): The ID of the button in the DOM.
             classes(str | None, optional): The CSS classes of the button.
@@ -298,8 +298,8 @@ class Button(Static, can_focus=True):
         """Utility constructor for creating a warning Button variant.
 
         Args:
-            label (str): The text that appears within the button.
-            disabled (bool): Whether the button is disabled or not.
+            label (str, optional): The text that appears within the button.
+            disabled (bool, optional): Whether the button is disabled or not.
             name (str | None, optional): The name of the button.
             id (str | None, optional): The ID of the button in the DOM.
             classes (str | None, optional): The CSS classes of the button.
@@ -329,8 +329,8 @@ class Button(Static, can_focus=True):
         """Utility constructor for creating an error Button variant.
 
         Args:
-            label (str): The text that appears within the button.
-            disabled (bool): Whether the button is disabled or not.
+            label (str, optional): The text that appears within the button.
+            disabled (bool, optional): Whether the button is disabled or not.
             name (str | None, optional): The name of the button.
             id (str | None, optional): The ID of the button in the DOM.
             classes (str | None, optional): The CSS classes of the button.

--- a/src/textual/widgets/tabs.py
+++ b/src/textual/widgets/tabs.py
@@ -177,16 +177,16 @@ class Tabs(Widget):
     Args:
         tabs (list[Tab]): A list of Tab objects defining the tabs which should be rendered.
         active_tab (str, optional): The name of the tab that should be active on first render.
-        active_tab_style (StyleType): Style to apply to the label of the active tab.
-        active_bar_style (StyleType): Style to apply to the underline of the active tab.
-        inactive_tab_style (StyleType): Style to apply to the label of inactive tabs.
-        inactive_bar_style (StyleType): Style to apply to the underline of inactive tabs.
-        inactive_text_opacity (float): Opacity of the text labels of inactive tabs.
-        animation_duration (float): The duration of the tab change animation, in seconds.
-        animation_function (str): The easing function to use for the tab change animation.
+        active_tab_style (StyleType, optional): Style to apply to the label of the active tab.
+        active_bar_style (StyleType, optional): Style to apply to the underline of the active tab.
+        inactive_tab_style (StyleType, optional): Style to apply to the label of inactive tabs.
+        inactive_bar_style (StyleType, optional): Style to apply to the underline of inactive tabs.
+        inactive_text_opacity (float, optional): Opacity of the text labels of inactive tabs.
+        animation_duration (float, optional): The duration of the tab change animation, in seconds.
+        animation_function (str, optional): The easing function to use for the tab change animation.
         tab_padding (int, optional): The padding at the side of each tab. If None, tabs will
             automatically be padded such that they fit the  available horizontal space.
-        search_by_first_character (bool): If True, entering a character on your keyboard
+        search_by_first_character (bool, optional): If True, entering a character on your keyboard
             will activate the next tab (in left-to-right order) with a label starting with
             that character.
     """


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes  ― no modified functions/classes
- [x] Updated documentation ― nothing to change
- [x] Updated CHANGELOG.md (where appropriate) ― not appropriate

Some optional arguments for some widgets were not listed as optional in their docstrings. Fixed this.