### PR TITLE
Add support for a `PRIORITY_BINDINGS` classvar to work alongside `BINDINGS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added `PRIORITY_BINDINGS` class variable, which can be used to control if a widget's bindings have priority by default. https://github.com/Textualize/textual/issues/1343
+
+### Changed
+
+- Renamed the `Binding` argument `universal` to `priority`. https://github.com/Textualize/textual/issues/1343
+- When looking for bindings that have priority, they are now looked from `App` downwards. https://github.com/Textualize/textual/issues/1343
+- `BINDINGS` on an `App`-derived class have priority by default. https://github.com/Textualize/textual/issues/1343
+- `BINDINGS` on a `Screen`-derived class have priority by default. https://github.com/Textualize/textual/issues/1343
+
 ### Fixed
 
 - Ensure only printable characters are used as key_display https://github.com/Textualize/textual/pull/1361

--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -127,6 +127,15 @@ Note how the footer displays bindings and makes them clickable.
     Multiple keys can be bound to a single action by comma-separating them.
     For example, `("r,t", "add_bar('red')", "Add Red")` means both ++r++ and ++t++ are bound to `add_bar('red')`.
 
+
+!!! note
+
+    Ordinarily a binding on a focused widget has precedence over the same key binding at a higher level. However, bindings at the `App` or `Screen` level always have priority.
+
+    The priority of a single binding can be controlled with the `priority` parameter of a `Binding` instance. Set it to `True` to give it priority, or `False` to not.
+
+    The default priority of all bindings on a class can be controlled with the `PRIORITY_BINDINGS` class variable. Set it to `True` or `False` to set the default priroty for all `BINDINGS`.
+
 ### Binding class
 
 The tuple of three strings may be enough for simple bindings, but you can also replace the tuple with a [Binding][textual.binding.Binding] instance which exposes a few more options.

--- a/examples/five_by_five.py
+++ b/examples/five_by_five.py
@@ -166,10 +166,10 @@ class Game(Screen):
         Binding("n", "new_game", "New Game"),
         Binding("question_mark", "push_screen('help')", "Help", key_display="?"),
         Binding("q", "quit", "Quit"),
-        Binding("up,w,k", "navigate(-1,0)", "Move Up", False, universal=True),
-        Binding("down,s,j", "navigate(1,0)", "Move Down", False, universal=True),
-        Binding("left,a,h", "navigate(0,-1)", "Move Left", False, universal=True),
-        Binding("right,d,l", "navigate(0,1)", "Move Right", False, universal=True),
+        Binding("up,w,k", "navigate(-1,0)", "Move Up", False),
+        Binding("down,s,j", "navigate(1,0)", "Move Down", False),
+        Binding("left,a,h", "navigate(0,-1)", "Move Left", False),
+        Binding("right,d,l", "navigate(0,1)", "Move Right", False),
         Binding("space", "move", "Toggle", False),
     ]
     """The bindings for the main game grid."""

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -298,7 +298,7 @@ class App(Generic[ReturnType], DOMNode):
 
         self._logger = Logger(self._log)
 
-        self._bindings.bind("ctrl+c", "quit", show=False, universal=True)
+        self._bindings.bind("ctrl+c", "quit", show=False, priority=True)
         self._refresh_required = False
 
         self.design = DEFAULT_COLORS
@@ -1729,12 +1729,12 @@ class App(Generic[ReturnType], DOMNode):
             ]
         return namespace_bindings
 
-    async def check_bindings(self, key: str, universal: bool = False) -> bool:
+    async def check_bindings(self, key: str, priority: bool = False) -> bool:
         """Handle a key press.
 
         Args:
             key (str): A key
-            universal (bool): Check universal keys if True, otherwise non-universal keys.
+            priority (bool): If `True` check from `App` down, otherwise from focused up.
 
         Returns:
             bool: True if the key was handled by a binding, otherwise False
@@ -1742,7 +1742,7 @@ class App(Generic[ReturnType], DOMNode):
 
         for namespace, bindings in self._binding_chain:
             binding = bindings.keys.get(key)
-            if binding is not None and binding.universal == universal:
+            if binding is not None and binding.priority == priority:
                 await self.action(binding.action, default_namespace=namespace)
                 return True
         return False
@@ -1762,7 +1762,7 @@ class App(Generic[ReturnType], DOMNode):
                 self.mouse_position = Offset(event.x, event.y)
                 await self.screen._forward_event(event)
             elif isinstance(event, events.Key):
-                if not await self.check_bindings(event.key, universal=True):
+                if not await self.check_bindings(event.key, priority=True):
                     forward_target = self.focused or self.screen
                     await forward_target._forward_event(event)
             else:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1743,7 +1743,7 @@ class App(Generic[ReturnType], DOMNode):
         """
 
         for namespace, bindings in (
-            reversed(self._binding_chain) if priority else self._binding_chain
+            list(reversed(self._binding_chain)) if priority else self._binding_chain
         ):
             binding = bindings.keys.get(key)
             if binding is not None and binding.priority == priority:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1743,7 +1743,7 @@ class App(Generic[ReturnType], DOMNode):
         """
 
         for namespace, bindings in (
-            list(reversed(self._binding_chain)) if priority else self._binding_chain
+            reversed(self._binding_chain) if priority else self._binding_chain
         ):
             binding = bindings.keys.get(key)
             if binding is not None and binding.priority == priority:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -231,6 +231,8 @@ class App(Generic[ReturnType], DOMNode):
     }
     """
 
+    PRIORITY_BINDINGS = True
+
     SCREENS: dict[str, Screen | Callable[[], Screen]] = {}
     _BASE_PATH: str | None = None
     CSS_PATH: CSSPathType = None

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1742,9 +1742,10 @@ class App(Generic[ReturnType], DOMNode):
             bool: True if the key was handled by a binding, otherwise False
         """
 
-        for namespace, bindings in (
-            list(reversed(self._binding_chain)) if priority else self._binding_chain
-        ):
+        # for namespace, bindings in (
+        #     list(reversed(self._binding_chain)) if priority else self._binding_chain
+        # ):
+        for namespace, bindings in self._binding_chain:
             binding = bindings.keys.get(key)
             if binding is not None and binding.priority == priority:
                 await self.action(binding.action, default_namespace=namespace)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1742,7 +1742,9 @@ class App(Generic[ReturnType], DOMNode):
             bool: True if the key was handled by a binding, otherwise False
         """
 
-        for namespace, bindings in self._binding_chain:
+        for namespace, bindings in (
+            reversed(self._binding_chain) if priority else self._binding_chain
+        ):
             binding = bindings.keys.get(key)
             if binding is not None and binding.priority == priority:
                 await self.action(binding.action, default_namespace=namespace)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1742,10 +1742,9 @@ class App(Generic[ReturnType], DOMNode):
             bool: True if the key was handled by a binding, otherwise False
         """
 
-        # for namespace, bindings in (
-        #     list(reversed(self._binding_chain)) if priority else self._binding_chain
-        # ):
-        for namespace, bindings in self._binding_chain:
+        for namespace, bindings in (
+            list(reversed(self._binding_chain)) if priority else self._binding_chain
+        ):
             binding = bindings.keys.get(key)
             if binding is not None and binding.priority == priority:
                 await self.action(binding.action, default_namespace=namespace)

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -20,6 +20,8 @@ class NoBinding(Exception):
 
 @dataclass(frozen=True)
 class Binding:
+    """The configuration of a key binding."""
+
     key: str
     """str: Key to bind. This can also be a comma-separated list of keys to map multiple keys to a single action."""
     action: str

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -32,8 +32,8 @@ class Binding:
     """bool: Show the action in Footer, or False to hide."""
     key_display: str | None = None
     """str | None: How the key should be shown in footer."""
-    universal: bool = False
-    """bool: Allow forwarding from app to focused widget."""
+    priority: bool = False
+    """bool: Is this a priority binding, checked form app down to focused widget?"""
 
 
 @rich.repr.auto
@@ -60,7 +60,7 @@ class Bindings:
                             description=binding.description,
                             show=binding.show,
                             key_display=binding.key_display,
-                            universal=binding.universal,
+                            priority=binding.priority,
                         )
                         yield new_binding
                 else:
@@ -107,7 +107,7 @@ class Bindings:
         description: str = "",
         show: bool = True,
         key_display: str | None = None,
-        universal: bool = False,
+        priority: bool = False,
     ) -> None:
         """Bind keys to an action.
 
@@ -117,7 +117,7 @@ class Bindings:
             description (str, optional): An optional description for the binding.
             show (bool, optional): A flag to say if the binding should appear in the footer.
             key_display (str | None, optional): Optional string to display in the footer for the key.
-            universal (bool, optional): Allow forwarding from the app to the focused widget.
+            priority (bool, optional): Is this a priority binding, checked form app down to focused widget?
         """
         all_keys = [key.strip() for key in keys.split(",")]
         for key in all_keys:
@@ -127,7 +127,7 @@ class Bindings:
                 description,
                 show=show,
                 key_display=key_display,
-                universal=universal,
+                priority=priority,
             )
 
     def get_key(self, key: str) -> Binding:

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -32,19 +32,24 @@ class Binding:
     """bool: Show the action in Footer, or False to hide."""
     key_display: str | None = None
     """str | None: How the key should be shown in footer."""
-    priority: bool = False
-    """bool: Is this a priority binding, checked form app down to focused widget?"""
+    priority: bool | None = None
+    """bool | None: Is this a priority binding, checked form app down to focused widget?"""
 
 
 @rich.repr.auto
 class Bindings:
     """Manage a set of bindings."""
 
-    def __init__(self, bindings: Iterable[BindingType] | None = None) -> None:
+    def __init__(
+        self,
+        bindings: Iterable[BindingType] | None = None,
+        default_priority: bool | None = None,
+    ) -> None:
         """Initialise a collection of bindings.
 
         Args:
             bindings (Iterable[BindingType] | None, optional): An optional set of initial bindings.
+            default_priority (bool | None, optional): The default priority of the bindings.
 
         Note:
             The iterable of bindings can contain either a `Binding`
@@ -72,7 +77,9 @@ class Bindings:
                         description=binding.description,
                         show=binding.show,
                         key_display=binding.key_display,
-                        priority=binding.priority,
+                        priority=default_priority
+                        if binding.priority is None
+                        else binding.priority,
                     )
 
         self.keys: MutableMapping[str, Binding] = (

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -62,20 +62,18 @@ class Bindings:
                         )
                     binding = Binding(*binding)
 
-                binding_keys = binding.key.split(",")
-                if len(binding_keys) > 1:
-                    for key in binding_keys:
-                        new_binding = Binding(
-                            key=key,
-                            action=binding.action,
-                            description=binding.description,
-                            show=binding.show,
-                            key_display=binding.key_display,
-                            priority=binding.priority,
-                        )
-                        yield new_binding
-                else:
-                    yield binding
+                # At this point we have a Binding instance, but the key may
+                # be a list of keys, so now we unroll that single Binding
+                # into a (potential) collection of Binding instances.
+                for key in binding.key.split(","):
+                    yield Binding(
+                        key=key.strip(),
+                        action=binding.action,
+                        description=binding.description,
+                        show=binding.show,
+                        key_display=binding.key_display,
+                        priority=binding.priority,
+                    )
 
         self.keys: MutableMapping[str, Binding] = (
             {binding.key: binding for binding in make_bindings(bindings)}

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -41,6 +41,17 @@ class Bindings:
     """Manage a set of bindings."""
 
     def __init__(self, bindings: Iterable[BindingType] | None = None) -> None:
+        """Initialise a collection of bindings.
+
+        Args:
+            bindings (Iterable[BindingType] | None, optional): An optional set of initial bindings.
+
+        Note:
+            The iterable of bindings can contain either a `Binding`
+            instance, or a tuple of 3 values mapping to the first three
+            properties of a `Binding`.
+        """
+
         def make_bindings(bindings: Iterable[BindingType]) -> Iterable[Binding]:
             for binding in bindings:
                 # If it's a tuple of length 3, convert into a Binding first

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -92,6 +92,9 @@ class DOMNode(MessagePump):
     # Virtual DOM nodes
     COMPONENT_CLASSES: ClassVar[set[str]] = set()
 
+    # Should the content of BINDINGS be treated as priority bindings?
+    PRIORITY_BINDINGS: ClassVar[bool] = False
+
     # Mapping of key bindings
     BINDINGS: ClassVar[list[BindingType]] = []
 
@@ -225,11 +228,18 @@ class DOMNode(MessagePump):
         """
         bindings: list[Bindings] = []
 
+        # To start with, assume that bindings won't be priority bindings.
+        priority = False
+
         for base in reversed(cls.__mro__):
             if issubclass(base, DOMNode):
+                # See if the current class wants to set the bindings as
+                # priority bindings. If it doesn't have that property on the
+                # class, go with what we saw last.
+                priority = base.__dict__.get("PRIORITY_BINDINGS", priority)
                 if not base._inherit_bindings:
                     bindings.clear()
-                bindings.append(Bindings(base.__dict__.get("BINDINGS", [])))
+                bindings.append(Bindings(base.__dict__.get("BINDINGS", []), priority))
         keys = {}
         for bindings_ in bindings:
             keys.update(bindings_.keys)

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -26,6 +26,11 @@ UPDATE_PERIOD: Final[float] = 1 / 120
 class Screen(Widget):
     """A widget for the root of the app."""
 
+    # The screen is a special case and unless a class that inherits from us
+    # says otherwise, all screen-level bindings should be treated as having
+    # priority.
+    PRIORITY_BINDINGS = True
+
     DEFAULT_CSS = """
     Screen {
         layout: vertical;

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1227,7 +1227,7 @@ class Widget(DOMNode):
         Returns:
             bool: True if this widget may be scrolled.
         """
-        return self.styles.layout is not None or bool(self.children)
+        return self.is_container
 
     @property
     def layer(self) -> str:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1227,7 +1227,7 @@ class Widget(DOMNode):
         Returns:
             bool: True if this widget may be scrolled.
         """
-        return self.is_container
+        return self.styles.layout is not None or bool(self.children)
 
     @property
     def layer(self) -> str:

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -6,18 +6,25 @@ from textual.binding import Bindings, Binding, BindingError, NoBinding
 
 BINDING1 = Binding("a,b", action="action1", description="description1")
 BINDING2 = Binding("c", action="action2", description="description2")
+BINDING3 = Binding(" d   , e ", action="action3", description="description3")
 
 
 @pytest.fixture
 def bindings():
     yield Bindings([BINDING1, BINDING2])
 
+@pytest.fixture
+def more_bindings():
+    yield Bindings([BINDING1, BINDING2, BINDING3])
 
 def test_bindings_get_key(bindings):
     assert bindings.get_key("b") == Binding("b", action="action1", description="description1")
     assert bindings.get_key("c") == BINDING2
     with pytest.raises(NoBinding):
         bindings.get_key("control+meta+alt+shift+super+hyper+t")
+
+def test_bindings_get_key_spaced_list(more_bindings):
+    assert more_bindings.get_key("d").action == more_bindings.get_key("e").action
 
 def test_bindings_merge_simple(bindings):
     left = Bindings([BINDING1])

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -77,7 +77,7 @@ class AppWithScreenThatHasABinding(App[None]):
     reason="Screen is incorrectly starting with bindings for movement keys [issue#1343]"
 )
 async def test_app_screen_with_bindings() -> None:
-    """An app with a screen and a binding should only have ctrl+c as a binding."""
+    """A screen with a single alpha key binding should only have that key as a binding."""
     async with AppWithScreenThatHasABinding().run_test() as pilot:
         assert list(pilot.app.screen._bindings.keys.keys()) == ["a"]
 

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -545,7 +545,7 @@ class PriorityOverlapWidget(Static, can_focus=True):
     """A focusable widget with a priority binding."""
 
     BINDINGS = [
-#        Binding("0", "app.record('widget_0')", "0", priority=False),
+        Binding("0", "app.record('widget_0')", "0", priority=False),
         Binding("a", "app.record('widget_a')", "a", priority=False),
         Binding("b", "app.record('widget_b')", "b", priority=False),
         Binding("c", "app.record('widget_c')", "c", priority=True),
@@ -559,7 +559,7 @@ class PriorityOverlapScreen(Screen):
     """A screen with a priority binding."""
 
     BINDINGS = [
-#        Binding("0", "app.record('screen_0')", "0", priority=False),
+        Binding("0", "app.record('screen_0')", "0", priority=False),
         Binding("a", "app.record('screen_a')", "a", priority=False),
         Binding("b", "app.record('screen_b')", "b", priority=True),
         Binding("c", "app.record('screen_c')", "c", priority=False),
@@ -579,7 +579,7 @@ class PriorityOverlapApp(AppKeyRecorder):
     """An application with a priority binding."""
 
     BINDINGS = [
-#        Binding("0", "record('app_0')", "0", priority=False),
+        Binding("0", "record('app_0')", "0", priority=False),
         Binding("a", "record('app_a')", "a", priority=True),
         Binding("b", "record('app_b')", "b", priority=False),
         Binding("c", "record('app_c')", "c", priority=False),
@@ -597,10 +597,10 @@ class PriorityOverlapApp(AppKeyRecorder):
 async def test_overlapping_priority_bindings() -> None:
     """Test an app stack with overlapping bindings."""
     async with PriorityOverlapApp().run_test() as pilot:
-        await pilot.press(*"abcdef")
+        await pilot.press(*"0abcdef")
         await pilot.pause(2 / 100)
         assert pilot.app.pressed_keys == [
-#            "widget_0",
+            "widget_0",
             "app_a",
             "screen_b",
             "widget_c",

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -146,7 +146,7 @@ async def test_pressing_movement_keys_app() -> None:
 
 
 ##############################################################################
-class WidgetWithBindings(Static, can_focus=True):
+class FocusableWidgetWithBindings(Static, can_focus=True):
     """A widget that has its own bindings for the movement keys."""
 
     BINDINGS = [
@@ -163,10 +163,10 @@ class AppWithWidgetWithBindings(AppKeyRecorder):
     """A test app that composes with a widget that has movement bindings."""
 
     def compose(self) -> ComposeResult:
-        yield WidgetWithBindings()
+        yield FocusableWidgetWithBindings()
 
     def on_mount(self) -> None:
-        self.query_one(WidgetWithBindings).focus()
+        self.query_one(FocusableWidgetWithBindings).focus()
 
 
 async def test_focused_child_widget_with_movement_bindings() -> None:

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -31,6 +31,7 @@ MOVEMENT_KEYS = ["up", "down", "left", "right", "home", "end", "pageup", "pagedo
 # bindings set anywhere, and uses a default screen, should only have the one
 # binding in place: ctrl+c; it's hard-coded in the app class for now.
 
+
 class NoBindings(App[None]):
     """An app with zero bindings."""
 
@@ -48,6 +49,7 @@ async def test_just_app_no_bindings() -> None:
 # BINDINGS on the app itself, and simply binds the letter a -- in other
 # words avoiding anything to do with movement keys. The result should be
 # that we see the letter a, ctrl+c, and nothing else.
+
 
 class AlphaBinding(App[None]):
     """An app with a simple alpha key binding."""
@@ -71,6 +73,7 @@ async def test_just_app_alpha_binding() -> None:
 # To start with the screen has no bindings -- it's just a direct subclass
 # with no other changes.
 
+
 class ScreenNoBindings(Screen):
     """A screen with no added bindings."""
 
@@ -90,7 +93,9 @@ class AppWithScreenNoBindings(App[None]):
 async def test_app_screen_has_no_movement_bindings() -> None:
     """A screen with no bindings should not have movement key bindings."""
     async with AppWithScreenNoBindings().run_test() as pilot:
-        assert sorted(list(pilot.app.screen._bindings.keys.keys())) != sorted(MOVEMENT_KEYS)
+        assert sorted(list(pilot.app.screen._bindings.keys.keys())) != sorted(
+            MOVEMENT_KEYS
+        )
 
 
 ##############################################################################
@@ -99,6 +104,7 @@ async def test_app_screen_has_no_movement_bindings() -> None:
 # Hacking checked things with a non-default screen with no bindings, let's
 # now do the same thing but with a binding added that isn't for a movement
 # key.
+
 
 class ScreenWithBindings(Screen):
     """A screen with a simple alpha key binding."""
@@ -132,6 +138,7 @@ async def test_app_screen_with_bindings() -> None:
 # to see zero bindings in place, but do so when the screen has a child;
 # presumably making it pass as a container.
 
+
 class NoBindingsAndStaticWidgetNoBindings(App[None]):
     """An app with no bindings, enclosing a widget with no bindings."""
 
@@ -153,6 +160,7 @@ async def test_just_app_no_bindings_widget_no_bindings() -> None:
 # any bindings that are in place actually fire the correct actions. To help
 # with this let's build a simple key/binding/action recorder base app.
 
+
 class AppKeyRecorder(App[None]):
     """Base application class that can be used to record keystrokes."""
 
@@ -163,7 +171,7 @@ class AppKeyRecorder(App[None]):
     """list[str]: All the test keys."""
 
     @staticmethod
-    def mk_bindings(prefix: str="") -> list[Binding]:
+    def mk_bindings(prefix: str = "") -> list[Binding]:
         """Make the binding list for testing an app.
 
         Args:
@@ -173,7 +181,8 @@ class AppKeyRecorder(App[None]):
             list[Binding]: The resulting list of bindings.
         """
         return [
-            Binding( key, f"{prefix}record('{key}')", key ) for key in [*AppKeyRecorder.ALPHAS, *MOVEMENT_KEYS]
+            Binding(key, f"{prefix}record('{key}')", key)
+            for key in [*AppKeyRecorder.ALPHAS, *MOVEMENT_KEYS]
         ]
 
     def __init__(self) -> None:
@@ -189,7 +198,7 @@ class AppKeyRecorder(App[None]):
         """
         self.pressed_keys.append(key)
 
-    def all_recorded(self, prefix: str="") -> None:
+    def all_recorded(self, prefix: str = "") -> None:
         """Were all the bindings recorded from the presses?
 
         Args:
@@ -206,8 +215,10 @@ class AppKeyRecorder(App[None]):
 # seeing what happens. First off let's start with an application that has
 # bindings, both for an alpha key, and also for all of the movement keys.
 
+
 class AppWithMovementKeysBound(AppKeyRecorder):
     """An application with bindings."""
+
     BINDINGS = AppKeyRecorder.mk_bindings()
 
 
@@ -215,7 +226,7 @@ async def test_pressing_alpha_on_app() -> None:
     """Test that pressing the alpha key, when it's bound on the app, results in an action fire."""
     async with AppWithMovementKeysBound().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALPHAS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         assert pilot.app.pressed_keys == [*AppKeyRecorder.ALPHAS]
 
 
@@ -226,7 +237,7 @@ async def test_pressing_movement_keys_app() -> None:
     """Test that pressing the movement keys, when they're bound on the app, results in an action fire."""
     async with AppWithMovementKeysBound().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded()
 
 
@@ -239,8 +250,10 @@ async def test_pressing_movement_keys_app() -> None:
 # able to handle all of the test keys on its own and nothing else should
 # grab them.
 
+
 class FocusableWidgetWithBindings(Static, can_focus=True):
     """A widget that has its own bindings for the movement keys."""
+
     BINDINGS = AppKeyRecorder.mk_bindings("local_")
 
     async def action_local_record(self, key: str) -> None:
@@ -262,8 +275,9 @@ async def test_focused_child_widget_with_movement_bindings() -> None:
     """A focused child widget with movement bindings should handle its own actions."""
     async with AppWithWidgetWithBindings().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded("locally_")
+
 
 ##############################################################################
 # A focused widget within a screen that handles bindings.
@@ -274,8 +288,10 @@ async def test_focused_child_widget_with_movement_bindings() -> None:
 # bindings. What we should expect to see is that the bindings don't fire on
 # the widget (it has none) and instead get caught by the screen.
 
+
 class FocusableWidgetWithNoBindings(Static, can_focus=True):
     """A widget that can receive focus but has no bindings."""
+
 
 class ScreenWithMovementBindings(Screen):
     """A screen that binds keys, including movement keys."""
@@ -292,13 +308,15 @@ class ScreenWithMovementBindings(Screen):
     def on_mount(self) -> None:
         self.query_one(FocusableWidgetWithNoBindings).focus()
 
+
 class AppWithScreenWithBindingsWidgetNoBindings(AppKeyRecorder):
     """An app with a non-default screen that handles movement key bindings."""
 
-    SCREENS = {"main":ScreenWithMovementBindings}
+    SCREENS = {"main": ScreenWithMovementBindings}
 
     def on_mount(self) -> None:
         self.push_screen("main")
+
 
 @pytest.mark.xfail(
     reason="Movement keys never make it to the screen with such bindings due to key inheritance and pre-bound movement keys [issue#1343]"
@@ -307,8 +325,9 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
     """A focused child widget, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindings().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded("screenly_")
+
 
 ##############################################################################
 # A focused widget within a container within a screen that handles bindings.
@@ -321,6 +340,7 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
 #
 # Although it's not at the end of the unit tests, this is potentially the
 # "final boss" of these tests.
+
 
 class ScreenWithMovementBindingsAndContainerAroundWidget(Screen):
     """A screen that binds keys, including movement keys."""
@@ -337,13 +357,15 @@ class ScreenWithMovementBindingsAndContainerAroundWidget(Screen):
     def on_mount(self) -> None:
         self.query_one(FocusableWidgetWithNoBindings).focus()
 
+
 class AppWithScreenWithBindingsWrappedWidgetNoBindings(AppKeyRecorder):
     """An app with a non-default screen that handles movement key bindings."""
 
-    SCREENS = {"main":ScreenWithMovementBindings}
+    SCREENS = {"main": ScreenWithMovementBindings}
 
     def on_mount(self) -> None:
         self.push_screen("main")
+
 
 @pytest.mark.xfail(
     reason="Movement keys never make it to the screen with such bindings due to key inheritance and pre-bound movement keys [issue#1343]"
@@ -352,8 +374,9 @@ async def test_contained_focused_child_widget_with_movement_bindings_on_screen()
     """A contained focused child widget, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWrappedWidgetNoBindings().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded("screenly_")
+
 
 ##############################################################################
 # A focused widget with bindings but no inheriting of bindings, on app.
@@ -365,8 +388,10 @@ async def test_contained_focused_child_widget_with_movement_bindings_on_screen()
 #
 # We should expect to see all of the test keys recorded post-press.
 
+
 class WidgetWithBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
     """A widget that has its own bindings for the movement keys, no binding inheritance."""
+
     BINDINGS = AppKeyRecorder.mk_bindings("local_")
 
     async def action_local_record(self, key: str) -> None:
@@ -388,8 +413,9 @@ async def test_focused_child_widget_with_movement_bindings_no_inherit() -> None:
     """A focused child widget with movement bindings and inherit_bindings=False should handle its own actions."""
     async with AppWithWidgetWithBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded("locally_")
+
 
 ##############################################################################
 # A focused widget with no bindings and no inheriting of bindings, on screen.
@@ -403,8 +429,12 @@ async def test_focused_child_widget_with_movement_bindings_no_inherit() -> None:
 # NOTE: no bindings are declared for the widget, which is different from
 # zero bindings declared.
 
-class FocusableWidgetWithNoBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
+
+class FocusableWidgetWithNoBindingsNoInherit(
+    Static, can_focus=True, inherit_bindings=False
+):
     """A widget that can receive focus but has no bindings and doesn't inherit bindings."""
+
 
 class ScreenWithMovementBindingsNoInheritChild(Screen):
     """A screen that binds keys, including movement keys."""
@@ -421,20 +451,23 @@ class ScreenWithMovementBindingsNoInheritChild(Screen):
     def on_mount(self) -> None:
         self.query_one(FocusableWidgetWithNoBindingsNoInherit).focus()
 
+
 class AppWithScreenWithBindingsWidgetNoBindingsNoInherit(AppKeyRecorder):
     """An app with a non-default screen that handles movement key bindings, child no-inherit."""
 
-    SCREENS = {"main":ScreenWithMovementBindingsNoInheritChild}
+    SCREENS = {"main": ScreenWithMovementBindingsNoInheritChild}
 
     def on_mount(self) -> None:
         self.push_screen("main")
+
 
 async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen() -> None:
     """A focused child widget, that doesn't inherit bindings, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded("screenly_")
+
 
 ##############################################################################
 # A focused widget with zero bindings declared, but no inheriting of
@@ -449,9 +482,14 @@ async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen(
 # NOTE: zero bindings are declared for the widget, which is different from
 # no bindings declared.
 
-class FocusableWidgetWithEmptyBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
+
+class FocusableWidgetWithEmptyBindingsNoInherit(
+    Static, can_focus=True, inherit_bindings=False
+):
     """A widget that can receive focus but has empty bindings and doesn't inherit bindings."""
+
     BINDINGS = []
+
 
 class ScreenWithMovementBindingsNoInheritEmptyChild(Screen):
     """A screen that binds keys, including movement keys."""
@@ -468,17 +506,19 @@ class ScreenWithMovementBindingsNoInheritEmptyChild(Screen):
     def on_mount(self) -> None:
         self.query_one(FocusableWidgetWithEmptyBindingsNoInherit).focus()
 
+
 class AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit(AppKeyRecorder):
     """An app with a non-default screen that handles movement key bindings, child no-inherit."""
 
-    SCREENS = {"main":ScreenWithMovementBindingsNoInheritEmptyChild}
+    SCREENS = {"main": ScreenWithMovementBindingsNoInheritEmptyChild}
 
     def on_mount(self) -> None:
         self.push_screen("main")
+
 
 async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bindings_on_screen() -> None:
     """A focused child widget, that doesn't inherit bindings and sets BINDINGS empty, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
-        await pilot.pause(2/100)
+        await pilot.pause(2 / 100)
         pilot.app.all_recorded("screenly_")

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -22,6 +22,12 @@ from textual.binding import Binding
 MOVEMENT_KEYS = ["up", "down", "left", "right", "home", "end", "pageup", "pagedown"]
 
 ##############################################################################
+# An application with no bindings anywhere.
+#
+# The idea of this first little test is that an application that has no
+# bindings set anywhere, and uses a default screen, should only have the one
+# binding in place: ctrl+c; it's hard-coded in the app class for now.
+
 class NoBindings(App[None]):
     """An app with zero bindings."""
 
@@ -33,6 +39,13 @@ async def test_just_app_no_bindings() -> None:
 
 
 ##############################################################################
+# An application with a single alpha binding.
+#
+# Sticking with just an app and the default screen: this configuration has a
+# BINDINGS on the app itself, and simply binds the letter a -- in other
+# words avoiding anything to do with movement keys. The result should be
+# that we see the letter a, ctrl+c, and nothing else.
+
 class AlphaBinding(App[None]):
     """An app with a simple alpha key binding."""
 
@@ -46,6 +59,15 @@ async def test_just_app_alpha_binding() -> None:
 
 
 ##############################################################################
+# Introduce a non-default screen.
+#
+# Having tested an app using the default screen, we now introduce a
+# non-default screen. Generally this won't make a difference, but we *are*
+# working with a subsclass of Screen now so this should be covered.
+#
+# To start with the screen has no bindings -- it's just a direct subclass
+# with no other changes.
+
 class ScreenNoBindings(Screen):
     """A screen with no added bindings."""
 
@@ -69,6 +91,12 @@ async def test_app_screen_has_no_movement_bindings() -> None:
 
 
 ##############################################################################
+# Add an alpha-binding to a non-default screen.
+#
+# Hacking checked things with a non-default screen with no bindings, let's
+# now do the same thing but with a binding added that isn't for a movement
+# key.
+
 class ScreenWithBindings(Screen):
     """A screen with a simple alpha key binding."""
 
@@ -94,6 +122,13 @@ async def test_app_screen_with_bindings() -> None:
 
 
 ##############################################################################
+# An app with a non-default screen wrapping a Static.
+#
+# So far the screens we've been pushing likely haven't passed the test of
+# being a container. So now we test with zero bindings in place, expecting
+# to see zero bindings in place, but do so when the screen has a child;
+# presumably making it pass as a container.
+
 class NoBindingsAndStaticWidgetNoBindings(App[None]):
     """An app with no bindings, enclosing a widget with no bindings."""
 
@@ -111,28 +146,66 @@ async def test_just_app_no_bindings_widget_no_bindings() -> None:
 
 
 ##############################################################################
+# From here on in we're going to start simulating key strokes to ensure that
+# any bindings that are in place actually fire the correct actions. To help
+# with this let's build a simple key/binding/action recorder base app.
+
 class AppKeyRecorder(App[None]):
+    """Base application class that can be used to record keystrokes."""
+
+    ALPHAS = "abcxyz"
+    """str: The alpha keys to test against."""
+
+    ALL_KEYS = [*ALPHAS, *MOVEMENT_KEYS]
+    """list[str]: All the test keys."""
+
+    @staticmethod
+    def mk_bindings(prefix: str="") -> list[Binding]:
+        """Make the binding list for testing an app.
+
+        Args:
+            prefix (str, optional): An optional prefix for the actions.
+
+        Returns:
+            list[Binding]: The resulting list of bindings.
+        """
+        return [
+            Binding( key, f"{prefix}record('{key}')", key ) for key in [*AppKeyRecorder.ALPHAS, *MOVEMENT_KEYS]
+        ]
+
     def __init__(self) -> None:
+        """Initialise the recording app."""
         super().__init__()
         self.pressed_keys: list[str] = []
 
     async def action_record(self, key: str) -> None:
+        """Record a key, as used from a binding.
+
+        Args:
+            key (str): The name of the key to record.
+        """
         self.pressed_keys.append(key)
 
 
 ##############################################################################
+# An app with bindings for movement keys.
+#
+# Having gone through various permutations of testing for what bindings are
+# seen to be in place, we now move on to adding bindings, invoking them and
+# seeing what happens. First off let's start with an application that has
+# bindings, both for an alpha key, and also for all of the movement keys.
+
 class AppWithMovementKeysBound(AppKeyRecorder):
-    BINDINGS = [
-        Binding("x", "record('x')", "x"),
-        *[Binding(key, f"record({key}')", key) for key in MOVEMENT_KEYS],
-    ]
+    """An application with bindings."""
+    BINDINGS = AppKeyRecorder.mk_bindings()
 
 
 async def test_pressing_alpha_on_app() -> None:
-    """Test that pressing the an alpha key, when it's bound on the app, results in an action fire."""
+    """Test that pressing the alpha key, when it's bound on the app, results in an action fire."""
     async with AppWithMovementKeysBound().run_test() as pilot:
-        await pilot.press(*"xxxxx")
-        assert "".join(pilot.app.pressed_keys) == "xxxxx"
+        await pilot.press(*AppKeyRecorder.ALPHAS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == [*AppKeyRecorder.ALPHAS]
 
 
 @pytest.mark.xfail(
@@ -141,18 +214,23 @@ async def test_pressing_alpha_on_app() -> None:
 async def test_pressing_movement_keys_app() -> None:
     """Test that pressing the movement keys, when they're bound on the app, results in an action fire."""
     async with AppWithMovementKeysBound().run_test() as pilot:
-        await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["x", *MOVEMENT_KEYS, "x"]
+        await pilot.press(*AppKeyRecorder.ALL_KEYS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == AppKeyRecorder.ALL_KEYS
 
 
 ##############################################################################
+# An app with a focused child widget with bindings.
+#
+# Now let's spin up an application, using the default screen, where the app
+# itself is composing in a widget that can have, and has, focus. The widget
+# also has bindings for all of the test keys. That child widget should be
+# able to handle all of the test keys on its own and nothing else should
+# grab them.
+
 class FocusableWidgetWithBindings(Static, can_focus=True):
     """A widget that has its own bindings for the movement keys."""
-
-    BINDINGS = [
-        Binding("x", "record('x')", "x"),
-        *[Binding(key, f"local_record('{key}')", key) for key in MOVEMENT_KEYS]
-    ]
+    BINDINGS = AppKeyRecorder.mk_bindings("local_")
 
     async def action_local_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -172,24 +250,30 @@ class AppWithWidgetWithBindings(AppKeyRecorder):
 async def test_focused_child_widget_with_movement_bindings() -> None:
     """A focused child widget with movement bindings should handle its own actions."""
     async with AppWithWidgetWithBindings().run_test() as pilot:
-        await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["x", *[f"locally_{key}" for key in MOVEMENT_KEYS], "x"]
+        await pilot.press(*AppKeyRecorder.ALL_KEYS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == [f"locally_{key}" for key in AppKeyRecorder.ALL_KEYS]
 
 ##############################################################################
+# A focused widget within a screen that handles bindings.
+#
+# Similar to the previous test, here we're wrapping an app around a
+# non-default screen, which in turn wraps a widget that can has, and will
+# have, focus. The difference here however is that the screen has the
+# bindings. What we should expect to see is that the bindings don't fire on
+# the widget (it has none) and instead get caught by the screen.
+
 class FocusableWidgetWithNoBindings(Static, can_focus=True):
     """A widget that can receive focus but has no bindings."""
 
 class ScreenWithMovementBindings(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = [
-        Binding("x", "screen_record('x')", "x"),
-        *[Binding(key, f"screen_record('{key}')", key) for key in MOVEMENT_KEYS]
-    ]
+    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
-        await self.app.action_record(f"screen_{key}")
+        await self.app.action_record(f"screenly_{key}")
 
     def compose(self) -> ComposeResult:
         yield FocusableWidgetWithNoBindings()
@@ -211,17 +295,23 @@ class AppWithScreenWithBindingsWidgetNoBindings(AppKeyRecorder):
 async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
     """A focused child widget, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindings().run_test() as pilot:
-        await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["screen_x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "screen_x"]
+        await pilot.press(*AppKeyRecorder.ALL_KEYS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]
 
 ##############################################################################
+# A focused widget with bindings but no inheriting of bindings, on app.
+#
+# Now we move on to testing inherit_bindings. To start with we go back to an
+# app with a default screen, with the app itself composing in a widget that
+# can and will have focus, which has bindings for all the test keys, and
+# crucially has inherit_bindings set to False.
+#
+# We should expect to see all of the test keys recorded post-press.
+
 class WidgetWithBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
     """A widget that has its own bindings for the movement keys, no binding inheritance."""
-
-    BINDINGS = [
-        Binding("x", "local_record('x')", "x"),
-        *[Binding(key, f"local_record('{key}')", key) for key in MOVEMENT_KEYS]
-    ]
+    BINDINGS = AppKeyRecorder.mk_bindings("local_")
 
     async def action_local_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -241,24 +331,33 @@ class AppWithWidgetWithBindingsNoInherit(AppKeyRecorder):
 async def test_focused_child_widget_with_movement_bindings_no_inherit() -> None:
     """A focused child widget with movement bindings and inherit_bindings=False should handle its own actions."""
     async with AppWithWidgetWithBindingsNoInherit().run_test() as pilot:
-        await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["locally_x", *[f"locally_{key}" for key in MOVEMENT_KEYS], "locally_x"]
+        await pilot.press(*AppKeyRecorder.ALL_KEYS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == [f"locally_{key}" for key in AppKeyRecorder.ALL_KEYS]
 
 ##############################################################################
+# A focused widget with no bindings and no inheriting of bindings, on screen.
+#
+# Now let's test with a widget that can and will have focus, which has no
+# bindings, and which won't inherit bindings either. The bindings we're
+# going to test are moved up to the screen. We should expect to see all of
+# the test keys not be consumed by the focused widget, but instead they
+# should make it up to the screen.
+#
+# NOTE: no bindings are declared for the widget, which is different from
+# zero bindings declared.
+
 class FocusableWidgetWithNoBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
     """A widget that can receive focus but has no bindings and doesn't inherit bindings."""
 
 class ScreenWithMovementBindingsNoInheritChild(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = [
-        Binding("x", "screen_record('x')", "x"),
-        *[Binding(key, f"screen_record('{key}')", key) for key in MOVEMENT_KEYS]
-    ]
+    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
-        await self.app.action_record(f"screen_{key}")
+        await self.app.action_record(f"screenly_{key}")
 
     def compose(self) -> ComposeResult:
         yield FocusableWidgetWithNoBindingsNoInherit()
@@ -277,10 +376,23 @@ class AppWithScreenWithBindingsWidgetNoBindingsNoInherit(AppKeyRecorder):
 async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen() -> None:
     """A focused child widget, that doesn't inherit bindings, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindingsNoInherit().run_test() as pilot:
-        await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["screen_x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "screen_x"]
+        await pilot.press(*AppKeyRecorder.ALL_KEYS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]
 
 ##############################################################################
+# A focused widget with zero bindings dwclared, but no inheriting of
+# bindings, on screen.
+#
+# Now let's test with a widget that can and will have focus, which has zero
+# (an empty collection of) bindings, and which won't inherit bindings
+# either. The bindings we're going to test are moved up to the screen. We
+# should expect to see all of the test keys not be consumed by the focused
+# widget, but instead they should make it up to the screen.
+#
+# NOTE: zero bindings are declared for the widget, which is different from
+# no bindings declared.
+
 class FocusableWidgetWithEmptyBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
     """A widget that can receive focus but has empty bindings and doesn't inherit bindings."""
     BINDINGS = []
@@ -288,14 +400,11 @@ class FocusableWidgetWithEmptyBindingsNoInherit(Static, can_focus=True, inherit_
 class ScreenWithMovementBindingsNoInheritEmptyChild(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = [
-        Binding("x", "screen_record('x')", "x"),
-        *[Binding(key, f"screen_record('{key}')", key) for key in MOVEMENT_KEYS]
-    ]
+    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
-        await self.app.action_record(f"screen_{key}")
+        await self.app.action_record(f"screenly_{key}")
 
     def compose(self) -> ComposeResult:
         yield FocusableWidgetWithEmptyBindingsNoInherit()
@@ -314,5 +423,6 @@ class AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit(AppKeyRecorder):
 async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bindings_on_screen() -> None:
     """A focused child widget, that doesn't inherit bindings and sets BINDINGS empty, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit().run_test() as pilot:
-        await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["screen_x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "screen_x"]
+        await pilot.press(*AppKeyRecorder.ALL_KEYS)
+        await pilot.pause(2/100)
+        assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -231,7 +231,7 @@ async def test_pressing_alpha_on_app() -> None:
 
 
 @pytest.mark.xfail(
-    reason="Up key isn't firing bound action on an app due to key inheritence of its screen [issue#1343]"
+    reason="Up key isn't firing bound action on an app due to key inheritance of its screen [issue#1343]"
 )
 async def test_pressing_movement_keys_app() -> None:
     """Test that pressing the movement keys, when they're bound on the app, results in an action fire."""

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -383,7 +383,7 @@ async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen(
         assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]
 
 ##############################################################################
-# A focused widget with zero bindings dwclared, but no inheriting of
+# A focused widget with zero bindings declared, but no inheriting of
 # bindings, on screen.
 #
 # Now let's test with a widget that can and will have focus, which has zero

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -183,7 +183,7 @@ class ScreenWithMovementBindings(Screen):
     """A screen that binds keys, including movement keys."""
 
     BINDINGS = [
-        Binding("x", "record('x')", "x"),
+        Binding("x", "screen_record('x')", "x"),
         *[Binding(key, f"screen_record('{key}')", key) for key in MOVEMENT_KEYS]
     ]
 
@@ -212,7 +212,7 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
     """A focused child widget, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindings().run_test() as pilot:
         await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "x"]
+        assert pilot.app.pressed_keys == ["screen_x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "screen_x"]
 
 ##############################################################################
 class WidgetWithBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -274,9 +274,6 @@ class AppWithScreenWithBindingsWidgetNoBindingsNoInherit(AppKeyRecorder):
     def on_mount(self) -> None:
         self.push_screen("main")
 
-@pytest.mark.xfail(
-    reason="A child widget that doesn't inherit bindings, but has no bindings, incorrectly defers to its parent class [issue#1351]"
-)
 async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen() -> None:
     """A focused child widget, that doesn't inherit bindings, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindingsNoInherit().run_test() as pilot:

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -51,10 +51,10 @@ class AppWithScreenNoBindings(App[None]):
 @pytest.mark.xfail(
     reason="Screen is incorrectly starting with bindings for movement keys [issue#1343]"
 )
-async def test_app_screen_no_bindings() -> None:
-    """An screen with no bindings should have no bindings."""
+async def test_app_screen_has_no_movement_bindings() -> None:
+    """A screen with no bindings should not have movement key bindings."""
     async with AppWithScreenNoBindings().run_test() as pilot:
-        assert list(pilot.app.screen._bindings.keys.keys()) == []
+        assert list(pilot.app.screen._bindings.keys.keys()) != MOVEMENT_KEYS
 
 
 ##############################################################################

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -179,7 +179,7 @@ class AppKeyRecorder(App[None]):
     """list[str]: All the test keys."""
 
     @staticmethod
-    def mk_bindings(action_prefix: str = "") -> list[Binding]:
+    def make_bindings(action_prefix: str = "") -> list[Binding]:
         """Make the binding list for testing an app.
 
         Args:
@@ -227,7 +227,7 @@ class AppKeyRecorder(App[None]):
 class AppWithMovementKeysBound(AppKeyRecorder):
     """An application with bindings."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings()
+    BINDINGS = AppKeyRecorder.make_bindings()
 
 
 async def test_pressing_alpha_on_app() -> None:
@@ -259,7 +259,7 @@ async def test_pressing_movement_keys_app() -> None:
 class FocusableWidgetWithBindings(Static, can_focus=True):
     """A widget that has its own bindings for the movement keys."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings("local_")
+    BINDINGS = AppKeyRecorder.make_bindings("local_")
 
     async def action_local_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -301,7 +301,7 @@ class FocusableWidgetWithNoBindings(Static, can_focus=True):
 class ScreenWithMovementBindings(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
+    BINDINGS = AppKeyRecorder.make_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -344,7 +344,7 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
 class ScreenWithMovementBindingsAndContainerAroundWidget(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
+    BINDINGS = AppKeyRecorder.make_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -388,7 +388,7 @@ async def test_contained_focused_child_widget_with_movement_bindings_on_screen()
 class WidgetWithBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
     """A widget that has its own bindings for the movement keys, no binding inheritance."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings("local_")
+    BINDINGS = AppKeyRecorder.make_bindings("local_")
 
     async def action_local_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -435,7 +435,7 @@ class FocusableWidgetWithNoBindingsNoInherit(
 class ScreenWithMovementBindingsNoInheritChild(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
+    BINDINGS = AppKeyRecorder.make_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -490,7 +490,7 @@ class FocusableWidgetWithEmptyBindingsNoInherit(
 class ScreenWithMovementBindingsNoInheritEmptyChild(Screen):
     """A screen that binds keys, including movement keys."""
 
-    BINDINGS = AppKeyRecorder.mk_bindings("screen_")
+    BINDINGS = AppKeyRecorder.make_bindings("screen_")
 
     async def action_screen_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -9,6 +9,8 @@ Textual.
 background relating to this.
 """
 
+from __future__ import annotations
+
 import pytest
 
 from textual.app import App, ComposeResult

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -545,29 +545,27 @@ class PriorityOverlapWidget(Static, can_focus=True):
     """A focusable widget with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "record('widget_0')", "0", priority=False),
-        Binding("a", "record('widget_a')", "a", priority=False),
-        Binding("b", "record('widget_b')", "b", priority=False),
-        Binding("c", "record('widget_c')", "c", priority=True),
-        Binding("d", "record('widget_d')", "d", priority=False),
-        Binding("e", "record('widget_e')", "e", priority=True),
-        Binding("f", "record('widget_f')", "f", priority=True),
+        Binding("0", "app.record('widget_0')", "0", priority=False),
+        Binding("a", "app.record('widget_a')", "a", priority=False),
+        Binding("b", "app.record('widget_b')", "b", priority=False),
+        Binding("c", "app.record('widget_c')", "c", priority=True),
+        Binding("d", "app.record('widget_d')", "d", priority=False),
+        Binding("e", "app.record('widget_e')", "e", priority=True),
+        Binding("f", "app.record('widget_f')", "f", priority=True),
     ]
 
-    async def action_record( self, key: str ) -> None:
-        await self.app.action_record( key )
 
 class PriorityOverlapScreen(Screen):
     """A screen with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "record('screen_0')", "0", priority=False),
-        Binding("a", "record('screen_a')", "a", priority=False),
-        Binding("b", "record('screen_b')", "b", priority=True),
-        Binding("c", "record('screen_c')", "c", priority=False),
-        Binding("d", "record('screen_d')", "c", priority=True),
-        Binding("e", "record('screen_e')", "e", priority=False),
-        Binding("f", "record('screen_f')", "f", priority=True),
+        Binding("0", "app.record('screen_0')", "0", priority=False),
+        Binding("a", "app.record('screen_a')", "a", priority=False),
+        Binding("b", "app.record('screen_b')", "b", priority=True),
+        Binding("c", "app.record('screen_c')", "c", priority=False),
+        Binding("d", "app.record('screen_d')", "c", priority=True),
+        Binding("e", "app.record('screen_e')", "e", priority=False),
+        Binding("f", "app.record('screen_f')", "f", priority=True),
     ]
 
     def compose(self) -> ComposeResult:
@@ -575,9 +573,6 @@ class PriorityOverlapScreen(Screen):
 
     def on_mount(self) -> None:
         self.query_one(PriorityOverlapWidget).focus()
-
-    async def action_record( self, key: str ) -> None:
-        await self.app.action_record( key )
 
 class PriorityOverlapApp(AppKeyRecorder):
     """An application with a priority binding."""
@@ -596,9 +591,6 @@ class PriorityOverlapApp(AppKeyRecorder):
 
     def on_mount(self) -> None:
         self.push_screen("main")
-
-    async def action_record( self, key: str ) -> None:
-        await super().action_record( key )
 
 
 async def test_overlapping_priority_bindings() -> None:

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -219,7 +219,7 @@ class WidgetWithBindingsNoInherit(Static, can_focus=True, inherit_bindings=False
     """A widget that has its own bindings for the movement keys, no binding inheritance."""
 
     BINDINGS = [
-        Binding("x", "record('x')", "x"),
+        Binding("x", "local_record('x')", "x"),
         *[Binding(key, f"local_record('{key}')", key) for key in MOVEMENT_KEYS]
     ]
 
@@ -242,4 +242,4 @@ async def test_focused_child_widget_with_movement_bindings_no_inherit() -> None:
     """A focused child widget with movement bindings and inherit_bindings=False should handle its own actions."""
     async with AppWithWidgetWithBindingsNoInherit().run_test() as pilot:
         await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["x", *[f"locally_{key}" for key in MOVEMENT_KEYS], "x"]
+        assert pilot.app.pressed_keys == ["locally_x", *[f"locally_{key}" for key in MOVEMENT_KEYS], "locally_x"]

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -88,6 +88,7 @@ async def test_just_app_low_priority_alpha_binding() -> None:
         assert pilot.app._bindings.get_key("ctrl+c").priority == True
         assert pilot.app._bindings.get_key("a").priority == False
 
+
 ##############################################################################
 # A non-default screen with a single alpha key binding.
 #
@@ -117,10 +118,14 @@ async def test_app_screen_with_bindings() -> None:
         # The screen will contain all of the movement keys, because it
         # inherits from Widget. That's fine. Let's check they're there, but
         # also let's check that they all have a non-priority binding.
-        assert all(pilot.app.screen._bindings.get_key(key).priority == False for key in MOVEMENT_KEYS)
+        assert all(
+            pilot.app.screen._bindings.get_key(key).priority == False
+            for key in MOVEMENT_KEYS
+        )
         # Let's also check that the 'a' key is there, and it *is* a priority
         # binding.
         assert pilot.app.screen._bindings.get_key("a").priority == True
+
 
 ##############################################################################
 # A non-default screen with a single low-priority alpha key binding.
@@ -152,7 +157,10 @@ async def test_app_screen_with_low_bindings() -> None:
         # Screens inherit from Widget which means they get movement keys
         # too, so let's ensure they're all in there, along with our own key,
         # and that everyone is low-priority.
-        assert all(pilot.app.screen._bindings.get_key(key).priority == False for key in ["a", *MOVEMENT_KEYS])
+        assert all(
+            pilot.app.screen._bindings.get_key(key).priority == False
+            for key in ["a", *MOVEMENT_KEYS]
+        )
 
 
 ##############################################################################

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -587,7 +587,7 @@ class PriorityOverlapApp(AppKeyRecorder):
         Binding("f", "record('app_f')", "f", priority=False),
     ]
 
-    SCREENS = {"main": PriorityOverlapScreen()}
+    SCREENS = {"main": PriorityOverlapScreen}
 
     def on_mount(self) -> None:
         self.push_screen("main")

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -93,9 +93,7 @@ class AppWithScreenNoBindings(App[None]):
 async def test_app_screen_has_no_movement_bindings() -> None:
     """A screen with no bindings should not have movement key bindings."""
     async with AppWithScreenNoBindings().run_test() as pilot:
-        assert sorted(list(pilot.app.screen._bindings.keys.keys())) != sorted(
-            MOVEMENT_KEYS
-        )
+        assert not list(pilot.app.screen._bindings.keys.keys())
 
 
 ##############################################################################

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -6,6 +6,20 @@ from textual.screen import Screen
 from textual.binding import Binding
 
 ##############################################################################
+# These are the movement keys within Textual; they kind of have a special
+# status in that they will get bound to movement-related methods.
+MOVEMENT_KEYS = [
+    "up",
+    "down",
+    "left",
+    "right",
+    "home",
+    "end",
+    "pageup",
+    "pagedown"
+]
+
+##############################################################################
 class NoBindings(App[None]):
     """An app with zero bindings."""
 
@@ -103,24 +117,24 @@ class AppKeyRecorder(App[None]):
         self.pressed_keys.append(key)
 
 ##############################################################################
-class AppWithUpKeyBound(AppKeyRecorder):
+class AppWithMovementKeysBound(AppKeyRecorder):
     BINDINGS=[
         Binding("x","record('x')","x"),
-        Binding("up","record('up')","up")
+        *[Binding(key,f"record({key}')",key) for key in MOVEMENT_KEYS]
     ]
 
 async def test_pressing_alpha_on_app() -> None:
     """Test that pressing the an alpha key, when it's bound on the app, results in an action fire."""
-    async with AppWithUpKeyBound().run_test() as pilot:
+    async with AppWithMovementKeysBound().run_test() as pilot:
         await pilot.press(*"xxxxx")
         assert "".join(pilot.app.pressed_keys) == "xxxxx"
 
 @pytest.mark.xfail(
     reason="Up key isn't firing bound action on an app due to key inheritence of its screen [issue#1343]"
 )
-async def test_pressing_up_on_app() -> None:
-    """Test that pressing the up key, when it's bound on the app, results in an action fire."""
-    async with AppWithUpKeyBound().run_test() as pilot:
-        await pilot.press("x", "up", "x")
-        assert pilot.app.pressed_keys == ["x", "up", "x"]
+async def test_pressing_movement_keys_app() -> None:
+    """Test that pressing the movement keys, when they're bound on the app, results in an action fire."""
+    async with AppWithMovementKeysBound().run_test() as pilot:
+        await pilot.press("x", *MOVEMENT_KEYS, "x")
+        assert pilot.app.pressed_keys == ["x", *MOVEMENT_KEYS, "x"]
 

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -188,16 +188,13 @@ class AppKeyRecorder(App[None]):
         """
         self.pressed_keys.append(key)
 
-    def all_recorded(self, prefix: str="") -> bool:
+    def all_recorded(self, prefix: str="") -> None:
         """Were all the bindings recorded from the presses?
 
         Args:
             prefix (str, optional): An optional prefix.
-
-        Returns:
-            bool: ``True`` if all the bindings were recorded, ``False``if not.
         """
-        return self.pressed_keys == [f"{prefix}{key}" for key in self.ALL_KEYS]
+        assert self.pressed_keys == [f"{prefix}{key}" for key in self.ALL_KEYS]
 
 
 ##############################################################################
@@ -229,7 +226,7 @@ async def test_pressing_movement_keys_app() -> None:
     async with AppWithMovementKeysBound().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.all_recorded()
+        pilot.app.all_recorded()
 
 
 ##############################################################################
@@ -265,7 +262,7 @@ async def test_focused_child_widget_with_movement_bindings() -> None:
     async with AppWithWidgetWithBindings().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.all_recorded("locally_")
+        pilot.app.all_recorded("locally_")
 
 ##############################################################################
 # A focused widget within a screen that handles bindings.
@@ -346,7 +343,7 @@ async def test_focused_child_widget_with_movement_bindings_no_inherit() -> None:
     async with AppWithWidgetWithBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.all_recorded("locally_")
+        pilot.app.all_recorded("locally_")
 
 ##############################################################################
 # A focused widget with no bindings and no inheriting of bindings, on screen.
@@ -391,7 +388,7 @@ async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen(
     async with AppWithScreenWithBindingsWidgetNoBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.all_recorded("screenly_")
+        pilot.app.all_recorded("screenly_")
 
 ##############################################################################
 # A focused widget with zero bindings declared, but no inheriting of
@@ -438,4 +435,4 @@ async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bind
     async with AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.all_recorded("screenly_")
+        pilot.app.all_recorded("screenly_")

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -532,22 +532,20 @@ async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bind
 # |-----|----------|----------|----------|--------|
 # | Key | App      | Screen   | Widget   | Winner |
 # |-----|----------|----------|----------|--------|
+# | 0   |          |          |          | Widget |
 # | A   | Priority |          |          | App    |
 # | B   |          | Priority |          | Screen |
 # | C   |          |          | Priority | Widget |
 # | D   | Priority | Priority |          | App    |
 # | E   | Priority |          | Priority | App    |
 # | F   |          | Priority | Priority | Screen |
-#
-# NOTE: The winner column is still up for grabs when there's more than one
-# priority binding. Need to check with Will which he feels makes more sense:
-# deeper priority wins, or shallower?
 
 
 class PriorityOverlapWidget(Static, can_focus=True):
     """A focusable widget with a priority binding."""
 
     BINDINGS = [
+        Binding("0", "record('widget_0')", "0", priority=False),
         Binding("a", "record('widget_a')", "a", priority=False),
         Binding("b", "record('widget_b')", "b", priority=False),
         Binding("c", "record('widget_c')", "c", priority=True),
@@ -561,6 +559,7 @@ class PriorityOverlapScreen(Screen):
     """A screen with a priority binding."""
 
     BINDINGS = [
+        Binding("0", "record('screen_0')", "0", priority=False),
         Binding("a", "record('screen_a')", "a", priority=False),
         Binding("b", "record('screen_b')", "b", priority=True),
         Binding("c", "record('screen_c')", "c", priority=False),
@@ -580,6 +579,7 @@ class PriorityOverlapApp(AppKeyRecorder):
     """An application with a priority binding."""
 
     BINDINGS = [
+        Binding("0", "record('app_0')", "0", priority=False),
         Binding("a", "record('app_a')", "a", priority=True),
         Binding("b", "record('app_b')", "b", priority=False),
         Binding("c", "record('app_c')", "c", priority=False),
@@ -594,13 +594,13 @@ class PriorityOverlapApp(AppKeyRecorder):
         self.push_screen("main")
 
 
-@pytest.mark.xfail(reason="The final decision about who wins when needs to be made")
 async def test_overlapping_priority_bindings() -> None:
     """Test an app stack with overlapping bindings."""
     async with PriorityOverlapApp().run_test() as pilot:
-        await pilot.press(*"abcdef")
+        await pilot.press(*"0abcdef")
         await pilot.pause(2 / 100)
         assert pilot.app.pressed_keys == [
+            "widget_0",
             "app_a",
             "screen_b",
             "widget_c",

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -94,9 +94,8 @@ class NoBindingsAndStaticWidgetNoBindings(App[None]):
     reason="Static is incorrectly starting with bindings for movement keys [issue#1343]"
 )
 async def test_just_app_no_bindings_widget_no_bindings() -> None:
-    """A widget with no bindings should have no bindings. Its app should have just ctrl+c"""
+    """A widget with no bindings should have no bindings"""
     async with NoBindingsAndStaticWidgetNoBindings().run_test() as pilot:
-        assert list(pilot.app._bindings.keys.keys()) == ["ctrl+c"]
         assert list(pilot.app.screen.query_one(Static)._bindings.keys.keys()) == []
 
 

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -545,27 +545,29 @@ class PriorityOverlapWidget(Static, can_focus=True):
     """A focusable widget with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "app.record('widget_0')", "0", priority=False),
-        Binding("a", "app.record('widget_a')", "a", priority=False),
-        Binding("b", "app.record('widget_b')", "b", priority=False),
-        Binding("c", "app.record('widget_c')", "c", priority=True),
-        Binding("d", "app.record('widget_d')", "d", priority=False),
-        Binding("e", "app.record('widget_e')", "e", priority=True),
-        Binding("f", "app.record('widget_f')", "f", priority=True),
+        Binding("0", "record('widget_0')", "0", priority=False),
+        Binding("a", "record('widget_a')", "a", priority=False),
+        Binding("b", "record('widget_b')", "b", priority=False),
+        Binding("c", "record('widget_c')", "c", priority=True),
+        Binding("d", "record('widget_d')", "d", priority=False),
+        Binding("e", "record('widget_e')", "e", priority=True),
+        Binding("f", "record('widget_f')", "f", priority=True),
     ]
 
+    async def action_record( self, key: str ) -> None:
+        await self.app.action_record( key )
 
 class PriorityOverlapScreen(Screen):
     """A screen with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "app.record('screen_0')", "0", priority=False),
-        Binding("a", "app.record('screen_a')", "a", priority=False),
-        Binding("b", "app.record('screen_b')", "b", priority=True),
-        Binding("c", "app.record('screen_c')", "c", priority=False),
-        Binding("d", "app.record('screen_d')", "c", priority=True),
-        Binding("e", "app.record('screen_e')", "e", priority=False),
-        Binding("f", "app.record('screen_f')", "f", priority=True),
+        Binding("0", "record('screen_0')", "0", priority=False),
+        Binding("a", "record('screen_a')", "a", priority=False),
+        Binding("b", "record('screen_b')", "b", priority=True),
+        Binding("c", "record('screen_c')", "c", priority=False),
+        Binding("d", "record('screen_d')", "c", priority=True),
+        Binding("e", "record('screen_e')", "e", priority=False),
+        Binding("f", "record('screen_f')", "f", priority=True),
     ]
 
     def compose(self) -> ComposeResult:
@@ -574,6 +576,8 @@ class PriorityOverlapScreen(Screen):
     def on_mount(self) -> None:
         self.query_one(PriorityOverlapWidget).focus()
 
+    async def action_record( self, key: str ) -> None:
+        await self.app.action_record( key )
 
 class PriorityOverlapApp(AppKeyRecorder):
     """An application with a priority binding."""
@@ -592,6 +596,9 @@ class PriorityOverlapApp(AppKeyRecorder):
 
     def on_mount(self) -> None:
         self.push_screen("main")
+
+    async def action_record( self, key: str ) -> None:
+        await super().action_record( key )
 
 
 async def test_overlapping_priority_bindings() -> None:

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -54,7 +54,7 @@ class AppWithScreenNoBindings(App[None]):
 async def test_app_screen_has_no_movement_bindings() -> None:
     """A screen with no bindings should not have movement key bindings."""
     async with AppWithScreenNoBindings().run_test() as pilot:
-        assert list(pilot.app.screen._bindings.keys.keys()) != MOVEMENT_KEYS
+        assert sorted(list(pilot.app.screen._bindings.keys.keys())) != sorted(MOVEMENT_KEYS)
 
 
 ##############################################################################

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -139,7 +139,10 @@ async def test_pressing_movement_keys_app() -> None:
 class WidgetWithBindings(Static, can_focus=True):
     """A widget that has its own bindings for the movement keys."""
 
-    BINDINGS = [Binding(key, f"local_record('{key}')", key) for key in MOVEMENT_KEYS]
+    BINDINGS = [
+        Binding("x", "record('x')", "x"),
+        *[Binding(key, f"local_record('{key}')", key) for key in MOVEMENT_KEYS]
+    ]
 
     async def action_local_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
@@ -159,5 +162,5 @@ class AppWithWidgetWithBindings(AppKeyRecorder):
 async def test_focused_child_widget_with_movement_bindings() -> None:
     """A focused child widget with movement bindings should handle its own actions."""
     async with AppWithWidgetWithBindings().run_test() as pilot:
-        await pilot.press(*MOVEMENT_KEYS)
-        assert pilot.app.pressed_keys == [f"locally_{key}" for key in MOVEMENT_KEYS]
+        await pilot.press("x", *MOVEMENT_KEYS, "x")
+        assert pilot.app.pressed_keys == ["x", *[f"locally_{key}" for key in MOVEMENT_KEYS], "x"]

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -1,3 +1,14 @@
+"""Tests relating to key binding inheritance.
+
+In here you'll find some tests for general key binding inheritance, but
+there is an emphasis on the inheriting of movement key bindings as they (as
+of the time of writing) hold a special place in the Widget hierarchy of
+Textual.
+
+<URL:https://github.com/Textualize/textual/issues/1343> holds much of the
+background relating to this.
+"""
+
 import pytest
 
 from textual.app import App, ComposeResult

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -545,13 +545,13 @@ class PriorityOverlapWidget(Static, can_focus=True):
     """A focusable widget with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "record('widget_0')", "0", priority=False),
-        Binding("a", "record('widget_a')", "a", priority=False),
-        Binding("b", "record('widget_b')", "b", priority=False),
-        Binding("c", "record('widget_c')", "c", priority=True),
-        Binding("d", "record('widget_d')", "d", priority=False),
-        Binding("e", "record('widget_e')", "e", priority=True),
-        Binding("f", "record('widget_f')", "f", priority=True),
+        Binding("0", "app.record('widget_0')", "0", priority=False),
+        Binding("a", "app.record('widget_a')", "a", priority=False),
+        Binding("b", "app.record('widget_b')", "b", priority=False),
+        Binding("c", "app.record('widget_c')", "c", priority=True),
+        Binding("d", "app.record('widget_d')", "d", priority=False),
+        Binding("e", "app.record('widget_e')", "e", priority=True),
+        Binding("f", "app.record('widget_f')", "f", priority=True),
     ]
 
 
@@ -559,13 +559,13 @@ class PriorityOverlapScreen(Screen):
     """A screen with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "record('screen_0')", "0", priority=False),
-        Binding("a", "record('screen_a')", "a", priority=False),
-        Binding("b", "record('screen_b')", "b", priority=True),
-        Binding("c", "record('screen_c')", "c", priority=False),
-        Binding("d", "record('screen_d')", "c", priority=True),
-        Binding("e", "record('screen_e')", "e", priority=False),
-        Binding("f", "record('screen_f')", "f", priority=True),
+        Binding("0", "app.record('screen_0')", "0", priority=False),
+        Binding("a", "app.record('screen_a')", "a", priority=False),
+        Binding("b", "app.record('screen_b')", "b", priority=True),
+        Binding("c", "app.record('screen_c')", "c", priority=False),
+        Binding("d", "app.record('screen_d')", "c", priority=True),
+        Binding("e", "app.record('screen_e')", "e", priority=False),
+        Binding("f", "app.record('screen_f')", "f", priority=True),
     ]
 
     def compose(self) -> ComposeResult:
@@ -598,7 +598,7 @@ async def test_overlapping_priority_bindings() -> None:
     """Test an app stack with overlapping bindings."""
     async with PriorityOverlapApp().run_test() as pilot:
         await pilot.press(*"0abcdef")
-        await pilot.pause(5 / 100)
+        await pilot.pause(2 / 100)
         assert pilot.app.pressed_keys == [
             "widget_0",
             "app_a",

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -40,7 +40,7 @@ async def test_just_app_no_bindings() -> None:
     """An app with no bindings should have no bindings, other than ctrl+c."""
     async with NoBindings().run_test() as pilot:
         assert list(pilot.app._bindings.keys.keys()) == ["ctrl+c"]
-        assert pilot.app._bindings.get_key("ctrl+c").priority == True
+        assert pilot.app._bindings.get_key("ctrl+c").priority is True
 
 
 ##############################################################################
@@ -62,8 +62,8 @@ async def test_just_app_alpha_binding() -> None:
     """An app with a single binding should have just the one binding."""
     async with AlphaBinding().run_test() as pilot:
         assert sorted(pilot.app._bindings.keys.keys()) == sorted(["ctrl+c", "a"])
-        assert pilot.app._bindings.get_key("ctrl+c").priority == True
-        assert pilot.app._bindings.get_key("a").priority == True
+        assert pilot.app._bindings.get_key("ctrl+c").priority is True
+        assert pilot.app._bindings.get_key("a").priority is True
 
 
 ##############################################################################
@@ -85,8 +85,8 @@ async def test_just_app_low_priority_alpha_binding() -> None:
     """An app with a single low-priority binding should have just the one binding."""
     async with LowAlphaBinding().run_test() as pilot:
         assert sorted(pilot.app._bindings.keys.keys()) == sorted(["ctrl+c", "a"])
-        assert pilot.app._bindings.get_key("ctrl+c").priority == True
-        assert pilot.app._bindings.get_key("a").priority == False
+        assert pilot.app._bindings.get_key("ctrl+c").priority is True
+        assert pilot.app._bindings.get_key("a").priority is False
 
 
 ##############################################################################
@@ -119,12 +119,12 @@ async def test_app_screen_with_bindings() -> None:
         # inherits from Widget. That's fine. Let's check they're there, but
         # also let's check that they all have a non-priority binding.
         assert all(
-            pilot.app.screen._bindings.get_key(key).priority == False
+            pilot.app.screen._bindings.get_key(key).priority is False
             for key in MOVEMENT_KEYS
         )
         # Let's also check that the 'a' key is there, and it *is* a priority
         # binding.
-        assert pilot.app.screen._bindings.get_key("a").priority == True
+        assert pilot.app.screen._bindings.get_key("a").priority is True
 
 
 ##############################################################################
@@ -158,7 +158,7 @@ async def test_app_screen_with_low_bindings() -> None:
         # too, so let's ensure they're all in there, along with our own key,
         # and that everyone is low-priority.
         assert all(
-            pilot.app.screen._bindings.get_key(key).priority == False
+            pilot.app.screen._bindings.get_key(key).priority is False
             for key in ["a", *MOVEMENT_KEYS]
         )
 

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -188,6 +188,17 @@ class AppKeyRecorder(App[None]):
         """
         self.pressed_keys.append(key)
 
+    def all_recorded(self, prefix: str="") -> bool:
+        """Were all the bindings recorded from the presses?
+
+        Args:
+            prefix (str, optional): An optional prefix.
+
+        Returns:
+            bool: ``True`` if all the bindings were recorded, ``False``if not.
+        """
+        return self.pressed_keys == [f"{prefix}{key}" for key in self.ALL_KEYS]
+
 
 ##############################################################################
 # An app with bindings for movement keys.
@@ -218,7 +229,7 @@ async def test_pressing_movement_keys_app() -> None:
     async with AppWithMovementKeysBound().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.pressed_keys == AppKeyRecorder.ALL_KEYS
+        assert pilot.app.all_recorded()
 
 
 ##############################################################################
@@ -254,7 +265,7 @@ async def test_focused_child_widget_with_movement_bindings() -> None:
     async with AppWithWidgetWithBindings().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.pressed_keys == [f"locally_{key}" for key in AppKeyRecorder.ALL_KEYS]
+        assert pilot.app.all_recorded("locally_")
 
 ##############################################################################
 # A focused widget within a screen that handles bindings.
@@ -299,7 +310,7 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
     async with AppWithScreenWithBindingsWidgetNoBindings().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]
+        assert pilot.app.all_recorded("screenly_")
 
 ##############################################################################
 # A focused widget with bindings but no inheriting of bindings, on app.
@@ -335,7 +346,7 @@ async def test_focused_child_widget_with_movement_bindings_no_inherit() -> None:
     async with AppWithWidgetWithBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.pressed_keys == [f"locally_{key}" for key in AppKeyRecorder.ALL_KEYS]
+        assert pilot.app.all_recorded("locally_")
 
 ##############################################################################
 # A focused widget with no bindings and no inheriting of bindings, on screen.
@@ -380,7 +391,7 @@ async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen(
     async with AppWithScreenWithBindingsWidgetNoBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]
+        assert pilot.app.all_recorded("screenly_")
 
 ##############################################################################
 # A focused widget with zero bindings declared, but no inheriting of
@@ -427,4 +438,4 @@ async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bind
     async with AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit().run_test() as pilot:
         await pilot.press(*AppKeyRecorder.ALL_KEYS)
         await pilot.pause(2/100)
-        assert pilot.app.pressed_keys == [f"screenly_{key}" for key in AppKeyRecorder.ALL_KEYS]
+        assert pilot.app.all_recorded("screenly_")

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -545,7 +545,7 @@ class PriorityOverlapWidget(Static, can_focus=True):
     """A focusable widget with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "app.record('widget_0')", "0", priority=False),
+#        Binding("0", "app.record('widget_0')", "0", priority=False),
         Binding("a", "app.record('widget_a')", "a", priority=False),
         Binding("b", "app.record('widget_b')", "b", priority=False),
         Binding("c", "app.record('widget_c')", "c", priority=True),
@@ -559,7 +559,7 @@ class PriorityOverlapScreen(Screen):
     """A screen with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "app.record('screen_0')", "0", priority=False),
+#        Binding("0", "app.record('screen_0')", "0", priority=False),
         Binding("a", "app.record('screen_a')", "a", priority=False),
         Binding("b", "app.record('screen_b')", "b", priority=True),
         Binding("c", "app.record('screen_c')", "c", priority=False),
@@ -579,7 +579,7 @@ class PriorityOverlapApp(AppKeyRecorder):
     """An application with a priority binding."""
 
     BINDINGS = [
-        Binding("0", "record('app_0')", "0", priority=False),
+#        Binding("0", "record('app_0')", "0", priority=False),
         Binding("a", "record('app_a')", "a", priority=True),
         Binding("b", "record('app_b')", "b", priority=False),
         Binding("c", "record('app_c')", "c", priority=False),
@@ -597,10 +597,10 @@ class PriorityOverlapApp(AppKeyRecorder):
 async def test_overlapping_priority_bindings() -> None:
     """Test an app stack with overlapping bindings."""
     async with PriorityOverlapApp().run_test() as pilot:
-        await pilot.press(*"0abcdef")
+        await pilot.press(*"abcdef")
         await pilot.pause(2 / 100)
         assert pilot.app.pressed_keys == [
-            "widget_0",
+#            "widget_0",
             "app_a",
             "screen_b",
             "widget_c",

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -527,7 +527,7 @@ async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bind
 # combination of overlapping bindings, each with different forms of
 # priority, so we can check who wins where.
 #
-# Here are the permurations tested, with the expected winner:
+# Here are the permutations tested, with the expected winner:
 #
 # |-----|----------|----------|----------|--------|
 # | Key | App      | Screen   | Widget   | Winner |

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -331,9 +331,6 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
 # that can have, and will have, focus. The issue here is that if the
 # container isn't scrolling, especially if it's set up to just wrap a widget
 # and do nothing else, it should not rob the screen of the binding hits.
-#
-# Although it's not at the end of the unit tests, this is potentially the
-# "final boss" of these tests.
 
 
 class ScreenWithMovementBindingsAndContainerAroundWidget(Screen):

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -202,4 +202,4 @@ async def test_focused_child_widget_with_movement_bindings_on_screen() -> None:
     """A focused child widget, with movement bindings in the screen, should trigger screen actions."""
     async with AppWithScreenWithBindingsWidgetNoBindings().run_test() as pilot:
         await pilot.press("x", *MOVEMENT_KEYS, "x")
-        assert pilot.app.pressed_keys == ["x", *[f"locally_{key}" for key in MOVEMENT_KEYS], "x"]
+        assert pilot.app.pressed_keys == ["x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "x"]

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -282,3 +282,40 @@ async def test_focused_child_widget_no_inherit_with_movement_bindings_on_screen(
     async with AppWithScreenWithBindingsWidgetNoBindingsNoInherit().run_test() as pilot:
         await pilot.press("x", *MOVEMENT_KEYS, "x")
         assert pilot.app.pressed_keys == ["screen_x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "screen_x"]
+
+##############################################################################
+class FocusableWidgetWithEmptyBindingsNoInherit(Static, can_focus=True, inherit_bindings=False):
+    """A widget that can receive focus but has empty bindings and doesn't inherit bindings."""
+    BINDINGS = []
+
+class ScreenWithMovementBindingsNoInheritEmptyChild(Screen):
+    """A screen that binds keys, including movement keys."""
+
+    BINDINGS = [
+        Binding("x", "screen_record('x')", "x"),
+        *[Binding(key, f"screen_record('{key}')", key) for key in MOVEMENT_KEYS]
+    ]
+
+    async def action_screen_record(self, key: str) -> None:
+        # Sneaky forward reference. Just for the purposes of testing.
+        await self.app.action_record(f"screen_{key}")
+
+    def compose(self) -> ComposeResult:
+        yield FocusableWidgetWithEmptyBindingsNoInherit()
+
+    def on_mount(self) -> None:
+        self.query_one(FocusableWidgetWithEmptyBindingsNoInherit).focus()
+
+class AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit(AppKeyRecorder):
+    """An app with a non-default screen that handles movement key bindings, child no-inherit."""
+
+    SCREENS = {"main":ScreenWithMovementBindingsNoInheritEmptyChild}
+
+    def on_mount(self) -> None:
+        self.push_screen("main")
+
+async def test_focused_child_widget_no_inherit_empty_bindings_with_movement_bindings_on_screen() -> None:
+    """A focused child widget, that doesn't inherit bindings and sets BINDINGS empty, with movement bindings in the screen, should trigger screen actions."""
+    async with AppWithScreenWithBindingsWidgetEmptyBindingsNoInherit().run_test() as pilot:
+        await pilot.press("x", *MOVEMENT_KEYS, "x")
+        assert pilot.app.pressed_keys == ["screen_x", *[f"screen_{key}" for key in MOVEMENT_KEYS], "screen_x"]

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -598,7 +598,7 @@ async def test_overlapping_priority_bindings() -> None:
     """Test an app stack with overlapping bindings."""
     async with PriorityOverlapApp().run_test() as pilot:
         await pilot.press(*"0abcdef")
-        await pilot.pause(2 / 100)
+        await pilot.pause(5 / 100)
         assert pilot.app.pressed_keys == [
             "widget_0",
             "app_a",

--- a/tests/test_binding_inheritance.py
+++ b/tests/test_binding_inheritance.py
@@ -8,16 +8,7 @@ from textual.binding import Binding
 ##############################################################################
 # These are the movement keys within Textual; they kind of have a special
 # status in that they will get bound to movement-related methods.
-MOVEMENT_KEYS = [
-    "up",
-    "down",
-    "left",
-    "right",
-    "home",
-    "end",
-    "pageup",
-    "pagedown"
-]
+MOVEMENT_KEYS = ["up", "down", "left", "right", "home", "end", "pageup", "pagedown"]
 
 ##############################################################################
 class NoBindings(App[None]):
@@ -90,12 +81,14 @@ async def test_app_screen_with_bindings() -> None:
     async with AppWithScreenThatHasABinding().run_test() as pilot:
         assert list(pilot.app.screen._bindings.keys.keys()) == ["a"]
 
+
 ##############################################################################
 class NoBindingsAndStaticWidgetNoBindings(App[None]):
     """An app with no bindings, enclosing a widget with no bindings."""
 
     def compose(self) -> ComposeResult:
         yield Static("Poetry! They should have sent a poet.")
+
 
 @pytest.mark.xfail(
     reason="Static is incorrectly starting with bindings for movement keys [issue#1343]"
@@ -106,9 +99,9 @@ async def test_just_app_no_bindings_widget_no_bindings() -> None:
         assert list(pilot.app._bindings.keys.keys()) == ["ctrl+c"]
         assert list(pilot.app.screen.query_one(Static)._bindings.keys.keys()) == []
 
+
 ##############################################################################
 class AppKeyRecorder(App[None]):
-
     def __init__(self) -> None:
         super().__init__()
         self.pressed_keys: list[str] = []
@@ -116,18 +109,21 @@ class AppKeyRecorder(App[None]):
     async def action_record(self, key: str) -> None:
         self.pressed_keys.append(key)
 
+
 ##############################################################################
 class AppWithMovementKeysBound(AppKeyRecorder):
-    BINDINGS=[
-        Binding("x","record('x')","x"),
-        *[Binding(key,f"record({key}')",key) for key in MOVEMENT_KEYS]
+    BINDINGS = [
+        Binding("x", "record('x')", "x"),
+        *[Binding(key, f"record({key}')", key) for key in MOVEMENT_KEYS],
     ]
+
 
 async def test_pressing_alpha_on_app() -> None:
     """Test that pressing the an alpha key, when it's bound on the app, results in an action fire."""
     async with AppWithMovementKeysBound().run_test() as pilot:
         await pilot.press(*"xxxxx")
         assert "".join(pilot.app.pressed_keys) == "xxxxx"
+
 
 @pytest.mark.xfail(
     reason="Up key isn't firing bound action on an app due to key inheritence of its screen [issue#1343]"
@@ -138,15 +134,17 @@ async def test_pressing_movement_keys_app() -> None:
         await pilot.press("x", *MOVEMENT_KEYS, "x")
         assert pilot.app.pressed_keys == ["x", *MOVEMENT_KEYS, "x"]
 
+
 ##############################################################################
-class WidgetWithBindings(Static,can_focus=True):
+class WidgetWithBindings(Static, can_focus=True):
     """A widget that has its own bindings for the movement keys."""
 
-    BINDINGS=[Binding(key,f"local_record('{key}')",key) for key in MOVEMENT_KEYS]
+    BINDINGS = [Binding(key, f"local_record('{key}')", key) for key in MOVEMENT_KEYS]
 
-    async def action_local_record(self, key:str) -> None:
+    async def action_local_record(self, key: str) -> None:
         # Sneaky forward reference. Just for the purposes of testing.
         await self.app.action_record(f"locally_{key}")
+
 
 class AppWithWidgetWithBindings(AppKeyRecorder):
     """A test app that composes with a widget that has movement bindings."""
@@ -156,6 +154,7 @@ class AppWithWidgetWithBindings(AppKeyRecorder):
 
     def on_mount(self) -> None:
         self.query_one(WidgetWithBindings).focus()
+
 
 async def test_focused_child_widget_with_movement_bindings() -> None:
     """A focused child widget with movement bindings should handle its own actions."""


### PR DESCRIPTION
~~This PR aims to explore, add tests for, and hopefully resolve the issue raised in #1343. For now this is just a draft PR as I work to build up a set of (hopefully comprehensive) unit tests for the issue. As this grows and ideally ends up implementing a solution for the problem, I'll edit this description to better describe what's gone into it.~~

~~As I started to pull on the thread first found as #1343, it became obvious that a fairly comprehensive set of unit tests were needed to document the issue, test what does and doesn't work right now, document expectations and also cover things that work now and should carry on working should any changes be made.~~

~~I feel it makes sense to merge these tests into `main` first and *then* move on to considering options for how to resolve the issue. Hence repurposing this PR for that and that alone.~~

This PR has now turned back into a fix for #1343, taking the approach of allowing the library user to say if the bindings on a particular widget should be considered to have priority or not, by use of a `PRIORITY_BINDINGS` classvar. Additionally, `App` and `Screen` are set so that all of their bindings are priority bindings by default.

Side quest: The binding system now handles situations where a library user may bind `"a, b, c, d"` rather than `"a,b,c,d"`.