### PR TITLE
prevent stuck scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed bug that prevented pilot from pressing some keys https://github.com/Textualize/textual/issues/1815
 - DataTable race condition that caused crash https://github.com/Textualize/textual/pull/1962
-- Fixed scrollbar getting "stuck" to cursor when cursor leaves window during drag https://github.com/Textualize/textual/pull/1968
+- Fixed scrollbar getting "stuck" to cursor when cursor leaves window during drag https://github.com/Textualize/textual/pull/1968 https://github.com/Textualize/textual/pull/2003
 - DataTable crash when enter pressed when table is empty https://github.com/Textualize/textual/pull/1973
 
 ## [0.13.0] - 2023-03-02

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -291,6 +291,7 @@ class ScrollBar(Widget):
     def _on_hide(self, event: events.Hide) -> None:
         if self.grabbed:
             self.release_mouse()
+            self.grabbed = None
 
     def _on_enter(self, event: events.Enter) -> None:
         self.mouse_over = True
@@ -299,10 +300,12 @@ class ScrollBar(Widget):
         self.mouse_over = False
 
     def action_scroll_down(self) -> None:
-        self.post_message(ScrollDown() if self.vertical else ScrollRight())
+        if not self.grabbed:
+            self.post_message(ScrollDown() if self.vertical else ScrollRight())
 
     def action_scroll_up(self) -> None:
-        self.post_message(ScrollUp() if self.vertical else ScrollLeft())
+        if not self.grabbed:
+            self.post_message(ScrollUp() if self.vertical else ScrollLeft())
 
     def action_grab(self) -> None:
         self.capture_mouse()
@@ -313,6 +316,8 @@ class ScrollBar(Widget):
     async def _on_mouse_up(self, event: events.MouseUp) -> None:
         if self.grabbed:
             self.release_mouse()
+            self.grabbed = None
+            print("RELEASED")
         event.stop()
 
     def _on_mouse_capture(self, event: events.MouseCapture) -> None:
@@ -324,6 +329,7 @@ class ScrollBar(Widget):
         event.stop()
 
     async def _on_mouse_move(self, event: events.MouseMove) -> None:
+        print("MOVE", self.grabbed, self.window_size)
         if self.grabbed and self.window_size:
             x: float | None = None
             y: float | None = None

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -328,7 +328,6 @@ class ScrollBar(Widget):
         event.stop()
 
     async def _on_mouse_move(self, event: events.MouseMove) -> None:
-        print("MOVE", self.grabbed, self.window_size)
         if self.grabbed and self.window_size:
             x: float | None = None
             y: float | None = None

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -317,7 +317,6 @@ class ScrollBar(Widget):
         if self.grabbed:
             self.release_mouse()
             self.grabbed = None
-            print("RELEASED")
         event.stop()
 
     def _on_mouse_capture(self, event: events.MouseCapture) -> None:


### PR DESCRIPTION
Fixes the issue when you grab a scrollbar, move outside the terminal, and release the mouse button. The scrollbar would get attached to the mouse until you clicked the button again.

There was a previous attempt at this in https://github.com/Textualize/textual/pull/1968 but it didn't quite do the job.