### PR TITLE
Tweak `query_one` and related methods docstrings

### DIFF
--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -233,6 +233,7 @@ class DOMQuery(Generic[QueryType]):
 
         Raises:
             WrongType: If the wrong type was found.
+            NoMatches: If no node matches the query.
             TooManyMatches: If there is more than one matching node in the query.
 
         Returns:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -745,12 +745,17 @@ class DOMNode(MessagePump):
         selector: str | type[ExpectType],
         expect_type: type[ExpectType] | None = None,
     ) -> ExpectType | Widget:
-        """Get the first Widget matching the given selector or selector type.
+        """Get a single Widget matching the given selector or selector type.
 
         Args:
             selector (str | type): A selector.
             expect_type (type | None, optional): Require the object be of the supplied type, or None for any type.
                 Defaults to None.
+
+        Raises:
+            WrongType: If the wrong type was found.
+            NoMatches: If no node matches the query.
+            TooManyMatches: If there is more than one matching node in the query.
 
         Returns:
             Widget | ExpectType: A widget matching the selector.


### PR DESCRIPTION
Changes to `query_one` and friends a couple of months back modified the behaviour of `query_one`, but the docstring was never updated to properly reflect the newer intent or the exceptions that could be raised. This seeks to address that.