### PR TITLE
feat(keys): add space alias to displays

### DIFF
--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -229,6 +229,7 @@ KEY_DISPLAY_ALIASES = {
     "escape": "ESC",
     "enter": "⏎",
     "minus": "-",
+    "space": "SPACE",
 }
 
 


### PR DESCRIPTION
Display `SPACE` rather than ambiguous 'empty' value ` ` in the app when referring  to the space key (e.g. in the Footer widget).