### PR TITLE
Allow `App.dark` to be set as early as `App.on_load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.8.0] - Unreleased
 
-### Fixed 
+### Fixed
 
 - Fixed issues with nested auto dimensions https://github.com/Textualize/textual/issues/1402
 - Fixed watch method incorrectly running on first set when value hasn't changed and init=False https://github.com/Textualize/textual/pull/1367

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed issues with nested auto dimensions https://github.com/Textualize/textual/issues/1402
 - Fixed watch method incorrectly running on first set when value hasn't changed and init=False https://github.com/Textualize/textual/pull/1367
+- `App.dark` can now be set from `App.on_load` without an error being raised  https://github.com/Textualize/textual/issues/1369
 
 ### Added
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -480,7 +480,14 @@ class App(Generic[ReturnType], DOMNode):
         """Watches the dark bool."""
         self.set_class(dark, "-dark-mode")
         self.set_class(not dark, "-light-mode")
-        self.refresh_css()
+        try:
+            self.refresh_css()
+        except ScreenStackError:
+            # It's possible that `dark` can be set before we have a default
+            # screen, in an app's `on_load`, for example. So let's eat the
+            # ScreenStackError -- the above styles will be handled once the
+            # screen is spun up anyway.
+            pass
 
     def get_driver_class(self) -> Type[Driver]:
         """Get a driver class for this platform.

--- a/tests/test_dark_toggle.py
+++ b/tests/test_dark_toggle.py
@@ -1,15 +1,18 @@
 from textual.app import App
 
+
 class OnLoadDarkSwitch(App[None]):
     """App for testing toggling dark mode in on_load."""
 
     def on_load(self) -> None:
         self.dark = not self.dark
 
+
 async def test_toggle_dark_on_load() -> None:
     """It should be possible to toggle dark mode in on_load."""
     async with OnLoadDarkSwitch().run_test() as pilot:
         assert not pilot.app.dark
+
 
 class OnMountDarkSwitch(App[None]):
     """App for testing toggling dark mode in on_mount."""
@@ -17,10 +20,12 @@ class OnMountDarkSwitch(App[None]):
     def on_mount(self) -> None:
         self.dark = not self.dark
 
+
 async def test_toggle_dark_on_mount() -> None:
     """It should be possible to toggle dark mode in on_mount."""
     async with OnMountDarkSwitch().run_test() as pilot:
         assert not pilot.app.dark
+
 
 class ActionDarkSwitch(App[None]):
     """App for testing toggling dark mode from an action."""
@@ -29,6 +34,7 @@ class ActionDarkSwitch(App[None]):
 
     def action_toggle(self) -> None:
         self.dark = not self.dark
+
 
 async def test_toggle_dark_in_action() -> None:
     """It should be possible to toggle dark mode with an action."""

--- a/tests/test_dark_toggle.py
+++ b/tests/test_dark_toggle.py
@@ -1,0 +1,38 @@
+from textual.app import App
+
+class OnLoadDarkSwitch(App[None]):
+    """App for testing toggling dark mode in on_load."""
+
+    def on_load(self) -> None:
+        self.dark = not self.dark
+
+async def test_toggle_dark_on_load() -> None:
+    """It should be possible to toggle dark mode in on_load."""
+    async with OnLoadDarkSwitch().run_test() as pilot:
+        assert not pilot.app.dark
+
+class OnMountDarkSwitch(App[None]):
+    """App for testing toggling dark mode in on_mount."""
+
+    def on_mount(self) -> None:
+        self.dark = not self.dark
+
+async def test_toggle_dark_on_mount() -> None:
+    """It should be possible to toggle dark mode in on_mount."""
+    async with OnMountDarkSwitch().run_test() as pilot:
+        assert not pilot.app.dark
+
+class ActionDarkSwitch(App[None]):
+    """App for testing toggling dark mode from an action."""
+
+    BINDINGS = [("d", "toggle", "Toggle Dark Mode")]
+
+    def action_toggle(self) -> None:
+        self.dark = not self.dark
+
+async def test_toggle_dark_in_action() -> None:
+    """It should be possible to toggle dark mode with an action."""
+    async with OnMountDarkSwitch().run_test() as pilot:
+        await pilot.press("d")
+        await pilot.pause(2 / 100)
+        assert not pilot.app.dark


### PR DESCRIPTION
This PR addresses #1369 by swallowing any `ScreenStackError` when attempting to update the styles within `App.watch_dark`; the idea being that if there isn't a screen, one will be coming soon, and the styles will get taken up then anyway.