### PR TITLE
Interlink the docs with the Python and Rich manuals

### DIFF
--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -67,6 +67,9 @@ plugins:
     default_handler: python
     handlers:
       python:
+        import:
+          - https://docs.python.org/3/objects.inv
+          - https://rich.readthedocs.io/en/stable/objects.inv
         options:
           show_root_heading: true
           show_root_full_path: false


### PR DESCRIPTION
All through our docs there are mentions of Python types and also Rich types. This change will make the vast majority of mentions of them into actual links that people can follow. So now, for example, when someone sees a method that returns a `Style`, they can click on it and see what a `Style` actually is.
