### PR TITLE
Correct the check list for the `ListItem`

### DIFF
--- a/docs/widgets/list_item.md
+++ b/docs/widgets/list_item.md
@@ -2,8 +2,8 @@
 
 `ListItem` is the type of the elements in a `ListView`.
 
-- [] Focusable
-- [] Container
+- [ ] Focusable
+- [ ] Container
 
 ## Example
 


### PR DESCRIPTION
The checks in the list, which were unckecked, needed spaces in them to render correctly in the docs.
