### PR TITLE
Sprinkle some pauses in the ListView tests

### DIFF
--- a/tests/listview/test_inherit_listview.py
+++ b/tests/listview/test_inherit_listview.py
@@ -31,8 +31,10 @@ async def test_empty_inherited_list_view() -> None:
     """An empty self-populating inherited ListView should work as expected."""
     async with ListViewApp().run_test() as pilot:
         await pilot.press("tab")
+        await pilot.pause(2 / 100)
         assert pilot.app.query_one(MyListView).index is None
         await pilot.press("down")
+        await pilot.pause(2 / 100)
         assert pilot.app.query_one(MyListView).index is None
 
 
@@ -40,6 +42,8 @@ async def test_populated_inherited_list_view() -> None:
     """A self-populating inherited ListView should work as normal."""
     async with ListViewApp(30).run_test() as pilot:
         await pilot.press("tab")
+        await pilot.pause(2 / 100)
         assert pilot.app.query_one(MyListView).index == 0
         await pilot.press("down")
+        await pilot.pause(2 / 100)
         assert pilot.app.query_one(MyListView).index == 1


### PR DESCRIPTION
The new ListView tests have been failing randomly in CI. Sprinkle some pauses to allow keys to be processed so see if this helps some.

Especially paging @darrenburns 