### PR TITLE
Rhymes with "Bed rock"

### DIFF
--- a/src/textual/_context.py
+++ b/src/textual/_context.py
@@ -4,6 +4,7 @@ from contextvars import ContextVar
 
 if TYPE_CHECKING:
     from .app import App
+    from .message_pump import MessagePump
 
 
 class NoActiveAppError(RuntimeError):
@@ -11,3 +12,4 @@ class NoActiveAppError(RuntimeError):
 
 
 active_app: ContextVar["App"] = ContextVar("active_app")
+active_message_pump: ContextVar["MessagePump"] = ContextVar("active_message_pump")

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2128,11 +2128,11 @@ class App(Generic[ReturnType], DOMNode):
         removed_widgets = self._detach_from_dom(widgets)
 
         finished_event = asyncio.Event()
-        create_task(
+        remove_task = create_task(
             prune_widgets_task(removed_widgets, finished_event), name="prune nodes"
         )
 
-        await_remove = AwaitRemove(finished_event)
+        await_remove = AwaitRemove(finished_event, remove_task)
         self.call_next(await_remove)
         return await_remove
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1095,8 +1095,12 @@ class App(Generic[ReturnType], DOMNode):
 
         Args:
             *widgets: The widget(s) to mount.
-            before: Optional location to mount before.
-            after: Optional location to mount after.
+            before: Optional location to mount before. An `int` is the index
+                of the child to mount before, a `str` is a `query_one` query to
+                find the widget to mount before.
+            after: Optional location to mount after. An `int` is the index
+                of the child to mount after, a `str` is a `query_one` query to
+                find the widget to mount after.
 
         Returns:
             An awaitable object that waits for widgets to be mounted.
@@ -1121,8 +1125,12 @@ class App(Generic[ReturnType], DOMNode):
 
         Args:
             widgets: An iterable of widgets.
-            before: Optional location to mount before.
-            after: Optional location to mount after.
+            before: Optional location to mount before. An `int` is the index
+                of the child to mount before, a `str` is a `query_one` query to
+                find the widget to mount before.
+            after: Optional location to mount after. An `int` is the index
+                of the child to mount after, a `str` is a `query_one` query to
+                find the widget to mount after.
 
         Returns:
             An awaitable object that waits for widgets to be mounted.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -46,7 +46,7 @@ from ._animator import DEFAULT_EASING, Animatable, Animator, EasingFunction
 from ._ansi_sequences import SYNC_END, SYNC_START
 from ._asyncio import create_task
 from ._callback import invoke
-from ._context import active_app
+from ._context import active_app, active_message_pump
 from ._event_broker import NoHandler, extract_handler_actions
 from ._filter import LineFilter, Monochrome
 from ._path import _make_path_object_relative
@@ -1113,6 +1113,7 @@ class App(Generic[ReturnType], DOMNode):
     def mount_all(
         self,
         widgets: Iterable[Widget],
+        *,
         before: int | str | Widget | None = None,
         after: int | str | Widget | None = None,
     ) -> AwaitMount:
@@ -2103,7 +2104,7 @@ class App(Generic[ReturnType], DOMNode):
         """Remove nodes from DOM, and return an awaitable that awaits cleanup.
 
         Args:
-            widgets: List of nodes to remvoe.
+            widgets: List of nodes to remove.
 
         Returns:
             Awaitable that returns when the nodes have been fully removed.
@@ -2131,13 +2132,15 @@ class App(Generic[ReturnType], DOMNode):
             prune_widgets_task(removed_widgets, finished_event), name="prune nodes"
         )
 
-        return AwaitRemove(finished_event)
+        await_remove = AwaitRemove(finished_event)
+        self.call_next(await_remove)
+        return await_remove
 
     async def _prune_nodes(self, widgets: list[Widget]) -> None:
         """Remove nodes and children.
 
         Args:
-            widgets: _description_
+            widgets: Widgets to remove.
         """
         async with self._dom_lock:
             for widget in widgets:

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -1,19 +1,20 @@
 """Provides the type of an awaitable remove."""
 
-from asyncio import Event
+from asyncio import Event, Task
 from typing import Generator
 
 
 class AwaitRemove:
     """An awaitable returned by App.remove and DOMQuery.remove."""
 
-    def __init__(self, finished_flag: Event) -> None:
+    def __init__(self, finished_flag: Event, task: Task) -> None:
         """Initialise the instance of ``AwaitRemove``.
 
         Args:
             finished_flag: The asyncio event to wait on.
         """
         self.finished_flag = finished_flag
+        self._task = task
 
     async def __call__(self) -> None:
         return await self

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -12,6 +12,7 @@ class AwaitRemove:
 
         Args:
             finished_flag: The asyncio event to wait on.
+            task: The task which does the remove (required to keep a reference).
         """
         self.finished_flag = finished_flag
         self._task = task

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -15,6 +15,9 @@ class AwaitRemove:
         """
         self.finished_flag = finished_flag
 
+    async def __call__(self) -> None:
+        return await self
+
     def __await__(self) -> Generator[None, None, None]:
         async def await_prune() -> None:
             """Wait for the prune operation to finish."""

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -618,6 +618,33 @@ class Widget(DOMNode):
         self.call_next(await_mount)
         return await_mount
 
+    def mount_all(
+        self,
+        widgets: Iterable[Widget],
+        *,
+        before: int | str | Widget | None = None,
+        after: int | str | Widget | None = None,
+    ) -> AwaitMount:
+        """Mount widgets from an iterable.
+
+        Args:
+            widgets: An iterable of widgets.
+            before: Optional location to mount before.
+            after: Optional location to mount after.
+
+        Returns:
+            An awaitable object that waits for widgets to be mounted.
+
+        Raises:
+            MountError: If there is a problem with the mount request.
+
+        Note:
+            Only one of ``before`` or ``after`` can be provided. If both are
+            provided a ``MountError`` will be raised.
+        """
+        await_mount = self.mount(*widgets, before=before, after=after)
+        return await_mount
+
     def move_child(
         self,
         child: int | Widget,

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -629,8 +629,12 @@ class Widget(DOMNode):
 
         Args:
             widgets: An iterable of widgets.
-            before: Optional location to mount before.
-            after: Optional location to mount after.
+            before: Optional location to mount before. An `int` is the index
+                of the child to mount before, a `str` is a `query_one` query to
+                find the widget to mount before.
+            after: Optional location to mount after. An `int` is the index
+                of the child to mount after, a `str` is a `query_one` query to
+                find the widget to mount after.
 
         Returns:
             An awaitable object that waits for widgets to be mounted.

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -170,7 +170,7 @@ async def test_remove():
 
     class RemoveApp(App):
         def compose(self) -> ComposeResult:
-            yield Container(RemoveMeLabel())
+            yield Container(RemoveMeLabel(), RemoveMeLabel())
 
         async def action_remove_all(self) -> None:
             await self.query_one(Container).clear()

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,13 +1,12 @@
 import pytest
-import rich
 
 from textual._node_list import DuplicateIds
 from textual.app import App, ComposeResult
 from textual.css.errors import StyleValueError
 from textual.css.query import NoMatches
-from textual.dom import DOMNode
 from textual.geometry import Size
 from textual.widget import Widget, MountError
+from textual.widgets import Label
 
 
 @pytest.mark.parametrize(
@@ -157,3 +156,29 @@ def test_widget_mount_ids_must_be_unique_mounting_multiple_calls(parent):
     parent.mount(widget1)
     with pytest.raises(DuplicateIds):
         parent.mount(widget2)
+
+
+# Regression test for https://github.com/Textualize/textual/issues/1634
+async def test_remove():
+    class RemoveMeLabel(Label):
+        async def on_mount(self) -> None:
+            await self.action("app.remove_all")
+
+    class Container(Widget):
+        async def clear(self) -> None:
+            await self.query("*").remove()
+
+    class RemoveApp(App):
+        def compose(self) -> ComposeResult:
+            yield Container(RemoveMeLabel())
+
+        async def action_remove_all(self) -> None:
+            await self.query_one(Container).clear()
+            self.exit(123)
+
+    app = RemoveApp()
+    async with app.run_test() as pilot:
+        await pilot.press("r")
+        await pilot.pause()
+    assert app.return_value == 123
+    assert True

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -181,4 +181,3 @@ async def test_remove():
         await pilot.press("r")
         await pilot.pause()
     assert app.return_value == 123
-    assert True

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -170,7 +170,7 @@ async def test_remove():
 
     class RemoveApp(App):
         def compose(self) -> ComposeResult:
-            yield Container(RemoveMeLabel(), RemoveMeLabel())
+            yield Container(RemoveMeLabel())
 
         async def action_remove_all(self) -> None:
             await self.query_one(Container).clear()


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1634

1. Clicking on a link happens in response to a Click event on Label.
2. Textual runs an action which tries to clear the label
3. The label waits for all the labels to close, but it never will because the label is waiting for itself to close.

- There is now an `active_message_pump` which is set the widget currently handling an event. The `_close_messages` functions uses this to avoid waiting on a message pump that will never return,
- Added a `Widget.mount_all` method. I find the pattern of `self.mount(*[foo for foo in bar])` to be too ugly.
