### PR TITLE
Fix a couple of typos in DirectoryTree.process_label

### DIFF
--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -47,19 +47,19 @@ class DirectoryTree(Tree[DirEntry]):
 
     DEFAULT_CSS = """
     DirectoryTree > .directory-tree--folder {
-        text-style: bold;        
+        text-style: bold;
     }
 
     DirectoryTree > .directory-tree--file {
-        
+
     }
 
-    DirectoryTree > .directory-tree--extension {               
-        text-style: italic;   
+    DirectoryTree > .directory-tree--extension {
+        text-style: italic;
     }
 
     DirectoryTree > .directory-tree--hidden {
-        color: $text 50%;        
+        color: $text 50%;
     }
     """
 
@@ -87,7 +87,7 @@ class DirectoryTree(Tree[DirEntry]):
         )
 
     def process_label(self, label: TextType):
-        """Process a str or Text in to a label. Maybe overridden in a subclass to change modify how labels are rendered.
+        """Process a str or Text into a label. Maybe overridden in a subclass to modify how labels are rendered.
 
         Args:
             label (TextType): Label.


### PR DESCRIPTION
Docstring typo fix.