### PR TITLE
Keep track of scheduled animations

### DIFF
--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -210,6 +210,11 @@ class Animator:
         """Bind the animator to a given object."""
         return BoundAnimator(self, obj)
 
+    def is_being_animated(self, obj: object, attribute: str) -> bool:
+        """Does the object/attribute pair have an ongoing or scheduled animation?"""
+        key = (id(obj), attribute)
+        return key in self._animations or key in self._scheduled
+
     def animate(
         self,
         obj: object,

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -43,8 +43,12 @@ class Pilot(Generic[ReturnType]):
         await asyncio.sleep(delay)
 
     async def wait_for_animation(self) -> None:
-        """Wait for any animation to complete."""
+        """Wait for any current animation to complete."""
         await self._app.animator.wait_for_idle()
+
+    async def wait_for_scheduled_animations(self) -> None:
+        """Wait for any current and scheduled animations to complete."""
+        await self._app.animator.wait_for_fully_idle()
 
     async def exit(self, result: ReturnType) -> None:
         """Exit the app with the given result.

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -9,7 +9,7 @@ class AnimApp(App):
     #foo {
         height: 1;
     }
-    
+
     """
 
     def compose(self) -> ComposeResult:
@@ -37,3 +37,123 @@ async def test_animate_height() -> None:
         assert elapsed >= 0.5
         # Check the height reached the maximum
         assert static.styles.height.value == 100
+
+
+async def test_scheduling_animation() -> None:
+    """Test that scheduling an animation works."""
+
+    app = AnimApp()
+    delay = 0.1
+
+    async with app.run_test() as pilot:
+        styles = app.query_one(Static).styles
+        styles.background = "black"
+
+        styles.animate("background", "white", delay=delay, duration=0)
+
+        await pilot.pause(0.9 * delay)
+        assert styles.background.rgb == (0, 0, 0)  # Still black
+
+        await pilot.wait_for_scheduled_animations()
+        assert styles.background.rgb == (255, 255, 255)
+
+
+async def test_wait_for_current_animations() -> None:
+    """Test that we can wait only for the current animations taking place."""
+
+    app = AnimApp()
+
+    delay = 10
+
+    async with app.run_test() as pilot:
+        styles = app.query_one(Static).styles
+        styles.animate("height", 100, duration=0.1)
+        start = perf_counter()
+        styles.animate("height", 200, duration=0.1, delay=delay)
+
+        # Wait for the first animation to finish
+        await pilot.wait_for_animation()
+        elapsed = perf_counter() - start
+        assert elapsed < (delay / 2)
+
+
+async def test_wait_for_current_and_scheduled_animations() -> None:
+    """Test that we can wait for current and scheduled animations."""
+
+    app = AnimApp()
+
+    async with app.run_test() as pilot:
+        styles = app.query_one(Static).styles
+
+        start = perf_counter()
+        styles.animate("height", 50, duration=0.01)
+        styles.animate("background", "black", duration=0.01, delay=0.05)
+
+        await pilot.wait_for_scheduled_animations()
+        elapsed = perf_counter() - start
+        assert elapsed >= 0.06
+        assert styles.background.rgb == (0, 0, 0)
+
+
+async def test_reverse_animations() -> None:
+    """Test that you can create reverse animations.
+
+    Regression test for #1372 https://github.com/Textualize/textual/issues/1372
+    """
+
+    app = AnimApp()
+
+    async with app.run_test() as pilot:
+        static = app.query_one(Static)
+        styles = static.styles
+
+        # Starting point.
+        styles.background = "black"
+        assert styles.background.rgb == (0, 0, 0)
+
+        # First, make sure we can go from black to white and back, step by step.
+        styles.animate("background", "white", duration=0.01)
+        await pilot.wait_for_animation()
+        assert styles.background.rgb == (255, 255, 255)
+
+        styles.animate("background", "black", duration=0.01)
+        await pilot.wait_for_animation()
+        assert styles.background.rgb == (0, 0, 0)
+
+        # Now, the actual test is to make sure we go back to black if scheduling both at once.
+        styles.animate("background", "white", duration=0.01)
+        styles.animate("background", "black", duration=0.01)
+        await pilot.wait_for_animation()
+        assert styles.background.rgb == (0, 0, 0)
+
+
+async def test_schedule_reverse_animations() -> None:
+    """Test that you can schedule reverse animations.
+
+    Regression test for #1372 https://github.com/Textualize/textual/issues/1372
+    """
+
+    app = AnimApp()
+
+    async with app.run_test() as pilot:
+        static = app.query_one(Static)
+        styles = static.styles
+
+        # Starting point.
+        styles.background = "black"
+        assert styles.background.rgb == (0, 0, 0)
+
+        # First, make sure we can go from black to white and back, step by step.
+        styles.animate("background", "white", delay=0.01, duration=0.01)
+        await pilot.wait_for_scheduled_animations()
+        assert styles.background.rgb == (255, 255, 255)
+
+        styles.animate("background", "black", delay=0.01, duration=0.01)
+        await pilot.wait_for_scheduled_animations()
+        assert styles.background.rgb == (0, 0, 0)
+
+        # Now, the actual test is to make sure we go back to black if scheduling both at once.
+        styles.animate("background", "white", delay=0.01, duration=0.01)
+        styles.animate("background", "black", delay=0.01, duration=0.01)
+        await pilot.wait_for_scheduled_animations()
+        assert styles.background.rgb == (0, 0, 0)


### PR DESCRIPTION
 - We keep track of animations that are scheduled but not running yet.
 - We add the ability to wait for current and scheduled animations.
 - We fix #1372. 
 - We fix #1658. 
 - We add regression tests for 1372 plus a couple of other tests for animation features.