### PR TITLE
Markdown accept path

### DIFF
--- a/examples/markdown.py
+++ b/examples/markdown.py
@@ -12,7 +12,7 @@ class MarkdownApp(App):
         ("f", "forward", "Forward"),
     ]
 
-    path = var(str(Path(__file__).parent / "demo.md"))
+    path = var(Path(__file__).parent / "demo.md")
 
     @property
     def markdown_viewer(self) -> MarkdownViewer:

--- a/examples/markdown.py
+++ b/examples/markdown.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from textual.app import App, ComposeResult
 from textual.reactive import var
 from textual.widgets import Footer, MarkdownViewer
@@ -10,7 +12,7 @@ class MarkdownApp(App):
         ("f", "forward", "Forward"),
     ]
 
-    path = var("demo.md")
+    path = var(str(Path(__file__).parent / "demo.md"))
 
     @property
     def markdown_viewer(self) -> MarkdownViewer:

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Iterable
 
 from markdown_it import MarkdownIt
@@ -37,7 +37,7 @@ class Navigator:
             return Path(".")
         return self.stack[self.index]
 
-    def go(self, path: str) -> Path:
+    def go(self, path: str | PurePath) -> Path:
         """Go to a new document.
 
         Args:
@@ -749,7 +749,7 @@ class MarkdownViewer(Vertical, can_focus=True, can_focus_children=True):
         if self._markdown is not None:
             await self.document.update(self._markdown)
 
-    async def go(self, location: str) -> bool:
+    async def go(self, location: str | PurePath) -> bool:
         """Navigate to a new document path."""
         return await self.document.load(self.navigator.go(location))
 


### PR DESCRIPTION
As a follow-on, or possibly alternative, to #1795 -- this lets folk use a `Path` or a `str` when asking the markdown viewer to navigate somewhere.