### PR TITLE
Update _list_view.py

### DIFF
--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -158,7 +158,7 @@ class ListView(Vertical, can_focus=True, can_focus_children=False):
                 the DOM has been updated to reflect all children being removed.
         """
         await_remove = self.query("ListView > ListItem").remove()
-        self.index = None
+        self.index = 0
         return await_remove
 
     def action_select_cursor(self) -> None:


### PR DESCRIPTION
To solve the NoneType error after clearing a ListView.

I'm working with an app where I add widgets to a ListView. Clear the ListView. Add new Widgets to a ListView. Clear the ListView. Over and over.

When changing the contents of a ListView container. `clear()` is called. This method originally set the `self.index = None`. After, new items are appended using the `append()` method, the index is still set to `None`.

Naturally to interact with the new list you use the arrow keys on your keyboard. 

When you press the down-arrow to highlight the first item, the app closes and an error is returned:
```
Traceback (most recent call last)
/home/anthony/textualize/lib/python3.8/site-packages/textual/widgets/_list_view.py:125 in action_cursor_down                             
122    self.emit_no_wait(self.Selected(self, selected_child))
123
124     def action_cursor_down(self) -> None: 
125       self.index += 1     #<------- This is trying to add int(1) to None
126
127    def action_cursor_up(self) -> None:
128      self.index -= 1

self = ListView(id='saved_output_list', pseudo_classes={'focus-within', 'focus'})
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'
```

Solution: In the `clear()` method set the `self.index = 0` so when items are appended and you attempt to navigate them, the index can appropriately be computed.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
