### PR TITLE
A warning from the future

### DIFF
--- a/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
+++ b/docs/blog/posts/on-dog-food-the-original-metaverse-and-not-being-bored.md
@@ -300,6 +300,12 @@ So, thanks to this bit of code in my `Activity` widget...
         self.save_activity_list()
 ```
 
+!!! warning
+
+    The code above used `emit_no_wait`. Since this blog post was first
+    published that method has been removed from Textual. You should use
+    [`post_message_no_wait` or `post_message`](/guide/events/#sending-messages) instead now.
+
 ### Pain points
 
 On top of the issues of getting to know terminal-based-CSS that I mentioned


### PR DESCRIPTION
Add a warning to my first blog post, letting the attentive reader know that `emit_no_wait` doesn't exist any more, and linking them to what they should be using if they want to do their own custom messages.
