### PR TITLE
DataTable - bug fix - Ensuring new caches cleared, location mapping reset when clear called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - DataTable scrollbars resize correctly when header is toggled https://github.com/Textualize/textual/pull/1803
+- DataTable location mapping cleared when clear called https://github.com/Textualize/textual/pull/1809
 
 ## [0.11.0] - 2023-02-15
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -755,6 +755,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._cell_render_cache.clear()
         self._line_cache.clear()
         self._styles_cache.clear()
+        self._offset_cache.clear()
+        self._ordered_row_cache.clear()
 
     def get_row_height(self, row_key: RowKey) -> int:
         """Given a row key, return the height of that row in terminal cells.
@@ -1018,8 +1020,10 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._y_offsets.clear()
         self._data.clear()
         self.rows.clear()
+        self._row_locations = TwoWayDict({})
         if columns:
             self.columns.clear()
+            self._column_locations = TwoWayDict({})
         self._require_update_dimensions = True
         self.cursor_coordinate = Coordinate(0, 0)
         self.hover_coordinate = Coordinate(0, 0)


### PR DESCRIPTION
I added two additional caches and forgot to clear them inside `_clear_caches()`. Additionally, when `clear()` was called, the mapping of row and column locations were not being cleared. This PR fixes both of these.