### PR TITLE
Add a Makefile target for installing pre-commit hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,7 @@ setup:
 .PHONY: update
 update:
 	poetry update
+
+.PHONY: install-pre-commit
+install-pre-commit:
+	$(run) pre-commit install


### PR DESCRIPTION
Any time I cause my venv to be rebuilt, I need to remember to do this, and I always have to search my shell history to remind myself what the command is. That feels like it deserves to go into the Makefile.
