### PR TITLE
Include the unit tests in the source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 include = [
-    "src/textual/py.typed"
+    "src/textual/py.typed",
+    { path = "docs/examples", format = "sdist" },
+    { path = "tests", format = "sdist" }
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
As requested in #631 and also #1349; this change should cause the tests (and also the examples from the docs directory which get pulled into the tests) to be pulled into the sdist.

With this change I can:

- `poetry build`
- Grab and extract the resulting tarball
- `poetry install --extras dev` inside the resulting directory
- `poetry run pytest -vv tests` inside the resulting directory

As I understand the request, I think this should provide everything necessary.

NOTE: We have spoken about rolling the CLI tools into snapshot tests too, so if that happens we should remember to make sure that the pipeline outlined above still works fine.

**ALSO NOTE:** My Python packaging experience is mostly with other tools, so double-checking not only of the content of this PR, but also the result of using it, is highly encouraged.