### PR TITLE
reactive fixes take 2

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1489,7 +1489,7 @@ class App(Generic[ReturnType], DOMNode):
                 finally:
                     self._mounted_event.set()
 
-                Reactive._initialize_object(self)
+                Reactive._initialize_reactable_object(self)
 
                 self.stylesheet.update(self)
                 self.refresh()

--- a/src/textual/cli/previews/easing.py
+++ b/src/textual/cli/previews/easing.py
@@ -5,7 +5,7 @@ from textual._easing import EASING
 from textual.app import App, ComposeResult
 from textual.cli.previews.borders import TEXT
 from textual.containers import Container, Horizontal, Vertical
-from textual.reactive import Reactive
+from textual.reactive import Reactive, var, init
 from textual.scrollbar import ScrollBarRender
 from textual.widget import Widget
 from textual.widgets import Button, Footer, Label, Input
@@ -23,7 +23,7 @@ class EasingButtons(Widget):
 
 
 class Bar(Widget):
-    position = Reactive.init(START_POSITION)
+    position = init(START_POSITION)
     animation_running = Reactive(False)
 
     DEFAULT_CSS = """
@@ -53,8 +53,8 @@ class Bar(Widget):
 
 
 class EasingApp(App):
-    position = Reactive.init(START_POSITION)
-    duration = Reactive.var(1.0)
+    position = init(START_POSITION)
+    duration = var(1.0, init=False)
 
     def on_load(self):
         self.bind(

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -19,11 +19,11 @@ from ._asyncio import create_task
 from ._callback import invoke
 from ._context import NoActiveAppError, active_app, active_message_pump
 from ._time import time
+from ._types import CallbackType
 from .case import camel_to_snake
 from .errors import DuplicateKeyHandlers
 from .events import Event
 from .message import Message
-from .reactive import Reactive
 from .timer import Timer, TimerCallback
 
 if TYPE_CHECKING:
@@ -310,7 +310,6 @@ class MessagePump(metaclass=MessagePumpMeta):
             await timer.stop()
         self._timers.clear()
         await self._message_queue.put(events.Unmount(sender=self))
-        Reactive._reset_object(self)
         await self._message_queue.put(None)
         if wait and self._task is not None and asyncio.current_task() != self._task:
             try:
@@ -358,7 +357,6 @@ class MessagePump(metaclass=MessagePumpMeta):
         finally:
             # This is critical, mount may be waiting
             self._mounted_event.set()
-        Reactive._initialize_object(self)
 
     async def _process_messages_loop(self) -> None:
         """Process messages until the queue is closed."""

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -10,31 +10,125 @@ from typing import (
     Generic,
     Type,
     TypeVar,
-    Union,
 )
 
 import rich.repr
 
 from . import events
-from ._callback import count_parameters, invoke
-from ._types import MessageTarget
+from ._callback import count_parameters
 
 if TYPE_CHECKING:
-    from .app import App
-    from .widget import Widget
+    from .dom import DOMNode
 
-    Reactable = Union[Widget, App]
+    Reactable = DOMNode
 
 ReactiveType = TypeVar("ReactiveType")
 
+"""
+Throughout this module:
 
-class _NotSet:
-    pass
+A "reactable" (an instance of `Reactable`) is an object holding reactive attributes.
+
+A "reactive" (an instance of `Reactive`) is a reactive attribute. There is an
+instance of `Reactive` for every reactive attribute of _class_ (not instance!) of a
+reactable object; so if 2 reactable objects of the same class had 3 reactive
+attributes each, there would be a total of 3 `Reactive` instances, not 6.
 
 
-_NOT_SET = _NotSet()
 
