### PR TITLE
Remove unused import of asyncio.Event in widget.py

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncio import Event as AsyncEvent
 from asyncio import Lock, create_task, wait
 from collections import Counter
 from fractions import Fraction


### PR DESCRIPTION
Nothing impactful; just removes a hangover import.