### PR TITLE
Use correct property to access message sender.

### DIFF
--- a/docs/examples/widgets/radio_set_changed.py
+++ b/docs/examples/widgets/radio_set_changed.py
@@ -35,7 +35,7 @@ class RadioSetChangedApp(App[None]):
             f"Pressed button label: {event.pressed.label}"
         )
         self.query_one("#index", Label).update(
-            f"Pressed button index: {event.input.pressed_index}"
+            f"Pressed button index: {event.radio_set.pressed_index}"
         )
 
 


### PR DESCRIPTION
In the aftermath of #1935 and #1940 this fell through the cracks.
