### PR TITLE
Add a post-run warning hook to `textual run`

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -108,8 +108,9 @@ Greetings("Well hello", "there").run()
 <a name="why-doesn't-textual-look-good-on-macos"></a>
 ## Why doesn't Textual look good on macOS?
 
-The default macOS `Terminal.app` is getting rather old now, and has problems
-such as being limited to just 256 colors. We recommend installing a newer
+The default macOS `Terminal.app` is getting rather old now; it has problems
+such as being limited to just 256 colors, being slow to draw and not all
+box-drawing characters are fully-supported. We recommend installing a newer
 terminal such as [iTerm2](https://iterm2.com/),
 [Kitty](https://sw.kovidgoyal.net/kitty/) or
 [WezTerm](https://wezfurlong.org/wezterm/).

--- a/FAQ.md
+++ b/FAQ.md
@@ -7,6 +7,7 @@
 - [How can I select and copy text in a Textual app?](#how-can-i-select-and-copy-text-in-a-textual-app)
 - [How do I center a widget in a screen?](#how-do-i-center-a-widget-in-a-screen)
 - [How do I pass arguments to an app?](#how-do-i-pass-arguments-to-an-app)
+- [Why doesn't Textual look good on macOS?](#why-doesn't-textual-look-good-on-macos)
 - [Why doesn't Textual support ANSI themes?](#why-doesn't-textual-support-ansi-themes)
 
 <a name="does-textual-support-images"></a>
@@ -103,6 +104,15 @@ Greetings(to_greet="davep").run()
 # Running with both positional arguments.
 Greetings("Well hello", "there").run()
 ```
+
+<a name="why-doesn't-textual-look-good-on-macos"></a>
+## Why doesn't Textual look good on macOS?
+
+The default macOS `Terminal.app` is getting rather old now, and has problems
+such as being limited to just 256 colors. We recommend installing a newer
+terminal such as [iTerm2](https://iterm2.com/),
+[Kitty](https://sw.kovidgoyal.net/kitty/) or
+[WezTerm](https://wezfurlong.org/wezterm/).
 
 <a name="why-doesn't-textual-support-ansi-themes"></a>
 ## Why doesn't Textual support ANSI themes?

--- a/questions/why-looks-bad-on-macos.question.md
+++ b/questions/why-looks-bad-on-macos.question.md
@@ -1,0 +1,17 @@
+---
+title: "Why doesn't Textual look good on macOS?"
+alt_titles:
+  - "looks bad on macOS"
+  - "dashed lines on macOS"
+  - "broken borders on macOS"
+  - "pale colors on macOS"
+  - "pale colours on macOS"
+  - "mac terminal"
+  - "macOS terminal"
+---
+
+The default macOS `Terminal.app` is getting rather old now, and has problems
+such as being limited to just 256 colors. We recommend installing a newer
+terminal such as [iTerm2](https://iterm2.com/),
+[Kitty](https://sw.kovidgoyal.net/kitty/) or
+[WezTerm](https://wezfurlong.org/wezterm/).

--- a/questions/why-looks-bad-on-macos.question.md
+++ b/questions/why-looks-bad-on-macos.question.md
@@ -10,8 +10,9 @@ alt_titles:
   - "macOS terminal"
 ---
 
-The default macOS `Terminal.app` is getting rather old now, and has problems
-such as being limited to just 256 colors. We recommend installing a newer
+The default macOS `Terminal.app` is getting rather old now; it has problems
+such as being limited to just 256 colors, being slow to draw and not all
+box-drawing characters are fully-supported. We recommend installing a newer
 terminal such as [iTerm2](https://iterm2.com/),
 [Kitty](https://sw.kovidgoyal.net/kitty/) or
 [WezTerm](https://wezfurlong.org/wezterm/).

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -49,6 +49,7 @@ def _post_run_warnings() -> None:
     import platform
 
     from rich.console import Console
+    from rich.panel import Panel
 
     console = Console()
 
@@ -56,14 +57,14 @@ def _post_run_warnings() -> None:
         (
             platform.system() == "Darwin"
             and os.environ.get("TERM_PROGRAM") == "Apple_Terminal",
-            "The default terminal app is limited to 256 colors. We recommend installing a newer terminal "
-            "such as iTerm2, Kitty, or WezTerm.",
+            "The default terminal app on macOS is limited to 256 colors. See our FAQ for more details:\n\n"
+            "https://github.com/Textualize/textual/blob/main/FAQ.md#why-doesn't-textual-look-good-on-macos",
         )
     ]
 
     for concering, concern in warnings:
         if concering:
-            console.print(f"[bold yellow]{concern}[/]")
+            console.print(Panel.fit(f"⚠️ [bold green] {concern}[/]", style="cyan"))
 
 
 @run.command(

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -53,6 +53,9 @@ def _post_run_warnings() -> None:
 
     console = Console()
 
+    # Add any test/warning pair here. The list contains a tuple where the
+    # first item is `True` if a problem situation is detected, and the
+    # second item is a message to show the user on exit from `textual run`.
     warnings = [
         (
             platform.system() == "Darwin"

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -38,6 +38,34 @@ def console(verbose: bool, exclude: list[str]) -> None:
         console.show_cursor(True)
 
 
+def _post_run_warnings() -> None:
+    """Look for and report any issues with the environment.
+
+    This is the right place to add code that looks at the terminal, or other
+    environmental issues, and if a problem is seen it should be printed so
+    the developer can see it easily.
+    """
+    import os
+    import platform
+
+    from rich.console import Console
+
+    console = Console()
+
+    warnings = [
+        (
+            platform.system() == "Darwin"
+            and os.environ.get("TERM_PROGRAM") == "Apple_Terminal",
+            "The default terminal app is limited to 256 colors. We recommend installing a newer terminal "
+            "such as iTerm2, Kitty, or WezTerm.",
+        )
+    ]
+
+    for concering, concern in warnings:
+        if concering:
+            console.print(f"[bold yellow]{concern}[/]")
+
+
 @run.command(
     "run",
     context_settings={
@@ -118,6 +146,8 @@ def run_app(import_name: str, dev: bool, press: str, screenshot: int | None) -> 
         console = Console()
         console.print("[b]The app returned:")
         console.print(Pretty(result))
+
+    _post_run_warnings()
 
 
 @run.command("borders")

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -65,8 +65,8 @@ def _post_run_warnings() -> None:
         )
     ]
 
-    for concering, concern in warnings:
-        if concering:
+    for concerning, concern in warnings:
+        if concerning:
             console.print(Panel.fit(f"⚠️ [bold green] {concern}[/]", style="cyan"))
 
 


### PR DESCRIPTION
Implements #1944 and in doing so adds a place to add more checks and warnings to a list. The idea here being that if a user is using `textual run`, on exit, problematic environments can be tested for and warnings displayed.

Right now the only warning added is for using `terminal.app` under macOS.

This also adds a new entry to the FAQ explaining how `terminal.app` isn't good for Textual.