-T = TypeVar("T")
+To illustrate the mechanism, let us walk through an example:
+
+```
+class MyWidget(Static):
+    foo = Reactive(1)
+    bar = Reactive(2)
+```
+
+When class `MyWidget` is deinfed (in Python parlance it is actually created, but
+let's not fuss) two instances of `Reactive` are created, hence `Reactive.__init__`
+is invoked twice.
+
+After both instances are created, Python invokes `Reactive.__set_name__` on each,
+telling the first instance that it is called "foo" and is in the class `MyWidget`,
+and telling the second instance that it is called "bar" and is also in the class
+`MyWidget`.
+
+Also during this stage, `DOMNode.__init_subclass__` is invoked (all reactable class
+inherit from DOMNode), and the code there sets up a map in `MyWidget` which reads:
+
+```
+MyWidget._reactives = {
+    "foo": <the first Reactive instance>,
+    "bar": <the second Reactive instance>,
+}
+```
+
+At this point, no instances of `MyWidget` have been created.
+
+At some later point, we create an instance of `MyWidget`:
+
+```
+w = MyWidget()
+```
+
+Nothing magical relating to reactives occurs at this point. `MyWidget.__init__` is
+simply invoked and nothing more.
+
+At a later point, `w` is mounted (yielded from `Compose()`, or throught `.mount())
+At this stage, code in `DOMNode` calls `_initialize_reactable_object(w)`, setting up
+attributes on `w` to hold the actual values of `w.foo` and `w.bar`. This is the
+first time that something specific to an instance of a reactive attribute on a
+specific reactable object occurs.
+
+At a later point still, the following may happen:
+
+```
+x = w.foo
+w.bar = 3
+```
+
+When `w.foo` is accessed, Python invokes `__get__` on the Reactive instance for
+`foo` ("the first instance" from above), passing it `w` as a parameter. The code in
+`__get__` can then access the attributes on `w` set up during
+`_initialize_reactable_object` mentioned above.
+
+When `w.bar` is assigned to, Python invokes `__get__` on the Reactive instance for
+`bar` ("the second instance" from above), passing it `w` as a parameter. The code in
+`__set__` can then access the attributes on `w` set up during
+`_initialize_reactable_object` mentioned above.
+
+Setting a reactive attribute may also trigger a reactable-wide recompute of reactive
+attributes, which is done by the code in `__set__` invoking
+`_recompute_reactable_object`.
+
+At a much later stage, when `w` is no longer needed, code in `DOMNode` calls
+`_reset_reactable_object(w)`.
+
+
+We see thus the following categories of methods involved:
+
+    * once per reactive attribute of a reactable class
+        `Reactive.__init__`
+        `Reactive.__set_name__`
+
+    * once per reactable class
+        `DOMNode.__init_subclass__`
+
+    * once per reactable object
+        `Reactive._initialize_reactable_object`
+        `Reactive._reset_reactable_object`
+
+    * once per reactive attribute on a specific reactable object:
+        `Reactive._initialize_reactive`
+
+    * every access to a specific reactive attribute of a specific reactable object:
+        `__get__`
+        `__set__`
+        `_set_reactive_inner`
+        `_compute_reactive`,
+        `_notify_reactive_watchers`
+        `_compute_reactable_object`
+"""
 
 
 @rich.repr.auto
@@ -49,8 +143,6 @@ class Reactive(Generic[ReactiveType]):
         always_update: Call watchers even when the new value equals the old value. Defaults to False.
         compute: Run compute methods when attribute is changed. Defaults to True.
     """
-
-    _reactives: TypeVar[dict[str, object]] = {}
 
     def __init__(
         self,
@@ -67,7 +159,7 @@ class Reactive(Generic[ReactiveType]):
         self._repaint = repaint
         self._init = init
         self._always_update = always_update
-        self._run_compute = compute
+        self._trigger_object_compute = compute
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield self._default
@@ -75,68 +167,117 @@ class Reactive(Generic[ReactiveType]):
         yield "repaint", self._repaint
         yield "init", self._init
         yield "always_update", self._always_update
-        yield "compute", self._run_compute
+        yield "compute", self._trigger_object_compute
 
-    @classmethod
-    def init(
-        cls,
-        default: ReactiveType | Callable[[], ReactiveType],
-        *,
-        layout: bool = False,
-        repaint: bool = True,
-        always_update: bool = False,
-        compute: bool = True,
-    ) -> Reactive:
-        """A reactive variable that calls watchers and compute on initialize (post mount).
+    def __set_name__(self, owner: Type[Reactable], name: str) -> None:
+        # The name of the attribute
+        self.name = name
+        # The internal name where the attribute's value is stored
+        self.internal_name = f"_reactive_{name}"
+        # Corresponding compute, watch and validate methods, if exist
+        # NOTE that these are all instance methods, but are stored here
+        # bound to the reactable class (and not the instance, which at
+        # this point is unknown.). This means that invoking them must
+        # supply a `self` parameter as well.
+        self.compute_function = getattr(owner, f"compute_{name}", None)
+        self.validate_function = getattr(owner, f"validate_{name}", None)
+        self.watch_function = getattr(owner, f"watch_{name}", None)
 
-        Args:
-            default: A default value or callable that returns a default.
-            layout: Perform a layout on change. Defaults to False.
-            repaint: Perform a repaint on change. Defaults to True.
-            always_update: Call watchers even when the new value equals the old value. Defaults to False.
-            compute: Run compute methods when attribute is changed. Defaults to True.
-
-        Returns:
-            A Reactive instance which calls watchers or initialize.
-        """
-        return cls(
-            default,
-            layout=layout,
-            repaint=repaint,
-            init=True,
-            always_update=always_update,
-            compute=compute,
-        )
-
-    @classmethod
-    def var(
-        cls,
-        default: ReactiveType | Callable[[], ReactiveType],
-    ) -> Reactive:
-        """A reactive variable that doesn't update or layout.
-
-        Args:
-            default: A default value or callable that returns a default.
-
-        Returns:
-            A Reactive descriptor.
-        """
-        return cls(default, layout=False, repaint=False, init=False)
-
-    def _initialize_reactive(self, obj: Reactable, name: str) -> None:
-        """Initialized a reactive attribute on an object.
+    def __get__(self, obj: Reactable, obj_type: type | None = None) -> ReactiveType:
+        """Return the cached value of the reactive attribute.
 
         Args:
             obj: An object with reactive attributes.
-            name: Name of attribute.
+            obj_type: used; Python will pass a type here if accessing the
+                the reactive on a class rather than on an instance.
         """
-        internal_name = f"_reactive_{name}"
+        _rich_traceback_omit = True
+        self._initialize_reactive(obj)
+        value: ReactiveType = getattr(obj, self.internal_name)
+        return value
+
+    def __set__(self, obj: Reactable, value: ReactiveType) -> None:
+        """Set the value of the reactive attribute, invoking any
+        validation and watch methods.
+
+        Then, maybe trigger object-wide recompute and refresh.
+
+        Args:
+            obj: An object with reactive attributes.
+            value: the value to set the reactive attribute to.
+        """
+        _rich_traceback_omit = True
+
+        self._set_reactive_inner(obj, value)
+
+        if self._trigger_object_compute:
+            self._compute_reactable_object(obj)
+
+        # Refresh according to descriptor flags
+        if self._layout or self._repaint:
+            obj.refresh(repaint=self._repaint, layout=self._layout)
+
+    def _set_reactive_inner(self, obj: Reactable, value: ReactiveType) -> None:
+        """Set the value of the reactive attribute, invoking any
+        validation and watch methods.
+
+        Does _not_ invoke object-wide recompute nor refresh.
+
+        Args:
+            obj: An object with reactive attributes.
+            value: the value to set the reactive attribute to.
+        """
+        _rich_traceback_omit = True
+
+        self._initialize_reactive(obj)
+
+        # Call validate function
+        validate_function = self.validate_function
+        if callable(validate_function):
+            value = validate_function(obj, value)
+
+        current_value = self.__get__(obj)
+        if current_value == value and not self._always_update:
+            return
+
+        # Store the internal value
+        setattr(obj, self.internal_name, value)
+
+        # Notify all watchers
+        self._notify_reactive_watchers(obj, current_value)
+
+    def _compute_reactive(self, obj: Reactable) -> None:
+        """Compute the value of the reactive attribute,
+        storing it the reactive cache (which itself invokes
+        any validation and watch methods).
+
+        Does _not_ invoke object-wide recompute nor refresh.
+
+        Args:
+            obj: An object with reactive attributes.
+        """
+        _rich_traceback_omit = True
+
+        compute_method = self.compute_function
+        if compute_method is None:
+            return
+        value = compute_method(obj)
+
+        self._set_reactive_inner(obj, value)
+
+    def _initialize_reactive(self, obj: Reactable) -> None:
+        """Initialize the reactive attribute on an object.
+
+        Args:
+            obj: An object with reactive attributes.
+        """
+        internal_name = self.internal_name
         if hasattr(obj, internal_name):
             # Attribute already has a value
             return
-        compute_method = getattr(obj, f"compute_{name}", None)
-        if compute_method is not None and self._init:
-            default = getattr(obj, f"compute_{name}")()
+        compute_function = self.compute_function
+        if compute_function is not None and self._init:
+            default = compute_function(obj)
         else:
             default_or_callable = self._default
             default = (
@@ -146,125 +287,31 @@ class Reactive(Generic[ReactiveType]):
             )
         setattr(obj, internal_name, default)
         if self._init:
-            self._check_watchers(obj, name, default)
+            self._notify_reactive_watchers(obj, default)
 
-    @classmethod
-    def _initialize_object(cls, obj: Reactable) -> None:
-        """Set defaults and call any watchers / computes for the first time.
-
-        Args:
-            obj: An object with Reactive descriptors
-        """
-
-        for name, reactive in obj._reactives.items():
-            reactive._initialize_reactive(obj, name)
-
-    @classmethod
-    def _reset_object(cls, obj: object) -> None:
-        """Reset reactive structures on object (to avoid reference cycles).
-
-        Args:
-            obj: A reactive object.
-        """
-        getattr(obj, "__watchers", {}).clear()
-        getattr(obj, "__computes", []).clear()
-
-    def __set_name__(self, owner: Type[MessageTarget], name: str) -> None:
-
-        # Check for compute method
-        if hasattr(owner, f"compute_{name}"):
-            # Compute methods are stored in a list called `__computes`
-            try:
-                computes = getattr(owner, "__computes")
-            except AttributeError:
-                computes = []
-                setattr(owner, "__computes", computes)
-            computes.append(name)
-
-        # The name of the attribute
-        self.name = name
-        # The internal name where the attribute's value is stored
-        self.internal_name = f"_reactive_{name}"
-        default = self._default
-        setattr(owner, f"_default_{name}", default)
-
-    def __get__(self, obj: Reactable, obj_type: type[object]) -> ReactiveType:
-        _rich_traceback_omit = True
-
-        self._initialize_reactive(obj, self.name)
-
-        value: ReactiveType
-        compute_method = getattr(self, f"compute_{self.name}", None)
-        if compute_method is not None:
-            old_value = getattr(obj, self.internal_name)
-            value = getattr(obj, f"compute_{self.name}")()
-            setattr(obj, self.internal_name, value)
-            self._check_watchers(obj, self.name, old_value)
-        else:
-            value = getattr(obj, self.internal_name)
-        return value
-
-    def __set__(self, obj: Reactable, value: ReactiveType) -> None:
-        _rich_traceback_omit = True
-
-        self._initialize_reactive(obj, self.name)
-        name = self.name
-        current_value = getattr(obj, name)
-        # Check for validate function
-        validate_function = getattr(obj, f"validate_{name}", None)
-        # Call validate
-        if callable(validate_function):
-            value = validate_function(value)
-        # If the value has changed, or this is the first time setting the value
-        if current_value != value or self._always_update:
-            # Store the internal value
-            setattr(obj, self.internal_name, value)
-
-            # Check all watchers
-            self._check_watchers(obj, name, current_value)
-
-            if self._run_compute:
-                self._compute(obj)
-
-            # Refresh according to descriptor flags
-            if self._layout or self._repaint:
-                obj.refresh(repaint=self._repaint, layout=self._layout)
-
-    @classmethod
-    def _check_watchers(cls, obj: Reactable, name: str, old_value: Any):
-        """Check watchers, and call watch methods / computes
+    def _notify_reactive_watchers(self, obj: Reactable, old_value: Any) -> None:
+        """Notify all watchers
 
         Args:
             obj: The reactable object.
-            name: Attribute name.
             old_value: The old (previous) value of the attribute.
         """
         _rich_traceback_omit = True
-        # Get the current value.
-        internal_name = f"_reactive_{name}"
-        value = getattr(obj, internal_name)
 
         async def await_watcher(awaitable: Awaitable) -> None:
             """Coroutine to await an awaitable returned from a watcher"""
             _rich_traceback_omit = True
             await awaitable
-            # Watcher may have changed the state, so run compute again
-            obj.post_message_no_wait(
-                events.Callback(sender=obj, callback=partial(Reactive._compute, obj))
-            )
 
         def invoke_watcher(
             watch_function: Callable, old_value: object, value: object
-        ) -> bool:
+        ) -> None:
             """Invoke a watch function.
 
             Args:
                 watch_function: A watch function, which may be sync or async.
                 old_value: The old value of the attribute.
                 value: The new value of the attribute.
-
-            Returns:
-                True if the watcher was run, or False if it was posted.
             """
             _rich_traceback_omit = True
             param_count = count_parameters(watch_function)
@@ -281,36 +328,53 @@ class Reactive(Generic[ReactiveType]):
                         sender=obj, callback=partial(await_watcher, watch_result)
                     )
                 )
-                return False
-            else:
-                return True
 
-        watch_function = getattr(obj, f"watch_{name}", None)
+        # Get the current value.
+        value = self.__get__(obj)
+
+        watch_function = self.watch_function
         if callable(watch_function):
-            invoke_watcher(watch_function, old_value, value)
+            invoke_watcher(partial(watch_function, obj), old_value, value)
 
-        watchers: list[Callable] = getattr(obj, "__watchers", {}).get(name, [])
+        watchers: list[Callable] = getattr(obj, "__watchers", {}).get(self.name, [])
         for watcher in watchers:
             invoke_watcher(watcher, old_value, value)
 
+    ##
+    ## ONCE PER `Reactable` OBJECT INSTANCE
+    ##
+
     @classmethod
-    def _compute(cls, obj: Reactable) -> None:
+    def _initialize_reactable_object(cls, obj: Reactable) -> None:
+        """Set defaults and call any watchers / computes for the first time.
+
+        Args:
+            obj: An object with Reactive descriptors
+        """
+        _rich_traceback_guard = True
+        for reactive in obj._reactives.values():
+            reactive._initialize_reactive(obj)
+
+    @classmethod
+    def _reset_reactable_object(cls, obj: Reactable) -> None:
+        """Reset reactive structures on object (to avoid reference cycles).
+
+        Args:
+            obj: A reactive object.
+        """
+        _rich_traceback_guard = True
+        getattr(obj, "__watchers", {}).clear()
+
+    @classmethod
+    def _compute_reactable_object(cls, obj: Reactable) -> None:
         """Invoke all computes.
 
         Args:
             obj: Reactable object.
         """
         _rich_traceback_guard = True
-        for compute in obj._reactives.keys():
-            try:
-                compute_method = getattr(obj, f"compute_{compute}")
-            except AttributeError:
-                continue
-            current_value = getattr(obj, f"_reactive_{compute}")
-            value = compute_method()
-            setattr(obj, f"_reactive_{compute}", value)
-            if value != current_value:
-                cls._check_watchers(obj, compute, current_value)
+        for reactive in obj._reactives.values():
+            reactive._compute_reactive(obj)
 
 
 class reactive(Reactive[ReactiveType]):
@@ -363,6 +427,35 @@ class var(Reactive[ReactiveType]):
         )
 
 
+class init(Reactive[ReactiveType]):
+    def init(
+        self,
+        default: ReactiveType | Callable[[], ReactiveType],
+        *,
+        layout: bool = False,
+        repaint: bool = True,
+        always_update: bool = False,
+        compute: bool = True,
+    ) -> None:
+        """A reactive variable that calls watchers and compute on initialize (post mount).
+
+        Args:
+            default: A default value or callable that returns a default.
+            layout: Perform a layout on change. Defaults to False.
+            repaint: Perform a repaint on change. Defaults to True.
+            always_update: Call watchers even when the new value equals the old value. Defaults to False.
+            compute: Run compute methods when attribute is changed. Defaults to True.
+        """
+        super().__init__(
+            default,
+            layout=layout,
+            repaint=repaint,
+            init=True,
+            always_update=always_update,
+            compute=compute,
+        )
+
+
 def watch(
     obj: Reactable,
     attribute_name: str,
@@ -386,5 +479,6 @@ def watch(
         return
     watcher_list.append(callback)
     if init:
-        current_value = getattr(obj, attribute_name, None)
-        Reactive._check_watchers(obj, attribute_name, current_value)
+        reactive = obj._reactives[attribute_name]
+        current_value = reactive.__get__(obj)
+        reactive._notify_reactive_watchers(obj, current_value)

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -10,7 +10,7 @@ from rich.text import Text, TextType
 from .. import events
 from ..css._error_tools import friendly_list
 from ..message import Message
-from ..reactive import Reactive
+from ..reactive import Reactive, init
 from ..widgets import Static
 from .._typing import Literal
 
@@ -197,7 +197,7 @@ class Button(Static, can_focus=True):
     label: Reactive[RenderableType] = Reactive("")
     """The text label that appears within the button."""
 
-    variant = Reactive.init("default")
+    variant = init("default")
     """The variant name for the button."""
 
     disabled = Reactive(False)

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -308,9 +308,9 @@ async def test_reactive_inheritance():
     # Secondary adds one new reactive
     assert len(secondary._reactives) == primary_reactive_count + 1
 
-    Reactive._initialize_object(primary)
-    Reactive._initialize_object(secondary)
-    Reactive._initialize_object(tertiary)
+    Reactive._initialize_reactable_object(primary)
+    Reactive._initialize_reactable_object(secondary)
+    Reactive._initialize_reactable_object(tertiary)
 
     # Primary doesn't have egg
     with pytest.raises(AttributeError):


### PR DESCRIPTION
(see #1611 for context, and in particular my promise to create a PR that refactors the duplicate logic; well here it is).

* Added detailed explanation of the mechanism and the code structure to the top of `reactive.py`. Please read that first.
* Refactored much of the duplicate logic between methods into instance variables of `Reactive`.
* Removed the `name` parameter from all methods in `Reactive` by turning them into instance methods that use the above-mentioned instance variables.
* Renamed some methods in `Reactive` to put some order into the mechanism and make it consistent.

* `MessagePump` cannot be a Reactable because it does not have `.refresh()`. Instead, moved the 2 lines of code in `MessagePump` that dealt with Reactives into `DOMNode`, which is the real base class of all Reactable.

* Made the class methods Reactive.init() into a global method of `reactive.py`, like the methods `var()` and `reactive()`.
* The class methods Reactive.var() was basically a duplicate of the method `var()` in `reactive.py`. Deleted it.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
