### PR TITLE
FIX css link

### DIFF
--- a/docs/examples/guide/widgets/hello04.py
+++ b/docs/examples/guide/widgets/hello04.py
@@ -48,7 +48,7 @@ class Hello(Static):
 
 
 class CustomApp(App):
-    CSS_PATH = "hello03.css"
+    CSS_PATH = "hello04.css"
 
     def compose(self) -> ComposeResult:
         yield Hello()


### PR DESCRIPTION
This is the part where the [guide](https://textual.textualize.io/guide/widgets/#default-css) explains the `DEFAULT_CSS` feature, leaving a small amount of css in `hello04.css`. However, the App class still links to the css file from the previous version (`hello03.css`). This PR fixes that and updates to the recent one.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
