### PR TITLE
Revert retrofitting of example code in an old blog post

### DIFF
--- a/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
+++ b/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
@@ -288,7 +288,7 @@ So, thanks to this bit of code in my `Activity` widget...
             parent.move_child(
                 self, before=parent.children.index( self ) - 1
             )
-            self.post_message_no_wait( self.Moved( self ) )
+            self.emit_no_wait( self.Moved( self ) )
             self.scroll_visible( top=True )
 ```
 


### PR DESCRIPTION
Makes sense to update all the docs to reflect the work done in #1738 but I feel it doesn't quite make sense to retrofit this into an old blog post -- especially if the code it is referring to was like that at the time and likely still will be for a wee while after this gets republished.