### PR TITLE
Make `textual keys` work on older supported Pythons

### DIFF
--- a/src/textual/cli/previews/keys.py
+++ b/src/textual/cli/previews/keys.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rich.panel import Panel
 
 from rich.text import Text


### PR DESCRIPTION
`keys.py` wasn't importing `annotations` from the `__future__`.