### PR TITLE
fix for child color refresh

### DIFF
--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -794,9 +794,8 @@ class NameListProperty:
 class ColorProperty:
     """Descriptor for getting and setting color properties."""
 
-    def __init__(self, default_color: Color | str, background: bool = False) -> None:
+    def __init__(self, default_color: Color | str) -> None:
         self._default_color = Color.parse(default_color)
-        self._is_background = background
 
     def __set_name__(self, owner: StylesBase, name: str) -> None:
         self.name = name
@@ -830,11 +829,10 @@ class ColorProperty:
         _rich_traceback_omit = True
         if color is None:
             if obj.clear_rule(self.name):
-                obj.refresh(children=self._is_background)
+                obj.refresh(children=True)
         elif isinstance(color, Color):
             if obj.set_rule(self.name, color):
-                obj.refresh(children=self._is_background)
-
+                obj.refresh(children=True)
         elif isinstance(color, str):
             alpha = 1.0
             parsed_color = Color(255, 255, 255)
@@ -855,8 +853,9 @@ class ColorProperty:
                         ),
                     )
             parsed_color = parsed_color.with_alpha(alpha)
+
             if obj.set_rule(self.name, parsed_color):
-                obj.refresh(children=self._is_background)
+                obj.refresh(children=True)
         else:
             raise StyleValueError(f"Invalid color value {color}")
 

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -214,7 +214,7 @@ class StylesBase(ABC):
 
     auto_color = BooleanProperty(default=False)
     color = ColorProperty(Color(255, 255, 255))
-    background = ColorProperty(Color(0, 0, 0, 0), background=True)
+    background = ColorProperty(Color(0, 0, 0, 0))
     text_style = StyleFlagsProperty()
 
     opacity = FractionalProperty()
@@ -421,7 +421,7 @@ class StylesBase(ABC):
 
         Args:
             layout (bool, optional): Also require a layout. Defaults to False.
-            children (bool, opional): Also refresh children. Defaults to False.
+            children (bool, optional): Also refresh children. Defaults to False.
         """
 
     @abstractmethod


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1404

This reverts an "optimization". I was under the mistaken assumption that only changing the background of a container required refreshing its children. This is not true: text color is inherited so children must be refreshed also.

