### PR TITLE
Reactive get

### DIFF
--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -143,23 +143,25 @@ class Reactive(Generic[ReactiveType]):
         self.name = name
         # The internal name where the attribute's value is stored
         self.internal_name = f"_reactive_{name}"
+        self.compute_name = f"compute_{name}"
         default = self._default
         setattr(owner, f"_default_{name}", default)
 
     def __get__(self, obj: Reactable, obj_type: type[object]) -> ReactiveType:
-        _rich_traceback_omit = True
-
-        self._initialize_reactive(obj, self.name)
+        internal_name = self.internal_name
+        if not hasattr(obj, internal_name):
+            self._initialize_reactive(obj, self.name)
 
         value: ReactiveType
-        compute_method = getattr(self, f"compute_{self.name}", None)
+        compute_method = getattr(obj, self.compute_name, None)
         if compute_method is not None:
-            old_value = getattr(obj, self.internal_name)
-            value = getattr(obj, f"compute_{self.name}")()
-            setattr(obj, self.internal_name, value)
+            old_value = getattr(obj, internal_name)
+            _rich_traceback_omit = True
+            value = compute_method()
+            setattr(obj, internal_name, value)
             self._check_watchers(obj, self.name, old_value)
         else:
-            value = getattr(obj, self.internal_name)
+            value = getattr(obj, internal_name)
         return value
 
     def __set__(self, obj: Reactable, value: ReactiveType) -> None:

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -160,9 +160,9 @@ class Reactive(Generic[ReactiveType]):
             value = compute_method()
             setattr(obj, internal_name, value)
             self._check_watchers(obj, self.name, old_value)
+            return value
         else:
-            value = getattr(obj, internal_name)
-        return value
+            return getattr(obj, internal_name)
 
     def __set__(self, obj: Reactable, value: ReactiveType) -> None:
         _rich_traceback_omit = True

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -152,12 +152,11 @@ class Reactive(Generic[ReactiveType]):
         if not hasattr(obj, internal_name):
             self._initialize_reactive(obj, self.name)
 
-        value: ReactiveType
-        compute_method = getattr(obj, self.compute_name, None)
-        if compute_method is not None:
+        if hasattr(obj, self.compute_name):
+            value: ReactiveType
             old_value = getattr(obj, internal_name)
             _rich_traceback_omit = True
-            value = compute_method()
+            value = getattr(obj, self.compute_name)()
             setattr(obj, internal_name, value)
             self._check_watchers(obj, self.name, old_value)
             return value

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -328,6 +328,27 @@ async def test_reactive_inheritance():
     assert tertiary.baz == "baz"
 
 
+async def test_compute():
+    """Check compute method is called."""
+
+    class ComputeApp(App):
+        count = var(0)
+        count_double = var(0)
+
+        def compute_count_double(self) -> int:
+            return self.count * 2
+
+    app = ComputeApp()
+
+    async with app.run_test():
+        assert app.count_double == 0
+        app.count = 1
+        assert app.count_double == 2
+        assert app.count_double == 2
+        app.count = 2
+        assert app.count_double == 4
+
+
 async def test_watch_compute():
     """Check that watching a computed attribute works."""
 
@@ -347,7 +368,9 @@ async def test_watch_compute():
 
     app = Calculator()
 
-    async with app.run_test() as pilot:
+    # Referencing the value calls compute
+    # Setting any reactive values calls compute
+    async with app.run_test():
         assert app.show_ac is True
         app.value = "1"
         assert app.show_ac is False
@@ -356,4 +379,4 @@ async def test_watch_compute():
         app.numbers = "123"
         assert app.show_ac is False
 
-    assert watch_called == [True, False, True, False]
+    assert watch_called == [True, True, False, False, True, True, False, False]

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -335,8 +335,12 @@ async def test_compute():
         count = var(0)
         count_double = var(0)
 
+        def __init__(self) -> None:
+            self.start = 0
+            super().__init__()
+
         def compute_count_double(self) -> int:
-            return self.count * 2
+            return self.start + self.count * 2
 
     app = ComputeApp()
 
@@ -347,6 +351,8 @@ async def test_compute():
         assert app.count_double == 2
         app.count = 2
         assert app.count_double == 4
+        app.start = 10
+        assert app.count_double == 14
 
 
 async def test_watch_compute():


### PR DESCRIPTION
- Fix that compute methods weren't being called on demand.
- Micro-optimizations on the descriptor getter. These are called a attribute access, so any savings add up.