### PR TITLE
Increase the coverage of API documentation

### DIFF
--- a/docs/api/await_remove.md
+++ b/docs/api/await_remove.md
@@ -1,0 +1,1 @@
+::: textual.await_remove

--- a/docs/api/binding.md
+++ b/docs/api/binding.md
@@ -1,1 +1,1 @@
-::: textual.binding.Binding
+::: textual.binding

--- a/docs/api/coordinate.md
+++ b/docs/api/coordinate.md
@@ -1,1 +1,1 @@
-::: textual.coordinate.Coordinate
+::: textual.coordinate

--- a/docs/api/dom_node.md
+++ b/docs/api/dom_node.md
@@ -1,1 +1,1 @@
-::: textual.dom.DOMNode
+::: textual.dom

--- a/docs/api/message.md
+++ b/docs/api/message.md
@@ -1,1 +1,1 @@
-::: textual.message.Message
+::: textual.message

--- a/docs/api/message_pump.md
+++ b/docs/api/message_pump.md
@@ -2,4 +2,4 @@ A message pump is a class that processes messages.
 
 It is a base class for the `App`, `Screen`, and `Widget` classes.
 
-::: textual.message_pump.MessagePump
+::: textual.message_pump

--- a/docs/api/scroll_view.md
+++ b/docs/api/scroll_view.md
@@ -1,1 +1,1 @@
-::: textual.scroll_view.ScrollView
+::: textual.scroll_view

--- a/docs/api/strip.md
+++ b/docs/api/strip.md
@@ -1,1 +1,1 @@
-::: textual.strip.Strip
+::: textual.strip

--- a/docs/api/widget.md
+++ b/docs/api/widget.md
@@ -1,1 +1,1 @@
-::: textual.widget.Widget
+::: textual.widget

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -142,6 +142,7 @@ nav:
       - "widgets/tree.md"
   - API:
     - "api/app.md"
+    - "api/await_remove.md"
     - "api/binding.md"
     - "api/button.md"
     - "api/checkbox.md"

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -5,7 +5,11 @@ from typing import Generator
 
 
 class AwaitRemove:
-    """An awaitable returned by App.remove and DOMQuery.remove."""
+    """An awaitable returned by a method that removes DOM nodes.
+
+    Returned by [Widget.remove][textual.widget.Widget.remove] and
+    [DOMQuery.remove][textual.css.query.DOMQuery.remove].
+    """
 
     def __init__(self, finished_flag: Event, task: Task) -> None:
         """Initialise the instance of ``AwaitRemove``.


### PR DESCRIPTION
See #1364 -- rather than pull in specific classes, this pulls in every publicly-documented item (function, class, type, "constant", etc) that can be found in each of the modules.