### PR TITLE
When in password mode have word-oriented actions act on whole input

### DIFF
--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -470,7 +470,7 @@ class Input(Widget, can_focus=True):
                 self.cursor_position = 0
             else:
                 self.cursor_position = hit.start()
-                self.value = f"{self.value[: self.cursor_position]}{after}"
+            self.value = f"{self.value[: self.cursor_position]}{after}"
 
     def action_delete_left_all(self) -> None:
         """Delete all characters to the left of the cursor position."""

--- a/tests/input/test_input_key_modification_actions.py
+++ b/tests/input/test_input_key_modification_actions.py
@@ -66,6 +66,17 @@ async def test_delete_left_word_from_end() -> None:
             assert input.value == expected[input.id]
 
 
+async def test_password_delete_left_word_from_end() -> None:
+    """Deleting word left from end of a password input should delete everything."""
+    async with InputTester().run_test() as pilot:
+        for input in pilot.app.query(Input):
+            input.action_end()
+            input.password = True
+            input.action_delete_left_word()
+            assert input.cursor_position == 0
+            assert input.value == ""
+
+
 async def test_delete_left_all_from_home() -> None:
     """Deleting all left from home should do nothing."""
     async with InputTester().run_test() as pilot:
@@ -117,6 +128,16 @@ async def test_delete_right_word_from_home() -> None:
             input.action_delete_right_word()
             assert input.cursor_position == 0
             assert input.value == expected[input.id]
+
+
+async def test_password_delete_right_word_from_home() -> None:
+    """Deleting word right from home of a password input should delete everything."""
+    async with InputTester().run_test() as pilot:
+        for input in pilot.app.query(Input):
+            input.password = True
+            input.action_delete_right_word()
+            assert input.cursor_position == 0
+            assert input.value == ""
 
 
 async def test_delete_right_word_from_end() -> None:

--- a/tests/input/test_input_key_movement_actions.py
+++ b/tests/input/test_input_key_movement_actions.py
@@ -97,6 +97,16 @@ async def test_input_left_word_from_end() -> None:
             assert input.cursor_position == expected_at[input.id]
 
 
+async def test_password_input_left_word_from_end() -> None:
+    """Going left one word from the end in a password field should land at home."""
+    async with InputTester().run_test() as pilot:
+        for input in pilot.app.query(Input):
+            input.action_end()
+            input.password = True
+            input.action_cursor_left_word()
+            assert input.cursor_position == 0
+
+
 async def test_input_right_word_from_home() -> None:
     """Going right one word from the start should land correctly.."""
     async with InputTester().run_test() as pilot:
@@ -110,6 +120,15 @@ async def test_input_right_word_from_home() -> None:
         for input in pilot.app.query(Input):
             input.action_cursor_right_word()
             assert input.cursor_position == expected_at[input.id]
+
+
+async def test_password_input_right_word_from_home() -> None:
+    """Going right one word from the start of a password input should go to the end."""
+    async with InputTester().run_test() as pilot:
+        for input in pilot.app.query(Input):
+            input.password = True
+            input.action_cursor_right_word()
+            assert input.cursor_position == len(input.value)
 
 
 async def test_input_right_word_from_end() -> None:


### PR DESCRIPTION
The idea here is that a password field should give no hint as to what's within, length notwithstanding. To this end have the actions that (re)move based on word boundaries act as if a password field is always just one word.

See #1692 (and previously #1676, prompted originally by #1310).
