### PR TITLE
don't scroll to docked widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Removed `screen.visible_widgets` and `screen.widgets`
 
-
 ### Fixed
 
 - Numbers in a descendant-combined selector no longer cause an error https://github.com/Textualize/textual/issues/1836
-
+- Fixed superfluous scrolling when focusing a docked widget https://github.com/Textualize/textual/issues/1816
 
 ## [0.11.1] - 2023-02-17
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -40,8 +40,8 @@ from . import errors, events, messages
 from ._animator import DEFAULT_EASING, Animatable, BoundAnimator, EasingFunction
 from ._arrange import DockArrangeResult, arrange
 from ._asyncio import create_task
-from ._compose import compose
 from ._cache import FIFOCache
+from ._compose import compose
 from ._context import active_app
 from ._easing import DEFAULT_SCROLL_EASING
 from ._layout import Layout
@@ -1891,18 +1891,22 @@ class Widget(DOMNode):
 
         while isinstance(widget.parent, Widget) and widget is not self:
             container = widget.parent
-            scroll_offset = container.scroll_to_region(
-                region,
-                spacing=widget.parent.gutter,
-                animate=animate,
-                speed=speed,
-                duration=duration,
-                top=top,
-                easing=easing,
-                force=force,
-            )
-            if scroll_offset:
-                scrolled = True
+
+            if widget.styles.dock:
+                scroll_offset = Offset(0, 0)
+            else:
+                scroll_offset = container.scroll_to_region(
+                    region,
+                    spacing=widget.parent.gutter,
+                    animate=animate,
+                    speed=speed,
+                    duration=duration,
+                    top=top,
+                    easing=easing,
+                    force=force,
+                )
+                if scroll_offset:
+                    scrolled = True
 
             # Adjust the region by the amount we just scrolled it, and convert to
             # it's parent's virtual coordinate system.


### PR DESCRIPTION
Fixed an issue with the Markdown example. When you focused the tree it scrolled the screen (and the markdown it contained). The problem was the docked things can't be scrolled in to view, since they are fixed.

Fixes https://github.com/Textualize/textual/issues/1816