### PR TITLE
add a "thin" horiz scrollbar

### DIFF
--- a/src/textual/css/_help_text.py
+++ b/src/textual/css/_help_text.py
@@ -622,9 +622,7 @@ def scrollbar_thin_property_help_text(context: StylingContext) -> HelpText:
                     ),
                 ],
             ).get_by_context(context),
-            Bullet(
-                "<horizontal> and <vertical> must be booleans"
-            ),
+            Bullet("<horizontal> and <vertical> must be booleans"),
         ],
     )
 

--- a/src/textual/css/_help_text.py
+++ b/src/textual/css/_help_text.py
@@ -590,6 +590,45 @@ def scrollbar_size_property_help_text(context: StylingContext) -> HelpText:
     )
 
 
+def scrollbar_thin_property_help_text(context: StylingContext) -> HelpText:
+    """Help text to show when the user supplies an invalid value for the scrollbar-thin property.
+
+    Args:
+        context (StylingContext | None): The context the property is being used in.
+
+    Returns:
+        HelpText: Renderable for displaying the help text for this property
+    """
+    return HelpText(
+        summary="Invalid value for [i]scrollbar-thin[/] property",
+        bullets=[
+            *ContextSpecificBullets(
+                inline=[
+                    Bullet(
+                        markup="The [i]scrollbar_thin[/] property expects a tuple of 2 values [i](<horizontal>, <vertical>)[/]",
+                        examples=[
+                            Example("widget.styles.scrollbar_thin = (True, False)"),
+                        ],
+                    ),
+                ],
+                css=[
+                    Bullet(
+                        markup="The [i]scrollbar-thin[/] property expects a value of the form [i]<horizontal> <vertical>[/]",
+                        examples=[
+                            Example(
+                                "scrollbar-thin: true false;  [dim]# thin horizontal scrollbar, regular vertical scrollbar"
+                            ),
+                        ],
+                    ),
+                ],
+            ).get_by_context(context),
+            Bullet(
+                "<horizontal> and <vertical> must be booleans"
+            ),
+        ],
+    )
+
+
 def scrollbar_size_single_axis_help_text(property_name: str) -> HelpText:
     """Help text to show when the user supplies an invalid value for a scrollbar-size-* property.
 
@@ -606,6 +645,28 @@ def scrollbar_size_single_axis_help_text(property_name: str) -> HelpText:
                 markup=f"The [i]{property_name}[/] property can only be set to a positive integer, greater than zero",
                 examples=[
                     Example(f"{property_name}: 2;"),
+                ],
+            ),
+        ],
+    )
+
+
+def scrollbar_thin_single_axis_help_text(property_name: str) -> HelpText:
+    """Help text to show when the user supplies an invalid value for a scrollbar-thin-* property.
+
+    Args:
+        property_name (str): The name of the property
+
+    Returns:
+        HelpText: Renderable for displaying the help text for this property
+    """
+    return HelpText(
+        summary=f"Invalid value for [i]{property_name}[/]",
+        bullets=[
+            Bullet(
+                markup=f"The [i]{property_name}[/] property can only be set to a boolean",
+                examples=[
+                    Example(f"{property_name}: true;"),
                 ],
             ),
         ],

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -26,7 +26,9 @@ from ._help_text import (
     property_invalid_value_help_text,
     scalar_help_text,
     scrollbar_size_property_help_text,
+    scrollbar_thin_property_help_text,
     scrollbar_size_single_axis_help_text,
+    scrollbar_thin_single_axis_help_text,
     spacing_invalid_value_help_text,
     spacing_wrong_number_of_values_help_text,
     string_enum_help_text,
@@ -47,6 +49,7 @@ from .constants import (
     VALID_TEXT_ALIGN,
     VALID_VISIBILITY,
 )
+from .bool import boolean_string_to_bool
 from .errors import DeclarationError, StyleValueError
 from .model import Declaration
 from .scalar import (
@@ -835,6 +838,27 @@ class StylesBuilder:
             self.styles._rules["scrollbar_size_horizontal"] = horizontal
             self.styles._rules["scrollbar_size_vertical"] = vertical
 
+    def process_scrollbar_thin(self, name: str, tokens: list[Token]) -> None:
+        def scrollbar_thin_error(name: str, token: Token) -> None:
+            self.error(name, token, scrollbar_thin_property_help_text(context="css"))
+
+        if not tokens:
+            return
+        if len(tokens) != 2:
+            scrollbar_thin_error(name, tokens[0])
+        else:
+            token1, token2 = tokens
+
+            if token1.name != "boolean":
+                scrollbar_thin_error(name, token1)
+            if token2.name != "boolean":
+                scrollbar_thin_error(name, token2)
+
+            horizontal = boolean_string_to_bool(token1.value)
+            vertical = boolean_string_to_bool(token2.value)
+            self.styles._rules["scrollbar_thin_horizontal"] = horizontal
+            self.styles._rules["scrollbar_thin_vertical"] = vertical
+
     def process_scrollbar_size_vertical(self, name: str, tokens: list[Token]) -> None:
         if not tokens:
             return
@@ -849,6 +873,18 @@ class StylesBuilder:
                 self.error(name, token, scrollbar_size_single_axis_help_text(name))
             self.styles._rules["scrollbar_size_vertical"] = value
 
+    def process_scrollbar_thin_vertical(self, name: str, tokens: list[Token]) -> None:
+        if not tokens:
+            return
+        if len(tokens) != 1:
+            self.error(name, tokens[0], scrollbar_thin_single_axis_help_text(name))
+        else:
+            token = tokens[0]
+            if token.name != "boolean":
+                self.error(name, token, scrollbar_thin_single_axis_help_text(name))
+            value = boolean_string_to_bool(token.value)
+            self.styles._rules["scrollbar_thin_vertical"] = value
+
     def process_scrollbar_size_horizontal(self, name: str, tokens: list[Token]) -> None:
         if not tokens:
             return
@@ -862,6 +898,18 @@ class StylesBuilder:
             if value == 0:
                 self.error(name, token, scrollbar_size_single_axis_help_text(name))
             self.styles._rules["scrollbar_size_horizontal"] = value
+
+    def process_scrollbar_thin_horizontal(self, name: str, tokens: list[Token]) -> None:
+        if not tokens:
+            return
+        if len(tokens) != 1:
+            self.error(name, tokens[0], scrollbar_thin_single_axis_help_text(name))
+        else:
+            token = tokens[0]
+            if token.name != "boolean":
+                self.error(name, token, scrollbar_thin_single_axis_help_text(name))
+            value = boolean_string_to_bool(token.value)
+            self.styles._rules["scrollbar_thin_horizontal"] = value
 
     def _process_grid_rows_or_columns(self, name: str, tokens: list[Token]) -> None:
         scalars: list[Scalar] = []

--- a/src/textual/css/bool.py
+++ b/src/textual/css/bool.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+
+def boolean_string_to_bool(string: str) -> bool:
+    """Convert a string to bool
+
+    Args:
+        string (str): The string to convert.
+    """
+
+    string = string.strip()
+    conv = {
+        "true": True,
+        "false": False,
+    }
+    if string not in conv:
+        raise ValueError(f"'{string}' is not a valid boolean literal")
+    return conv[string]
+
+
+def bool_to_boolean_string(b: bool) -> str:
+    """Convert a bool to a css-string
+
+    Args:
+        b (bool): The bool to convert.
+    """
+
+    return str(b).lower()

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -861,18 +861,18 @@ class Styles(StylesBase):
                         self.scrollbar_thin_horizontal,
                         self.scrollbar_thin_vertical,
                     )
-                )
+                ),
             )
         else:
             if has_rule("scrollbar_thin_horizontal"):
                 append_declaration(
                     "scrollbar-thin-horizontal",
-                    bool_to_boolean_string(self.scrollbar_thin_horizontal)
+                    bool_to_boolean_string(self.scrollbar_thin_horizontal),
                 )
             if has_rule("scrollbar_thin_vertical"):
                 append_declaration(
                     "scrollbar-thin-vertical",
-                    bool_to_boolean_string(self.scrollbar_thin_vertical)
+                    bool_to_boolean_string(self.scrollbar_thin_vertical),
                 )
         if has_rule("box_sizing"):
             append_declaration("box-sizing", self.box_sizing)

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -43,6 +43,7 @@ from .constants import (
     VALID_VISIBILITY,
     VALID_TEXT_ALIGN,
 )
+from .bool import bool_to_boolean_string
 from .scalar import Scalar, ScalarOffset, Unit
 from .scalar_animation import ScalarAnimation
 from .transition import Transition
@@ -134,6 +135,9 @@ class RulesMap(TypedDict, total=False):
 
     scrollbar_size_vertical: int
     scrollbar_size_horizontal: int
+
+    scrollbar_thin_vertical: bool
+    scrollbar_thin_horizontal: bool
 
     align_horizontal: AlignHorizontal
     align_vertical: AlignVertical
@@ -268,6 +272,9 @@ class StylesBase(ABC):
 
     scrollbar_size_vertical = IntegerProperty(default=1, layout=True)
     scrollbar_size_horizontal = IntegerProperty(default=1, layout=True)
+
+    scrollbar_thin_vertical = BooleanProperty(default=False, layout=True)
+    scrollbar_thin_horizontal = BooleanProperty(default=False, layout=True)
 
     align_horizontal = StringEnumProperty(VALID_ALIGN_HORIZONTAL, "left")
     align_vertical = StringEnumProperty(VALID_ALIGN_VERTICAL, "top")
@@ -845,7 +852,28 @@ class Styles(StylesBase):
                 append_declaration(
                     "scrollbar-size-vertical", str(self.scrollbar_size_vertical)
                 )
-
+        if has_rule("scrollbar_thin"):
+            append_declaration(
+                "scrollbar-thin",
+                " ".join(
+                    bool_to_boolean_string(b)
+                    for b in (
+                        self.scrollbar_thin_horizontal,
+                        self.scrollbar_thin_vertical,
+                    )
+                )
+            )
+        else:
+            if has_rule("scrollbar_thin_horizontal"):
+                append_declaration(
+                    "scrollbar-thin-horizontal",
+                    bool_to_boolean_string(self.scrollbar_thin_horizontal)
+                )
+            if has_rule("scrollbar_thin_vertical"):
+                append_declaration(
+                    "scrollbar-thin-vertical",
+                    bool_to_boolean_string(self.scrollbar_thin_vertical)
+                )
         if has_rule("box_sizing"):
             append_declaration("box-sizing", self.box_sizing)
         if has_rule("width"):

--- a/src/textual/css/tokenize.py
+++ b/src/textual/css/tokenize.py
@@ -16,6 +16,7 @@ HEX_COLOR = r"\#[0-9a-fA-F]{8}|\#[0-9a-fA-F]{6}|\#[0-9a-fA-F]{4}|\#[0-9a-fA-F]{3
 RGB_COLOR = rf"rgb{OPEN_BRACE}{DECIMAL}{COMMA}{DECIMAL}{COMMA}{DECIMAL}{CLOSE_BRACE}|rgba{OPEN_BRACE}{DECIMAL}{COMMA}{DECIMAL}{COMMA}{DECIMAL}{COMMA}{DECIMAL}{CLOSE_BRACE}"
 HSL_COLOR = rf"hsl{OPEN_BRACE}{DECIMAL}{COMMA}{PERCENT}{COMMA}{PERCENT}{CLOSE_BRACE}|hsla{OPEN_BRACE}{DECIMAL}{COMMA}{PERCENT}{COMMA}{PERCENT}{COMMA}{DECIMAL}{CLOSE_BRACE}"
 
+BOOLEAN = r"true|false"
 COMMENT_START = r"\/\*"
 SCALAR = rf"{DECIMAL}(?:fr|%|w|h|vw|vh)"
 DURATION = r"\d+\.?\d*(?:ms|s)"
@@ -30,6 +31,7 @@ IDENTIFIER = r"[a-zA-Z_\-][a-zA-Z0-9_\-]*"
 
 # Values permitted in variable and rule declarations.
 DECLARATION_VALUES = {
+    "boolean": BOOLEAN,
     "scalar": SCALAR,
     "duration": DURATION,
     "number": NUMBER,

--- a/src/textual/demo.css
+++ b/src/textual/demo.css
@@ -207,6 +207,7 @@ LocationLink:hover {
 
 DataTable {
     height: 16;
+    scrollbar-thin: true true;
 }
 
 

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -101,8 +101,8 @@ class ScrollBarRender:
         _Style = Style
         _Segment = Segment
 
-        norm_style  = _Style(bgcolor=back_color, color=bar_color)
-        rev_style   = _Style(bgcolor=bar_color,  color=back_color)
+        norm_style = _Style(bgcolor=back_color, color=bar_color)
+        rev_style = _Style(bgcolor=bar_color, color=back_color)
 
         if vertical:
             bars_start = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", " "]
@@ -136,31 +136,31 @@ class ScrollBarRender:
 
         len_bars = len(bars_start)
 
-        upper_meta  = {"@mouse.up": "scroll_up"}
+        upper_meta = {"@mouse.up": "scroll_up"}
         middle_meta = {"@mouse.up": "release", "@mouse.down": "grab"}
-        lower_meta  = {"@mouse.up": "scroll_down"}
+        lower_meta = {"@mouse.up": "scroll_down"}
 
         upper_back_style = blank_style + _Style.from_meta(upper_meta)
-        middle_fg_style  = full_style  + _Style.from_meta(middle_meta)
+        middle_fg_style = full_style + _Style.from_meta(middle_meta)
         lower_back_style = blank_style + _Style.from_meta(lower_meta)
 
         upper_back_segment = _Segment(blank, upper_back_style)
-        middle_fg_segment  = _Segment(full,  middle_fg_style)
+        middle_fg_segment = _Segment(full, middle_fg_style)
         lower_back_segment = _Segment(blank, lower_back_style)
 
         if window_size and size and virtual_size and size != virtual_size:
             step_size = virtual_size / size
 
             start = int(position / step_size * len_bars)
-            end   = start + max(len_bars, int(ceil(window_size / step_size * len_bars)))
+            end = start + max(len_bars, int(ceil(window_size / step_size * len_bars)))
 
             start_index, start_bar = divmod(max(0, start), len_bars)
-            end_index,   end_bar   = divmod(max(0, end  ), len_bars)
+            end_index, end_bar = divmod(max(0, end), len_bars)
 
             segments = (
-                [lower_back_segment] * (start_index) +
-                [middle_fg_segment]  * (end_index - start_index) +
-                [upper_back_segment] * (size - end_index)
+                [lower_back_segment] * (start_index)
+                + [middle_fg_segment] * (end_index - start_index)
+                + [upper_back_segment] * (size - end_index)
             )
 
             # Apply the smaller bar characters to head and tail of scrollbar for more "granularity"
@@ -229,7 +229,12 @@ class ScrollBar(Widget):
     """
 
     def __init__(
-        self, vertical: bool = True, name: str | None = None, *, thickness: int = 1, thin: bool = False,
+        self,
+        vertical: bool = True,
+        name: str | None = None,
+        *,
+        thickness: int = 1,
+        thin: bool = False,
     ) -> None:
         self.vertical = vertical
         self.thickness = thickness

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -961,7 +961,9 @@ class Widget(DOMNode):
             int: Number of columns in the vertical scrollbar.
         """
         styles = self.styles
-        would_be_size = 1 if styles.scrollbar_thin_vertical else styles.scrollbar_size_vertical
+        would_be_size = (
+            1 if styles.scrollbar_thin_vertical else styles.scrollbar_size_vertical
+        )
         if styles.scrollbar_gutter == "stable" and styles.overflow_y == "auto":
             return would_be_size
         return would_be_size if self.show_vertical_scrollbar else 0
@@ -984,7 +986,9 @@ class Widget(DOMNode):
             int: Number of rows in the horizontal scrollbar.
         """
         styles = self.styles
