### PR TITLE
docs(compound example): fix typo

### DIFF
--- a/docs/examples/guide/compound/compound01.py
+++ b/docs/examples/guide/compound/compound01.py
@@ -42,7 +42,7 @@ class CompoundApp(App):
     """
 
     def compose(self) -> ComposeResult:
-        yield InputWithLabel("Fist Name")
+        yield InputWithLabel("First Name")
         yield InputWithLabel("Last Name")
         yield InputWithLabel("Email")
 


### PR DESCRIPTION
Spotted a typo in the example on the new Compound widget docs.
