### PR TITLE
Simplify Bindings.shown_keys docstring

### DIFF
--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -118,11 +118,7 @@ class Bindings:
 
     @property
     def shown_keys(self) -> list[Binding]:
-        """A list of bindings for shown keys.
-
-        Returns:
-            Shown bindings.
-        """
+        """A list of bindings for shown keys."""
         keys = [binding for binding in self.keys.values() if binding.show]
         return keys
 


### PR DESCRIPTION
In the public interface it's a property, not a method, so it doesn't need a 'Returns'.