-        would_be_size = 1 if styles.scrollbar_thin_horizontal else styles.scrollbar_size_horizontal
+        would_be_size = (
+            1 if styles.scrollbar_thin_horizontal else styles.scrollbar_size_horizontal
+        )
         return would_be_size if self.show_horizontal_scrollbar else 0
 
     @property

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -866,7 +866,10 @@ class Widget(DOMNode):
         if self._vertical_scrollbar is not None:
             return self._vertical_scrollbar
         self._vertical_scrollbar = scroll_bar = ScrollBar(
-            vertical=True, name="vertical", thickness=self.scrollbar_size_vertical
+            vertical=True,
+            name="vertical",
+            thickness=self.scrollbar_size_vertical,
+            thin=self.scrollbar_thin_vertical,
         )
         self._vertical_scrollbar.display = False
         self.app._start_widget(self, scroll_bar)
@@ -885,7 +888,10 @@ class Widget(DOMNode):
         if self._horizontal_scrollbar is not None:
             return self._horizontal_scrollbar
         self._horizontal_scrollbar = scroll_bar = ScrollBar(
-            vertical=False, name="horizontal", thickness=self.scrollbar_size_horizontal
+            vertical=False,
+            name="horizontal",
+            thickness=self.scrollbar_size_horizontal,
+            thin=self.scrollbar_thin_horizontal,
         )
         self._horizontal_scrollbar.display = False
         self.app._start_widget(self, scroll_bar)
