### PR TITLE
Fix for DataTable race-condition crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed bug that prevented app pilot to press some keys https://github.com/Textualize/textual/issues/1815
+- DataTable race condition that caused crash https://github.com/Textualize/textual/pull/1962
 
 ## [0.13.0] - 2023-03-02
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1069,6 +1069,12 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         console = self.app.console
         for row_key in new_rows:
             row_index = self._row_locations.get(row_key)
+
+            # The row could have been removed before on_idle was called, so we
+            # need to be quite defensive here and don't assume that the row exists.
+            if row_index is None:
+                continue
+
             row = self.rows.get(row_key)
 
             if row.label is not None:
@@ -1079,9 +1085,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             self._label_column.content_width = max(
                 self._label_column.content_width, label_content_width
             )
-
-            if row_index is None:
-                continue
 
             for column, renderable in zip(self.ordered_columns, cells_in_row):
                 content_width = measure(console, renderable, 1)


### PR DESCRIPTION
I think this fixes a crash reported https://github.com/Textualize/textual/issues/1955 in the DataTable. I wasn't able to reproduce the issue locally, so will wait to hear back on whether this fixes the issue.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
