### PR TITLE
Don't watch the generated mkdocs configs

### DIFF
--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -80,8 +80,6 @@ plugins:
             - "!^can_replace$"
     watch:
       - mkdocs-common.yml
-      - mkdocs-nav-offline.yml
-      - mkdocs-nav-online.yml
       - mkdocs-offline.yml
       - mkdocs-online.yml
       - src/textual


### PR DESCRIPTION
I got a bit carried away with what to watch, and it looks like the mkdocs watch plugin doesn't much care for watching for files that don't exist but may.

@willmcgugan This should correct the error you were seeing when deploying.