### PR TITLE
Request that people include `textual diagnose` output in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,3 +16,5 @@ What Operating System are you running on?
 Feel free to add screenshots and/or videos. These can be very helpful!
 
 If you can, include a complete working example that demonstrates the bug. Check it can run without modifications.
+
+Please include the output of running `textual diagnose`.


### PR DESCRIPTION
Adds a wee prompt to a bug report issue to ask folk to run a `textual diagnose` and include it in the issue.