### PR TITLE
Correct the example Python code for the border style

### DIFF
--- a/docs/styles/border.md
+++ b/docs/styles/border.md
@@ -134,10 +134,10 @@ border-left: outer red;
 
 ```python
 # Set a heavy white border
-widget.border = ("heavy", "white")
+widget.styles.border = ("heavy", "white")
 
 # Set a red border on the left
-widget.border_left = ("outer", "red")
+widget.styles.border_left = ("outer", "red")
 ```
 
 ## See also


### PR DESCRIPTION
To the best of my knowledge, and in testing myself, border and border_* are properties of a widget's `styles` property, they're not a property of the widget itself.
