### PR TITLE
Add a couple of extra type hints to reactives

### DIFF
--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -150,7 +150,7 @@ class Button(Static, can_focus=True):
     ACTIVE_EFFECT_DURATION = 0.3
     """When buttons are clicked they get the `-active` class for this duration (in seconds)"""
 
-    label: reactive[RenderableType] = reactive("")
+    label: reactive[RenderableType] = reactive[RenderableType]("")
     """The text label that appears within the button."""
 
     variant = reactive("default")

--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -71,7 +71,7 @@ class Placeholder(Widget):
     _COLORS = cycle(_PLACEHOLDER_BACKGROUND_COLORS)
     _SIZE_RENDER_TEMPLATE = "[b]{} x {}[/b]"
 
-    variant: Reactive[PlaceholderVariant] = reactive("default")
+    variant: Reactive[PlaceholderVariant] = reactive[PlaceholderVariant]("default")
 
     _renderables: dict[PlaceholderVariant, RenderResult]
 


### PR DESCRIPTION
Help reduce the warnings in IDEs and the like, especially when pylance/right is in use.
