### PR TITLE
don't request sync on macOS app

### DIFF
--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -145,7 +145,11 @@ class LinuxDriver(Driver):
         self._request_terminal_sync_mode_support()
         self._enable_bracketed_paste()
 
-    def _request_terminal_sync_mode_support(self):
+    def _request_terminal_sync_mode_support(self) -> None:
+        """Writes an escape sequence to query the terminal support for the sync protocol."""
+        # Terminals should ignore this sequence if not supported.
+        # Apple terminal doesn't, and writes a single 'p' in to the terminal,
+        # so we will make a special case for Apple terminal (which doesn't support sync anyway).
         if self.console._environ.get("TERM_PROGRAM", "") != "Apple_Terminal":
             self.console.file.write("\033[?2026$p")
             self.console.file.flush()

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -146,8 +146,9 @@ class LinuxDriver(Driver):
         self._enable_bracketed_paste()
 
     def _request_terminal_sync_mode_support(self):
-        self.console.file.write("\033[?2026$p")
-        self.console.file.flush()
+        if self.console._environ.get("TERM", "") != "iTerm.app":
+            self.console.file.write("\033[?2026$p")
+            self.console.file.flush()
 
     @classmethod
     def _patch_lflag(cls, attrs: int) -> int:

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -146,7 +146,7 @@ class LinuxDriver(Driver):
         self._enable_bracketed_paste()
 
     def _request_terminal_sync_mode_support(self):
-        if self.console._environ.get("TERM", "") != "iTerm.app":
+        if self.console._environ.get("TERM_PROGRAM", "") != "Apple_Terminal":
             self.console.file.write("\033[?2026$p")
             self.console.file.flush()
 


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1622

I think the terminal *should* ignore this escape sequence. It isn't so we will have to workaround it.