### PR TITLE
MouseScrollUp/MouseScrollDown => plain MousEvent's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.10.0] - Unreleased
+
+### Changed
+
+- `MouseScrollUp` and `MouseScrollDown` now inherit from `MouseEvent` and have attached modifier keys. https://github.com/Textualize/textual/pull/1458
+
 ## [0.9.1] - 2022-12-30
 
 ### Added

--- a/src/textual/_win_sleep.py
+++ b/src/textual/_win_sleep.py
@@ -12,7 +12,6 @@ WAIT_FAILED = 0xFFFFFFFF
 CREATE_WAITABLE_TIMER_HIGH_RESOLUTION = 0x00000002
 
 
-
 def sleep(sleep_for: float) -> None:
     """A replacement sleep for Windows.
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -60,16 +60,19 @@ class XTermParser(Parser[events.Event]):
             delta_y = y - self.last_y
             self.last_x = x
             self.last_y = y
-            event_cls = (
-                (events.MouseScrollDown if buttons & 1 else events.MouseScrollUp)
-                if buttons & 64
-                else events.MouseMove
-                if buttons & 32
-                else (events.MouseDown if state == "M" else events.MouseUp)
-            )
-            if event_cls in (events.MouseScrollUp, events.MouseScrollDown):
-                buttons &= ~(64 | 3)
-            button = (buttons + 1) & 3
+
+            event_cls: type[events.MouseEvent]
+            button: int
+            if buttons & 64:
+                event_cls = events.MouseScrollDown if buttons & 1 else events.MouseScrollUp
+                button = 0
+            else:
+                event_cls = (
+                    events.MouseMove
+                    if buttons & 32
+                    else (events.MouseDown if state == "M" else events.MouseUp)
+                )
+                button = (buttons + 1) & 3
             event = event_cls(
                 sender,
                 x,

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -60,22 +60,22 @@ class XTermParser(Parser[events.Event]):
             delta_y = y - self.last_y
             self.last_x = x
             self.last_y = y
+            event_class: type[events.MouseEvent]
 
-            event_cls: type[events.MouseEvent]
-            button: int
             if buttons & 64:
-                event_cls = (
+                event_class = (
                     events.MouseScrollDown if buttons & 1 else events.MouseScrollUp
                 )
                 button = 0
             else:
-                event_cls = (
-                    events.MouseMove
-                    if buttons & 32
-                    else (events.MouseDown if state == "M" else events.MouseUp)
-                )
+                if buttons & 32:
+                    event_class = events.MouseMove
+                else:
+                    event_class = events.MouseDown if state == "M" else events.MouseUp
+
                 button = (buttons + 1) & 3
-            event = event_cls(
+
+            event = event_class(
                 sender,
                 x,
                 y,

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -64,7 +64,9 @@ class XTermParser(Parser[events.Event]):
             event_cls: type[events.MouseEvent]
             button: int
             if buttons & 64:
-                event_cls = events.MouseScrollDown if buttons & 1 else events.MouseScrollUp
+                event_cls = (
+                    events.MouseScrollDown if buttons & 1 else events.MouseScrollUp
+                )
                 button = 0
             else:
                 event_cls = (

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -419,22 +419,14 @@ class MouseUp(MouseEvent, bubble=True, verbose=True):
     pass
 
 
-class MouseScrollDown(InputEvent, bubble=True, verbose=True):
-    __slots__ = ["x", "y"]
-
-    def __init__(self, sender: MessageTarget, x: int, y: int) -> None:
-        super().__init__(sender)
-        self.x = x
-        self.y = y
+@rich.repr.auto
+class MouseScrollDown(MouseEvent, bubble=True):
+    pass
 
 
-class MouseScrollUp(InputEvent, bubble=True, verbose=True):
-    __slots__ = ["x", "y"]
-
-    def __init__(self, sender: MessageTarget, x: int, y: int) -> None:
-        super().__init__(sender)
-        self.x = x
-        self.y = y
+@rich.repr.auto
+class MouseScrollUp(MouseEvent, bubble=True):
+    pass
 
 
 class Click(MouseEvent, bubble=True):

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -236,14 +236,14 @@ def test_mouse_move(parser, sequence, shift, meta, button):
 
 
 @pytest.mark.parametrize(
-    "sequence",
+    "sequence, shift, meta",
     [
-        "\x1b[<64;18;25M",
-        "\x1b[<68;18;25M",
-        "\x1b[<72;18;25M",
+        ("\x1b[<64;18;25M", False, False),
+        ("\x1b[<68;18;25M", True,  False),
+        ("\x1b[<72;18;25M", False, True),
     ],
 )
-def test_mouse_scroll_up(parser, sequence):
+def test_mouse_scroll_up(parser, sequence, shift, meta):
     """Scrolling the mouse with and without modifiers held down.
     We don't currently capture modifier keys in scroll events.
     """
@@ -256,17 +256,19 @@ def test_mouse_scroll_up(parser, sequence):
     assert isinstance(event, MouseScrollUp)
     assert event.x == 17
     assert event.y == 24
+    assert event.shift is shift
+    assert event.meta is meta
 
 
 @pytest.mark.parametrize(
-    "sequence",
+    "sequence, shift, meta",
     [
-        "\x1b[<65;18;25M",
-        "\x1b[<69;18;25M",
-        "\x1b[<73;18;25M",
+        ("\x1b[<65;18;25M", False, False),
+        ("\x1b[<69;18;25M", True,  False),
+        ("\x1b[<73;18;25M", False, True),
     ],
 )
-def test_mouse_scroll_down(parser, sequence):
+def test_mouse_scroll_down(parser, sequence, shift, meta):
     events = list(parser.feed(sequence))
 
     assert len(events) == 1
@@ -276,6 +278,8 @@ def test_mouse_scroll_down(parser, sequence):
     assert isinstance(event, MouseScrollDown)
     assert event.x == 17
     assert event.y == 24
+    assert event.shift is shift
+    assert event.meta is meta
 
 
 def test_mouse_event_detected_but_info_not_parsed(parser):

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -239,7 +239,7 @@ def test_mouse_move(parser, sequence, shift, meta, button):
     "sequence, shift, meta",
     [
         ("\x1b[<64;18;25M", False, False),
-        ("\x1b[<68;18;25M", True,  False),
+        ("\x1b[<68;18;25M", True, False),
         ("\x1b[<72;18;25M", False, True),
     ],
 )
@@ -264,7 +264,7 @@ def test_mouse_scroll_up(parser, sequence, shift, meta):
     "sequence, shift, meta",
     [
         ("\x1b[<65;18;25M", False, False),
-        ("\x1b[<69;18;25M", True,  False),
+        ("\x1b[<69;18;25M", True, False),
         ("\x1b[<73;18;25M", False, True),
     ],
 )


### PR DESCRIPTION
... which means they get passesd x, y, etc. In particular, they are passed the keyboard modifiers. This allows widgets to use e.g. ctrl-wheel to scroll right/left.
