### PR TITLE
Make list_view snapshot test pass more reliably

### DIFF
--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -103,7 +103,7 @@ def test_header_render(snap_compare):
 
 def test_list_view(snap_compare):
     assert snap_compare(
-        WIDGET_EXAMPLES_DIR / "list_view.py", press=["tab", "down", "down", "up"]
+        WIDGET_EXAMPLES_DIR / "list_view.py", press=["tab", "down", "down", "up", "_"]
     )
 
 


### PR DESCRIPTION
This test keeps failing in CI for no apparent reason and giving it a short pause will likely make the test pass more reliably.