### PR TITLE
Add an example of using a RadioSet.Changed message

### DIFF
--- a/docs/examples/widgets/radio_set_changed.css
+++ b/docs/examples/widgets/radio_set_changed.css
@@ -1,0 +1,12 @@
+Vertical {
+    align: center middle;
+}
+
+Horizontal {
+    align: center middle;
+    height: auto;
+}
+
+RadioSet {
+    width: 45%;
+}

--- a/docs/examples/widgets/radio_set_changed.py
+++ b/docs/examples/widgets/radio_set_changed.py
@@ -1,0 +1,43 @@
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Label, RadioButton, RadioSet
+
+
+class RadioSetChangedApp(App[None]):
+    CSS_PATH = "radio_set_changed.css"
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            with Horizontal():
+                with RadioSet():
+                    yield RadioButton("Battlestar Galactica")
+                    yield RadioButton("Dune 1984")
+                    yield RadioButton("Dune 2021")
+                    yield RadioButton("Serenity", value=True)
+                    yield RadioButton("Star Trek: The Motion Picture")
+                    yield RadioButton("Star Wars: A New Hope")
+                    yield RadioButton("The Last Starfighter")
+                    yield RadioButton(
+                        "Total Recall :backhand_index_pointing_right: :red_circle:",
+                        id="focus_me",
+                    )
+                    yield RadioButton("Wing Commander")
+            with Horizontal():
+                yield Label(id="pressed")
+            with Horizontal():
+                yield Label(id="index")
+
+    def on_mount(self) -> None:
+        self.query_one("#focus_me", RadioButton).focus()
+
+    def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
+        self.query_one("#pressed", Label).update(
+            f"Pressed button label: {event.pressed.label}"
+        )
+        self.query_one("#index", Label).update(
+            f"Pressed button index: {event.input.pressed_index}"
+        )
+
+
+if __name__ == "__main__":
+    RadioSetChangedApp().run()

--- a/docs/widgets/radioset.md
+++ b/docs/widgets/radioset.md
@@ -31,6 +31,25 @@ The example below shows two radio sets, one built using a collection of
 
 ### ::: textual.widgets.RadioSet.Changed
 
+Here is an example of using the message to react to changes in a `RadioSet`:
+
+=== "Output"
+
+    ```{.textual path="docs/examples/widgets/radio_set_changed.py" press="enter"}
+    ```
+
+=== "radio_set_changed.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/radio_set_changed.py"
+    ```
+
+=== "radio_set_changed.css"
+
+    ```sass
+    --8<-- "docs/examples/widgets/radio_set_changed.css"
+    ```
+
 ## See Also
 
 - [RadioSet](../api/radioset.md) code reference


### PR DESCRIPTION
Unlike a few other widgets, the RadioSet is pretty much all about reacting to the selection result; the question of how you go about it has already come up and while the message is documented, complete with all properties, it can't hurt to have an illustrative example of code that uses it.

Here I add an extra RadioSet example that sits with the message in the reference. This should help the reader better follow how to use it, and also gives something to link to if someone hasn't got that far into the documentation yet but is attempting to use the RadioSet.
