### PR TITLE
Fix 1196 add focus selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added a `Tree.NodeHighlighted` message, giving a `on_tree_node_highlighted` event handler https://github.com/Textualize/textual/issues/1400
 - Added a `inherit_component_classes` subclassing parameter to control whether or not component classes are inherited from base classes https://github.com/Textualize/textual/issues/1399
 - Added `diagnose` as a `textual` command https://github.com/Textualize/textual/issues/1542
+- Added an optional parameter `selector` to the methods `Screen.focus_next` and `Screen.focus_previous` that enable using a CSS selector to narrow down which widgets can get focus https://github.com/Textualize/textual/issues/1196
 
 ### Changed
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -186,6 +186,9 @@ class Screen(Widget):
     ) -> Widget | None:
         """Move the focus in the given direction.
 
+        If no widget is currently focused, this will focus the first focusable widget.
+        If no focusable widget matches the given CSS selector, focus is set to `None`.
+
         Args:
             direction (int, optional): 1 to move forward, -1 to move backward, or
                 0 to keep the current focus.
@@ -243,28 +246,38 @@ class Screen(Widget):
     def focus_next(
         self, selector: str | type[DOMNode.ExpectType] = "*"
     ) -> Widget | None:
-        """Focus the next widget.
+        """Focus the next widget, optionally filtered by a CSS selector.
+
+        If no widget is currently focused, this will focus the first focusable widget.
+        If no focusable widget matches the given CSS selector, focus is set to `None`.
 
         Args:
             selector (str | type[DOMNode.ExpectType], optional): CSS selector to filter
                 what nodes can be focused.
 
         Returns:
-            Widget | None: Newly focused widget, or None for no focus.
+            Widget | None: Newly focused widget, or None for no focus. If the return
+                is not `None`, then it is guaranteed that the widget returned matches
+                the CSS selectors given in the argument.
         """
         return self._move_focus(1, selector)
 
     def focus_previous(
         self, selector: str | type[DOMNode.ExpectType] = "*"
     ) -> Widget | None:
-        """Focus the previous widget.
+        """Focus the previous widget, optionally filtered by a CSS selector.
+
+        If no widget is currently focused, this will focus the first focusable widget.
+        If no focusable widget matches the given CSS selector, focus is set to `None`.
 
         Args:
             selector (str | type[DOMNode.ExpectType], optional): CSS selector to filter
                 what nodes can be focused.
 
         Returns:
-            Widget | None: Newly focused widget, or None for no focus.
+            Widget | None: Newly focused widget, or None for no focus. If the return
+                is not `None`, then it is guaranteed that the widget returned matches
+                the CSS selectors given in the argument.
         """
         return self._move_focus(-1, selector)
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -240,43 +240,14 @@ class Screen(Widget):
 
         return self.focused
 
-    def __move_focus(self, direction: int = 0) -> Widget | None:
-        """Move the focus in the given direction.
-
-        Args:
-            direction (int, optional): 1 to move forward, -1 to move backward, or
-                0 to keep the current focus.
-
-        Returns:
-            Widget | None: Newly focused widget, or None for no focus.
-        """
-        focusable_widgets = self.focus_chain
-
-        if not focusable_widgets:
-            # Nothing focusable, so nothing to do
-            return self.focused
-        if self.focused is None:
-            # Nothing currently focused, so focus the first one
-            self.set_focus(focusable_widgets[0])
-        else:
-            try:
-                # Find the index of the currently focused widget
-                current_index = focusable_widgets.index(self.focused)
-            except ValueError:
-                # Focused widget was removed in the interim, start again
-                self.set_focus(focusable_widgets[0])
-            else:
-                # Only move the focus if we are currently showing the focus
-                if direction:
-                    current_index = (current_index + direction) % len(focusable_widgets)
-                    self.set_focus(focusable_widgets[current_index])
-
-        return self.focused
-
     def focus_next(
         self, selector: str | type[DOMNode.ExpectType] = "*"
     ) -> Widget | None:
         """Focus the next widget.
+
+        Args:
+            selector (str | type[DOMNode.ExpectType], optional): CSS selector to filter
+                what nodes can be focused.
 
         Returns:
             Widget | None: Newly focused widget, or None for no focus.
