### PR TITLE
Be more assertive when shutting down

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -985,7 +985,7 @@ class App(Generic[ReturnType], DOMNode):
             )
         finally:
             try:
-                if auto_pilot_task is not None:
+                if auto_pilot_task is not None and not self._exit_renderables:
                     await auto_pilot_task
             finally:
                 await app._shutdown()
@@ -1809,11 +1809,11 @@ class App(Generic[ReturnType], DOMNode):
             if isinstance(screen, Screen) and screen._running:
                 await self._prune_node(screen)
 
-        # Close any remaining nodes
-        # Should be empty by now
+        # Close any remaining nodes. This should be empty by now, unless we couldn't
+        # even compose the app cleanly when starting up.
         remaining_nodes = list(self._registry)
         for child in remaining_nodes:
-            await child._close_messages()
+            await child._close_messages(wait=False)
 
     async def _shutdown(self) -> None:
         self._begin_batch()  # Prevents any layout / repaint while shutting down

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -372,7 +372,7 @@ class MessagePump(metaclass=MessagePumpMeta):
         """Request the message queue to immediately exit."""
         self._message_queue.put_nowait(messages.CloseMessages())
 
-    async def _on_close_messages(self, message: messages.CloseMessages) -> None:
+    async def _on_close_messages(self) -> None:
         await self._close_messages()
 
     async def _close_messages(self, wait: bool = True) -> None:
@@ -408,6 +408,10 @@ class MessagePump(metaclass=MessagePumpMeta):
             self._closed = True
 
     async def _process_messages(self) -> None:
+        # Don't even bother if the app is already shutting down.
+        if self.app._closing or self.app._closed:
+            return
+
         self._running = True
 
         await self._pre_process()


### PR DESCRIPTION
Possibly fixes #1949 

This feels more like a patch and less like a proper fix.
Why?

When running the example app (below) you would eventually try to shutdown the app via `_shutdown`, which would in turn try to close all the message pumps.
Even if you say you do NOT want to wait for the message pumps to process previous messages, we close the message pump for the app screen and then, later on, the code starts running `Screen._process_messages` either way, which will then trigger the composition of the screen, which would raise the second instance of the CSS error.
That is why I added the check

```py
if self.app._closing or self.app._closed: return
```

to the method `MessagePump._process_messages`.

What is funny is that I _cannot_ tell why `Screen._process_messages` is running.
I tried printing the call stack and I get this:

```py
File "myapp.py", line 31, in <module>
    app.run()
File "/Users/rodrigogs/Documents/textualize/textual/src/textual/app.py", line 1044, in run
    event_loop.run_until_complete(run_app())
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 574, in run_until_complete
    self.run_forever()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 541, in run_forever
    self._run_once()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 1786, in _run_once
    handle._run()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
File "/Users/rodrigogs/Documents/textualize/textual/src/textual/message_pump.py", line 420, in _process_messages
    for line in traceback.format_stack():
```

It is just a bunch of `asyncio` calls and our very own `run_app` call...

<details>
<summary>Example app</summary>

```py
from textual.app import App, ComposeResult
from textual.widget import Widget
from textual.widgets import Label


class InputWithLabel(Widget):
    """An input with a label."""

    DEFAULT_CSS = """
    InputWithLabel {
        text-align: right
        width: 1fr;
    }
    """

    def compose(self) -> ComposeResult:
        print("Composing widget")
        yield Label("oi")
        print("Done composing widget")


class CompoundApp(App):
    def compose(self) -> ComposeResult:
        print("Composing custom app")
        yield InputWithLabel()
        print("Custom app composed.")


if __name__ == "__main__":
    app = CompoundApp()
    app.run()
```

</details>