### PR TITLE
Change emit to post to self.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Breaking change: `TreeNode` can no longer be imported from `textual.widgets`; it is now available via `from textual.widgets.tree import TreeNode`. https://github.com/Textualize/textual/pull/1637
 - `Tree` now shows a (subdued) cursor for a highlighted node when focus has moved elsewhere https://github.com/Textualize/textual/issues/1471
+- `MessagePump.emit` and `MessagePump.emit_no_wait` now emit events to self instead of to the parent
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Breaking change: `TreeNode` can no longer be imported from `textual.widgets`; it is now available via `from textual.widgets.tree import TreeNode`. https://github.com/Textualize/textual/pull/1637
 - `Tree` now shows a (subdued) cursor for a highlighted node when focus has moved elsewhere https://github.com/Textualize/textual/issues/1471
-- `MessagePump.emit` and `MessagePump.emit_no_wait` now emit events to self instead of to the parent
 
 ### Fixed
 
@@ -39,6 +38,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with renderable width calculation https://github.com/Textualize/textual/issues/1685
 - Fixed issue with app not processing Paste event https://github.com/Textualize/textual/issues/1666
 - Fixed glitch with view position with auto width inputs https://github.com/Textualize/textual/issues/1693
+
+### Removed
+
+- Methods `MessagePump.emit` and `MessagePump.emit_no_wait` https://github.com/Textualize/textual/pull/1738
 
 ## [0.10.1] - 2023-01-20
 

--- a/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
+++ b/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
@@ -288,7 +288,7 @@ So, thanks to this bit of code in my `Activity` widget...
             parent.move_child(
                 self, before=parent.children.index( self ) - 1
             )
-            self.emit_no_wait( self.Moved( self ) )
+            self.post_messa_no_wait( self.Moved( self ) )
             self.scroll_visible( top=True )
 ```
 

--- a/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
+++ b/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
@@ -288,7 +288,7 @@ So, thanks to this bit of code in my `Activity` widget...
             parent.move_child(
                 self, before=parent.children.index( self ) - 1
             )
-            self.post_messa_no_wait( self.Moved( self ) )
+            self.post_message_no_wait( self.Moved( self ) )
             self.scroll_visible( top=True )
 ```
 

--- a/docs/examples/events/custom01.py
+++ b/docs/examples/events/custom01.py
@@ -25,8 +25,8 @@ class ColorButton(Static):
         self.styles.border = ("tall", self.color)
 
     async def on_click(self) -> None:
-        # The emit method sends an event to a widget's parent
-        await self.emit(self.Selected(self, self.color))
+        # The post_message method sends an event to be handled in the DOM
+        await self.post_message(self.Selected(self, self.color))
 
     def render(self) -> str:
         return str(self.color)

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -110,7 +110,7 @@ The message class is defined within the widget class itself. This is not strictl
 
 ## Sending events
 
-In the previous example we used [emit()][textual.message_pump.MessagePump.emit] to send an event to its parent. We could also have used [emit_no_wait()][textual.message_pump.MessagePump.emit_no_wait] for non async code. Sending messages in this way allows you to write custom widgets without needing to know in what context they will be used.
+In the previous example we used [post_message()][textual.message_pump.MessagePump.post_message] to send an event to its parent. We could also have used [post_message_no_wait()][textual.message_pump.MessagePump.post_message_no_wait] for non async code. Sending messages in this way allows you to write custom widgets without needing to know in what context they will be used.
 
 There are other ways of sending (posting) messages, which you may need to use less frequently.
 

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -580,28 +580,6 @@ class MessagePump(metaclass=MessagePumpMeta):
     async def on_callback(self, event: events.Callback) -> None:
         await invoke(event.callback)
 
-    def emit_no_wait(self, message: Message) -> bool:
-        """Send a message to self, non-async version.
-
-        Args:
-            message: A message object.
-
-        Returns:
-            True if the message was posted successfully.
-        """
-        return self.post_message_no_wait(message)
-
-    async def emit(self, message: Message) -> bool:
-        """Send a message to self.
-
-        Args:
-            message: A message object.
-
-        Returns:
-            True if the message was posted successfully.
-        """
-        return await self.post_message(message)
-
     # TODO: Does dispatch_key belong on message pump?
     async def dispatch_key(self, event: events.Key) -> bool:
         """Dispatch a key event to method.

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -581,7 +581,7 @@ class MessagePump(metaclass=MessagePumpMeta):
         await invoke(event.callback)
 
     def emit_no_wait(self, message: Message) -> bool:
-        """Send a message to the _parent_, non async version.
+        """Send a message to self, non-async version.
 
         Args:
             message: A message object.
@@ -589,13 +589,10 @@ class MessagePump(metaclass=MessagePumpMeta):
         Returns:
             True if the message was posted successfully.
         """
-        if self._parent:
-            return self._parent._post_message_from_child_no_wait(message)
-        else:
-            return False
+        return self.post_message_no_wait(message)
 
     async def emit(self, message: Message) -> bool:
