### PR TITLE
Add docstrings to app title an sub-titles

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -249,6 +249,11 @@ class App(Generic[ReturnType], DOMNode):
     """
 
     SUB_TITLE: str | None = None
+    """str | None: The default sub-title for the application.
+
+    If set to a string, this sets the default sub-title for the application. See
+    also the `sub_title` attribute.
+    """
 
     BINDINGS = [
         Binding("ctrl+c", "quit", "Quit", show=False, priority=True),

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -240,7 +240,14 @@ class App(Generic[ReturnType], DOMNode):
     SCREENS: dict[str, Screen | Callable[[], Screen]] = {}
     _BASE_PATH: str | None = None
     CSS_PATH: CSSPathType = None
+
     TITLE: str | None = None
+    """str | None: The default title for the application.
+
+    If set to a string, this sets the default title for the application. See
+    also the `title` attribute.
+    """
+
     SUB_TITLE: str | None = None
 
     BINDINGS = [

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -262,21 +262,7 @@ class App(Generic[ReturnType], DOMNode):
     ]
 
     title: Reactive[str] = Reactive("", compute=False)
-    """Reactive[str]: The title for the application.
-
-    The initial value in a running application will be that set in `TITLE`
-    (if one is set). Assign new values to this instance attribute to change
-    the title.
-    """
-
     sub_title: Reactive[str] = Reactive("", compute=False)
-    """Reactive[str]: The sub-title for the application.
-
-    The initial value in a running application will be that set in `SUB_TITLE`
-    (if one is set). Assign new values to this instance attribute to change
-    the sub-title.
-    """
-
     dark: Reactive[bool] = Reactive(True, compute=False)
 
     def __init__(
@@ -329,10 +315,24 @@ class App(Generic[ReturnType], DOMNode):
         self._animator = Animator(self)
         self._animate = self._animator.bind(self)
         self.mouse_position = Offset(0, 0)
+
         self.title = (
             self.TITLE if self.TITLE is not None else f"{self.__class__.__name__}"
         )
+        """The title for the application.
+
+        The initial value in a running application will be that set in `TITLE`
+        (if one is set). Assign new values to this instance attribute to change
+        the title.
+        """
+
         self.sub_title = self.SUB_TITLE if self.SUB_TITLE is not None else ""
+        """The sub-title for the application.
+
+        The initial value in a running application will be that set in `SUB_TITLE`
+        (if one is set). Assign new values to this instance attribute to change
+        the sub-title.
+        """
 
         self._logger = Logger(self._log)
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -262,6 +262,13 @@ class App(Generic[ReturnType], DOMNode):
     ]
 
     title: Reactive[str] = Reactive("", compute=False)
+    """Reactive[str]: The title for the application.
+
+    The initial value in a running application will be that set in `TITLE`
+    (if one is set). Assign new values to this instance attribute to change
+    the title.
+    """
+
     sub_title: Reactive[str] = Reactive("", compute=False)
     dark: Reactive[bool] = Reactive(True, compute=False)
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -270,6 +270,13 @@ class App(Generic[ReturnType], DOMNode):
     """
 
     sub_title: Reactive[str] = Reactive("", compute=False)
+    """Reactive[str]: The sub-title for the application.
+
+    The initial value in a running application will be that set in `SUB_TITLE`
+    (if one is set). Assign new values to this instance attribute to change
+    the sub-title.
+    """
+
     dark: Reactive[bool] = Reactive(True, compute=False)
 
     def __init__(


### PR DESCRIPTION
As of now this doesn't result in documentation appearing for everything; it seems that something in our documentation chain (perhaps `mkdocstrings`) treats properties as case-insensitive; so when there's a docstring for `TITLE` and `title` only the former seems to show up in the docs.

At some point soon I'll try and isolate this issue to the correct part of the documentation pipeline and make an issue. Meanwhile, this gets docstrings in place (which is also a benefit to development environments which show docstrings).

**Edit to add:** Testing the mkdocs/mkdocs-material/mkdocstrings pipeline in isolation, this isn't a problem. Need to look into that aspect some more (as an aside from this).