### PR TITLE
Seek to improve the explanation of what a percentage does

### DIFF
--- a/docs/guide/styles.md
+++ b/docs/guide/styles.md
@@ -155,7 +155,7 @@ If you run this you will see the height of the widget now grows to accommodate t
 
 Textual offers a few different *units* which allow you to specify dimensions relative to the screen or container. Relative units can better make use of available space if the user resizes the terminal.
 
-- Percentage units are given as a string containing a number followed by a percentage symbol, e.g. `"50%"`. Setting a dimension to a percentage unit will size that dimension to that percentage of the *parent's* size in that dimension. For instance, setting width to `"50%"` will cause the width of the widget to be half the width of its parent.
+- Percentage units are given as a number followed by a percent (`%`) symbol and will set a dimension to a proportion of the widget's *parent* size. For instance, setting width to `"50%"` will cause a widget to be half the width of its parent.
 - View units are similar to percentage units, but explicitly reference a dimension. The `vw` unit sets a dimension to a percentage of the terminal *width*, and `vh` sets a dimension to a percentage of the terminal *height*.
 - The `w` unit sets a dimension to a percentage of the available width (which may be smaller than the terminal size if the widget is within another widget).
 - The `h` unit sets a dimension to a percentage of the available height.

--- a/docs/guide/styles.md
+++ b/docs/guide/styles.md
@@ -155,7 +155,7 @@ If you run this you will see the height of the widget now grows to accommodate t
 
 Textual offers a few different *units* which allow you to specify dimensions relative to the screen or container. Relative units can better make use of available space if the user resizes the terminal.
 
-- Percentage units are given as a string containing a number followed by a percentage symbol, e.g. `"50%"`. Setting a dimension to a percentage unit will cause it to fit in that percentage of the available space. For instance, setting width to `"50%"` will cause the width of the widget to be half the available space.
+- Percentage units are given as a string containing a number followed by a percentage symbol, e.g. `"50%"`. Setting a dimension to a percentage unit will size that dimension to that percentage of the *parent's* size in that dimension. For instance, setting width to `"50%"` will cause the width of the widget to be half the width of its parent.
 - View units are similar to percentage units, but explicitly reference a dimension. The `vw` unit sets a dimension to a percentage of the terminal *width*, and `vh` sets a dimension to a percentage of the terminal *height*.
 - The `w` unit sets a dimension to a percentage of the available width (which may be smaller than the terminal size if the widget is within another widget).
 - The `h` unit sets a dimension to a percentage of the available height.


### PR DESCRIPTION
I've seen a couple or so folk get confused about what a percentage value for a dimension means, often seeming to think it means that percentage of the *remaining* space within a container as opposed to a percentage of the space in the container (note total space, not remaining space).

I'm not sure the wording here is the final form we want (there's more mention of "dimension" here than your average Star Trek or Doctor Who episode!), but I think it's narrowing in on it.

Making this change to place-hold the need to improve this and perhaps gather some input to find the best final wording.