-        """Send a message to the _parent_.
+        """Send a message to self.
 
         Args:
             message: A message object.
@@ -603,10 +600,7 @@ class MessagePump(metaclass=MessagePumpMeta):
         Returns:
             True if the message was posted successfully.
         """
-        if self._parent:
-            return await self._parent._post_message_from_child(message)
-        else:
-            return False
+        return await self.post_message(message)
 
     # TODO: Does dispatch_key belong on message pump?
     async def dispatch_key(self, event: events.Key) -> bool:

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -280,10 +280,12 @@ class ScrollBar(Widget):
         self.mouse_over = False
 
     async def action_scroll_down(self) -> None:
-        await self.emit(ScrollDown(self) if self.vertical else ScrollRight(self))
+        await self.post_message(
+            ScrollDown(self) if self.vertical else ScrollRight(self)
+        )
 
     async def action_scroll_up(self) -> None:
-        await self.emit(ScrollUp(self) if self.vertical else ScrollLeft(self))
+        await self.post_message(ScrollUp(self) if self.vertical else ScrollLeft(self))
 
     def action_grab(self) -> None:
         self.capture_mouse()
@@ -324,7 +326,7 @@ class ScrollBar(Widget):
                         * (self.window_virtual_size / self.window_size)
                     )
                 )
-            await self.emit(ScrollTo(self, x=x, y=y))
+            await self.post_message(ScrollTo(self, x=x, y=y))
         event.stop()
 
     async def _on_click(self, event: events.Click) -> None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2465,12 +2465,12 @@ class Widget(DOMNode):
     def _on_focus(self, event: events.Focus) -> None:
         self.has_focus = True
         self.refresh()
-        self.emit_no_wait(events.DescendantFocus(self))
+        self.post_message_no_wait(events.DescendantFocus(self))
 
     def _on_blur(self, event: events.Blur) -> None:
         self.has_focus = False
         self.refresh()
-        self.emit_no_wait(events.DescendantBlur(self))
+        self.post_message_no_wait(events.DescendantBlur(self))
 
     def _on_descendant_blur(self, event: events.DescendantBlur) -> None:
         if self._has_focus_within:

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -255,7 +255,7 @@ class Button(Static, can_focus=True):
         # Manage the "active" effect:
         self._start_active_affect()
         # ...and let other components know that we've just been clicked:
-        self.emit_no_wait(Button.Pressed(self))
+        self.post_message_no_wait(Button.Pressed(self))
 
     def _start_active_affect(self) -> None:
         """Start a small animation to show the button was clicked."""
@@ -267,7 +267,7 @@ class Button(Static, can_focus=True):
     async def _on_key(self, event: events.Key) -> None:
         if event.key == "enter" and not self.disabled:
             self._start_active_affect()
-            await self.emit(Button.Pressed(self))
+            await self.post_message(Button.Pressed(self))
 
     @classmethod
     def success(

--- a/src/textual/widgets/_checkbox.py
+++ b/src/textual/widgets/_checkbox.py
@@ -77,7 +77,7 @@ class Checkbox(Widget, can_focus=True):
     """The position of the slider."""
 
     class Changed(Message, bubble=True):
-        """Emitted when the status of the checkbox changes.
+        """Posted when the status of the checkbox changes.
 
         Can be handled using `on_checkbox_changed` in a subclass of `Checkbox`
         or in a parent widget in the DOM.
@@ -122,7 +122,7 @@ class Checkbox(Widget, can_focus=True):
             self.animate("slider_pos", target_slider_pos, duration=0.3)
         else:
             self.slider_pos = target_slider_pos
-        self.emit_no_wait(self.Changed(self, self.value))
+        self.post_message_no_wait(self.Changed(self, self.value))
 
     def watch_slider_pos(self, slider_pos: float) -> None:
         self.set_class(slider_pos == 1, "-on")
@@ -151,5 +151,5 @@ class Checkbox(Widget, can_focus=True):
 
     def toggle(self) -> None:
         """Toggle the checkbox value. As a result of the value changing,
