### PR TITLE
Reactive refactor and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added Widget._refresh_scroll to avoid expensive layout when scrolling https://github.com/Textualize/textual/pull/1524
 - `events.Paste` now bubbles https://github.com/Textualize/textual/issues/1434
 - Clock color in the `Header` widget now matches the header color https://github.com/Textualize/textual/issues/1459
+- Watch methods may now take no parameters
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `events.Paste` now bubbles https://github.com/Textualize/textual/issues/1434
 - Clock color in the `Header` widget now matches the header color https://github.com/Textualize/textual/issues/1459
 - Watch methods may now take no parameters
+- Added `compute` parameter to reactive
 
 ### Fixed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
-
 # Introduction
 
 Welcome to the [Textual](https://github.com/Textualize/textual) framework documentation. Built with ❤️ by [Textualize.io](https://www.textualize.io)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -249,9 +249,9 @@ class App(Generic[ReturnType], DOMNode):
         Binding("shift+tab", "focus_previous", "Focus Previous", show=False),
     ]
 
-    title: Reactive[str] = Reactive("")
-    sub_title: Reactive[str] = Reactive("")
-    dark: Reactive[bool] = Reactive(True)
+    title: Reactive[str] = Reactive("", no_compute=True)
+    sub_title: Reactive[str] = Reactive("", no_compute=True)
+    dark: Reactive[bool] = Reactive(True, no_compute=True)
 
     def __init__(
         self,

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -249,9 +249,9 @@ class App(Generic[ReturnType], DOMNode):
         Binding("shift+tab", "focus_previous", "Focus Previous", show=False),
     ]
 
