### PR TITLE
Correct what looks to be a typo in the Bindings.merge docstring

### DIFF
--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -75,7 +75,7 @@ class Bindings:
 
     @classmethod
     def merge(cls, bindings: Iterable[Bindings]) -> Bindings:
-        """Merge a bindings. Subsequence bound keys override initial keys.
+        """Merge a bindings. Subsequent bound keys override initial keys.
 
         Args:
             bindings (Iterable[Bindings]): A number of bindings.


### PR DESCRIPTION
In the given context, I suspect subsequent makes more sense than subsequence.
