### PR TITLE
Scroll sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added the coroutines `Animator.wait_until_complete` and `pilot.wait_for_scheduled_animations` that allow waiting for all current and scheduled animations https://github.com/Textualize/textual/issues/1658
 - Added the method `Animator.is_being_animated` that checks if an attribute of an object is being animated or is scheduled for animation
-- Added App.scroll_sensitivity to adjust how many lines the scroll wheel moves the scroll position https://github.com/orgs/Textualize/projects/5?pane=issue&itemId=12998591
+- Added App.scroll_sensitivity_x and App.scroll_sensitivity_y to adjust how many lines the scroll wheel moves the scroll position https://github.com/orgs/Textualize/projects/5?pane=issue&itemId=12998591
 - Added Shift+scroll wheel and ctrl+scroll wheen to scroll horizontally
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added the coroutines `Animator.wait_until_complete` and `pilot.wait_for_scheduled_animations` that allow waiting for all current and scheduled animations https://github.com/Textualize/textual/issues/1658
 - Added the method `Animator.is_being_animated` that checks if an attribute of an object is being animated or is scheduled for animation
+- Added App.scroll_sensitivity to adjust how many lines the scroll wheel moves the scroll position https://github.com/orgs/Textualize/projects/5?pane=issue&itemId=12998591
+- Added Shift+scroll wheel and ctrl+scroll wheen to scroll horizontally
 
 ### Changed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -369,6 +369,8 @@ class App(Generic[ReturnType], DOMNode):
         self.css_path = css_paths
         self._registry: WeakSet[DOMNode] = WeakSet()
 
+        self.scroll_sensitivity: float = 3
+
         self._installed_screens: WeakValueDictionary[
             str, Screen | Callable[[], Screen]
         ] = WeakValueDictionary()

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -369,7 +369,8 @@ class App(Generic[ReturnType], DOMNode):
         self.css_path = css_paths
         self._registry: WeakSet[DOMNode] = WeakSet()
 
-        self.scroll_sensitivity: float = 3
+        self.scroll_sensitivity_x: float = 4
+        self.scroll_sensitivity_y: float = 2
 
         self._installed_screens: WeakValueDictionary[
             str, Screen | Callable[[], Screen]

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1575,7 +1575,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            x=self.scroll_target_x - self.app.scroll_sensitivity,
+            x=self.scroll_target_x - self.app.scroll_sensitivity_x,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -1607,7 +1607,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            x=self.scroll_target_x + self.app.scroll_sensitivity,
+            x=self.scroll_target_x + self.app.scroll_sensitivity_x,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -1639,7 +1639,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            y=self.scroll_target_y + self.app.scroll_sensitivity,
+            y=self.scroll_target_y + self.app.scroll_sensitivity_y,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -1671,7 +1671,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            y=self.scroll_target_y - +self.app.scroll_sensitivity,
+            y=self.scroll_target_y - +self.app.scroll_sensitivity_y,
             animate=animate,
             speed=speed,
             duration=duration,

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1575,7 +1575,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            x=self.scroll_target_x - 1,
+            x=self.scroll_target_x - self.app.scroll_sensitivity,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -1607,7 +1607,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            x=self.scroll_target_x + 1,
+            x=self.scroll_target_x + self.app.scroll_sensitivity,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -1639,7 +1639,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            y=self.scroll_target_y + 1,
+            y=self.scroll_target_y + self.app.scroll_sensitivity,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -1671,7 +1671,7 @@ class Widget(DOMNode):
 
         """
         return self.scroll_to(
-            y=self.scroll_target_y - 1,
+            y=self.scroll_target_y - +self.app.scroll_sensitivity,
             animate=animate,
             speed=speed,
             duration=duration,
@@ -2478,15 +2478,25 @@ class Widget(DOMNode):
         if self._has_focus_within:
             self.app.update_styles(self)
 
-    def _on_mouse_scroll_down(self, event) -> None:
-        if self.allow_vertical_scroll:
-            if self.scroll_down(animate=False):
-                event.stop()
+    def _on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        if event.ctrl or event.shift:
+            if self.allow_horizontal_scroll:
+                if self.scroll_right(animate=False):
+                    event.stop()
+        else:
+            if self.allow_vertical_scroll:
+                if self.scroll_down(animate=False):
+                    event.stop()
 
-    def _on_mouse_scroll_up(self, event) -> None:
-        if self.allow_vertical_scroll:
-            if self.scroll_up(animate=False):
-                event.stop()
+    def _on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        if event.ctrl or event.shift:
+            if self.allow_horizontal_scroll:
+                if self.scroll_left(animate=False):
+                    event.stop()
+        else:
+            if self.allow_vertical_scroll:
+                if self.scroll_up(animate=False):
+                    event.stop()
 
     def _on_scroll_to(self, message: ScrollTo) -> None:
         if self._allow_scroll:


### PR DESCRIPTION
- Adds scroll_sensitivity_x and scroll_sensitivity_y to change the number of lines to move the scroll position by when using the scroll wheel and trackpad
- Adds horizontal scrolling, with shift or ctrl + scroll wheel. Horizontal scrolling uses shift + mouse wheel on macOS, but for some reason ITerm won't send mouse wheel events when shift is pressed. Kitty does. iTerm bug? Don't know, but for now both ctrl and shift will scroll horizontally.

I've doubled the scroll speed which makes the wheel somewhat usable, and the trackpad remains usable if a little faster.

There is no way to know which is being used, which means we need to find settings that works with both.

**Please check this out and play with scrolling**. I'm concerned that it may work for me, and break others. 