### PR TITLE
Explain the significance of the before/after types

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -557,8 +557,12 @@ class Widget(DOMNode):
 
         Args:
             *widgets: The widget(s) to mount.
-            before: Optional location to mount before.
-            after: Optional location to mount after.
+            before: Optional location to mount before. An `int` is the index
+                of the child to mount before, a `str` is a `query_one` query to
+                find the widget to mount before.
+            after: Optional location to mount after. An `int` is the index
+                of the child to mount after, a `str` is a `query_one` query to
+                find the widget to mount after.
 
         Returns:
             An awaitable object that waits for widgets to be mounted.
@@ -618,8 +622,12 @@ class Widget(DOMNode):
 
         Args:
             child: The child widget to move.
-            before: Optional location to move before.
-            after: Optional location to move after.
+            before: Optional location to move before. An `int` is the index
+                of the child to move before, a `str` is a `query_one` query to
+                find the widget to move before.
+            after: Optional location to move after. An `int` is the index
+                of the child to move after, a `str` is a `query_one` query to
+                find the widget to move after.
 
         Raises:
             WidgetError: If there is a problem with the child or target.


### PR DESCRIPTION
This was asked about on Discord; reading the docs over again it's not obvious what an `int` is for, or a `str`. This change seeks to explain things at the API level at least.
