### PR TITLE
Remove the import/export of TreeNode from the widgets pyi file

### DIFF
--- a/src/textual/widgets/__init__.pyi
+++ b/src/textual/widgets/__init__.pyi
@@ -14,5 +14,4 @@ from ._static import Static as Static
 from ._input import Input as Input
 from ._text_log import TextLog as TextLog
 from ._tree import Tree as Tree
-from ._tree_node import TreeNode as TreeNode
 from ._welcome import Welcome as Welcome


### PR DESCRIPTION
We've moved `TreeNode` out of the general widgets import, requiring the user to import from widgets.tree. When I made that change I missed this.