### PR TITLE
Export the types that _typing.py imports and makes available

### DIFF
--- a/src/textual/_typing.py
+++ b/src/textual/_typing.py
@@ -9,3 +9,5 @@ if sys.version_info >= (3, 8):
     from typing import Final, Literal, Protocol, TypedDict
 else:
     from typing_extensions import Final, Literal, Protocol, TypedDict
+
+__all__ = ["TypeAlias", "Final", "Literal", "Protocol", "TypedDict"]


### PR DESCRIPTION
Mostly adding this so that it turns this:

$ poetry run mypy --strict binding.py
binding.py:8: error: Module "textual._typing" does not explicitly export attribute "TypeAlias"  [attr-defined] Found 1 error in 1 file (checked 1 source file)

into this:

$ poetry run mypy --strict binding.py
Success: no issues found in 1 source file
