### PR TITLE
Catch an attempt to use the `textual` command in a non-dev context

### DIFF
--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import sys
 
-import click
+try:
+    import click
+except ImportError:
+    print("Please install 'textual[dev]' to use the 'textual' command")
+    sys.exit(1)
+
 from importlib_metadata import version
 
 from textual.pilot import Pilot


### PR DESCRIPTION
This provides an interim fix for #983. While the longer-term solution for this is for us to *not* have the `textual` command available if the user has installed textual rather than textual[dev], this at least informs the user what's going on and why for now.
