### PR TITLE
prevent double errors

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1460,7 +1460,6 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             error: An exception instance.
         """
-
         if hasattr(error, "__rich__"):
             # Exception has a rich method, so we can defer to that for the rendering
             self.panic(error)

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -146,7 +146,12 @@ class Stylesheet:
             List of rules sets for this stylesheet.
         """
         if self._require_parse:
-            self.parse()
+            try:
+                self.parse()
+            except Exception:
+                self._require_parse = False
+                self._rules = []
+                raise
             self._require_parse = False
         assert self._rules is not None
         return self._rules


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1949

Here's what I think was happening:

When screen is composed, it registers children and starts their message pumps. Each of which will get a compose message.

When an app is composed it will parse the CSS (all of the CSS) and trigger the error. This is because parsing the CSS is a lazy operation, done on demand.

The solution is for the parser to store the fact that parsing failed, and not attempt to reparse it (because it can only fail again).