@@ -955,9 +961,20 @@ class Widget(DOMNode):
             int: Number of columns in the vertical scrollbar.
         """
         styles = self.styles
+        would_be_size = 1 if styles.scrollbar_thin_vertical else styles.scrollbar_size_vertical
         if styles.scrollbar_gutter == "stable" and styles.overflow_y == "auto":
-            return styles.scrollbar_size_vertical
-        return styles.scrollbar_size_vertical if self.show_vertical_scrollbar else 0
+            return would_be_size
+        return would_be_size if self.show_vertical_scrollbar else 0
+
+    @property
+    def scrollbar_thin_vertical(self) -> bool:
+        """Get whether the *vertical* scroll should be thin
+            (which in the case of the vertical scrollbar means 1 char)
+
+        Returns:
+            bool: Should the vertical scrollbar be one char in width
+        """
+        return self.styles.scrollbar_thin_vertical
 
     @property
     def scrollbar_size_horizontal(self) -> int:
@@ -967,7 +984,17 @@ class Widget(DOMNode):
             int: Number of rows in the horizontal scrollbar.
         """
         styles = self.styles
-        return styles.scrollbar_size_horizontal if self.show_horizontal_scrollbar else 0
+        would_be_size = 1 if styles.scrollbar_thin_horizontal else styles.scrollbar_size_horizontal
+        return would_be_size if self.show_horizontal_scrollbar else 0
+
+    @property
+    def scrollbar_thin_horizontal(self) -> bool:
+        """Get whether the *horizontal* scroll should be thin ("one-half" char in height)
+
+        Returns:
+            bool: Should the horizontal scrollbar be one-half char in height
+        """
+        return self.styles.scrollbar_thin_horizontal
 
     @property
     def scrollbar_gutter(self) -> Spacing:


### PR DESCRIPTION
First, a screenshot:

<img width="575" alt="Screen Shot 2022-12-31 at 21 12 24" src="https://user-images.githubusercontent.com/1918551/210153611-3de4809a-8e11-483a-afa3-e18cb5de8910.png">

I don't like the horizontal scrollbar; even at "size" 1 it is still too fat. So I added an option for a "thin" version, refactoring ScrollBarRender along the way.

I didn't presume to know how you'd like the CSS to behave, so I went for the simplest I could think of: add a new "scrollbar-thin" boolean style. I am not married to the css design around it, I really only want the "thin" version.

There's no need to do anything special for a "thin" vertical scrollbar: imo it looks very nice at width 1.