-        a Checkbox.Changed message will be emitted."""
+        a Checkbox.Changed message will be posted."""
         self.value = not self.value

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -67,7 +67,7 @@ class DirectoryTree(Tree[DirEntry]):
     """
 
     class FileSelected(Message, bubble=True):
-        """Emitted when a file is selected.
+        """Posted when a file is selected.
 
         Can be handled using `on_directory_tree_file_selected` in a subclass of
         `DirectoryTree` or in a parent widget in the DOM.
@@ -173,7 +173,7 @@ class DirectoryTree(Tree[DirEntry]):
             if not dir_entry.loaded:
                 self.load_directory(event.node)
         else:
-            self.emit_no_wait(self.FileSelected(self, dir_entry.path))
+            self.post_message_no_wait(self.FileSelected(self, dir_entry.path))
 
     def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         event.stop()
@@ -181,4 +181,4 @@ class DirectoryTree(Tree[DirEntry]):
         if dir_entry is None:
             return
         if not dir_entry.is_dir:
-            self.emit_no_wait(self.FileSelected(self, dir_entry.path))
+            self.post_message_no_wait(self.FileSelected(self, dir_entry.path))

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -139,7 +139,7 @@ class Input(Widget, can_focus=True):
     max_size: reactive[int | None] = reactive(None)
 
     class Changed(Message, bubble=True):
-        """Emitted when the value changes.
+        """Posted when the value changes.
 
         Can be handled using `on_input_changed` in a subclass of `Input` or in a parent
         widget in the DOM.
@@ -155,7 +155,7 @@ class Input(Widget, can_focus=True):
             self.input: Input = sender
 
     class Submitted(Message, bubble=True):
-        """Emitted when the enter key is pressed within an `Input`.
+        """Posted when the enter key is pressed within an `Input`.
 
         Can be handled using `on_input_submitted` in a subclass of `Input` or in a
         parent widget in the DOM.
@@ -244,7 +244,7 @@ class Input(Widget, can_focus=True):
     async def watch_value(self, value: str) -> None:
         if self.styles.auto_dimensions:
             self.refresh(layout=True)
-        await self.emit(self.Changed(self, value))
+        await self.post_message(self.Changed(self, value))
 
     @property
     def cursor_width(self) -> int:
@@ -479,4 +479,4 @@ class Input(Widget, can_focus=True):
             self.cursor_position = 0
 
     async def action_submit(self) -> None:
-        await self.emit(self.Submitted(self, self.value))
+        await self.post_message(self.Submitted(self, self.value))

--- a/src/textual/widgets/_list_item.py
+++ b/src/textual/widgets/_list_item.py
@@ -34,7 +34,7 @@ class ListItem(Widget, can_focus=False):
         pass
 
     def on_click(self, event: events.Click) -> None:
-        self.emit_no_wait(self._ChildClicked(self))
+        self.post_message_no_wait(self._ChildClicked(self))
 
     def watch_highlighted(self, value: bool) -> None:
         self.set_class(value, "--highlight")

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -35,7 +35,7 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
     index = reactive(0, always_update=True)
 
     class Highlighted(Message, bubble=True):
-        """Emitted when the highlighted item changes.
+        """Posted when the highlighted item changes.
 
         Highlighted item is controlled using up/down keys.
         Can be handled using `on_list_view_highlighted` in a subclass of `ListView`
@@ -50,7 +50,7 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
             self.item: ListItem | None = item
 
     class Selected(Message, bubble=True):
-        """Emitted when a list item is selected, e.g. when you press the enter key on it.
+        """Posted when a list item is selected, e.g. when you press the enter key on it.
 
         Can be handled using `on_list_view_selected` in a subclass of `ListView` or in
         a parent widget in the DOM.
@@ -125,7 +125,7 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
             new_child = None
 
         self._scroll_highlighted_region()
-        self.emit_no_wait(self.Highlighted(self, new_child))
+        self.post_message_no_wait(self.Highlighted(self, new_child))
 
     def append(self, item: ListItem) -> AwaitMount:
         """Append a new ListItem to the end of the ListView.
@@ -155,7 +155,7 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
 
     def action_select_cursor(self) -> None:
         selected_child = self.highlighted_child
-        self.emit_no_wait(self.Selected(self, selected_child))
+        self.post_message_no_wait(self.Selected(self, selected_child))
 
     def action_cursor_down(self) -> None:
         self.index += 1
@@ -166,7 +166,7 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
     def on_list_item__child_clicked(self, event: ListItem._ChildClicked) -> None:
         self.focus()
         self.index = self.children.index(event.sender)
-        self.emit_no_wait(self.Selected(self, event.sender))
+        self.post_message_no_wait(self.Selected(self, event.sender))
 
     def _scroll_highlighted_region(self) -> None:
         """Used to keep the highlighted index within vision"""


### PR DESCRIPTION
The point of this PR is that it makes it simpler to subclass widgets because you can capture messages that would be sent by the parent and repurpose them.

E.g., in the app below, the subclass of `Input` no longer emits `Input.Submitted` events, but rather `MyInput.MyMessage` events.

<details>
<summary>Code</summary>

```py
from textual.app import App, ComposeResult
from textual.message import Message
from textual.widgets import Input, TextLog


class MyInput(Input):
    class MyMessage(Message):
        pass

    def on_input_submitted(self, event: Input.Submitted):
        event.stop()
        self.emit_no_wait(self.MyMessage(self))


class MyApp(App[None]):
    def compose(self) -> ComposeResult:
        yield MyInput()
        yield TextLog()

    def on_input_submitted(self) -> None:
        self.query_one(TextLog).write("input")

    def on_my_input_my_message(self) -> None:
        self.query_one(TextLog).write("mymessage")


app = MyApp()


if __name__ == "__main__":
    app.run()
```

</details>