### PR TITLE
Reraise compose TypeError from the error rather than None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `COMPONENT_CLASSES` are now inherited from base classes https://github.com/Textualize/textual/issues/1399
 - Watch methods may now take no parameters
 - Added `compute` parameter to reactive
-- A `KeyError` raised during `compose` now carries the full traceback.
+- A `TypeError` raised during `compose` now carries the full traceback.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `COMPONENT_CLASSES` are now inherited from base classes https://github.com/Textualize/textual/issues/1399
 - Watch methods may now take no parameters
 - Added `compute` parameter to reactive
+- A `KeyError` raised during `compose` now carries the full traceback.
 
 ### Fixed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1569,7 +1569,7 @@ class App(Generic[ReturnType], DOMNode):
         except TypeError as error:
             raise TypeError(
                 f"{self!r} compose() returned an invalid response; {error}"
-            ) from None
+            ) from error
         await self.mount_all(widgets)
 
     def _on_idle(self) -> None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2395,7 +2395,7 @@ class Widget(DOMNode):
         except TypeError as error:
             raise TypeError(
                 f"{self!r} compose() returned an invalid response; {error}"
-            ) from None
+            ) from error
         except Exception:
             self.app.panic(Traceback())
         else:


### PR DESCRIPTION
In its current form, if someone's `compose` results in an uncaught TypeError in their own code, the resulting error will hide the source. This small change ensures that the main problem (compose returned something that can't be turned into a list) is still reported, but also provides the developer a trackback they can look at to see what the ultimate source of the issue was.
