### PR TITLE
Fix text log refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `App.batch_update` https://github.com/Textualize/textual/pull/1832
 - Added horizontal rule to Markdown https://github.com/Textualize/textual/pull/1832
 - Added `Widget.disabled` https://github.com/Textualize/textual/pull/1785
+- Added `DOMNode.notify_style_update` to replace `messages.StylesUpdated` message
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Removed `screen.visible_widgets` and `screen.widgets`
+- Removed `StylesUpdate` message.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `App.batch_update` https://github.com/Textualize/textual/pull/1832
 - Added horizontal rule to Markdown https://github.com/Textualize/textual/pull/1832
 - Added `Widget.disabled` https://github.com/Textualize/textual/pull/1785
-- Added `DOMNode.notify_style_update` to replace `messages.StylesUpdated` message
+- Added `DOMNode.notify_style_update` to replace `messages.StylesUpdated` message https://github.com/Textualize/textual/pull/1861
 
 ### Changed
 
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Removed `screen.visible_widgets` and `screen.widgets`
-- Removed `StylesUpdate` message.
+- Removed `StylesUpdate` message. https://github.com/Textualize/textual/pull/1861
 
 ### Fixed
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -500,7 +500,7 @@ class Stylesheet:
             for key in modified_rule_keys:
                 setattr(base_styles, key, get_rule(key))
 
-        node.post_message_no_wait(messages.StylesUpdated(sender=node))
+        node.notify_style_update()
 
     def update(self, root: DOMNode, animate: bool = False) -> None:
         """Update styles on node and its children.

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -223,6 +223,9 @@ class DOMNode(MessagePump):
         """Called after the object has been mounted."""
         Reactive._initialize_object(self)
 
+    def notify_style_update(self) -> None:
+        """Called after styles are updated."""
+
     @property
     def _node_bases(self) -> Sequence[Type[DOMNode]]:
         """The DOMNode bases classes (including self.__class__)"""

--- a/src/textual/messages.py
+++ b/src/textual/messages.py
@@ -80,15 +80,6 @@ class ScrollToRegion(Message, bubble=False):
         super().__init__(sender)
 
 
-@rich.repr.auto
-class StylesUpdated(Message, verbose=True):
-    def __init__(self, sender: MessagePump) -> None:
-        super().__init__(sender)
-
-    def can_replace(self, message: Message) -> bool:
-        return isinstance(message, StylesUpdated)
-
-
 class Prompt(Message, no_dispatch=True):
     """Used to 'wake up' an event loop."""
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2503,7 +2503,7 @@ class Widget(DOMNode):
     async def broker_event(self, event_name: str, event: events.Event) -> bool:
         return await self.app._broker_event(event_name, event, default_namespace=self)
 
-    def _on_styles_updated(self) -> None:
+    def notify_style_update(self) -> None:
         self._rich_style_cache.clear()
 
     async def _on_mouse_down(self, event: events.MouseDown) -> None:

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -132,7 +132,6 @@ class Footer(Widget):
 
     def notify_style_update(self) -> None:
         self._key_text = None
-        self.refresh()
 
     def post_render(self, renderable):
         return renderable

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -130,7 +130,7 @@ class Footer(Widget):
             text.append_text(key_text)
         return text
 
-    def _on_styles_updated(self) -> None:
+    def notify_style_update(self) -> None:
         self._key_text = None
         self.refresh()
 

--- a/src/textual/widgets/_text_log.py
+++ b/src/textual/widgets/_text_log.py
@@ -58,8 +58,9 @@ class TextLog(ScrollView, can_focus=True):
         self.markup = markup
         self.highlighter = ReprHighlighter()
 
-    def _on_styles_updated(self) -> None:
+    def notify_style_update(self) -> None:
         self._line_cache.clear()
+        self.refresh()
 
     def write(
         self,

--- a/src/textual/widgets/_text_log.py
+++ b/src/textual/widgets/_text_log.py
@@ -60,7 +60,6 @@ class TextLog(ScrollView, can_focus=True):
 
     def notify_style_update(self) -> None:
         self._line_cache.clear()
-        self.refresh()
 
     def write(
         self,

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -993,7 +993,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
                 self.cursor_line = cursor_line
                 await self.action("select_cursor")
 
-    def _on_styles_updated(self) -> None:
+    def notify_style_update(self) -> None:
         self._invalidate()
 
     def action_cursor_up(self) -> None:


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1859

Replaces StylesUpdated message with a callback  `notify_styles_updated`. The issue with the message is that the callback can occur a moment after the styles are updated, so there is a lag behind the styles taking effect, which creates a little flicker.