### PR TITLE
Add some missing widget event attributes

### DIFF
--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -151,6 +151,11 @@ class Button(Static, can_focus=True):
     """When buttons are clicked they get the `-active` class for this duration (in seconds)"""
 
     class Pressed(Message, bubble=True):
+        """Event sent when a `Button` is pressed.
+
+        Attributes:
+            button (Button): The button that was pressed.
+        """
         @property
         def button(self) -> Button:
             return cast(Button, self.sender)

--- a/src/textual/widgets/_checkbox.py
+++ b/src/textual/widgets/_checkbox.py
@@ -123,7 +123,12 @@ class Checkbox(Widget, can_focus=True):
         self.value = not self.value
 
     class Changed(Message, bubble=True):
-        """Checkbox was toggled."""
+        """Checkbox was toggled.
+
+        Attributes:
+            value (bool): The value that the checkbox was changed to.
+            input (Checkbox): The checkout widget that was changed.
+        """
 
         def __init__(self, sender: Checkbox, value: bool) -> None:
             super().__init__(sender)

--- a/src/textual/widgets/_checkbox.py
+++ b/src/textual/widgets/_checkbox.py
@@ -127,7 +127,7 @@ class Checkbox(Widget, can_focus=True):
 
         Attributes:
             value (bool): The value that the checkbox was changed to.
-            input (Checkbox): The checkout widget that was changed.
+            input (Checkbox): The `Checkbox` widget that was changed.
         """
 
         def __init__(self, sender: Checkbox, value: bool) -> None:

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -314,7 +314,12 @@ class Input(Widget, can_focus=True):
         await self.emit(self.Submitted(self, self.value))
 
     class Changed(Message, bubble=True):
-        """Value was changed."""
+        """Value was changed.
+
+        Attributes:
+            value (str): The value that the input was changed to.
+            input (Input): The `Input` widget that was changed.
+        """
 
         def __init__(self, sender: Input, value: str) -> None:
             super().__init__(sender)

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -327,7 +327,12 @@ class Input(Widget, can_focus=True):
             self.input = sender
 
     class Submitted(Message, bubble=True):
-        """Value was updated via enter key or blur."""
+        """Sent when the enter key is pressed within an `Input`.
+
+        Attributes:
+            value (str): The value of the `Input` being submitted..
+            input (Input): The `Input` widget that is being submitted.
+        """
 
         def __init__(self, sender: Input, value: str) -> None:
             super().__init__(sender)

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -143,7 +143,11 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
         return len(self.children)
 
     class Highlighted(Message, bubble=True):
-        """Emitted when the highlighted item changes. Highlighted item is controlled using up/down keys"""
+        """Emitted when the highlighted item changes. Highlighted item is controlled using up/down keys.
+
+        Attributes:
+            item (ListItem | None): The highlighted item, if there is one highlighted.
+        """
 
         def __init__(self, sender: ListView, item: ListItem | None) -> None:
             super().__init__(sender)

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -154,7 +154,11 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
             self.item = item
 
     class Selected(Message, bubble=True):
-        """Emitted when a list item is selected, e.g. when you press the enter key on it"""
+        """Emitted when a list item is selected, e.g. when you press the enter key on it
+
+        Attributes:
+            item (ListItem): The selected item.
+        """
 
         def __init__(self, sender: ListView, item: ListItem) -> None:
             super().__init__(sender)

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -322,7 +322,11 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             super().__init__(sender)
 
     class NodeExpanded(Generic[EventTreeDataType], Message, bubble=True):
-        """Event sent when a node is expanded."""
+        """Event sent when a node is expanded.
+
+        Attributes:
+            TreeNode[EventTreeDataType]: The node that was expanded.
+        """
 
         def __init__(
             self, sender: MessageTarget, node: TreeNode[EventTreeDataType]

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -309,7 +309,11 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
     }
 
     class NodeSelected(Generic[EventTreeDataType], Message, bubble=True):
-        """Event sent when a node is selected."""
+        """Event sent when a node is selected.
+
+        Attributes:
+            TreeNode[EventTreeDataType]: The node that was selected.
+        """
 
         def __init__(
             self, sender: MessageTarget, node: TreeNode[EventTreeDataType]

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -335,7 +335,11 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             super().__init__(sender)
 
     class NodeCollapsed(Generic[EventTreeDataType], Message, bubble=True):
-        """Event sent when a node is collapsed."""
+        """Event sent when a node is collapsed.
+
+        Attributes:
+            TreeNode[EventTreeDataType]: The node that was collapsed.
+        """
 
         def __init__(
             self, sender: MessageTarget, node: TreeNode[EventTreeDataType]

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -232,21 +232,21 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         color: $text;
     }
     Tree > .tree--label {
-        
+
     }
     Tree > .tree--guides {
         color: $success-darken-3;
     }
 
-    Tree > .tree--guides-hover {  
-        color: $success;      
+    Tree > .tree--guides-hover {
+        color: $success;
         text-style: bold;
     }
 
     Tree > .tree--guides-selected {
         color: $warning;
         text-style: bold;
-    }    
+    }
 
     Tree > .tree--cursor {
         background: $secondary;
@@ -254,11 +254,11 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         text-style: bold;
     }
 
-    Tree > .tree--highlight {        
+    Tree > .tree--highlight {
         text-style: underline;
     }
-    
-    Tree > .tree--highlight-line {        
+
+    Tree > .tree--highlight-line {
         background: $boost;
     }
 


### PR DESCRIPTION
Various widgets have events that the "user" of the library needs to make use of to untangle who sent what; but none of the events seem to document their properties, making it tricky to discover how to fully use them. This PR hits the main ones.

Also takes in #1263 as I was passing that way.