### PR TITLE
Remove mention of `ChildrenUpdated` from the `ListView` docs

### DIFF
--- a/docs/widgets/list_view.md
+++ b/docs/widgets/list_view.md
@@ -64,21 +64,6 @@ or by clicking on it.
 | `item`    | `ListItem` | The item that was selected. |
 
 
-### ChildrenUpdated
-
-The `ListView.ChildrenUpdated` message is emitted when the elements in the `ListView`
-are changed (e.g. a child is added, or the list is cleared).
-
-- [x] Bubbles
-
-#### Attributes
-
-| attribute  | type             | purpose                   |
-| ---------- | ---------------- | ------------------------- |
-| `children` | `list[ListItem]` | The new ListView children |
-
-
-
 ## See Also
 
 * [ListView](../api/list_view.md) code reference


### PR DESCRIPTION
As pointed out in #1649, a `ChildrenUpdated` message is documented but it doesn't exist in the code. It looks like it got added during development, then removed after it was realised it wasn't needed, but presumably it got left in the docs:

  https://github.com/Textualize/textual/pull/1143#discussion_r1030409026
