### PR TITLE
fix remove freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed containers with transparent background not showing borders https://github.com/Textualize/textual/issues/1175
 - Fixed auto-width in horizontal containers https://github.com/Textualize/textual/pull/1155
 - Fixed Input cursor invisible when placeholder empty https://github.com/Textualize/textual/pull/1202
-- Fixed deadlock when remove widgets from the App https://github.com/Textualize/textual/pull/1219
+- Fixed deadlock when removing widgets from the App https://github.com/Textualize/textual/pull/1219
 
 ## [0.4.0] - 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed containers with transparent background not showing borders https://github.com/Textualize/textual/issues/1175
 - Fixed auto-width in horizontal containers https://github.com/Textualize/textual/pull/1155
 - Fixed Input cursor invisible when placeholder empty https://github.com/Textualize/textual/pull/1202
+- Fixed deadlock when remove widgets from the App https://github.com/Textualize/textual/pull/1219
 
 ## [0.4.0] - 2022-11-08
 

--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -356,16 +356,9 @@ class DOMQuery(Generic[QueryType]):
         Returns:
             AwaitRemove: An awaitable object that waits for the widgets to be removed.
         """
-        prune_finished_event = asyncio.Event()
         app = active_app.get()
-        app.post_message_no_wait(
-            events.Prune(
-                app,
-                widgets=app._detach_from_dom(list(self)),
-                finished_flag=prune_finished_event,
-            )
-        )
-        return AwaitRemove(prune_finished_event)
+        await_remove = app._remove_nodes(list(self))
+        return await_remove
 
     def set_styles(
         self, css: str | None = None, **update_styles

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -127,28 +127,6 @@ class Unmount(Mount, bubble=False, verbose=False):
     """Sent when a widget is unmounted and may not longer receive messages."""
 
 
-class Prune(Event, bubble=False):
-    """Sent to the app to ask it to prune one or more widgets from the DOM.
-
-    Attributes:
-        widgets (list[Widgets]): The list of widgets to prune.
-        finished_flag (asyncio.Event): An asyncio Event to that will be flagged when the prune is done.
-    """
-
-    def __init__(
-        self, sender: MessageTarget, widgets: list[Widget], finished_flag: asyncio.Event
-    ) -> None:
-        """Initialise the event.
-
-        Args:
-            widgets (list[Widgets]): The list of widgets to prune.
-            finished_flag (asyncio.Event): An asyncio Event to that will be flagged when the prune is done.
-        """
-        super().__init__(sender)
-        self.finished_flag = finished_flag
-        self.widgets = widgets
-
-
 class Show(Event, bubble=False):
     """Sent when a widget has become visible."""
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -310,18 +310,19 @@ class Screen(Widget):
         # Check for any widgets marked as 'dirty' (needs a repaint)
         event.prevent_default()
 
-        if self.is_current:
-            if self._layout_required:
-                self._refresh_layout()
-                self._layout_required = False
-                self._dirty_widgets.clear()
-            if self._repaint_required:
-                self._dirty_widgets.clear()
-                self._dirty_widgets.add(self)
-                self._repaint_required = False
+        async with self.app._dom_lock:
+            if self.is_current:
+                if self._layout_required:
+                    self._refresh_layout()
+                    self._layout_required = False
+                    self._dirty_widgets.clear()
+                if self._repaint_required:
+                    self._dirty_widgets.clear()
+                    self._dirty_widgets.add(self)
+                    self._repaint_required = False
 
-            if self._dirty_widgets:
-                self.update_timer.resume()
+                if self._dirty_widgets:
+                    self.update_timer.resume()
 
         # The Screen is idle - a good opportunity to invoke the scheduled callbacks
         await self._invoke_and_clear_callbacks()


### PR DESCRIPTION
Fixes a deadlock when removing widgets from the app.

Pruning the nodes is now down in a task. There's is a lock around the DOM to prevent it from rendering in the middle of a prune operation.