### PR TITLE
Allow populating a child class of `ListView` purely from its `compose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Behavior of widget `Input` when rendering after programmatic value change and related scenarios https://github.com/Textualize/textual/issues/1477 https://github.com/Textualize/textual/issues/1443
 - Fixed TextLog wrapping issue https://github.com/Textualize/textual/issues/1554
 - Fixed issue with TextLog not writing anything before layout https://github.com/Textualize/textual/issues/1498
+- Fixed an exception when populating a child class of `ListView` purely from `compose` https://github.com/Textualize/textual/issues/1588
 
 ## [0.9.1] - 2022-12-30
 

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -50,16 +50,11 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
             classes: The CSS classes of the widget.
         """
         super().__init__(*children, name=name, id=id, classes=classes)
-        self.index = initial_index
+        self._index = initial_index
 
     def on_mount(self) -> None:
         """Ensure the ListView is fully-settled after mounting."""
-        # If someone inherits from ListView, they might be populating it
-        # from Widget.compose rather than from passing the ListItems to the
-        # initialisation call. Given that watch_index does all the work,
-        # let's just tickle it again after the DOM has been spun up and all
-        # children of this widget will have been mounted.
-        self.index = self.index or 0
+        self.index = self._index
 
     @property
     def highlighted_child(self) -> ListItem | None:

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -52,6 +52,15 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
         super().__init__(*children, name=name, id=id, classes=classes)
         self.index = initial_index
 
+    def on_mount(self) -> None:
+        """Ensure the ListView is fully-settled after mounting."""
+        # If someone inherits from ListView, they might be populating it
+        # from Widget.compose rather than from passing the ListItems to the
+        # initialisation call. Given that watch_index does all the work,
+        # let's just tickle it again after the DOM has been spun up and all
+        # children of this widget will have been mounted.
+        self.index = self.index or 0
+
     @property
     def highlighted_child(self) -> ListItem | None:
         """ListItem | None: The currently highlighted ListItem,

--- a/tests/listview/test_inherit_listview.py
+++ b/tests/listview/test_inherit_listview.py
@@ -1,0 +1,26 @@
+from textual.app import App, ComposeResult
+from textual.widgets import ListView, ListItem, Label
+
+
+class MyListView(ListView):
+    def compose(self) -> ComposeResult:
+        """Compose the child widgets."""
+        for n in range(20):
+            yield ListView(Label(f"This is item {n}"))
+
+
+class ListViewApp(App[None]):
+    """ListView test app."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the child widgets."""
+        yield MyListView()
+
+
+async def test_inherited_list_view() -> None:
+    """A self-populating inherited ListView should work as normal."""
+    async with ListViewApp().run_test() as pilot:
+        await pilot.press("tab")
+        assert pilot.app.query_one(MyListView).index == 0
+        await pilot.press("down")
+        assert pilot.app.query_one(MyListView).index == 1

--- a/tests/listview/test_inherit_listview.py
+++ b/tests/listview/test_inherit_listview.py
@@ -3,23 +3,42 @@ from textual.widgets import ListView, ListItem, Label
 
 
 class MyListView(ListView):
+    """Test child class of a ListView."""
+
+    def __init__(self, items: int = 0) -> None:
+        super().__init__()
+        self._items = items
+
     def compose(self) -> ComposeResult:
         """Compose the child widgets."""
-        for n in range(20):
-            yield ListView(Label(f"This is item {n}"))
+        for n in range(self._items):
+            yield ListItem(Label(f"This is item {n}"))
 
 
 class ListViewApp(App[None]):
     """ListView test app."""
 
+    def __init__(self, items: int = 0) -> None:
+        super().__init__()
+        self._items = items
+
     def compose(self) -> ComposeResult:
         """Compose the child widgets."""
-        yield MyListView()
+        yield MyListView(self._items)
 
 
-async def test_inherited_list_view() -> None:
-    """A self-populating inherited ListView should work as normal."""
+async def test_empty_inherited_list_view() -> None:
+    """An empty self-populating inherited ListView should work as expected."""
     async with ListViewApp().run_test() as pilot:
+        await pilot.press("tab")
+        assert pilot.app.query_one(MyListView).index is None
+        await pilot.press("down")
+        assert pilot.app.query_one(MyListView).index is None
+
+
+async def test_populated_inherited_list_view() -> None:
+    """A self-populating inherited ListView should work as normal."""
+    async with ListViewApp(30).run_test() as pilot:
         await pilot.press("tab")
         assert pilot.app.query_one(MyListView).index == 0
         await pilot.press("down")


### PR DESCRIPTION
See #1588. Simply put, this change will remove the problems encountered (no default highlighted item, no item gets highlighted on focus, exception thrown when attempting to cursor through the items) when inherited from a `ListView` and then populating its items purely from `compose`.