### PR TITLE
Not ugly

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -368,6 +368,7 @@ class App(Generic[ReturnType], DOMNode):
         self._screenshot: str | None = None
         self._dom_lock = asyncio.Lock()
         self._dom_ready = False
+        self.set_class(self.dark, "-dark-mode")
 
     @property
     def return_value(self) -> ReturnType | None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2179,11 +2179,7 @@ class Widget(DOMNode):
             for ancestor in self.ancestors:
                 if not isinstance(ancestor, Widget):
                     break
-                if ancestor.styles.auto_dimensions:
-                    for ancestor in self.ancestors_with_self:
-                        if isinstance(ancestor, Widget):
-                            ancestor._clear_arrangement_cache()
-                    break
+                ancestor._clear_arrangement_cache()
 
         if repaint:
             self._set_dirty(*regions)

--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -97,8 +97,7 @@ class Header(Widget):
     }
     Header.-tall {
         height: 3;
-    }
-    
+    }    
     """
 
     tall = Reactive(False)

--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -91,13 +91,14 @@ class Header(Widget):
     Header {
         dock: top;
         width: 100%;
-        background: $secondary-background;
+        background: $foreground 5%;
         color: $text;
         height: 1;
     }
     Header.-tall {
         height: 3;
     }
+    
     """
 
     tall = Reactive(False)

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -4779,169 +4779,169 @@
           font-weight: 700;
       }
   
