### PR TITLE
Correct the wording of the description of `Switch.value`

### DIFF
--- a/docs/widgets/switch.md
+++ b/docs/widgets/switch.md
@@ -28,9 +28,9 @@ The example below shows switches in various states.
 
 ## Reactive Attributes
 
-| Name    | Type   | Default | Description                      |
-|---------|--------|---------|----------------------------------|
-| `value` | `bool` | `False` | The default value of the switch. |
+| Name    | Type   | Default | Description              |
+|---------|--------|---------|--------------------------|
+| `value` | `bool` | `False` | The value of the switch. |
 
 ## Bindings
 


### PR DESCRIPTION
It's not just the default value, it's the ongoing value too and can be used to change the switch.
