### PR TITLE
Fix binding merging when binding inheritance is set to `False`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with auto width/height and relative children https://github.com/Textualize/textual/issues/1319
 - Fixed issue with offset applied to containers https://github.com/Textualize/textual/issues/1256
 - Fixed default CSS retrieval for widgets with no `DEFAULT_CSS` that inherited from widgets with `DEFAULT_CSS` https://github.com/Textualize/textual/issues/1335
+- Fixed merging of `BINDINGS` when binding inheritance is set to `None` https://github.com/Textualize/textual/issues/1351
 
 ## [0.5.0] - 2022-11-20
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -229,7 +229,7 @@ class DOMNode(MessagePump):
             if issubclass(base, DOMNode):
                 if not base._inherit_bindings:
                     bindings.clear()
-                bindings.append(Bindings(base.BINDINGS))
+                bindings.append(Bindings(base.__dict__.get("BINDINGS", [])))
         keys = {}
         for bindings_ in bindings:
             keys.update(bindings_.keys)

--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -45,6 +45,39 @@ def test_validate():
         node.toggle_class("1")
 
 
+def test_inherited_bindings():
+    """Test if binding merging is done correctly when (not) inheriting bindings."""
+    class A(DOMNode):
+        BINDINGS = [("a", "a", "a")]
+
+    class B(A):
+        BINDINGS = [("b", "b", "b")]
+
+    class C(B, inherit_bindings=False):
+        BINDINGS = [("c", "c", "c")]
+
+    class D(C, inherit_bindings=False):
+        pass
+
+    class E(D):
+        BINDINGS = [("e", "e", "e")]
+
+    a = A()
+    assert list(a._bindings.keys.keys()) == ["a"]
+
+    b = B()
+    assert list(b._bindings.keys.keys()) == ["a", "b"]
+
+    c = C()
+    assert list(c._bindings.keys.keys()) == ["c"]
+
+    d = D()
+    assert not list(d._bindings.keys.keys())
+
+    e = E()
+    assert list(e._bindings.keys.keys()) == ["e"]
+
+
 @pytest.fixture
 def search():
     """


### PR DESCRIPTION
This fixes #1351 with a strategy _very_ similar to that of #1336.