### PR TITLE
Workaround for a Windows paste issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed relative units in `grid-rows` and `grid-columns` being computed with respect to the wrong dimension https://github.com/Textualize/textual/issues/1406
 - Programmatically setting `overflow_x`/`overflow_y` refreshes the layout correctly https://github.com/Textualize/textual/issues/1616
 - Fixed double-paste into `Input` https://github.com/Textualize/textual/issues/1657
+- Added a workaround for an apparent Windows Terminal paste issue https://github.com/Textualize/textual/issues/1661
 
 ## [0.10.1] - 2023-01-20
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -118,7 +118,10 @@ class XTermParser(Parser[events.Event]):
                 # ESC from the closing bracket, since at that point we didn't know what
                 # the full escape code was.
                 pasted_text = "".join(paste_buffer[:-1])
-                on_token(events.Paste(self.sender, text=pasted_text))
+                # Note the removal of NUL characters: https://github.com/Textualize/textual/issues/1661
+                on_token(
+                    events.Paste(self.sender, text=pasted_text.replace("\x000", ""))
+                )
                 paste_buffer.clear()
 
             character = ESC if use_prior_escape else (yield read1())

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -120,7 +120,7 @@ class XTermParser(Parser[events.Event]):
                 pasted_text = "".join(paste_buffer[:-1])
                 # Note the removal of NUL characters: https://github.com/Textualize/textual/issues/1661
                 on_token(
-                    events.Paste(self.sender, text=pasted_text.replace("\x000", ""))
+                    events.Paste(self.sender, text=pasted_text.replace("\x00", ""))
                 )
                 paste_buffer.clear()
 


### PR DESCRIPTION
See https://github.com/Textualize/textual/issues/1661 for lots of context. Long story short, in Windows Terminal it looks like any character that would require the press of a modifier key causes a NUL to appear in the pasted text for that character. This feels like it could be a bug in Windows Terminal and we will investigate and report at some point.

Meanwhile though this provides a workaround that has the paste experience work the same as I'm seeing on macOS (and I would imagine in most terminals on GNU/Linux too).