### PR TITLE
Docs show empty app screenshot

### DIFF
--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -68,7 +68,7 @@ Let's look at a trivial Textual app.
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/dom1.py"}
+    ```{.textual path="docs/examples/guide/dom1.py" press="_"}
     ```
 
 This example creates an instance of `ExampleApp`, which will implicitly create a `Screen` object. In DOM terms, the `Screen` is a _child_ of `ExampleApp`.

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -56,7 +56,7 @@ Another such event is the *key* event which is sent when the user presses a key.
 
 The `on_mount` handler sets the `self.screen.styles.background` attribute to `"darkblue"` which (as you can probably guess) turns the background blue. Since the mount event is sent immediately after entering application mode, you will see a blue screen when you run this code.
 
-```{.textual path="docs/examples/app/event01.py" hl_lines="23-25"}
+```{.textual path="docs/examples/app/event01.py" hl_lines="23-25" press="_"}
 ```
 
 The key event handler (`on_key`) has an `event` parameter which will receive a [Key][textual.events.Key] instance. Every event has an associated event object which will be passed to the handler method if it is present in the method's parameter list.

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -27,7 +27,7 @@ Apps don't get much simpler than this&mdash;don't expect it to do much.
 
 If we run this app with `python simple02.py` you will see a blank terminal, something like the following:
 
-```{.textual path="docs/examples/app/simple02.py"}
+```{.textual path="docs/examples/app/simple02.py" press="_"}
 ```
 
 When you call [App.run()][textual.app.App.run] Textual puts the terminal in to a special state called *application mode*. When in application mode the terminal will no longer echo what you type. Textual will take over responding to user input (keyboard and mouse) and will update the visible portion of the terminal (i.e. the *screen*).

--- a/docs/guide/styles.md
+++ b/docs/guide/styles.md
@@ -20,7 +20,7 @@ The first line sets the [background](../styles/background.md) style to `"darkblu
 
 The second line sets [border](../styles/border.md) to a tuple of `("heavy", "white")` which tells Textual to draw a white border with a style of `"heavy"`. Running this code will show the following:
 
-```{.textual path="docs/examples/guide/styles/screen.py"}
+```{.textual path="docs/examples/guide/styles/screen.py" press="_"}
 ```
 
 ## Styling widgets


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Updated documentation

The docs page [Guide/App](https://textual.textualize.io/guide/app/) has an empty screenshot immediately above the section [Async Events](https://textual.textualize.io/guide/app/#async-events):

![Screenshot_1](https://user-images.githubusercontent.com/5621605/203587376-e1cdc79e-2c45-469e-9e8d-59eeb874feb9.png)

Adding a pause before the screenshot seems to fix this issue (the screenshot below is from a local docs build with the fix):

![Screenshot_2](https://user-images.githubusercontent.com/5621605/203587567-da835af2-1a5d-4009-ad96-9950b9a6077b.png)
