### PR TITLE
Added module level getattr to get version

### DIFF
--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -1,20 +1,31 @@
 from __future__ import annotations
 
 import inspect
-from typing import Callable
 
 import rich.repr
 from rich.console import RenderableType
-
-__all__ = ["log", "panic"]
-
 
 from ._context import active_app
 from ._log import LogGroup, LogVerbosity
 from ._typing import TypeAlias
 
+__all__ = ["log", "panic"]
+
 
 LogCallable: TypeAlias = "Callable"
+
+
+def __getattr__(name: str) -> str:
+    if name == "__version__":
+        try:
+            from importlib.metadata import version
+        except ImportError:
+            import pkg_resources
+
+            return pkg_resources.get_distribution("textual").version
+        else:
+            return version("textual")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class LoggerError(Exception):

--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -9,7 +9,7 @@ from ._context import active_app
 from ._log import LogGroup, LogVerbosity
 from ._typing import TypeAlias
 
-__all__ = ["log", "panic"]
+__all__ = ["log", "panic", "__version__"]  # type: ignore
 
 
 LogCallable: TypeAlias = "Callable"

--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -16,6 +16,7 @@ LogCallable: TypeAlias = "Callable"
 
 
 def __getattr__(name: str) -> str:
+    """Lazily get the version from whatever API is available."""
     if name == "__version__":
         try:
             from importlib.metadata import version

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,41 @@
+import re
+
+# https://stackoverflow.com/questions/37972029/regex-to-match-pep440-compliant-version-strings
+VERSION_PATTERN = r"""
+    v?
+    (?:
+        (?:(?P<epoch>[0-9]+)!)?                           # epoch
+        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
+        (?P<pre>                                          # pre-release
+            [-_\.]?
+            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+            [-_\.]?
+            (?P<pre_n>[0-9]+)?
+        )?
+        (?P<post>                                         # post release
+            (?:-(?P<post_n1>[0-9]+))
+            |
+            (?:
+                [-_\.]?
+                (?P<post_l>post|rev|r)
+                [-_\.]?
+                (?P<post_n2>[0-9]+)?
+            )
+        )?
+        (?P<dev>                                          # dev release
+            [-_\.]?
+            (?P<dev_l>dev)
+            [-_\.]?
+            (?P<dev_n>[0-9]+)?
+        )?
+    )
+    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+"""
+
+
+def test_version():
+    import textual
+
+    version = textual.__version__
+    assert isinstance(version, str)
+    assert re.match(VERSION_PATTERN, version, re.VERBOSE) is not None


### PR DESCRIPTION
Implements a `__version__`, so you can do the following:

```
>>> import textual
>>> textual.__version__
'0.10.0'
```

Fixes https://github.com/Textualize/textual/issues/1287