-    title: Reactive[str] = Reactive("", no_compute=True)
-    sub_title: Reactive[str] = Reactive("", no_compute=True)
-    dark: Reactive[bool] = Reactive(True, no_compute=True)
+    title: Reactive[str] = Reactive("", compute=False)
+    sub_title: Reactive[str] = Reactive("", compute=False)
+    dark: Reactive[bool] = Reactive(True, compute=False)
 
     def __init__(
         self,

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1687,7 +1687,7 @@ class App(Generic[ReturnType], DOMNode):
         """Close all message pumps."""
 
         # Close all screens on the stack
-        for screen in self._screen_stack:
+        for screen in reversed(self._screen_stack):
             if screen._running:
                 await self._prune_node(screen)
 
@@ -2051,8 +2051,9 @@ class App(Generic[ReturnType], DOMNode):
 
         while stack:
             widget = pop()
-            if widget.children:
-                yield [*widget.children, *widget._get_virtual_dom()]
+            children = [*widget.children, *widget._get_virtual_dom()]
+            if children:
+                yield children
             for child in widget.children:
                 push(child)
 
@@ -2121,7 +2122,7 @@ class App(Generic[ReturnType], DOMNode):
                 for child in children:
                     self._unregister(child)
 
-        await root._close_messages(wait=False)
+        await root._close_messages(wait=True)
         self._unregister(root)
 
     async def action_check_bindings(self, key: str) -> None:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -108,6 +108,8 @@ class DOMNode(MessagePump):
     # Generated list of bindings
     _merged_bindings: ClassVar[Bindings] | None = None
 
+    _reactives: ClassVar[dict[str, Reactive]]
+
     def __init__(
         self,
         *,
@@ -164,6 +166,17 @@ class DOMNode(MessagePump):
         cls, inherit_css: bool = True, inherit_bindings: bool = True
     ) -> None:
         super().__init_subclass__()
+
+        reactives = cls._reactives = {}
+        for base in reversed(cls.__mro__):
+            reactives.update(
+                {
+                    name: reactive
+                    for name, reactive in base.__dict__.items()
+                    if isinstance(reactive, Reactive)
+                }
+            )
+
         cls._inherit_css = inherit_css
         cls._inherit_bindings = inherit_bindings
         css_type_names: set[str] = set()

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -31,6 +31,7 @@ from .css.parse import parse_declarations
 from .css.styles import RenderStyles, Styles
 from .css.tokenize import IDENTIFIER
 from .message_pump import MessagePump
+from .reactive import Reactive
 from .timer import Timer
 from .walk import walk_breadth_first, walk_depth_first
 

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -108,6 +108,7 @@ class MessagePump(metaclass=MessagePumpMeta):
 
     @property
     def is_running(self) -> bool:
+        """bool: Check if the message pump is running (potentially processing messages)"""
         return self._running
 
     @property
@@ -326,6 +327,8 @@ class MessagePump(metaclass=MessagePumpMeta):
         try:
             await self._dispatch_message(events.Compose(sender=self))
             await self._dispatch_message(events.Mount(sender=self))
+        except Exception as error:
+            self.app._handle_exception(error)
         finally:
             # This is critical, mount may be waiting
             self._mounted_event.set()

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -108,7 +108,7 @@ class MessagePump(metaclass=MessagePumpMeta):
 
     @property
     def is_running(self) -> bool:
-        """bool: Check if the message pump is running (potentially processing messages)"""
+        """bool: Is the message pump running (potentially processing messages)."""
         return self._running
 
     @property

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -124,6 +124,12 @@ class Reactive(Generic[ReactiveType]):
         return cls(default, layout=False, repaint=False, init=False)
 
     def _initialize_reactive(self, obj: Reactable, name: str) -> None:
+        """Initialized a reactive attribute on an object.
+
+        Args:
+            obj (Reactable): An object with reactive attributes.
+            name (str): name of attribute.
+        """
         internal_name = f"_reactive_{name}"
         if hasattr(obj, internal_name):
             # Attribute already has a value

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -47,7 +47,7 @@ class Reactive(Generic[ReactiveType]):
         repaint (bool, optional): Perform a repaint on change. Defaults to True.
         init (bool, optional): Call watchers on initialize (post mount). Defaults to False.
         always_update (bool, optional): Call watchers even when the new value equals the old value. Defaults to False.
-        compute (bool, optional): Don't run compute methods when attribute is changed. Defaults to True.
+        compute (bool, optional): Run compute methods when attribute is changed. Defaults to True.
     """
 
     _reactives: TypeVar[dict[str, object]] = {}
@@ -94,7 +94,7 @@ class Reactive(Generic[ReactiveType]):
             layout (bool, optional): Perform a layout on change. Defaults to False.
             repaint (bool, optional): Perform a repaint on change. Defaults to True.
             always_update (bool, optional): Call watchers even when the new value equals the old value. Defaults to False.
-            compute (bool, optional): Don't run compute methods when attribute is changed. Defaults to False.
+            compute (bool, optional): Run compute methods when attribute is changed. Defaults to True.
 
         Returns:
             Reactive: A Reactive instance which calls watchers or initialize.

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -123,7 +123,7 @@ class Reactive(Generic[ReactiveType]):
         """
         return cls(default, layout=False, repaint=False, init=False)
 
-    def _initialize_reactive(self, obj: Reactable, name: str) -> bool:
+    def _initialize_reactive(self, obj: Reactable, name: str) -> None:
         internal_name = f"_reactive_{name}"
         if hasattr(obj, internal_name):
             # Attribute already has a value

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -935,8 +935,11 @@ class Widget(DOMNode):
 
         self.show_horizontal_scrollbar = show_horizontal
         self.show_vertical_scrollbar = show_vertical
-        self.horizontal_scrollbar.display = show_horizontal
-        self.vertical_scrollbar.display = show_vertical
+
+        if self._horizontal_scrollbar is not None or show_horizontal:
+            self.horizontal_scrollbar.display = show_horizontal
+        if self._vertical_scrollbar is not None or show_vertical:
+            self.vertical_scrollbar.display = show_vertical
 
     @property
     def scrollbars_enabled(self) -> tuple[bool, bool]:

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -13035,136 +13035,136 @@
           font-weight: 700;
       }
   
