### PR TITLE
Ensure pretty traceback for error in Widget compose method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `MouseScrollUp` and `MouseScrollDown` now inherit from `MouseEvent` and have attached modifier keys. https://github.com/Textualize/textual/pull/1458
+- Fail-fast and print pretty tracebacks for Widget compose errors https://github.com/Textualize/textual/pull/1505
 
 ### Fixed
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -33,6 +33,7 @@ from rich.measure import Measurement
 from rich.segment import Segment
 from rich.style import Style
 from rich.text import Text
+from rich.traceback import Traceback
 
 from . import errors, events, messages
 from ._animator import DEFAULT_EASING, Animatable, BoundAnimator, EasingFunction
@@ -2333,7 +2334,10 @@ class Widget(DOMNode):
             raise TypeError(
                 f"{self!r} compose() returned an invalid response; {error}"
             ) from None
-        await self.mount(*widgets)
+        except Exception:
+            self.app.panic(Traceback())
+        else:
+            await self.mount(*widgets)
 
     def _on_mount(self, event: events.Mount) -> None:
         if self.styles.overflow_y == "scroll":


### PR DESCRIPTION
It now fails immediately and displays a Rich traceback.
Previously it still rendered (although incorrectly) and then displayed a plain traceback on app exit.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
