### PR TITLE
Make the cursor keys work in 5x5 again

### DIFF
--- a/examples/five_by_five.py
+++ b/examples/five_by_five.py
@@ -166,10 +166,10 @@ class Game(Screen):
         Binding("n", "new_game", "New Game"),
         Binding("question_mark", "push_screen('help')", "Help", key_display="?"),
         Binding("q", "quit", "Quit"),
-        Binding("up,w,k", "navigate(-1,0)", "Move Up", False),
-        Binding("down,s,j", "navigate(1,0)", "Move Down", False),
-        Binding("left,a,h", "navigate(0,-1)", "Move Left", False),
-        Binding("right,d,l", "navigate(0,1)", "Move Right", False),
+        Binding("up,w,k", "navigate(-1,0)", "Move Up", False, universal=True),
+        Binding("down,s,j", "navigate(1,0)", "Move Down", False, universal=True),
+        Binding("left,a,h", "navigate(0,-1)", "Move Left", False, universal=True),
+        Binding("right,d,l", "navigate(0,1)", "Move Right", False, universal=True),
         Binding("space", "move", "Toggle", False),
     ]
     """The bindings for the main game grid."""


### PR DESCRIPTION
The cursor keys stopped working in 5x5 once binding inheritance was introduced in 0.6.0 (see #1343). Making them `universal` keys here fixes the issue. This won't be the final form of this change, but this fixes this example so that it works with 0.6.0 (so anyone cloning down the code and running with an installed 0.6.0 will get the full effect).

Once the final work resulting from #1343 takes place this will need a final update (and should be a good test example for the changes).
