### PR TITLE
Import type annotations from the future for `textual diagnose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added Strip.text property https://github.com/Textualize/textual/issues/1620
 
+### Fixed
+
+- Fixed `textual diagnose` crash on older supported Python versions.
+
 ### Changed
 
 - The default filename for screenshots uses a datetime format similar to ISO8601, but with reserved characters replaced by underscores https://github.com/Textualize/textual/pull/1518

--- a/src/textual/cli/tools/diagnose.py
+++ b/src/textual/cli/tools/diagnose.py
@@ -1,5 +1,6 @@
 """Textual CLI command code to print diagnostic information."""
 
+from __future__ import annotations
 import os
 import sys
 import platform


### PR DESCRIPTION
I mean, I guess flat out crashing on older versions of Python is *a* way of reporting the Python version. Kinda?

See the side issue reported in #1622.
