### PR TITLE
Switch to using anyio for async

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,7 +35,7 @@ frozenlist = ">=1.1.0"
 name = "anyio"
 version = "3.6.2"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.2"
 
@@ -879,7 +879,7 @@ python-versions = ">=3.6"
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1019,7 +1019,7 @@ dev = ["aiohttp", "click", "msgpack"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "578d7f611a797d406b8db7c61f28796e81af2e637d9671caab9b4ea2b1cf93c6"
+content-hash = "0ca916cb4ecb4596aef790abb972d6d89a8cc29909b079c2cf3304b93b14b9b5"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 include = [
-    "src/textual/py.typed"   
+    "src/textual/py.typed"
 ]
 
 [tool.poetry.scripts]
@@ -40,6 +40,7 @@ aiohttp = { version = ">=3.8.1", optional = true }
 click = {version = ">=8.1.2", optional = true}
 msgpack = { version = ">=1.0.3", optional = true }
 nanoid = ">=2.0.0"
+anyio = "^3.6.2"
 
 [tool.poetry.extras]
 dev = ["aiohttp", "click", "msgpack"]

--- a/src/textual/_anyio.py
+++ b/src/textual/_anyio.py
@@ -1,0 +1,42 @@
+from contextlib import contextmanager
+from typing import Generator
+import anyio
+import sniffio
+
+
+class Flag:
+    def __init__(self):
+        self._event = anyio.Event()
+
+    def set(self) -> None:
+        self._event.set()
+
+    def clear(self) -> None:
+        if self._event.is_set():
+            self._event = anyio.Event()
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+
+@contextmanager
+def _spoof_asyncio_if_needed() -> Generator[str, None, None]:
+    """
+    A context manager that ensures anyio has an async library set, forcing
+    asyncio if we are not running in an async context.
+
+    Returns:
+        str: The flavor of async library that is in use.
+    """
+    try:
+        current_lib = sniffio.current_async_library()
+        reset_token = None
+    except sniffio.AsyncLibraryNotFoundError:
+        current_lib = "asyncio"
+        reset_token = sniffio.current_async_library_cvar.set("asyncio")
+
+    try:
+        yield current_lib
+    finally:
+        if reset_token is not None:
+            sniffio.current_async_library_cvar.reset(reset_token)

--- a/src/textual/_clock.py
+++ b/src/textual/_clock.py
@@ -1,11 +1,11 @@
-import asyncio
+import anyio
 
 from ._time import time
 
 
 """
 A module that serves as the single source of truth for everything time-related in a Textual app.
-Having this logic centralised makes it easier to simulate time in integration tests, 
+Having this logic centralised makes it easier to simulate time in integration tests,
 by mocking the few functions exposed by this module.
 """
 
@@ -21,7 +21,7 @@ class _Clock:
         return time()
 
     async def sleep(self, seconds: float) -> None:
-        await asyncio.sleep(seconds)
+        await anyio.sleep(seconds)
 
 
 _clock = _Clock()
@@ -39,7 +39,7 @@ def get_time_no_wait() -> float:
 
 async def get_time() -> float:
     """
-    Asynchronous version of `get_time`. Useful in situations where we want asyncio to be
+    Asynchronous version of `get_time`. Useful in situations where we want anyio to be
     able to "do things" elsewhere right before we fetch the time.
 
     Returns:

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -1,6 +1,6 @@
 """Provides the type of an awaitable remove."""
 
-from asyncio import Event
+from anyio import Event
 from typing import Generator
 
 
@@ -11,7 +11,7 @@ class AwaitRemove:
         """Initialise the instance of ``AwaitRemove``.
 
         Args:
-            finished_flag (asyncio.Event): The asyncio event to wait on.
+            finished_flag (anyio.Event): The anyio event to wait on.
         """
         self.finished_flag = finished_flag
 

--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -17,7 +17,6 @@ a method which evaluates the query, such as first() and last().
 from __future__ import annotations
 
 from typing import cast, Generic, TYPE_CHECKING, Iterator, TypeVar, overload
-import asyncio
 
 import rich.repr
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -394,7 +394,7 @@ class DOMNode(MessagePump):
         Returns:
             bool: ``True`` if this DOMNode is displayed (``display != "none"``) otherwise ``False`` .
         """
-        return self.styles.display != "none" and not (self._closing or self._closed)
+        return self.styles.display != "none" and self._state.accepts_messages()
 
     @display.setter
     def display(self, new_val: bool | str) -> None:

--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from ..driver import Driver
 from ..geometry import Size
 from .. import events
@@ -31,22 +30,17 @@ class HeadlessDriver(Driver):
         height = height or 25
         return width, height
 
-    def start_application_mode(self) -> None:
-        loop = asyncio.get_running_loop()
-
-        def send_size_event():
+    async def start_application_mode(self) -> None:
+        async def send_size_event():
             terminal_size = self._get_terminal_size()
             width, height = terminal_size
             textual_size = Size(width, height)
             event = events.Resize(self._target, textual_size, textual_size)
-            asyncio.run_coroutine_threadsafe(
-                self._target.post_message(event),
-                loop=loop,
-            )
+            await self._target.post_message(event)
 
-        send_size_event()
+        await send_size_event()
 
-    def disable_input(self) -> None:
+    async def disable_input(self) -> None:
         pass
 
     def stop_application_mode(self) -> None:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from .timer import Timer as TimerClass
     from .timer import TimerCallback
     from .widget import Widget
-    import asyncio
 
 
 @rich.repr.auto

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import rich.repr
 
-import asyncio
+import anyio
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -40,8 +40,8 @@ class Pilot:
         Args:
             delay (float, optional): Seconds to pause. Defaults to 50ms.
         """
-        # These sleep zeros, are to force asyncio to give up a time-slice,
-        await asyncio.sleep(delay)
+        # These sleep zeros, are to force anyio to give up a time-slice,
+        await anyio.sleep(delay)
 
     async def wait_for_animation(self) -> None:
         """Wait for any animation to complete."""

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -94,8 +94,6 @@ class Timer:
         """
         assert not self._has_task, "Timer has already been started"
         app = active_app.get()
-        if not app._running:
-            return
         # Being able to wait on the task to start would simplify this class and
         # remove potential race conditions, but this method is not async.
         app._task_group.start_soon(self._run_timer, name=self.name)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2239,7 +2239,7 @@ class Widget(DOMNode):
         Args:
             event (events.Idle): Idle event.
         """
-        if self._parent is not None and not self._closing:
+        if self._parent is not None and self._state != self._State.Closing:
             try:
                 screen = self.screen
             except NoScreen:

--- a/tests/layouts/test_horizontal.py
+++ b/tests/layouts/test_horizontal.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 import pytest
 
 from textual.app import App, ComposeResult
@@ -5,8 +6,8 @@ from textual.containers import Horizontal
 from textual.widget import Widget
 
 
-@pytest.fixture
-async def app():
+@asynccontextmanager
+async def run_app():
     class HorizontalAutoWidth(App):
         def compose(self) -> ComposeResult:
             child1 = Widget(id="child1")
@@ -23,7 +24,8 @@ async def app():
         yield app
 
 
-async def test_horizontal_get_content_width(app):
-    size = app.screen.size
-    width = app.horizontal.get_content_width(size, size)
-    assert width == 15
+async def test_horizontal_get_content_width():
+    async with run_app() as app:
+        size = app.screen.size
+        width = app.horizontal.get_content_width(size, size)
+        assert width == 15

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 import pytest
 import rich
 
@@ -83,77 +84,88 @@ class GetByIdApp(App):
         )
 
 
-@pytest.fixture
-async def hierarchy_app():
+@asynccontextmanager
+async def run_hierarchy_app():
     app = GetByIdApp()
     async with app.run_test():
         yield app
 
 
-@pytest.fixture
-async def parent(hierarchy_app):
-    yield hierarchy_app.get_widget_by_id("parent")
+@asynccontextmanager
+async def run_parent():
+    async with run_hierarchy_app() as app:
+        yield app, app.get_widget_by_id("parent")
 
 
-def test_get_child_by_id_gets_first_child(parent):
-    child = parent.get_child_by_id(id="child1")
-    assert child.id == "child1"
-    assert child.get_child_by_id(id="grandchild1").id == "grandchild1"
-    assert parent.get_child_by_id(id="child2").id == "child2"
+async def test_get_child_by_id_gets_first_child():
+    async with run_parent() as (_, parent):
+        child = parent.get_child_by_id(id="child1")
+        assert child.id == "child1"
+        assert child.get_child_by_id(id="grandchild1").id == "grandchild1"
+        assert parent.get_child_by_id(id="child2").id == "child2"
 
 
-def test_get_child_by_id_no_matching_child(parent):
-    with pytest.raises(NoMatches):
-        parent.get_child_by_id(id="doesnt-exist")
+async def test_get_child_by_id_no_matching_child():
+    async with run_parent() as (_, parent):
+        with pytest.raises(NoMatches):
+            parent.get_child_by_id(id="doesnt-exist")
 
 
-def test_get_child_by_id_only_immediate_descendents(parent):
-    with pytest.raises(NoMatches):
-        parent.get_child_by_id(id="grandchild1")
+async def test_get_child_by_id_only_immediate_descendents():
+    async with run_parent() as (_, parent):
+        with pytest.raises(NoMatches):
+            parent.get_child_by_id(id="grandchild1")
 
 
-def test_get_widget_by_id_no_matching_child(parent):
-    with pytest.raises(NoMatches):
-        parent.get_widget_by_id(id="i-dont-exist")
+async def test_get_widget_by_id_no_matching_child():
+    async with run_parent() as (_, parent):
+        with pytest.raises(NoMatches):
+            parent.get_widget_by_id(id="i-dont-exist")
 
 
-def test_get_widget_by_id_non_immediate_descendants(parent):
-    result = parent.get_widget_by_id("grandchild1")
-    assert result.id == "grandchild1"
+async def test_get_widget_by_id_non_immediate_descendants():
+    async with run_parent() as (_, parent):
+        result = parent.get_widget_by_id("grandchild1")
+        assert result.id == "grandchild1"
 
 
-def test_get_widget_by_id_immediate_descendants(parent):
-    result = parent.get_widget_by_id("child1")
-    assert result.id == "child1"
+async def test_get_widget_by_id_immediate_descendants():
+    async with run_parent() as (_, parent):
+        result = parent.get_widget_by_id("child1")
+        assert result.id == "child1"
 
 
-def test_get_widget_by_id_doesnt_return_self(parent):
-    with pytest.raises(NoMatches):
-        parent.get_widget_by_id("parent")
+async def test_get_widget_by_id_doesnt_return_self():
+    async with run_parent() as (_, parent):
+        with pytest.raises(NoMatches):
+            parent.get_widget_by_id("parent")
 
 
-def test_get_widgets_app_delegated(hierarchy_app, parent):
-    # Check that get_child_by_id finds the parent, which is a child of the default Screen
-    queried_parent = hierarchy_app.get_child_by_id("parent")
-    assert queried_parent is parent
+async def test_get_widgets_app_delegated():
+    async with run_parent() as (hierarchy_app, parent):
+        # Check that get_child_by_id finds the parent, which is a child of the default Screen
+        queried_parent = hierarchy_app.get_child_by_id("parent")
+        assert queried_parent is parent
 
-    # Check that the grandchild (descendant of the default screen) is found
-    grandchild = hierarchy_app.get_widget_by_id("grandchild1")
-    assert grandchild.id == "grandchild1"
-
-
-def test_widget_mount_ids_must_be_unique_mounting_all_in_one_go(parent):
-    widget1 = Widget(id="hello")
-    widget2 = Widget(id="hello")
-
-    with pytest.raises(MountError):
-        parent.mount(widget1, widget2)
+        # Check that the grandchild (descendant of the default screen) is found
+        grandchild = hierarchy_app.get_widget_by_id("grandchild1")
+        assert grandchild.id == "grandchild1"
 
 
-def test_widget_mount_ids_must_be_unique_mounting_multiple_calls(parent):
-    widget1 = Widget(id="hello")
-    widget2 = Widget(id="hello")
+async def test_widget_mount_ids_must_be_unique_mounting_all_in_one_go():
+    async with run_parent() as (_, parent):
+        widget1 = Widget(id="hello")
+        widget2 = Widget(id="hello")
 
-    parent.mount(widget1)
-    with pytest.raises(DuplicateIds):
-        parent.mount(widget2)
+        with pytest.raises(MountError):
+            parent.mount(widget1, widget2)
+
+
+async def test_widget_mount_ids_must_be_unique_mounting_multiple_calls():
+    async with run_parent() as (_, parent):
+        widget1 = Widget(id="hello")
+        widget2 = Widget(id="hello")
+
+        parent.mount(widget1)
+        with pytest.raises(DuplicateIds):
+            parent.mount(widget2)


### PR DESCRIPTION
This is a draft that switches from asyncio to anyio, which is necessary for
trio compatibility. I've tested it with a version of `calculator.py` that
runs under Trio:
```python
import anyio

async def main():
    await CalculatorApp().run_async()

if __name__ == "__main__":
    anyio.run(main, backend="trio")
```

Here's a short list of design decisions and changes:
- There is a single task group that lives as long as the app is running and
  all background tasks (e.g. the driver, timers, and the message pump) run in
  it. The app will not finish running until all of these tasks stop, which is
  part of the shutdown process. Any hangs in exiting an app are likely due to
  a task that is still living, indicating an issue in the shutdown process.
- The task group must be exited on the same task as it was entered, which
  makes `App.run_test` unable to be used in a pytest fixture.
- anyio does not know which backend to use when creating objects outside of an
  async context. This breaks the common idiom of `MyApp().run()` being called
  outside of an async context. To work around this, we force anyio to believe
  it's running under `asyncio` if there is no async context. This does
  introduce the possibility for a mismatch and `App.run_async` checks for this.
  Trio users should create the app inside of the Trio context and perhaps the
  Textual can be reworked a bit to make this better (e.g. lazily creating locks
  and other `anyio` objects once we know what backend we're running under).
- The message pump switched to using a memory send / receive stream. This is
  analagous to `asyncio`'s queue class but has a built-in notion of whether
  the stream is closed or not.
- Reworked message pump state handling, which turned out to be somewhat tricky.
  This was necessary because send / receive streams can't be used once they're
  closed, but message pumps can be re-used multiple times. It also addresses some
  potential race conditions between starting the pump and waiting for it to close.
- The devtools are only compatible with the `asyncio` backend because
  `aiohttp` requires `asyncio`.
- Removed references to `uvloop` with the thought being that users can
  explicitly opt into that. An alternate approach would be to do that in the
  `_spoof_asyncio_if_needed` when we default to `asyncio`.
- `anyio.Event` lacks `clear()`, so a new class, `Flag`, was created to provide
  that functionality.
- The `Timer` implementation got a bit messy due to a race condition between
  `start` enqueueing the task, `stop` getting called, and the task actually
  executing. Making `Timer.start` async would allow this to be implemented
  more cleanly but is an API breakage.
- `Timer.start` no longer returns a `Task` object.
- All the tests continue to run under `asyncio`.

Almost all tests pass, with some exceptions:
- test_screens: Has an error because the app isn't actually running, but
  `_remove_nodes` needs to schedule a task to run in its task group. Might
  need to restructure this test to use `App.run_test`.
- test_animate_height: Fails with an assertion about the height being 0. This
  stems from `Screen.find_widget` being unable to find the widget. Adding
  `await anyio.wait_all_tasks_blocked()` right after the `async with` makes the
  test pass, which makes me think there's some async race conditions going
  on.

Outstanding tasks:
- [ ] Fix the above test issues.
- [ ] The Win32 driver was not updated, but should be relatively straightforward to
  do based off of the Linux driver.
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
