### PR TITLE
Key minus

### DIFF
--- a/src/textual/cli/previews/keys.py
+++ b/src/textual/cli/previews/keys.py
@@ -1,15 +1,18 @@
 from rich.panel import Panel
 
+from rich.text import Text
+
 from textual.app import App, ComposeResult
+from textual.reactive import var, Reactive
 from textual import events
 from textual.containers import Horizontal
 from textual.widgets import Button, Header, TextLog
 
 
 INSTRUCTIONS = """\
-Press some keys!    
+[u]Press some keys![/]
 
-Because we want to display all the keys, ctrl+C won't quit this example. Use the Quit button below to exit the app.\
+To quit the app press [b]ctrl+c[/b] [i]twice[i] or press the Quit button below.\
 """
 
 
@@ -32,6 +35,8 @@ class KeysApp(App, inherit_bindings=False):
     }
     """
 
+    last_key: Reactive[str | None] = var(None)
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Horizontal(
@@ -42,10 +47,13 @@ class KeysApp(App, inherit_bindings=False):
         yield KeyLog()
 
     def on_ready(self) -> None:
-        self.query_one(KeyLog).write(Panel(INSTRUCTIONS), expand=True)
+        self.query_one(KeyLog).write(Panel(Text.from_markup(INSTRUCTIONS)), expand=True)
 
     def on_key(self, event: events.Key) -> None:
         self.query_one(KeyLog).write(event)
+        if event.key == "ctrl+c" and self.last_key == "ctrl+c":
+            self.exit()
+        self.last_key = event.key
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "quit":

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -7,7 +7,7 @@ from rich.style import Style
 
 from ._types import MessageTarget
 from .geometry import Offset, Size
-from .keys import _get_key_aliases
+from .keys import _get_key_aliases, _get_key_display
 from .message import Message
 
 MouseEventT = TypeVar("MouseEventT", bound="MouseEvent")

--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -228,6 +228,7 @@ KEY_DISPLAY_ALIASES = {
     "backspace": "⌫",
     "escape": "ESC",
     "enter": "⏎",
+    "minus": "-",
 }
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,7 +1,7 @@
 import pytest
 
 from textual.app import App
-from textual.keys import _character_to_key
+from textual.keys import _character_to_key, _get_key_display
 
 
 @pytest.mark.parametrize(
@@ -48,3 +48,7 @@ async def test_character_bindings():
         await pilot.press("x")
         await pilot.pause()
         assert counter == 3
+
+
+def test_get_key_display():
+    assert _get_key_display("minus") == "-"


### PR DESCRIPTION
- Fixes https://github.com/Textualize/textual/issues/1482
- Tweak to `textual keys` to allow pressing Ctrl+C twice to exit