### PR TITLE
Added typing for watch callbacks

### DIFF
--- a/src/textual/_types.py
+++ b/src/textual/_types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Awaitable, Callable, List, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Union
 
 from rich.segment import Segment
 from typing_extensions import Protocol
@@ -28,3 +28,4 @@ class EventTarget(Protocol):
 
 SegmentLines = List[List["Segment"]]
 CallbackType = Union[Callable[[], Awaitable[None]], Callable[[], None]]
+WatchCallbackType = Union[Callable[[Any], Awaitable[None]], Callable[[Any], None]]

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -23,7 +23,7 @@ from rich.tree import Tree
 
 from ._context import NoActiveAppError
 from ._node_list import NodeList
-from ._types import CallbackType
+from ._types import WatchCallbackType
 from .binding import Binding, Bindings, BindingType
 from .color import BLACK, WHITE, Color
 from .css._error_tools import friendly_list
@@ -661,7 +661,7 @@ class DOMNode(MessagePump):
         self,
         obj: DOMNode,
         attribute_name: str,
-        callback: CallbackType,
+        callback: WatchCallbackType,
         init: bool = True,
     ) -> None:
         """Watches for modifications to reactive attributes on another object.

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -17,7 +17,7 @@ import rich.repr
 
 from . import events
 from ._callback import count_parameters
-from ._types import CallbackType, MessageTarget
+from ._types import MessageTarget, WatchCallbackType
 
 if TYPE_CHECKING:
     from .dom import DOMNode
@@ -333,7 +333,7 @@ def _watch(
     node: DOMNode,
     obj: Reactable,
     attribute_name: str,
-    callback: CallbackType,
+    callback: WatchCallbackType,
     *,
     init: bool = True,
 ) -> None:

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -66,7 +66,7 @@ class Footer(Widget):
         self.refresh()
 
     def on_mount(self) -> None:
-        self.watch(self.screen, "focused", self._focus_changed)  # type: ignore[arg-type]
+        self.watch(self.screen, "focused", self._focus_changed)
 
     def _focus_changed(self, focused: Widget | None) -> None:
         self._key_text = None

--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -166,5 +166,5 @@ class Header(Widget):
         def set_sub_title(sub_title: str) -> None:
             self.query_one(HeaderTitle).sub_text = sub_title
 
-        self.watch(self.app, "title", set_title)  # type: ignore[arg-type]
-        self.watch(self.app, "sub_title", set_sub_title)  # type: ignore[arg-type]
+        self.watch(self.app, "title", set_title)
+        self.watch(self.app, "sub_title", set_sub_title)


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1805

I think we might adopt a policy of requiring a comment explaining why `type: ignore` was necessary.