### PR TITLE
Sanitise issue titles before running suggest on them

### DIFF
--- a/.github/workflows/new_issue.yml
+++ b/.github/workflows/new_issue.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Install FAQtory
         run: pip install FAQtory
       - name: Run Suggest
-        run: faqtory suggest "${{ github.event.issue.title }}" > suggest.md
+        env:
+          TITLE: ${{ github.event.issue.title }}
+        run: faqtory suggest "$TITLE" > suggest.md
       - name: Read suggest.md
         id: suggest
         uses: juliangruber/read-file-action@v1


### PR DESCRIPTION
Applying
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable to #1472.

Likely best to double-check this as I'm not actually sure how you can check a workflow before actually deploying it, but if I'm reading things correctly this should make the user of issue titles in the FAQtory workflow safer and less likely to run into errors.