@@ -287,6 +258,10 @@ class Screen(Widget):
         self, selector: str | type[DOMNode.ExpectType] = "*"
     ) -> Widget | None:
         """Focus the previous widget.
+
+        Args:
+            selector (str | type[DOMNode.ExpectType], optional): CSS selector to filter
+                what nodes can be focused.
 
         Returns:
             Widget | None: Newly focused widget, or None for no focus.

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -1,3 +1,5 @@
+import pytest
+
 from textual.app import App
 from textual.screen import Screen
 from textual.widget import Widget
@@ -13,6 +15,28 @@ class NonFocusable(Widget, can_focus=False, can_focus_children=False):
 
 class ChildrenFocusableOnly(Widget, can_focus=False, can_focus_children=True):
     pass
+
+
+@pytest.fixture
+def screen() -> Screen:
+    app = App()
+    app._set_active()
+    app.push_screen(Screen())
+
+    screen = app.screen
+
+    # The classes even/odd alternate along the focus chain.
+    # The classes in/out identify nested widgets.
+    screen._add_children(
+        Focusable(id="foo", classes="a"),
+        NonFocusable(id="bar"),
+        Focusable(Focusable(id="Paul", classes="c"), id="container1", classes="b"),
+        NonFocusable(Focusable(id="Jessica", classes="a"), id="container2"),
+        Focusable(id="baz", classes="b"),
+        ChildrenFocusableOnly(Focusable(id="child", classes="c")),
+    )
+
+    return screen
 
 
 def test_focus_chain():
@@ -38,22 +62,7 @@ def test_focus_chain():
     assert focus_chain == ["foo", "container1", "Paul", "baz", "child"]
 
 
-def test_focus_next_and_previous():
-    app = App()
-    app._set_active()
-    app.push_screen(Screen())
-
-    screen = app.screen
-
-    screen._add_children(
-        Focusable(id="foo"),
-        NonFocusable(id="bar"),
-        Focusable(Focusable(id="Paul"), id="container1"),
-        NonFocusable(Focusable(id="Jessica"), id="container2"),
-        Focusable(id="baz"),
-        ChildrenFocusableOnly(Focusable(id="child")),
-    )
-
+def test_focus_next_and_previous(screen: Screen):
     assert screen.focus_next().id == "foo"
     assert screen.focus_next().id == "container1"
     assert screen.focus_next().id == "Paul"
@@ -64,3 +73,95 @@ def test_focus_next_and_previous():
     assert screen.focus_previous().id == "Paul"
     assert screen.focus_previous().id == "container1"
     assert screen.focus_previous().id == "foo"
+
+
+def test_focus_next_and_previous_with_type_selector(screen: Screen):
+    """Move focus with a selector that matches the currently focused node."""
+    screen.set_focus(screen.query_one("#Paul"))
+    assert screen.focused.id == "Paul"
+
+    assert screen.focus_next(Focusable).id == "Jessica"
+    assert screen.focus_next(Focusable).id == "baz"
+    assert screen.focus_next(Focusable).id == "child"
+
+    assert screen.focus_previous(Focusable).id == "baz"
+    assert screen.focus_previous(Focusable).id == "Jessica"
+    assert screen.focus_previous(Focusable).id == "Paul"
+    assert screen.focus_previous(Focusable).id == "container1"
+    assert screen.focus_previous(Focusable).id == "foo"
+
+
+def test_focus_next_and_previous_with_str_selector(screen: Screen):
+    """Move focus with a selector that matches the currently focused node."""
+    screen.set_focus(screen.query_one("#foo"))
+    assert screen.focused.id == "foo"
+
+    assert screen.focus_next(".a").id == "Jessica"
+    assert screen.focus_next("Focusable").id == "baz"
+
+    assert screen.focus_previous(".b").id == "container1"
+
+    assert screen.focus_next("Focusable").id == "Paul"
+    assert screen.focus_next(".c").id == "child"
+
+    assert screen.focus_previous(".c").id == "Paul"
+
+
+def test_focus_next_and_previous_with_type_selector_without_self():
+    """Test moving the focus with a selector that does not match the currently focused node."""
+    app = App()
+    app._set_active()
+    app.push_screen(Screen())
+
+    screen = app.screen
+
+    from textual.containers import Horizontal, Vertical
+    from textual.widgets import Input, Label, Static
+
+    screen._add_children(
+        Vertical(
+            Horizontal(
+                Input(id="w3"),
+                Label(id="w4"),
+                Input(id="w5"),
+                Static(id="w6"),
+                Label(id="w7"),
+                id="w2",
+            ),
+            Horizontal(
+                Static(id="w9"),
+                Label(id="w10"),
+                Static(id="w11"),
+                Input(id="w12"),
+                Input(id="w13"),
+                id="w8",
+            ),
+            id="w1",
+        )
+    )
+
+    screen.set_focus(screen.query_one("#w3"))
+    assert screen.focused.id == "w3"
+
+    assert screen.focus_next(Static).id == "w6"
+    assert screen.focus_next(Label).id == "w7"
+    assert screen.focus_next(Input).id == "w12"
+
+    assert screen.focus_previous(Static).id == "w11"
+    assert screen.focus_previous(Label).id == "w10"
+    assert screen.focus_previous(Static).id == "w9"
+    assert screen.focus_previous(Input).id == "w5"
+
+
+def test_focus_next_and_previous_with_str_selector_without_self(screen: Screen):
+    """Test moving the focus with a selector that does not match the currently focused node."""
+    screen.set_focus(screen.query_one("#foo"))
+    assert screen.focused.id == "foo"
+
+    assert screen.focus_next(".c").id == "Paul"
+    assert screen.focus_next(".b").id == "baz"
+    assert screen.focus_next(".c").id == "child"
+
+    assert screen.focus_previous(".a").id == "Jessica"
+    assert screen.focus_previous(".b").id == "container1"
+    assert screen.focus_previous(".a").id == "foo"

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -80,12 +80,10 @@ def test_focus_next_and_previous_with_type_selector(screen: Screen):
     screen.set_focus(screen.query_one("#Paul"))
     assert screen.focused.id == "Paul"
 
-    assert screen.focus_next(Focusable).id == "Jessica"
     assert screen.focus_next(Focusable).id == "baz"
     assert screen.focus_next(Focusable).id == "child"
 
     assert screen.focus_previous(Focusable).id == "baz"
-    assert screen.focus_previous(Focusable).id == "Jessica"
     assert screen.focus_previous(Focusable).id == "Paul"
     assert screen.focus_previous(Focusable).id == "container1"
     assert screen.focus_previous(Focusable).id == "foo"
@@ -96,15 +94,12 @@ def test_focus_next_and_previous_with_str_selector(screen: Screen):
     screen.set_focus(screen.query_one("#foo"))
     assert screen.focused.id == "foo"
 
-    assert screen.focus_next(".a").id == "Jessica"
-    assert screen.focus_next("Focusable").id == "baz"
-
-    assert screen.focus_previous(".b").id == "container1"
-
-    assert screen.focus_next("Focusable").id == "Paul"
+    assert screen.focus_next(".a").id == "foo"
+    assert screen.focus_next(".c").id == "Paul"
     assert screen.focus_next(".c").id == "child"
 
     assert screen.focus_previous(".c").id == "Paul"
+    assert screen.focus_previous(".a").id == "foo"
 
 
 def test_focus_next_and_previous_with_type_selector_without_self():
@@ -162,6 +157,6 @@ def test_focus_next_and_previous_with_str_selector_without_self(screen: Screen):
     assert screen.focus_next(".b").id == "baz"
     assert screen.focus_next(".c").id == "child"
 
-    assert screen.focus_previous(".a").id == "Jessica"
-    assert screen.focus_previous(".b").id == "container1"
     assert screen.focus_previous(".a").id == "foo"
+    assert screen.focus_previous(".a").id == "foo"
+    assert screen.focus_previous(".b").id == "baz"

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -75,6 +75,47 @@ def test_focus_next_and_previous(screen: Screen):
     assert screen.focus_previous().id == "foo"
 
 
+def test_focus_next_wrap_around(screen: Screen):
+    """Ensure focusing the next widget wraps around the focus chain."""
+    screen.set_focus(screen.query_one("#child"))
+    assert screen.focused.id == "child"
+
+    assert screen.focus_next().id == "foo"
+
+
+def test_focus_previous_wrap_around(screen: Screen):
+    """Ensure focusing the previous widget wraps around the focus chain."""
+    screen.set_focus(screen.query_one("#foo"))
+    assert screen.focused.id == "foo"
+
+    assert screen.focus_previous().id == "child"
+
+
+def test_wrap_around_selector(screen: Screen):
+    """Ensure moving focus in both directions wraps around the focus chain."""
+    screen.set_focus(screen.query_one("#foo"))
+    assert screen.focused.id == "foo"
+
+    assert screen.focus_previous("#Paul").id == "Paul"
+    assert screen.focus_next("#foo").id == "foo"
+
+
+def test_no_focus_empty_selector(screen: Screen):
+    """Ensure focus is cleared when selector matches nothing."""
+    assert screen.focus_next("#bananas") is None
+    assert screen.focus_previous("#bananas") is None
+
+    screen.set_focus(screen.query_one("#foo"))
+    assert screen.focused is not None
+    assert screen.focus_next("bananas") is None
+    assert screen.focused is None
+
+    screen.set_focus(screen.query_one("#foo"))
+    assert screen.focused is not None
+    assert screen.focus_previous("bananas") is None
+    assert screen.focused is None
+
+
 def test_focus_next_and_previous_with_type_selector(screen: Screen):
     """Move focus with a selector that matches the currently focused node."""
     screen.set_focus(screen.query_one("#Paul"))

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -152,22 +152,22 @@ def test_focus_next_and_previous_with_type_selector_without_self():
     screen = app.screen
 
     from textual.containers import Horizontal, Vertical
-    from textual.widgets import Input, Label, Static
+    from textual.widgets import Button, Checkbox, Input
 
     screen._add_children(
         Vertical(
             Horizontal(
                 Input(id="w3"),
-                Label(id="w4"),
+                Checkbox(id="w4"),
                 Input(id="w5"),
-                Static(id="w6"),
-                Label(id="w7"),
+                Button(id="w6"),
+                Checkbox(id="w7"),
                 id="w2",
             ),
             Horizontal(
-                Static(id="w9"),
-                Label(id="w10"),
-                Static(id="w11"),
+                Button(id="w9"),
+                Checkbox(id="w10"),
+                Button(id="w11"),
                 Input(id="w12"),
                 Input(id="w13"),
                 id="w8",
@@ -179,13 +179,13 @@ def test_focus_next_and_previous_with_type_selector_without_self():
     screen.set_focus(screen.query_one("#w3"))
     assert screen.focused.id == "w3"
 
-    assert screen.focus_next(Static).id == "w6"
-    assert screen.focus_next(Label).id == "w7"
+    assert screen.focus_next(Button).id == "w6"
+    assert screen.focus_next(Checkbox).id == "w7"
     assert screen.focus_next(Input).id == "w12"
 
-    assert screen.focus_previous(Static).id == "w11"
-    assert screen.focus_previous(Label).id == "w10"
-    assert screen.focus_previous(Static).id == "w9"
+    assert screen.focus_previous(Button).id == "w11"
+    assert screen.focus_previous(Checkbox).id == "w10"
+    assert screen.focus_previous(Button).id == "w9"
     assert screen.focus_previous(Input).id == "w5"
 
 


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

The changes made in this PR embody some design decisions that were implicit in the original issue:

 - When the focused widget does not match the selector, the meaning of "previous" and "next" is "the first widget that _does_ match in the correct direction, starting from the currently focused widget".
 - If the focused widget is not `None`, it is guaranteed that it will match the selector in the argument:
   - if the direction is `0` and the selector doesn't match the currently focused widget, this will push focus to the next widget that matches.
   - if the selector doesn't match a single focusable widget, focus is set to `None`.
 - If the currently focused widget is the only widget that matches the given selector, focus will be explicitly set to that same widget.