### PR TITLE
test_auto_refresh: change the way time is measured

### DIFF
--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -1,33 +1,43 @@
 import asyncio
-from time import time
+import time
 
 from textual.app import App
 from textual.pilot import Pilot
 
 
-class RefreshApp(App[float]):
-    def __init__(self):
+class RefreshApp(App[tuple[float, float]]):
+    def __init__(self) -> None:
         self.count = 0
         super().__init__()
 
-    def on_mount(self):
-        self.start = time()
+    def on_mount(self) -> None:
+        self.start_wall_clock = time.time()
+        self.start_thread_clock = time.thread_time()
         self.auto_refresh = 0.1
 
-    def _automatic_refresh(self):
+    def _automatic_refresh(self) -> None:
         self.count += 1
         if self.count == 3:
-            self.exit(time() - self.start)
+            app_result = (
+                time.time() - self.start_wall_clock,
+                time.thread_time() - self.start_thread_clock,
+            )
+            self.exit(app_result)
         super()._automatic_refresh()
 
 
-def test_auto_refresh():
+def test_auto_refresh() -> None:
     app = RefreshApp()
 
     async def quit_after(pilot: Pilot) -> None:
         await asyncio.sleep(1)
 
-    elapsed = app.run(auto_pilot=quit_after, headless=True)
-    assert elapsed is not None
+    app_result = app.run(auto_pilot=quit_after, headless=True)
+    assert app_result is not None
+    elapsed_wall_clock, elapsed_thread_clock = app_result
+
     # CI can run slower, so we need to give this a bit of margin
-    assert 0.2 <= elapsed < 0.8
+    # in terms of thread time this should take ~0.01s, but let's
+    # give it 0.2s.
+    assert 0.3 <= elapsed_wall_clock
+    assert elapsed_thread_clock < 0.2

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -1,11 +1,12 @@
 import asyncio
 import time
+from typing import Tuple
 
 from textual.app import App
 from textual.pilot import Pilot
 
 
-class RefreshApp(App[tuple[float, float]]):
+class RefreshApp(App[Tuple[float, float]]):
     def __init__(self) -> None:
         self.count = 0
         super().__init__()


### PR DESCRIPTION
While running tests for #1456 I ran into this annoyance of a test timing out. This is an initial attempt to solve it.

The idea is to measure *thread* time to make sure we haven't slowed time too much, and also wall-clock time to make sure we actually have been sleeping as expected.

Notice I measure thread time rather than process time because the process (in theory) could be running multiple event loops and tests).

I wonder whether this works for Windows. Let's see...

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
