### PR TITLE
Add setup and update targets to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,11 @@ build: docs-build-offline
 
 .PHONY: clean
 clean: clean-screenshot-cache clean-offline-docs
+
+.PHONY: setup
+setup:
+	poetry install --extras dev
+
+.PHONY: update
+update:
+	poetry update


### PR DESCRIPTION
Simply adds `make setup` as a shorthand for running the poetry command that does the initial install for local development, and also `make update` to do a package update. Simply aimed as handy extras for development.