-      .terminal-4137661484-matrix {
+      .terminal-3727479996-matrix {
           font-family: Fira Code, monospace;
           font-size: 20px;
           line-height: 24.4px;
           font-variant-east-asian: full-width;
       }
   
-      .terminal-4137661484-title {
+      .terminal-3727479996-title {
           font-size: 18px;
           font-weight: bold;
           font-family: arial;
       }
   
-      .terminal-4137661484-r1 { fill: #ffff00 }
-  .terminal-4137661484-r2 { fill: #c5c8c6 }
-  .terminal-4137661484-r3 { fill: #e3e3e3 }
-  .terminal-4137661484-r4 { fill: #ddeedd }
-  .terminal-4137661484-r5 { fill: #dde8f3;font-weight: bold }
-  .terminal-4137661484-r6 { fill: #ddedf9 }
+      .terminal-3727479996-r1 { fill: #ffff00 }
+  .terminal-3727479996-r2 { fill: #e3e3e3 }
+  .terminal-3727479996-r3 { fill: #c5c8c6 }
+  .terminal-3727479996-r4 { fill: #ddeedd }
+  .terminal-3727479996-r5 { fill: #dde8f3;font-weight: bold }
+  .terminal-3727479996-r6 { fill: #ddedf9 }
       </style>
   
       <defs>
-      <clipPath id="terminal-4137661484-clip-terminal">
+      <clipPath id="terminal-3727479996-clip-terminal">
         <rect x="0" y="0" width="975.0" height="584.5999999999999" />
       </clipPath>
-      <clipPath id="terminal-4137661484-line-0">
+      <clipPath id="terminal-3727479996-line-0">
       <rect x="0" y="1.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-1">
+  <clipPath id="terminal-3727479996-line-1">
       <rect x="0" y="25.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-2">
+  <clipPath id="terminal-3727479996-line-2">
       <rect x="0" y="50.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-3">
+  <clipPath id="terminal-3727479996-line-3">
       <rect x="0" y="74.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-4">
+  <clipPath id="terminal-3727479996-line-4">
       <rect x="0" y="99.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-5">
+  <clipPath id="terminal-3727479996-line-5">
       <rect x="0" y="123.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-6">
+  <clipPath id="terminal-3727479996-line-6">
       <rect x="0" y="147.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-7">
+  <clipPath id="terminal-3727479996-line-7">
       <rect x="0" y="172.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-8">
+  <clipPath id="terminal-3727479996-line-8">
       <rect x="0" y="196.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-9">
+  <clipPath id="terminal-3727479996-line-9">
       <rect x="0" y="221.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-10">
+  <clipPath id="terminal-3727479996-line-10">
       <rect x="0" y="245.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-11">
+  <clipPath id="terminal-3727479996-line-11">
       <rect x="0" y="269.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-12">
+  <clipPath id="terminal-3727479996-line-12">
       <rect x="0" y="294.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-13">
+  <clipPath id="terminal-3727479996-line-13">
       <rect x="0" y="318.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-14">
+  <clipPath id="terminal-3727479996-line-14">
       <rect x="0" y="343.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-15">
+  <clipPath id="terminal-3727479996-line-15">
       <rect x="0" y="367.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-16">
+  <clipPath id="terminal-3727479996-line-16">
       <rect x="0" y="391.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-17">
+  <clipPath id="terminal-3727479996-line-17">
       <rect x="0" y="416.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-18">
+  <clipPath id="terminal-3727479996-line-18">
       <rect x="0" y="440.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-19">
+  <clipPath id="terminal-3727479996-line-19">
       <rect x="0" y="465.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-20">
+  <clipPath id="terminal-3727479996-line-20">
       <rect x="0" y="489.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-21">
+  <clipPath id="terminal-3727479996-line-21">
       <rect x="0" y="513.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-4137661484-line-22">
+  <clipPath id="terminal-3727479996-line-22">
       <rect x="0" y="538.3" width="976" height="24.65"/>
               </clipPath>
       </defs>
   
-      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-4137661484-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Layers</text>
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3727479996-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Layers</text>
               <g transform="translate(26,22)">
               <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
               <circle cx="22" cy="0" r="7" fill="#febc2e"/>
               <circle cx="44" cy="0" r="7" fill="#28c840"/>
               </g>
           
-      <g transform="translate(9, 41)" clip-path="url(#terminal-4137661484-clip-terminal)">
-      <rect fill="#ff0000" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="1.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="439.2" y="1.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="475.8" y="1.5" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="963.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="50.3" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="50.3" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="36.6" y="74.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="74.7" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="99.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="123.5" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="147.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="562.7" width="756.4" height="24.65" shape-rendering="crispEdges"/>
-      <g class="terminal-4137661484-matrix">
-      <text class="terminal-4137661484-r1" x="0" y="20" textLength="12.2" clip-path="url(#terminal-4137661484-line-0)">┌</text><text class="terminal-4137661484-r1" x="12.2" y="20" textLength="85.4" clip-path="url(#terminal-4137661484-line-0)">───────</text><text class="terminal-4137661484-r1" x="97.6" y="20" textLength="329.4" clip-path="url(#terminal-4137661484-line-0)">───────────────────────────</text><text class="terminal-4137661484-r1" x="427" y="20" textLength="12.2" clip-path="url(#terminal-4137661484-line-0)">┐</text><text class="terminal-4137661484-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-4137661484-line-0)">
-  </text><text class="terminal-4137661484-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-1)">│</text><text class="terminal-4137661484-r1" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-1)">│</text><text class="terminal-4137661484-r4" x="439.2" y="44.4" textLength="536.8" clip-path="url(#terminal-4137661484-line-1)">It&#x27;s&#160;full&#160;of&#160;stars!&#160;My&#160;God!&#160;It&#x27;s&#160;full&#160;of&#160;sta</text><text class="terminal-4137661484-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-1)">
-  </text><text class="terminal-4137661484-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-2)">│</text><text class="terminal-4137661484-r1" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-2)">│</text><text class="terminal-4137661484-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-2)">
-  </text><text class="terminal-4137661484-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-4137661484-line-3)">│</text><text class="terminal-4137661484-r1" x="36.6" y="93.2" textLength="366" clip-path="url(#terminal-4137661484-line-3)">This&#160;should&#160;float&#160;over&#160;the&#160;top</text><text class="terminal-4137661484-r1" x="427" y="93.2" textLength="12.2" clip-path="url(#terminal-4137661484-line-3)">│</text><text class="terminal-4137661484-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-4137661484-line-3)">
-  </text><text class="terminal-4137661484-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-4137661484-line-4)">│</text><text class="terminal-4137661484-r1" x="427" y="117.6" textLength="12.2" clip-path="url(#terminal-4137661484-line-4)">│</text><text class="terminal-4137661484-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-4137661484-line-4)">
-  </text><text class="terminal-4137661484-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-4137661484-line-5)">│</text><text class="terminal-4137661484-r1" x="427" y="142" textLength="12.2" clip-path="url(#terminal-4137661484-line-5)">│</text><text class="terminal-4137661484-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-4137661484-line-5)">
-  </text><text class="terminal-4137661484-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-6)">└</text><text class="terminal-4137661484-r1" x="12.2" y="166.4" textLength="414.8" clip-path="url(#terminal-4137661484-line-6)">──────────────────────────────────</text><text class="terminal-4137661484-r1" x="427" y="166.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-6)">┘</text><text class="terminal-4137661484-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-6)">
-  </text><text class="terminal-4137661484-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-7)">
-  </text><text class="terminal-4137661484-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-4137661484-line-8)">
-  </text><text class="terminal-4137661484-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-4137661484-line-9)">
-  </text><text class="terminal-4137661484-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-4137661484-line-10)">
-  </text><text class="terminal-4137661484-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-11)">
-  </text><text class="terminal-4137661484-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-12)">
-  </text><text class="terminal-4137661484-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-4137661484-line-13)">
-  </text><text class="terminal-4137661484-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-4137661484-line-14)">
-  </text><text class="terminal-4137661484-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-4137661484-line-15)">
-  </text><text class="terminal-4137661484-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-16)">
-  </text><text class="terminal-4137661484-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-17)">
-  </text><text class="terminal-4137661484-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-4137661484-line-18)">
-  </text><text class="terminal-4137661484-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-4137661484-line-19)">
-  </text><text class="terminal-4137661484-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-4137661484-line-20)">
-  </text><text class="terminal-4137661484-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-4137661484-line-21)">
-  </text><text class="terminal-4137661484-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-4137661484-line-22)">
-  </text><text class="terminal-4137661484-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-4137661484-line-23)">&#160;T&#160;</text><text class="terminal-4137661484-r6" x="36.6" y="581.2" textLength="183" clip-path="url(#terminal-4137661484-line-23)">&#160;Toggle&#160;Screen&#160;</text>
+      <g transform="translate(9, 41)" clip-path="url(#terminal-3727479996-clip-terminal)">
+      <rect fill="#ff0000" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="1.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="439.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="512.4" y="1.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="963.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="50.3" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="50.3" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="36.6" y="74.7" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="74.7" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="99.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="123.5" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="12.2" y="147.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="427" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="439.2" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#008000" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="562.7" width="756.4" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-3727479996-matrix">
+      <text class="terminal-3727479996-r1" x="0" y="20" textLength="12.2" clip-path="url(#terminal-3727479996-line-0)">┌</text><text class="terminal-3727479996-r1" x="12.2" y="20" textLength="85.4" clip-path="url(#terminal-3727479996-line-0)">───────</text><text class="terminal-3727479996-r1" x="97.6" y="20" textLength="329.4" clip-path="url(#terminal-3727479996-line-0)">───────────────────────────</text><text class="terminal-3727479996-r1" x="427" y="20" textLength="12.2" clip-path="url(#terminal-3727479996-line-0)">┐</text><text class="terminal-3727479996-r2" x="439.2" y="20" textLength="73.2" clip-path="url(#terminal-3727479996-line-0)">Layers</text><text class="terminal-3727479996-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3727479996-line-0)">
+  </text><text class="terminal-3727479996-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-1)">│</text><text class="terminal-3727479996-r1" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-1)">│</text><text class="terminal-3727479996-r4" x="439.2" y="44.4" textLength="536.8" clip-path="url(#terminal-3727479996-line-1)">It&#x27;s&#160;full&#160;of&#160;stars!&#160;My&#160;God!&#160;It&#x27;s&#160;full&#160;of&#160;sta</text><text class="terminal-3727479996-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-1)">
+  </text><text class="terminal-3727479996-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-2)">│</text><text class="terminal-3727479996-r1" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-2)">│</text><text class="terminal-3727479996-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-2)">
+  </text><text class="terminal-3727479996-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-3727479996-line-3)">│</text><text class="terminal-3727479996-r1" x="36.6" y="93.2" textLength="366" clip-path="url(#terminal-3727479996-line-3)">This&#160;should&#160;float&#160;over&#160;the&#160;top</text><text class="terminal-3727479996-r1" x="427" y="93.2" textLength="12.2" clip-path="url(#terminal-3727479996-line-3)">│</text><text class="terminal-3727479996-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3727479996-line-3)">
+  </text><text class="terminal-3727479996-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-3727479996-line-4)">│</text><text class="terminal-3727479996-r1" x="427" y="117.6" textLength="12.2" clip-path="url(#terminal-3727479996-line-4)">│</text><text class="terminal-3727479996-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3727479996-line-4)">
+  </text><text class="terminal-3727479996-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-3727479996-line-5)">│</text><text class="terminal-3727479996-r1" x="427" y="142" textLength="12.2" clip-path="url(#terminal-3727479996-line-5)">│</text><text class="terminal-3727479996-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3727479996-line-5)">
+  </text><text class="terminal-3727479996-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-6)">└</text><text class="terminal-3727479996-r1" x="12.2" y="166.4" textLength="414.8" clip-path="url(#terminal-3727479996-line-6)">──────────────────────────────────</text><text class="terminal-3727479996-r1" x="427" y="166.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-6)">┘</text><text class="terminal-3727479996-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-6)">
+  </text><text class="terminal-3727479996-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-7)">
+  </text><text class="terminal-3727479996-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3727479996-line-8)">
+  </text><text class="terminal-3727479996-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3727479996-line-9)">
+  </text><text class="terminal-3727479996-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3727479996-line-10)">
+  </text><text class="terminal-3727479996-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-11)">
+  </text><text class="terminal-3727479996-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-12)">
+  </text><text class="terminal-3727479996-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3727479996-line-13)">
+  </text><text class="terminal-3727479996-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3727479996-line-14)">
+  </text><text class="terminal-3727479996-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3727479996-line-15)">
+  </text><text class="terminal-3727479996-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-16)">
+  </text><text class="terminal-3727479996-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-17)">
+  </text><text class="terminal-3727479996-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3727479996-line-18)">
+  </text><text class="terminal-3727479996-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3727479996-line-19)">
+  </text><text class="terminal-3727479996-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3727479996-line-20)">
+  </text><text class="terminal-3727479996-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3727479996-line-21)">
+  </text><text class="terminal-3727479996-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3727479996-line-22)">
+  </text><text class="terminal-3727479996-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-3727479996-line-23)">&#160;T&#160;</text><text class="terminal-3727479996-r6" x="36.6" y="581.2" textLength="183" clip-path="url(#terminal-3727479996-line-23)">&#160;Toggle&#160;Screen&#160;</text>
       </g>
       </g>
   </svg>

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -159,7 +159,7 @@ async def test_reactive_with_callable_default():
     Textual will call it in order to retrieve the default value."""
     called_with_app = None
 
-    def set_called(app: App) -> int:
+    def set_called() -> int:
         nonlocal called_with_app
         called_with_app = app
         return OLD_VALUE

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -218,7 +218,6 @@ async def test_validate_init_true_set_before_dom_ready():
         assert validator_call_count == 1
 
 
-# @pytest.mark.xfail(reason="Compute methods not called when init=True [issue#1227]")
 async def test_reactive_compute_first_time_set():
     class ReactiveComputeFirstTimeSet(App):
         number = reactive(1)


### PR DESCRIPTION
This PR sponsored by "How did this ever work?"

- Fixes a numbers of reactive interactions.
- Fixes ugly errors from compose and mount events.
- Adds a `compute` parameter to reactives, with a default of `True`. Set this to `False` to disable running (potentially expensive) computes.
- Implements watch methods with no args.
- Fixed issue where scrollbars widgets are needlessly created.