-      .terminal-3370343471-matrix {
+      .terminal-746150767-matrix {
           font-family: Fira Code, monospace;
           font-size: 20px;
           line-height: 24.4px;
           font-variant-east-asian: full-width;
       }
   
-      .terminal-3370343471-title {
+      .terminal-746150767-title {
           font-size: 18px;
           font-weight: bold;
           font-family: arial;
       }
   
-      .terminal-3370343471-r1 { fill: #c5c8c6 }
-  .terminal-3370343471-r2 { fill: #e8e7e5 }
-  .terminal-3370343471-r3 { fill: #e1e1e1 }
-  .terminal-3370343471-r4 { fill: #23568b }
-  .terminal-3370343471-r5 { fill: #e2e2e2 }
-  .terminal-3370343471-r6 { fill: #004578 }
-  .terminal-3370343471-r7 { fill: #14191f }
-  .terminal-3370343471-r8 { fill: #262626 }
-  .terminal-3370343471-r9 { fill: #e2e2e2;font-weight: bold;text-decoration: underline; }
-  .terminal-3370343471-r10 { fill: #e2e2e2;font-weight: bold }
-  .terminal-3370343471-r11 { fill: #7ae998 }
-  .terminal-3370343471-r12 { fill: #4ebf71;font-weight: bold }
-  .terminal-3370343471-r13 { fill: #008139 }
-  .terminal-3370343471-r14 { fill: #dde8f3;font-weight: bold }
-  .terminal-3370343471-r15 { fill: #ddedf9 }
+      .terminal-746150767-r1 { fill: #c5c8c6 }
+  .terminal-746150767-r2 { fill: #e3e3e3 }
+  .terminal-746150767-r3 { fill: #e1e1e1 }
+  .terminal-746150767-r4 { fill: #23568b }
+  .terminal-746150767-r5 { fill: #e2e2e2 }
+  .terminal-746150767-r6 { fill: #004578 }
+  .terminal-746150767-r7 { fill: #14191f }
+  .terminal-746150767-r8 { fill: #262626 }
+  .terminal-746150767-r9 { fill: #e2e2e2;font-weight: bold;text-decoration: underline; }
+  .terminal-746150767-r10 { fill: #e2e2e2;font-weight: bold }
+  .terminal-746150767-r11 { fill: #7ae998 }
+  .terminal-746150767-r12 { fill: #4ebf71;font-weight: bold }
+  .terminal-746150767-r13 { fill: #008139 }
+  .terminal-746150767-r14 { fill: #dde8f3;font-weight: bold }
+  .terminal-746150767-r15 { fill: #ddedf9 }
       </style>
   
       <defs>
-      <clipPath id="terminal-3370343471-clip-terminal">
+      <clipPath id="terminal-746150767-clip-terminal">
         <rect x="0" y="0" width="1219.0" height="731.0" />
       </clipPath>
-      <clipPath id="terminal-3370343471-line-0">
+      <clipPath id="terminal-746150767-line-0">
       <rect x="0" y="1.5" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-1">
+  <clipPath id="terminal-746150767-line-1">
       <rect x="0" y="25.9" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-2">
+  <clipPath id="terminal-746150767-line-2">
       <rect x="0" y="50.3" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-3">
+  <clipPath id="terminal-746150767-line-3">
       <rect x="0" y="74.7" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-4">
+  <clipPath id="terminal-746150767-line-4">
       <rect x="0" y="99.1" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-5">
+  <clipPath id="terminal-746150767-line-5">
       <rect x="0" y="123.5" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-6">
+  <clipPath id="terminal-746150767-line-6">
       <rect x="0" y="147.9" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-7">
+  <clipPath id="terminal-746150767-line-7">
       <rect x="0" y="172.3" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-8">
+  <clipPath id="terminal-746150767-line-8">
       <rect x="0" y="196.7" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-9">
+  <clipPath id="terminal-746150767-line-9">
       <rect x="0" y="221.1" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-10">
+  <clipPath id="terminal-746150767-line-10">
       <rect x="0" y="245.5" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-11">
+  <clipPath id="terminal-746150767-line-11">
       <rect x="0" y="269.9" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-12">
+  <clipPath id="terminal-746150767-line-12">
       <rect x="0" y="294.3" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-13">
+  <clipPath id="terminal-746150767-line-13">
       <rect x="0" y="318.7" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-14">
+  <clipPath id="terminal-746150767-line-14">
       <rect x="0" y="343.1" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-15">
+  <clipPath id="terminal-746150767-line-15">
       <rect x="0" y="367.5" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-16">
+  <clipPath id="terminal-746150767-line-16">
       <rect x="0" y="391.9" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-17">
+  <clipPath id="terminal-746150767-line-17">
       <rect x="0" y="416.3" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-18">
+  <clipPath id="terminal-746150767-line-18">
       <rect x="0" y="440.7" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-19">
+  <clipPath id="terminal-746150767-line-19">
       <rect x="0" y="465.1" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-20">
+  <clipPath id="terminal-746150767-line-20">
       <rect x="0" y="489.5" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-21">
+  <clipPath id="terminal-746150767-line-21">
       <rect x="0" y="513.9" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-22">
+  <clipPath id="terminal-746150767-line-22">
       <rect x="0" y="538.3" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-23">
+  <clipPath id="terminal-746150767-line-23">
       <rect x="0" y="562.7" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-24">
+  <clipPath id="terminal-746150767-line-24">
       <rect x="0" y="587.1" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-25">
+  <clipPath id="terminal-746150767-line-25">
       <rect x="0" y="611.5" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-26">
+  <clipPath id="terminal-746150767-line-26">
       <rect x="0" y="635.9" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-27">
+  <clipPath id="terminal-746150767-line-27">
       <rect x="0" y="660.3" width="1220" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3370343471-line-28">
+  <clipPath id="terminal-746150767-line-28">
       <rect x="0" y="684.7" width="1220" height="24.65"/>
               </clipPath>
       </defs>
   
-      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-3370343471-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Textual&#160;Demo</text>
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-746150767-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Textual&#160;Demo</text>
               <g transform="translate(26,22)">
               <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
               <circle cx="22" cy="0" r="7" fill="#febc2e"/>
               <circle cx="44" cy="0" r="7" fill="#28c840"/>
               </g>
           
-      <g transform="translate(9, 41)" clip-path="url(#terminal-3370343471-clip-terminal)">
-      <rect fill="#534838" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="24.4" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="97.6" y="1.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="524.6" y="1.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="671" y="1.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="1098" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="1110.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="1110.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="25.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="50.3" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="50.3" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="74.7" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="170.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="207.4" y="74.7" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="74.7" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="99.1" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="99.1" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="390.4" y="123.5" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="147.9" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="147.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="146.4" y="172.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="231.8" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="172.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="172.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="196.7" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="196.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="707.6" y="196.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="854" y="196.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="221.1" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="245.5" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="245.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="512.4" y="245.5" width="622.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="269.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="109.8" y="269.9" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="256.2" y="269.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="269.9" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="294.3" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="294.3" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="427" y="318.7" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="343.1" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="427" y="343.1" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#0a180e" x="732" y="343.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="817.4" y="343.1" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="170.8" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="207.4" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="427" y="367.5" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="391.9" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="391.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="390.4" y="416.3" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="440.7" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="465.1" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="489.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="513.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="538.3" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="562.7" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="587.1" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="611.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="635.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="635.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="660.3" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="414.8" y="684.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1146.8" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="97.6" y="709.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="170.8" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="268.4" y="709.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="378.2" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="475.8" y="709.1" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="695.4" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="793" y="709.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="939.4" y="709.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="988.2" y="709.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="1073.6" y="709.1" width="146.4" height="24.65" shape-rendering="crispEdges"/>
-      <g class="terminal-3370343471-matrix">
-      <text class="terminal-3370343471-r2" x="12.2" y="20" textLength="12.2" clip-path="url(#terminal-3370343471-line-0)">⭘</text><text class="terminal-3370343471-r2" x="524.6" y="20" textLength="146.4" clip-path="url(#terminal-3370343471-line-0)">Textual&#160;Demo</text><text class="terminal-3370343471-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-3370343471-line-0)">
-  </text><text class="terminal-3370343471-r4" x="1195.6" y="44.4" textLength="24.4" clip-path="url(#terminal-3370343471-line-1)">▅▅</text><text class="terminal-3370343471-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-1)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-2)">
-  </text><text class="terminal-3370343471-r5" x="170.8" y="93.2" textLength="36.6" clip-path="url(#terminal-3370343471-line-3)">TOP</text><text class="terminal-3370343471-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-3)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-4)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="142" textLength="780.8" clip-path="url(#terminal-3370343471-line-5)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-3370343471-r7" x="1195.6" y="142" textLength="24.4" clip-path="url(#terminal-3370343471-line-5)">▃▃</text><text class="terminal-3370343471-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-3370343471-line-5)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-6)">▎</text><text class="terminal-3370343471-r8" x="1159" y="166.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-6)">▋</text><text class="terminal-3370343471-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-6)">
-  </text><text class="terminal-3370343471-r5" x="146.4" y="190.8" textLength="85.4" clip-path="url(#terminal-3370343471-line-7)">Widgets</text><text class="terminal-3370343471-r6" x="390.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-7)">▎</text><text class="terminal-3370343471-r8" x="1159" y="190.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-7)">▋</text><text class="terminal-3370343471-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-7)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-8)">▎</text><text class="terminal-3370343471-r9" x="707.6" y="215.2" textLength="146.4" clip-path="url(#terminal-3370343471-line-8)">Textual&#160;Demo</text><text class="terminal-3370343471-r8" x="1159" y="215.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-8)">▋</text><text class="terminal-3370343471-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-8)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="239.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-9)">▎</text><text class="terminal-3370343471-r8" x="1159" y="239.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-9)">▋</text><text class="terminal-3370343471-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-9)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="264" textLength="12.2" clip-path="url(#terminal-3370343471-line-10)">▎</text><text class="terminal-3370343471-r10" x="427" y="264" textLength="85.4" clip-path="url(#terminal-3370343471-line-10)">Welcome</text><text class="terminal-3370343471-r5" x="512.4" y="264" textLength="622.2" clip-path="url(#terminal-3370343471-line-10)">!&#160;Textual&#160;is&#160;a&#160;framework&#160;for&#160;creating&#160;sophisticated</text><text class="terminal-3370343471-r8" x="1159" y="264" textLength="12.2" clip-path="url(#terminal-3370343471-line-10)">▋</text><text class="terminal-3370343471-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-3370343471-line-10)">
-  </text><text class="terminal-3370343471-r5" x="109.8" y="288.4" textLength="146.4" clip-path="url(#terminal-3370343471-line-11)">Rich&#160;content</text><text class="terminal-3370343471-r6" x="390.4" y="288.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-11)">▎</text><text class="terminal-3370343471-r5" x="427" y="288.4" textLength="707.6" clip-path="url(#terminal-3370343471-line-11)">applications&#160;with&#160;the&#160;terminal.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3370343471-r8" x="1159" y="288.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-11)">▋</text><text class="terminal-3370343471-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-11)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="312.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-12)">▎</text><text class="terminal-3370343471-r8" x="1159" y="312.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-12)">▋</text><text class="terminal-3370343471-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-12)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="337.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-13)">▎</text><text class="terminal-3370343471-r11" x="427" y="337.2" textLength="707.6" clip-path="url(#terminal-3370343471-line-13)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-3370343471-r8" x="1159" y="337.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-13)">▋</text><text class="terminal-3370343471-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-13)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="361.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-14)">▎</text><text class="terminal-3370343471-r12" x="732" y="361.6" textLength="85.4" clip-path="url(#terminal-3370343471-line-14)">&#160;Start&#160;</text><text class="terminal-3370343471-r8" x="1159" y="361.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-14)">▋</text><text class="terminal-3370343471-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-14)">
-  </text><text class="terminal-3370343471-r5" x="170.8" y="386" textLength="36.6" clip-path="url(#terminal-3370343471-line-15)">CSS</text><text class="terminal-3370343471-r6" x="390.4" y="386" textLength="12.2" clip-path="url(#terminal-3370343471-line-15)">▎</text><text class="terminal-3370343471-r13" x="427" y="386" textLength="707.6" clip-path="url(#terminal-3370343471-line-15)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-3370343471-r8" x="1159" y="386" textLength="12.2" clip-path="url(#terminal-3370343471-line-15)">▋</text><text class="terminal-3370343471-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-3370343471-line-15)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="410.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-16)">▎</text><text class="terminal-3370343471-r8" x="1159" y="410.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-16)">▋</text><text class="terminal-3370343471-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-16)">
-  </text><text class="terminal-3370343471-r6" x="390.4" y="434.8" textLength="780.8" clip-path="url(#terminal-3370343471-line-17)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-3370343471-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-17)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-18)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-19)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-3370343471-line-20)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-21)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-22)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-23)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-3370343471-line-24)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-3370343471-line-25)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-3370343471-line-26)">
-  </text><text class="terminal-3370343471-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-3370343471-line-27)">
-  </text><text class="terminal-3370343471-r10" x="414.8" y="703.2" textLength="732" clip-path="url(#terminal-3370343471-line-28)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Widgets&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3370343471-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-3370343471-line-28)">
-  </text><text class="terminal-3370343471-r14" x="0" y="727.6" textLength="97.6" clip-path="url(#terminal-3370343471-line-29)">&#160;CTRL+C&#160;</text><text class="terminal-3370343471-r15" x="97.6" y="727.6" textLength="73.2" clip-path="url(#terminal-3370343471-line-29)">&#160;Quit&#160;</text><text class="terminal-3370343471-r14" x="170.8" y="727.6" textLength="97.6" clip-path="url(#terminal-3370343471-line-29)">&#160;CTRL+B&#160;</text><text class="terminal-3370343471-r15" x="268.4" y="727.6" textLength="109.8" clip-path="url(#terminal-3370343471-line-29)">&#160;Sidebar&#160;</text><text class="terminal-3370343471-r14" x="378.2" y="727.6" textLength="97.6" clip-path="url(#terminal-3370343471-line-29)">&#160;CTRL+T&#160;</text><text class="terminal-3370343471-r15" x="475.8" y="727.6" textLength="219.6" clip-path="url(#terminal-3370343471-line-29)">&#160;Toggle&#160;Dark&#160;mode&#160;</text><text class="terminal-3370343471-r14" x="695.4" y="727.6" textLength="97.6" clip-path="url(#terminal-3370343471-line-29)">&#160;CTRL+S&#160;</text><text class="terminal-3370343471-r15" x="793" y="727.6" textLength="146.4" clip-path="url(#terminal-3370343471-line-29)">&#160;Screenshot&#160;</text><text class="terminal-3370343471-r14" x="939.4" y="727.6" textLength="48.8" clip-path="url(#terminal-3370343471-line-29)">&#160;F1&#160;</text><text class="terminal-3370343471-r15" x="988.2" y="727.6" textLength="85.4" clip-path="url(#terminal-3370343471-line-29)">&#160;Notes&#160;</text>
+      <g transform="translate(9, 41)" clip-path="url(#terminal-746150767-clip-terminal)">
+      <rect fill="#282828" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="24.4" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="97.6" y="1.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="524.6" y="1.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="671" y="1.5" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1098" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1110.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="1110.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="25.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="50.3" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="50.3" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="74.7" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="170.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="207.4" y="74.7" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="74.7" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="99.1" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="99.1" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="390.4" y="123.5" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="1195.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="147.9" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="147.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="146.4" y="172.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="231.8" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="172.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="172.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="196.7" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="196.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="707.6" y="196.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="854" y="196.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="221.1" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="245.5" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="245.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="512.4" y="245.5" width="622.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="269.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="109.8" y="269.9" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="256.2" y="269.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="427" y="269.9" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="294.3" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="294.3" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="427" y="318.7" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="343.1" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="427" y="343.1" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#0a180e" x="732" y="343.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="817.4" y="343.1" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="170.8" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="207.4" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#4ebf71" x="427" y="367.5" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1134.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="391.9" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="402.6" y="391.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="1159" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="390.4" y="416.3" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="440.7" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="465.1" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="489.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="513.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="538.3" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="562.7" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="587.1" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="611.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="635.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="635.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="660.3" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="366" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="390.4" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="414.8" y="684.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="1146.8" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="1171.2" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="1195.6" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="97.6" y="709.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="170.8" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="268.4" y="709.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="378.2" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="475.8" y="709.1" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="695.4" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="793" y="709.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="939.4" y="709.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="988.2" y="709.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="1073.6" y="709.1" width="146.4" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-746150767-matrix">
+      <text class="terminal-746150767-r2" x="12.2" y="20" textLength="12.2" clip-path="url(#terminal-746150767-line-0)">⭘</text><text class="terminal-746150767-r2" x="524.6" y="20" textLength="146.4" clip-path="url(#terminal-746150767-line-0)">Textual&#160;Demo</text><text class="terminal-746150767-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-746150767-line-0)">
+  </text><text class="terminal-746150767-r4" x="1195.6" y="44.4" textLength="24.4" clip-path="url(#terminal-746150767-line-1)">▅▅</text><text class="terminal-746150767-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-746150767-line-1)">
+  </text><text class="terminal-746150767-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-746150767-line-2)">
+  </text><text class="terminal-746150767-r5" x="170.8" y="93.2" textLength="36.6" clip-path="url(#terminal-746150767-line-3)">TOP</text><text class="terminal-746150767-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-746150767-line-3)">
+  </text><text class="terminal-746150767-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-746150767-line-4)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="142" textLength="780.8" clip-path="url(#terminal-746150767-line-5)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-746150767-r7" x="1195.6" y="142" textLength="24.4" clip-path="url(#terminal-746150767-line-5)">▃▃</text><text class="terminal-746150767-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-746150767-line-5)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="166.4" textLength="12.2" clip-path="url(#terminal-746150767-line-6)">▎</text><text class="terminal-746150767-r8" x="1159" y="166.4" textLength="12.2" clip-path="url(#terminal-746150767-line-6)">▋</text><text class="terminal-746150767-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-746150767-line-6)">
+  </text><text class="terminal-746150767-r5" x="146.4" y="190.8" textLength="85.4" clip-path="url(#terminal-746150767-line-7)">Widgets</text><text class="terminal-746150767-r6" x="390.4" y="190.8" textLength="12.2" clip-path="url(#terminal-746150767-line-7)">▎</text><text class="terminal-746150767-r8" x="1159" y="190.8" textLength="12.2" clip-path="url(#terminal-746150767-line-7)">▋</text><text class="terminal-746150767-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-746150767-line-7)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="215.2" textLength="12.2" clip-path="url(#terminal-746150767-line-8)">▎</text><text class="terminal-746150767-r9" x="707.6" y="215.2" textLength="146.4" clip-path="url(#terminal-746150767-line-8)">Textual&#160;Demo</text><text class="terminal-746150767-r8" x="1159" y="215.2" textLength="12.2" clip-path="url(#terminal-746150767-line-8)">▋</text><text class="terminal-746150767-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-746150767-line-8)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="239.6" textLength="12.2" clip-path="url(#terminal-746150767-line-9)">▎</text><text class="terminal-746150767-r8" x="1159" y="239.6" textLength="12.2" clip-path="url(#terminal-746150767-line-9)">▋</text><text class="terminal-746150767-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-746150767-line-9)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="264" textLength="12.2" clip-path="url(#terminal-746150767-line-10)">▎</text><text class="terminal-746150767-r10" x="427" y="264" textLength="85.4" clip-path="url(#terminal-746150767-line-10)">Welcome</text><text class="terminal-746150767-r5" x="512.4" y="264" textLength="622.2" clip-path="url(#terminal-746150767-line-10)">!&#160;Textual&#160;is&#160;a&#160;framework&#160;for&#160;creating&#160;sophisticated</text><text class="terminal-746150767-r8" x="1159" y="264" textLength="12.2" clip-path="url(#terminal-746150767-line-10)">▋</text><text class="terminal-746150767-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-746150767-line-10)">
+  </text><text class="terminal-746150767-r5" x="109.8" y="288.4" textLength="146.4" clip-path="url(#terminal-746150767-line-11)">Rich&#160;content</text><text class="terminal-746150767-r6" x="390.4" y="288.4" textLength="12.2" clip-path="url(#terminal-746150767-line-11)">▎</text><text class="terminal-746150767-r5" x="427" y="288.4" textLength="707.6" clip-path="url(#terminal-746150767-line-11)">applications&#160;with&#160;the&#160;terminal.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-746150767-r8" x="1159" y="288.4" textLength="12.2" clip-path="url(#terminal-746150767-line-11)">▋</text><text class="terminal-746150767-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-746150767-line-11)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="312.8" textLength="12.2" clip-path="url(#terminal-746150767-line-12)">▎</text><text class="terminal-746150767-r8" x="1159" y="312.8" textLength="12.2" clip-path="url(#terminal-746150767-line-12)">▋</text><text class="terminal-746150767-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-746150767-line-12)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="337.2" textLength="12.2" clip-path="url(#terminal-746150767-line-13)">▎</text><text class="terminal-746150767-r11" x="427" y="337.2" textLength="707.6" clip-path="url(#terminal-746150767-line-13)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-746150767-r8" x="1159" y="337.2" textLength="12.2" clip-path="url(#terminal-746150767-line-13)">▋</text><text class="terminal-746150767-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-746150767-line-13)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="361.6" textLength="12.2" clip-path="url(#terminal-746150767-line-14)">▎</text><text class="terminal-746150767-r12" x="732" y="361.6" textLength="85.4" clip-path="url(#terminal-746150767-line-14)">&#160;Start&#160;</text><text class="terminal-746150767-r8" x="1159" y="361.6" textLength="12.2" clip-path="url(#terminal-746150767-line-14)">▋</text><text class="terminal-746150767-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-746150767-line-14)">
+  </text><text class="terminal-746150767-r5" x="170.8" y="386" textLength="36.6" clip-path="url(#terminal-746150767-line-15)">CSS</text><text class="terminal-746150767-r6" x="390.4" y="386" textLength="12.2" clip-path="url(#terminal-746150767-line-15)">▎</text><text class="terminal-746150767-r13" x="427" y="386" textLength="707.6" clip-path="url(#terminal-746150767-line-15)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-746150767-r8" x="1159" y="386" textLength="12.2" clip-path="url(#terminal-746150767-line-15)">▋</text><text class="terminal-746150767-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-746150767-line-15)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="410.4" textLength="12.2" clip-path="url(#terminal-746150767-line-16)">▎</text><text class="terminal-746150767-r8" x="1159" y="410.4" textLength="12.2" clip-path="url(#terminal-746150767-line-16)">▋</text><text class="terminal-746150767-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-746150767-line-16)">
+  </text><text class="terminal-746150767-r6" x="390.4" y="434.8" textLength="780.8" clip-path="url(#terminal-746150767-line-17)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-746150767-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-746150767-line-17)">
+  </text><text class="terminal-746150767-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-746150767-line-18)">
+  </text><text class="terminal-746150767-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-746150767-line-19)">
+  </text><text class="terminal-746150767-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-746150767-line-20)">
+  </text><text class="terminal-746150767-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-746150767-line-21)">
+  </text><text class="terminal-746150767-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-746150767-line-22)">
+  </text><text class="terminal-746150767-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-746150767-line-23)">
+  </text><text class="terminal-746150767-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-746150767-line-24)">
+  </text><text class="terminal-746150767-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-746150767-line-25)">
+  </text><text class="terminal-746150767-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-746150767-line-26)">
+  </text><text class="terminal-746150767-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-746150767-line-27)">
+  </text><text class="terminal-746150767-r10" x="414.8" y="703.2" textLength="732" clip-path="url(#terminal-746150767-line-28)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Widgets&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-746150767-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-746150767-line-28)">
+  </text><text class="terminal-746150767-r14" x="0" y="727.6" textLength="97.6" clip-path="url(#terminal-746150767-line-29)">&#160;CTRL+C&#160;</text><text class="terminal-746150767-r15" x="97.6" y="727.6" textLength="73.2" clip-path="url(#terminal-746150767-line-29)">&#160;Quit&#160;</text><text class="terminal-746150767-r14" x="170.8" y="727.6" textLength="97.6" clip-path="url(#terminal-746150767-line-29)">&#160;CTRL+B&#160;</text><text class="terminal-746150767-r15" x="268.4" y="727.6" textLength="109.8" clip-path="url(#terminal-746150767-line-29)">&#160;Sidebar&#160;</text><text class="terminal-746150767-r14" x="378.2" y="727.6" textLength="97.6" clip-path="url(#terminal-746150767-line-29)">&#160;CTRL+T&#160;</text><text class="terminal-746150767-r15" x="475.8" y="727.6" textLength="219.6" clip-path="url(#terminal-746150767-line-29)">&#160;Toggle&#160;Dark&#160;mode&#160;</text><text class="terminal-746150767-r14" x="695.4" y="727.6" textLength="97.6" clip-path="url(#terminal-746150767-line-29)">&#160;CTRL+S&#160;</text><text class="terminal-746150767-r15" x="793" y="727.6" textLength="146.4" clip-path="url(#terminal-746150767-line-29)">&#160;Screenshot&#160;</text><text class="terminal-746150767-r14" x="939.4" y="727.6" textLength="48.8" clip-path="url(#terminal-746150767-line-29)">&#160;F1&#160;</text><text class="terminal-746150767-r15" x="988.2" y="727.6" textLength="85.4" clip-path="url(#terminal-746150767-line-29)">&#160;Notes&#160;</text>
       </g>
       </g>
   </svg>
@@ -5909,132 +5909,132 @@
           font-weight: 700;
       }
   
-      .terminal-2939949418-matrix {
+      .terminal-1066078378-matrix {
           font-family: Fira Code, monospace;
           font-size: 20px;
           line-height: 24.4px;
           font-variant-east-asian: full-width;
       }
   
-      .terminal-2939949418-title {
+      .terminal-1066078378-title {
           font-size: 18px;
           font-weight: bold;
           font-family: arial;
       }
   
-      .terminal-2939949418-r1 { fill: #c5c8c6 }
-  .terminal-2939949418-r2 { fill: #e8e7e5 }
-  .terminal-2939949418-r3 { fill: #e1e1e1 }
+      .terminal-1066078378-r1 { fill: #c5c8c6 }
+  .terminal-1066078378-r2 { fill: #e3e3e3 }
+  .terminal-1066078378-r3 { fill: #e1e1e1 }
       </style>
   
       <defs>
-      <clipPath id="terminal-2939949418-clip-terminal">
+      <clipPath id="terminal-1066078378-clip-terminal">
         <rect x="0" y="0" width="975.0" height="584.5999999999999" />
       </clipPath>
-      <clipPath id="terminal-2939949418-line-0">
+      <clipPath id="terminal-1066078378-line-0">
       <rect x="0" y="1.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-1">
+  <clipPath id="terminal-1066078378-line-1">
       <rect x="0" y="25.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-2">
+  <clipPath id="terminal-1066078378-line-2">
       <rect x="0" y="50.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-3">
+  <clipPath id="terminal-1066078378-line-3">
       <rect x="0" y="74.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-4">
+  <clipPath id="terminal-1066078378-line-4">
       <rect x="0" y="99.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-5">
+  <clipPath id="terminal-1066078378-line-5">
       <rect x="0" y="123.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-6">
+  <clipPath id="terminal-1066078378-line-6">
       <rect x="0" y="147.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-7">
+  <clipPath id="terminal-1066078378-line-7">
       <rect x="0" y="172.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-8">
+  <clipPath id="terminal-1066078378-line-8">
       <rect x="0" y="196.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-9">
+  <clipPath id="terminal-1066078378-line-9">
       <rect x="0" y="221.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-10">
+  <clipPath id="terminal-1066078378-line-10">
       <rect x="0" y="245.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-11">
+  <clipPath id="terminal-1066078378-line-11">
       <rect x="0" y="269.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-12">
+  <clipPath id="terminal-1066078378-line-12">
       <rect x="0" y="294.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-13">
+  <clipPath id="terminal-1066078378-line-13">
       <rect x="0" y="318.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-14">
+  <clipPath id="terminal-1066078378-line-14">
       <rect x="0" y="343.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-15">
+  <clipPath id="terminal-1066078378-line-15">
       <rect x="0" y="367.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-16">
+  <clipPath id="terminal-1066078378-line-16">
       <rect x="0" y="391.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-17">
+  <clipPath id="terminal-1066078378-line-17">
       <rect x="0" y="416.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-18">
+  <clipPath id="terminal-1066078378-line-18">
       <rect x="0" y="440.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-19">
+  <clipPath id="terminal-1066078378-line-19">
       <rect x="0" y="465.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-20">
+  <clipPath id="terminal-1066078378-line-20">
       <rect x="0" y="489.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-21">
+  <clipPath id="terminal-1066078378-line-21">
       <rect x="0" y="513.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2939949418-line-22">
+  <clipPath id="terminal-1066078378-line-22">
       <rect x="0" y="538.3" width="976" height="24.65"/>
               </clipPath>
       </defs>
   
-      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-2939949418-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">HeaderApp</text>
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-1066078378-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">HeaderApp</text>
               <g transform="translate(26,22)">
               <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
               <circle cx="22" cy="0" r="7" fill="#febc2e"/>
               <circle cx="44" cy="0" r="7" fill="#28c840"/>
               </g>
           
-      <g transform="translate(9, 41)" clip-path="url(#terminal-2939949418-clip-terminal)">
-      <rect fill="#534838" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="24.4" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="97.6" y="1.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="414.8" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="524.6" y="1.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-      <g class="terminal-2939949418-matrix">
-      <text class="terminal-2939949418-r2" x="12.2" y="20" textLength="12.2" clip-path="url(#terminal-2939949418-line-0)">⭘</text><text class="terminal-2939949418-r2" x="414.8" y="20" textLength="109.8" clip-path="url(#terminal-2939949418-line-0)">HeaderApp</text><text class="terminal-2939949418-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2939949418-line-0)">
-  </text><text class="terminal-2939949418-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2939949418-line-1)">
-  </text><text class="terminal-2939949418-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2939949418-line-2)">
-  </text><text class="terminal-2939949418-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2939949418-line-3)">
-  </text><text class="terminal-2939949418-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2939949418-line-4)">
-  </text><text class="terminal-2939949418-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2939949418-line-5)">
-  </text><text class="terminal-2939949418-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2939949418-line-6)">
-  </text><text class="terminal-2939949418-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2939949418-line-7)">
-  </text><text class="terminal-2939949418-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2939949418-line-8)">
-  </text><text class="terminal-2939949418-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2939949418-line-9)">
-  </text><text class="terminal-2939949418-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2939949418-line-10)">
-  </text><text class="terminal-2939949418-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2939949418-line-11)">
-  </text><text class="terminal-2939949418-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2939949418-line-12)">
-  </text><text class="terminal-2939949418-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2939949418-line-13)">
-  </text><text class="terminal-2939949418-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2939949418-line-14)">
-  </text><text class="terminal-2939949418-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2939949418-line-15)">
-  </text><text class="terminal-2939949418-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2939949418-line-16)">
-  </text><text class="terminal-2939949418-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2939949418-line-17)">
-  </text><text class="terminal-2939949418-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2939949418-line-18)">
-  </text><text class="terminal-2939949418-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2939949418-line-19)">
-  </text><text class="terminal-2939949418-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2939949418-line-20)">
-  </text><text class="terminal-2939949418-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2939949418-line-21)">
-  </text><text class="terminal-2939949418-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2939949418-line-22)">
+      <g transform="translate(9, 41)" clip-path="url(#terminal-1066078378-clip-terminal)">
+      <rect fill="#282828" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="24.4" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="97.6" y="1.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="414.8" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="524.6" y="1.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-1066078378-matrix">
+      <text class="terminal-1066078378-r2" x="12.2" y="20" textLength="12.2" clip-path="url(#terminal-1066078378-line-0)">⭘</text><text class="terminal-1066078378-r2" x="414.8" y="20" textLength="109.8" clip-path="url(#terminal-1066078378-line-0)">HeaderApp</text><text class="terminal-1066078378-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1066078378-line-0)">
+  </text><text class="terminal-1066078378-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1066078378-line-1)">
+  </text><text class="terminal-1066078378-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1066078378-line-2)">
+  </text><text class="terminal-1066078378-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1066078378-line-3)">
+  </text><text class="terminal-1066078378-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1066078378-line-4)">
+  </text><text class="terminal-1066078378-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1066078378-line-5)">
+  </text><text class="terminal-1066078378-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1066078378-line-6)">
+  </text><text class="terminal-1066078378-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1066078378-line-7)">
+  </text><text class="terminal-1066078378-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1066078378-line-8)">
+  </text><text class="terminal-1066078378-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1066078378-line-9)">
+  </text><text class="terminal-1066078378-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1066078378-line-10)">
+  </text><text class="terminal-1066078378-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1066078378-line-11)">
+  </text><text class="terminal-1066078378-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1066078378-line-12)">
+  </text><text class="terminal-1066078378-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1066078378-line-13)">
+  </text><text class="terminal-1066078378-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1066078378-line-14)">
+  </text><text class="terminal-1066078378-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1066078378-line-15)">
+  </text><text class="terminal-1066078378-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1066078378-line-16)">
+  </text><text class="terminal-1066078378-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1066078378-line-17)">
+  </text><text class="terminal-1066078378-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1066078378-line-18)">
+  </text><text class="terminal-1066078378-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1066078378-line-19)">
+  </text><text class="terminal-1066078378-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1066078378-line-20)">
+  </text><text class="terminal-1066078378-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1066078378-line-21)">
+  </text><text class="terminal-1066078378-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1066078378-line-22)">
   </text>
       </g>
       </g>
@@ -7482,136 +7482,136 @@
           font-weight: 700;
       }
   
-      .terminal-3854349595-matrix {
+      .terminal-3751523503-matrix {
           font-family: Fira Code, monospace;
           font-size: 20px;
           line-height: 24.4px;
           font-variant-east-asian: full-width;
       }
   
-      .terminal-3854349595-title {
+      .terminal-3751523503-title {
           font-size: 18px;
           font-weight: bold;
           font-family: arial;
       }
   
-      .terminal-3854349595-r1 { fill: #ffff00 }
-  .terminal-3854349595-r2 { fill: #e8e7e5 }
-  .terminal-3854349595-r3 { fill: #c5c8c6 }
-  .terminal-3854349595-r4 { fill: #e1e1e1 }
-  .terminal-3854349595-r5 { fill: #dde8f3;font-weight: bold }
-  .terminal-3854349595-r6 { fill: #ddedf9 }
+      .terminal-3751523503-r1 { fill: #ffff00 }
+  .terminal-3751523503-r2 { fill: #e3e3e3 }
+  .terminal-3751523503-r3 { fill: #c5c8c6 }
+  .terminal-3751523503-r4 { fill: #e1e1e1 }
+  .terminal-3751523503-r5 { fill: #dde8f3;font-weight: bold }
+  .terminal-3751523503-r6 { fill: #ddedf9 }
       </style>
   
       <defs>
-      <clipPath id="terminal-3854349595-clip-terminal">
+      <clipPath id="terminal-3751523503-clip-terminal">
         <rect x="0" y="0" width="975.0" height="584.5999999999999" />
       </clipPath>
-      <clipPath id="terminal-3854349595-line-0">
+      <clipPath id="terminal-3751523503-line-0">
       <rect x="0" y="1.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-1">
+  <clipPath id="terminal-3751523503-line-1">
       <rect x="0" y="25.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-2">
+  <clipPath id="terminal-3751523503-line-2">
       <rect x="0" y="50.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-3">
+  <clipPath id="terminal-3751523503-line-3">
       <rect x="0" y="74.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-4">
+  <clipPath id="terminal-3751523503-line-4">
       <rect x="0" y="99.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-5">
+  <clipPath id="terminal-3751523503-line-5">
       <rect x="0" y="123.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-6">
+  <clipPath id="terminal-3751523503-line-6">
       <rect x="0" y="147.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-7">
+  <clipPath id="terminal-3751523503-line-7">
       <rect x="0" y="172.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-8">
+  <clipPath id="terminal-3751523503-line-8">
       <rect x="0" y="196.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-9">
+  <clipPath id="terminal-3751523503-line-9">
       <rect x="0" y="221.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-10">
+  <clipPath id="terminal-3751523503-line-10">
       <rect x="0" y="245.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-11">
+  <clipPath id="terminal-3751523503-line-11">
       <rect x="0" y="269.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-12">
+  <clipPath id="terminal-3751523503-line-12">
       <rect x="0" y="294.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-13">
+  <clipPath id="terminal-3751523503-line-13">
       <rect x="0" y="318.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-14">
+  <clipPath id="terminal-3751523503-line-14">
       <rect x="0" y="343.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-15">
+  <clipPath id="terminal-3751523503-line-15">
       <rect x="0" y="367.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-16">
+  <clipPath id="terminal-3751523503-line-16">
       <rect x="0" y="391.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-17">
+  <clipPath id="terminal-3751523503-line-17">
       <rect x="0" y="416.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-18">
+  <clipPath id="terminal-3751523503-line-18">
       <rect x="0" y="440.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-19">
+  <clipPath id="terminal-3751523503-line-19">
       <rect x="0" y="465.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-20">
+  <clipPath id="terminal-3751523503-line-20">
       <rect x="0" y="489.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-21">
+  <clipPath id="terminal-3751523503-line-21">
       <rect x="0" y="513.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-3854349595-line-22">
+  <clipPath id="terminal-3751523503-line-22">
       <rect x="0" y="538.3" width="976" height="24.65"/>
               </clipPath>
       </defs>
   
-      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3854349595-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Layers</text>
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3751523503-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Layers</text>
               <g transform="translate(26,22)">
               <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
               <circle cx="22" cy="0" r="7" fill="#febc2e"/>
               <circle cx="44" cy="0" r="7" fill="#28c840"/>
               </g>
           
-      <g transform="translate(9, 41)" clip-path="url(#terminal-3854349595-clip-terminal)">
-      <rect fill="#ff0000" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="439.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="512.4" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="50.3" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="50.3" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="36.6" y="74.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="74.7" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="99.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="123.5" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="562.7" width="756.4" height="24.65" shape-rendering="crispEdges"/>
-      <g class="terminal-3854349595-matrix">
-      <text class="terminal-3854349595-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-3854349595-line-0)">┌───────</text><text class="terminal-3854349595-r1" x="97.6" y="20" textLength="341.6" clip-path="url(#terminal-3854349595-line-0)">───────────────────────────┐</text><text class="terminal-3854349595-r2" x="439.2" y="20" textLength="73.2" clip-path="url(#terminal-3854349595-line-0)">Layers</text><text class="terminal-3854349595-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3854349595-line-0)">
-  </text><text class="terminal-3854349595-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-1)">│</text><text class="terminal-3854349595-r1" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-1)">│</text><text class="terminal-3854349595-r4" x="439.2" y="44.4" textLength="536.8" clip-path="url(#terminal-3854349595-line-1)">It&#x27;s&#160;full&#160;of&#160;stars!&#160;My&#160;God!&#160;It&#x27;s&#160;full&#160;of&#160;sta</text><text class="terminal-3854349595-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-1)">
-  </text><text class="terminal-3854349595-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-2)">│</text><text class="terminal-3854349595-r1" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-2)">│</text><text class="terminal-3854349595-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-2)">
-  </text><text class="terminal-3854349595-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-3854349595-line-3)">│</text><text class="terminal-3854349595-r1" x="36.6" y="93.2" textLength="366" clip-path="url(#terminal-3854349595-line-3)">This&#160;should&#160;float&#160;over&#160;the&#160;top</text><text class="terminal-3854349595-r1" x="427" y="93.2" textLength="12.2" clip-path="url(#terminal-3854349595-line-3)">│</text><text class="terminal-3854349595-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3854349595-line-3)">
-  </text><text class="terminal-3854349595-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-3854349595-line-4)">│</text><text class="terminal-3854349595-r1" x="427" y="117.6" textLength="12.2" clip-path="url(#terminal-3854349595-line-4)">│</text><text class="terminal-3854349595-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3854349595-line-4)">
-  </text><text class="terminal-3854349595-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-3854349595-line-5)">│</text><text class="terminal-3854349595-r1" x="427" y="142" textLength="12.2" clip-path="url(#terminal-3854349595-line-5)">│</text><text class="terminal-3854349595-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3854349595-line-5)">
-  </text><text class="terminal-3854349595-r1" x="0" y="166.4" textLength="439.2" clip-path="url(#terminal-3854349595-line-6)">└──────────────────────────────────┘</text><text class="terminal-3854349595-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-6)">
-  </text><text class="terminal-3854349595-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-7)">
-  </text><text class="terminal-3854349595-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3854349595-line-8)">
-  </text><text class="terminal-3854349595-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3854349595-line-9)">
-  </text><text class="terminal-3854349595-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3854349595-line-10)">
-  </text><text class="terminal-3854349595-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-11)">
-  </text><text class="terminal-3854349595-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-12)">
-  </text><text class="terminal-3854349595-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3854349595-line-13)">
-  </text><text class="terminal-3854349595-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3854349595-line-14)">
-  </text><text class="terminal-3854349595-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3854349595-line-15)">
-  </text><text class="terminal-3854349595-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-16)">
-  </text><text class="terminal-3854349595-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-17)">
-  </text><text class="terminal-3854349595-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3854349595-line-18)">
-  </text><text class="terminal-3854349595-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3854349595-line-19)">
-  </text><text class="terminal-3854349595-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3854349595-line-20)">
-  </text><text class="terminal-3854349595-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3854349595-line-21)">
-  </text><text class="terminal-3854349595-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3854349595-line-22)">
-  </text><text class="terminal-3854349595-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-3854349595-line-23)">&#160;T&#160;</text><text class="terminal-3854349595-r6" x="36.6" y="581.2" textLength="183" clip-path="url(#terminal-3854349595-line-23)">&#160;Toggle&#160;Screen&#160;</text>
+      <g transform="translate(9, 41)" clip-path="url(#terminal-3751523503-clip-terminal)">
+      <rect fill="#ff0000" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="439.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="512.4" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="50.3" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="50.3" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="36.6" y="74.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="74.7" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="99.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="123.5" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="562.7" width="756.4" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-3751523503-matrix">
+      <text class="terminal-3751523503-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-3751523503-line-0)">┌───────</text><text class="terminal-3751523503-r1" x="97.6" y="20" textLength="341.6" clip-path="url(#terminal-3751523503-line-0)">───────────────────────────┐</text><text class="terminal-3751523503-r2" x="439.2" y="20" textLength="73.2" clip-path="url(#terminal-3751523503-line-0)">Layers</text><text class="terminal-3751523503-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3751523503-line-0)">
+  </text><text class="terminal-3751523503-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-1)">│</text><text class="terminal-3751523503-r1" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-1)">│</text><text class="terminal-3751523503-r4" x="439.2" y="44.4" textLength="536.8" clip-path="url(#terminal-3751523503-line-1)">It&#x27;s&#160;full&#160;of&#160;stars!&#160;My&#160;God!&#160;It&#x27;s&#160;full&#160;of&#160;sta</text><text class="terminal-3751523503-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-1)">
+  </text><text class="terminal-3751523503-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-2)">│</text><text class="terminal-3751523503-r1" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-2)">│</text><text class="terminal-3751523503-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-2)">
+  </text><text class="terminal-3751523503-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-3751523503-line-3)">│</text><text class="terminal-3751523503-r1" x="36.6" y="93.2" textLength="366" clip-path="url(#terminal-3751523503-line-3)">This&#160;should&#160;float&#160;over&#160;the&#160;top</text><text class="terminal-3751523503-r1" x="427" y="93.2" textLength="12.2" clip-path="url(#terminal-3751523503-line-3)">│</text><text class="terminal-3751523503-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3751523503-line-3)">
+  </text><text class="terminal-3751523503-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-3751523503-line-4)">│</text><text class="terminal-3751523503-r1" x="427" y="117.6" textLength="12.2" clip-path="url(#terminal-3751523503-line-4)">│</text><text class="terminal-3751523503-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3751523503-line-4)">
+  </text><text class="terminal-3751523503-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-3751523503-line-5)">│</text><text class="terminal-3751523503-r1" x="427" y="142" textLength="12.2" clip-path="url(#terminal-3751523503-line-5)">│</text><text class="terminal-3751523503-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3751523503-line-5)">
+  </text><text class="terminal-3751523503-r1" x="0" y="166.4" textLength="439.2" clip-path="url(#terminal-3751523503-line-6)">└──────────────────────────────────┘</text><text class="terminal-3751523503-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-6)">
+  </text><text class="terminal-3751523503-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-7)">
+  </text><text class="terminal-3751523503-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3751523503-line-8)">
+  </text><text class="terminal-3751523503-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3751523503-line-9)">
+  </text><text class="terminal-3751523503-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3751523503-line-10)">
+  </text><text class="terminal-3751523503-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-11)">
+  </text><text class="terminal-3751523503-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-12)">
+  </text><text class="terminal-3751523503-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3751523503-line-13)">
+  </text><text class="terminal-3751523503-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3751523503-line-14)">
+  </text><text class="terminal-3751523503-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3751523503-line-15)">
+  </text><text class="terminal-3751523503-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-16)">
+  </text><text class="terminal-3751523503-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-17)">
+  </text><text class="terminal-3751523503-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3751523503-line-18)">
+  </text><text class="terminal-3751523503-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3751523503-line-19)">
+  </text><text class="terminal-3751523503-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3751523503-line-20)">
+  </text><text class="terminal-3751523503-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3751523503-line-21)">
+  </text><text class="terminal-3751523503-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3751523503-line-22)">
+  </text><text class="terminal-3751523503-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-3751523503-line-23)">&#160;T&#160;</text><text class="terminal-3751523503-r6" x="36.6" y="581.2" textLength="183" clip-path="url(#terminal-3751523503-line-23)">&#160;Toggle&#160;Screen&#160;</text>
       </g>
       </g>
   </svg>
@@ -7641,136 +7641,136 @@
           font-weight: 700;
       }
   
-      .terminal-674792427-matrix {
+      .terminal-3245245315-matrix {
           font-family: Fira Code, monospace;
           font-size: 20px;
           line-height: 24.4px;
           font-variant-east-asian: full-width;
       }
   
-      .terminal-674792427-title {
+      .terminal-3245245315-title {
           font-size: 18px;
           font-weight: bold;
           font-family: arial;
       }
   
-      .terminal-674792427-r1 { fill: #ffff00 }
-  .terminal-674792427-r2 { fill: #c5c8c6 }
-  .terminal-674792427-r3 { fill: #e8e7e5 }
-  .terminal-674792427-r4 { fill: #ddeedd }
-  .terminal-674792427-r5 { fill: #dde8f3;font-weight: bold }
-  .terminal-674792427-r6 { fill: #ddedf9 }
+      .terminal-3245245315-r1 { fill: #ffff00 }
+  .terminal-3245245315-r2 { fill: #c5c8c6 }
+  .terminal-3245245315-r3 { fill: #e3e3e3 }
+  .terminal-3245245315-r4 { fill: #ddeedd }
+  .terminal-3245245315-r5 { fill: #dde8f3;font-weight: bold }
+  .terminal-3245245315-r6 { fill: #ddedf9 }
       </style>
   
       <defs>
-      <clipPath id="terminal-674792427-clip-terminal">
+      <clipPath id="terminal-3245245315-clip-terminal">
         <rect x="0" y="0" width="975.0" height="584.5999999999999" />
       </clipPath>
-      <clipPath id="terminal-674792427-line-0">
+      <clipPath id="terminal-3245245315-line-0">
       <rect x="0" y="1.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-1">
+  <clipPath id="terminal-3245245315-line-1">
       <rect x="0" y="25.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-2">
+  <clipPath id="terminal-3245245315-line-2">
       <rect x="0" y="50.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-3">
+  <clipPath id="terminal-3245245315-line-3">
       <rect x="0" y="74.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-4">
+  <clipPath id="terminal-3245245315-line-4">
       <rect x="0" y="99.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-5">
+  <clipPath id="terminal-3245245315-line-5">
       <rect x="0" y="123.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-6">
+  <clipPath id="terminal-3245245315-line-6">
       <rect x="0" y="147.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-7">
+  <clipPath id="terminal-3245245315-line-7">
       <rect x="0" y="172.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-8">
+  <clipPath id="terminal-3245245315-line-8">
       <rect x="0" y="196.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-9">
+  <clipPath id="terminal-3245245315-line-9">
       <rect x="0" y="221.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-10">
+  <clipPath id="terminal-3245245315-line-10">
       <rect x="0" y="245.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-11">
+  <clipPath id="terminal-3245245315-line-11">
       <rect x="0" y="269.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-12">
+  <clipPath id="terminal-3245245315-line-12">
       <rect x="0" y="294.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-13">
+  <clipPath id="terminal-3245245315-line-13">
       <rect x="0" y="318.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-14">
+  <clipPath id="terminal-3245245315-line-14">
       <rect x="0" y="343.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-15">
+  <clipPath id="terminal-3245245315-line-15">
       <rect x="0" y="367.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-16">
+  <clipPath id="terminal-3245245315-line-16">
       <rect x="0" y="391.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-17">
+  <clipPath id="terminal-3245245315-line-17">
       <rect x="0" y="416.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-18">
+  <clipPath id="terminal-3245245315-line-18">
       <rect x="0" y="440.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-19">
+  <clipPath id="terminal-3245245315-line-19">
       <rect x="0" y="465.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-20">
+  <clipPath id="terminal-3245245315-line-20">
       <rect x="0" y="489.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-21">
+  <clipPath id="terminal-3245245315-line-21">
       <rect x="0" y="513.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-674792427-line-22">
+  <clipPath id="terminal-3245245315-line-22">
       <rect x="0" y="538.3" width="976" height="24.65"/>
               </clipPath>
       </defs>
   
-      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-674792427-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Layers</text>
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3245245315-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Layers</text>
               <g transform="translate(26,22)">
               <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
               <circle cx="22" cy="0" r="7" fill="#febc2e"/>
               <circle cx="44" cy="0" r="7" fill="#28c840"/>
               </g>
           
-      <g transform="translate(9, 41)" clip-path="url(#terminal-674792427-clip-terminal)">
-      <rect fill="#ff0000" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="439.2" y="1.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="475.8" y="1.5" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#534838" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="50.3" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="50.3" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="36.6" y="74.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="74.7" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="99.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="123.5" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="562.7" width="756.4" height="24.65" shape-rendering="crispEdges"/>
-      <g class="terminal-674792427-matrix">
-      <text class="terminal-674792427-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-674792427-line-0)">┌───────</text><text class="terminal-674792427-r1" x="97.6" y="20" textLength="341.6" clip-path="url(#terminal-674792427-line-0)">───────────────────────────┐</text><text class="terminal-674792427-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-674792427-line-0)">
-  </text><text class="terminal-674792427-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-674792427-line-1)">│</text><text class="terminal-674792427-r1" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-674792427-line-1)">│</text><text class="terminal-674792427-r4" x="439.2" y="44.4" textLength="536.8" clip-path="url(#terminal-674792427-line-1)">It&#x27;s&#160;full&#160;of&#160;stars!&#160;My&#160;God!&#160;It&#x27;s&#160;full&#160;of&#160;sta</text><text class="terminal-674792427-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-674792427-line-1)">
-  </text><text class="terminal-674792427-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-674792427-line-2)">│</text><text class="terminal-674792427-r1" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-674792427-line-2)">│</text><text class="terminal-674792427-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-674792427-line-2)">
-  </text><text class="terminal-674792427-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-674792427-line-3)">│</text><text class="terminal-674792427-r1" x="36.6" y="93.2" textLength="366" clip-path="url(#terminal-674792427-line-3)">This&#160;should&#160;float&#160;over&#160;the&#160;top</text><text class="terminal-674792427-r1" x="427" y="93.2" textLength="12.2" clip-path="url(#terminal-674792427-line-3)">│</text><text class="terminal-674792427-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-674792427-line-3)">
-  </text><text class="terminal-674792427-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-674792427-line-4)">│</text><text class="terminal-674792427-r1" x="427" y="117.6" textLength="12.2" clip-path="url(#terminal-674792427-line-4)">│</text><text class="terminal-674792427-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-674792427-line-4)">
-  </text><text class="terminal-674792427-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-674792427-line-5)">│</text><text class="terminal-674792427-r1" x="427" y="142" textLength="12.2" clip-path="url(#terminal-674792427-line-5)">│</text><text class="terminal-674792427-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-674792427-line-5)">
-  </text><text class="terminal-674792427-r1" x="0" y="166.4" textLength="439.2" clip-path="url(#terminal-674792427-line-6)">└──────────────────────────────────┘</text><text class="terminal-674792427-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-674792427-line-6)">
-  </text><text class="terminal-674792427-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-674792427-line-7)">
-  </text><text class="terminal-674792427-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-674792427-line-8)">
-  </text><text class="terminal-674792427-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-674792427-line-9)">
-  </text><text class="terminal-674792427-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-674792427-line-10)">
-  </text><text class="terminal-674792427-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-674792427-line-11)">
-  </text><text class="terminal-674792427-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-674792427-line-12)">
-  </text><text class="terminal-674792427-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-674792427-line-13)">
-  </text><text class="terminal-674792427-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-674792427-line-14)">
-  </text><text class="terminal-674792427-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-674792427-line-15)">
-  </text><text class="terminal-674792427-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-674792427-line-16)">
-  </text><text class="terminal-674792427-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-674792427-line-17)">
-  </text><text class="terminal-674792427-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-674792427-line-18)">
-  </text><text class="terminal-674792427-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-674792427-line-19)">
-  </text><text class="terminal-674792427-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-674792427-line-20)">
-  </text><text class="terminal-674792427-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-674792427-line-21)">
-  </text><text class="terminal-674792427-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-674792427-line-22)">
-  </text><text class="terminal-674792427-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-674792427-line-23)">&#160;T&#160;</text><text class="terminal-674792427-r6" x="36.6" y="581.2" textLength="183" clip-path="url(#terminal-674792427-line-23)">&#160;Toggle&#160;Screen&#160;</text>
+      <g transform="translate(9, 41)" clip-path="url(#terminal-3245245315-clip-terminal)">
+      <rect fill="#ff0000" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="439.2" y="1.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="475.8" y="1.5" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="50.3" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="50.3" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="36.6" y="74.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="74.7" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="99.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="123.5" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="562.7" width="756.4" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-3245245315-matrix">
+      <text class="terminal-3245245315-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-3245245315-line-0)">┌───────</text><text class="terminal-3245245315-r1" x="97.6" y="20" textLength="341.6" clip-path="url(#terminal-3245245315-line-0)">───────────────────────────┐</text><text class="terminal-3245245315-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3245245315-line-0)">
+  </text><text class="terminal-3245245315-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-1)">│</text><text class="terminal-3245245315-r1" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-1)">│</text><text class="terminal-3245245315-r4" x="439.2" y="44.4" textLength="536.8" clip-path="url(#terminal-3245245315-line-1)">It&#x27;s&#160;full&#160;of&#160;stars!&#160;My&#160;God!&#160;It&#x27;s&#160;full&#160;of&#160;sta</text><text class="terminal-3245245315-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-1)">
+  </text><text class="terminal-3245245315-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-2)">│</text><text class="terminal-3245245315-r1" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-2)">│</text><text class="terminal-3245245315-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-2)">
+  </text><text class="terminal-3245245315-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-3245245315-line-3)">│</text><text class="terminal-3245245315-r1" x="36.6" y="93.2" textLength="366" clip-path="url(#terminal-3245245315-line-3)">This&#160;should&#160;float&#160;over&#160;the&#160;top</text><text class="terminal-3245245315-r1" x="427" y="93.2" textLength="12.2" clip-path="url(#terminal-3245245315-line-3)">│</text><text class="terminal-3245245315-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3245245315-line-3)">
+  </text><text class="terminal-3245245315-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-3245245315-line-4)">│</text><text class="terminal-3245245315-r1" x="427" y="117.6" textLength="12.2" clip-path="url(#terminal-3245245315-line-4)">│</text><text class="terminal-3245245315-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3245245315-line-4)">
+  </text><text class="terminal-3245245315-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-3245245315-line-5)">│</text><text class="terminal-3245245315-r1" x="427" y="142" textLength="12.2" clip-path="url(#terminal-3245245315-line-5)">│</text><text class="terminal-3245245315-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3245245315-line-5)">
+  </text><text class="terminal-3245245315-r1" x="0" y="166.4" textLength="439.2" clip-path="url(#terminal-3245245315-line-6)">└──────────────────────────────────┘</text><text class="terminal-3245245315-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-6)">
+  </text><text class="terminal-3245245315-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-7)">
+  </text><text class="terminal-3245245315-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3245245315-line-8)">
+  </text><text class="terminal-3245245315-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3245245315-line-9)">
+  </text><text class="terminal-3245245315-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3245245315-line-10)">
+  </text><text class="terminal-3245245315-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-11)">
+  </text><text class="terminal-3245245315-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-12)">
+  </text><text class="terminal-3245245315-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3245245315-line-13)">
+  </text><text class="terminal-3245245315-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3245245315-line-14)">
+  </text><text class="terminal-3245245315-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3245245315-line-15)">
+  </text><text class="terminal-3245245315-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-16)">
+  </text><text class="terminal-3245245315-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-17)">
+  </text><text class="terminal-3245245315-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3245245315-line-18)">
+  </text><text class="terminal-3245245315-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3245245315-line-19)">
+  </text><text class="terminal-3245245315-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3245245315-line-20)">
+  </text><text class="terminal-3245245315-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3245245315-line-21)">
+  </text><text class="terminal-3245245315-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3245245315-line-22)">
+  </text><text class="terminal-3245245315-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-3245245315-line-23)">&#160;T&#160;</text><text class="terminal-3245245315-r6" x="36.6" y="581.2" textLength="183" clip-path="url(#terminal-3245245315-line-23)">&#160;Toggle&#160;Screen&#160;</text>
       </g>
       </g>
   </svg>

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -12,7 +12,9 @@ async def test_run_test() -> None:
 
     app = TestApp()
     async with app.run_test() as pilot:
-        assert str(pilot) == "<Pilot app=TestApp(title='TestApp')>"
+        assert (
+            str(pilot) == "<Pilot app=TestApp(title='TestApp', classes={'-dark-mode'})>"
+        )
         await pilot.press("tab", *"foo")
         await pilot.pause(1 / 100)
         await pilot.exit("bar")


### PR DESCRIPTION
- Fixes https://github.com/Textualize/textual/issues/1411
- Fixes issue with `-dark-mode` class not applied by default
- Reverts "optimization" to refresh

Header is now neutral in color
<img width="1326" alt="Screenshot 2022-12-20 at 14 14 18" src="https://user-images.githubusercontent.com/554369/208687256-afd6a41b-d6d4-4c13-9256-7cf6cbe08bf1.png">
<img width="1326" alt="Screenshot 2022-12-20 at 14 14 13" src="https://user-images.githubusercontent.com/554369/208687267-adc490eb-805d-4bd0-bfb1-7c02ff135558.png">


