### PR TITLE
Remove underscore pauses from (hopefully) all snapshots

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,7 +44,7 @@ python -m textual
 
 If Textual is installed you should see the following:
 
-```{.textual path="src/textual/demo.py" columns="127" lines="53" press="enter,_,_,_,_,_,_,tab,_,w,i,l,l"}
+```{.textual path="src/textual/demo.py" columns="127" lines="53" press="enter,tab,w,i,l,l"}
 ```
 
 ## Examples

--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -68,7 +68,7 @@ Let's look at a trivial Textual app.
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/dom1.py" press="_"}
+    ```{.textual path="docs/examples/guide/dom1.py"}
     ```
 
 This example creates an instance of `ExampleApp`, which will implicitly create a `Screen` object. In DOM terms, the `Screen` is a _child_ of `ExampleApp`.

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -27,7 +27,7 @@ Apps don't get much simpler than this&mdash;don't expect it to do much.
 
 If we run this app with `python simple02.py` you will see a blank terminal, something like the following:
 
-```{.textual path="docs/examples/app/simple02.py" press="_"}
+```{.textual path="docs/examples/app/simple02.py"}
 ```
 
 When you call [App.run()][textual.app.App.run] Textual puts the terminal in to a special state called *application mode*. When in application mode the terminal will no longer echo what you type. Textual will take over responding to user input (keyboard and mouse) and will update the visible portion of the terminal (i.e. the *screen*).
@@ -57,7 +57,7 @@ Another such event is the *key* event which is sent when the user presses a key.
 
 The `on_mount` handler sets the `self.screen.styles.background` attribute to `"darkblue"` which (as you can probably guess) turns the background blue. Since the mount event is sent immediately after entering application mode, you will see a blue screen when you run this code.
 
-```{.textual path="docs/examples/app/event01.py" hl_lines="23-25" press="_"}
+```{.textual path="docs/examples/app/event01.py" hl_lines="23-25"}
 ```
 
 The key event handler (`on_key`) has an `event` parameter which will receive a [Key][textual.events.Key] instance. Every event has an associated event object which will be passed to the handler method if it is present in the method's parameter list.
@@ -114,7 +114,7 @@ Here's an app which adds a welcome widget in response to any key press:
 
 When you first run this you will get a blank screen. Press any key to add the welcome widget. You can even press a key multiple times to add several widgets.
 
-```{.textual path="docs/examples/app/widgets02.py" press="a,a,a,down,down,down,down,down,down,_,_,_,_,_,_"}
+```{.textual path="docs/examples/app/widgets02.py" press="a,a,a,down,down,down,down,down,down"}
 ```
 
 ## Exiting

--- a/docs/guide/devtools.md
+++ b/docs/guide/devtools.md
@@ -60,7 +60,7 @@ textual console
 
 You should see the Textual devtools welcome message:
 
-```{.textual title="textual console" path="docs/examples/getting_started/console.py", press="_,_"}
+```{.textual title="textual console" path="docs/examples/getting_started/console.py"}
 ```
 
 In the other console, run your application with `textual run` and the `--dev` switch:

--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -20,7 +20,7 @@ The most fundamental way to receive input is via [Key][textual.events.Key] event
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/input/key01.py", press="T,e,x,t,u,a,l,!,_"}
+    ```{.textual path="docs/examples/guide/input/key01.py", press="T,e,x,t,u,a,l,!"}
     ```
 
 When you press a key, the app will receive the event and write it to a [TextLog](../widgets/text_log.md) widget. Try pressing a few keys to see what happens.
@@ -102,7 +102,7 @@ The following example shows how focus works in practice.
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/input/key03.py", press="tab,H,e,l,l,o,tab,W,o,r,l,d,!,_"}
+    ```{.textual path="docs/examples/guide/input/key03.py", press="tab,H,e,l,l,o,tab,W,o,r,l,d,!"}
     ```
 
 The app splits the screen in to quarters, with a `TextLog` widget in each quarter. If you click any of the text logs, you should see that it is highlighted to show that the widget has focus. Key events will be sent to the focused widget only.

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -444,7 +444,7 @@ The code below shows a simple sidebar implementation.
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/layout/dock_layout1_sidebar.py" press="pagedown,down,down,_,_,_,_,_"}
+    ```{.textual path="docs/examples/guide/layout/dock_layout1_sidebar.py" press="pagedown,down,down"}
     ```
 
 === "dock_layout1_sidebar.py"
@@ -468,7 +468,7 @@ This new sidebar is double the width of the one previous one, and has a `deeppin
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/layout/dock_layout2_sidebar.py" press="pagedown,down,down,_,_,_,_,_"}
+    ```{.textual path="docs/examples/guide/layout/dock_layout2_sidebar.py" press="pagedown,down,down"}
     ```
 
 === "dock_layout2_sidebar.py"

--- a/docs/guide/screens.md
+++ b/docs/guide/screens.md
@@ -36,7 +36,7 @@ Let's look at a simple example of writing a screen class to simulate Window's [b
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/screens/screen01.py" press="b,_"}
+    ```{.textual path="docs/examples/guide/screens/screen01.py" press="b"}
     ```
 
 If you run this you will see an empty screen. Hit the ++b++ key to show a blue screen of death. Hit ++escape++ to return to the default screen.
@@ -65,7 +65,7 @@ You can also _install_ new named screens dynamically with the [install_screen][t
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/screens/screen02.py" press="b,_"}
+    ```{.textual path="docs/examples/guide/screens/screen02.py" press="b"}
     ```
 
 Although both do the same thing, we recommend `SCREENS` for screens that exist for the lifetime of your app.
@@ -145,7 +145,7 @@ Screens can be used to implement modal dialogs. The following example pushes a s
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/screens/modal01.py" press="q,_"}
+    ```{.textual path="docs/examples/guide/screens/modal01.py" press="q"}
     ```
 
 Note the `request_quit` action in the app which pushes a new instance of `QuitScreen`. This makes the quit screen active. if you click cancel, the quit screen calls `pop_screen` to return the default screen. This also removes and deletes the `QuitScreen` object.

--- a/docs/guide/styles.md
+++ b/docs/guide/styles.md
@@ -20,7 +20,7 @@ The first line sets the [background](../styles/background.md) style to `"darkblu
 
 The second line sets [border](../styles/border.md) to a tuple of `("heavy", "white")` which tells Textual to draw a white border with a style of `"heavy"`. Running this code will show the following:
 
-```{.textual path="docs/examples/guide/styles/screen.py" press="_"}
+```{.textual path="docs/examples/guide/styles/screen.py"}
 ```
 
 ## Styling widgets

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -136,7 +136,7 @@ Let's use markup links in the hello example so that the greeting becomes a link 
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/widgets/hello05.py" press="_"}
+    ```{.textual path="docs/examples/guide/widgets/hello05.py"}
     ```
 
 If you run this example you will see that the greeting has been underlined, which indicates it is clickable. If you click on the greeting it will run the `next_word` action which updates the next word.

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Build sophisticated user interfaces with a simple Python API. Run your apps in t
 ```{.textual path="examples/pride.py"}
 ```
 
-```{.textual path="docs/examples/tutorial/stopwatch.py" columns="100" lines="30" press="d,tab,enter,_,_"}
+```{.textual path="docs/examples/tutorial/stopwatch.py" columns="100" lines="30" press="d,tab,enter"}
 ```
 
 

--- a/docs/styles/dock.md
+++ b/docs/styles/dock.md
@@ -19,7 +19,7 @@ Notice that even though the content is scrolled, the sidebar remains fixed.
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/layout/dock_layout1_sidebar.py" press="pagedown,down,down,_,_,_,_,_"}
+    ```{.textual path="docs/examples/guide/layout/dock_layout1_sidebar.py" press="pagedown,down,down"}
     ```
 
 === "dock_layout1_sidebar.py"

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -25,7 +25,7 @@ This will be a simple yet **fully featured** app &mdash; you could distribute th
 Here's what the finished app will look like:
 
 
-```{.textual path="docs/examples/tutorial/stopwatch.py" press="tab,enter,_,tab,enter,_,tab,_,enter,_,tab,enter,_,_"}
+```{.textual path="docs/examples/tutorial/stopwatch.py" press="tab,enter,tab,enter,tab,enter,tab,enter"}
 ```
 
 ### Get the code
@@ -339,7 +339,7 @@ The `on_button_pressed` method is an *event handler*. Event handlers are methods
 
 If you run `stopwatch04.py` now you will be able to toggle between the two states by clicking the first button:
 
-```{.textual path="docs/examples/tutorial/stopwatch04.py" title="stopwatch04.py" press="tab,tab,tab,_,enter,_,_,_"}
+```{.textual path="docs/examples/tutorial/stopwatch04.py" title="stopwatch04.py" press="tab,tab,tab,enter"}
 ```
 
 ## Reactive attributes
@@ -421,7 +421,7 @@ This code supplies missing features and makes our app useful. We've made the fol
 
 If you run `stopwatch06.py` you will be able to use the stopwatches independently.
 
-```{.textual path="docs/examples/tutorial/stopwatch06.py" title="stopwatch06.py" press="tab,enter,_,_,tab,enter,_,tab"}
+```{.textual path="docs/examples/tutorial/stopwatch06.py" title="stopwatch06.py" press="tab,enter,tab,enter,tab"}
 ```
 
 The only remaining feature of the Stopwatch app left to implement is the ability to add and remove stopwatches.
@@ -449,7 +449,7 @@ The `action_remove_stopwatch` function calls [query()][textual.dom.DOMNode.query
 
 If you run `stopwatch.py` now you can add a new stopwatch with the ++a++ key and remove a stopwatch with ++r++.
 
-```{.textual path="docs/examples/tutorial/stopwatch.py" press="d,a,a,a,a,a,a,a,tab,enter,_,_,_,_,tab,_"}
+```{.textual path="docs/examples/tutorial/stopwatch.py" press="d,a,a,a,a,a,a,a,tab,enter,tab"}
 ```
 
 ## What next?

--- a/docs/widget_gallery.md
+++ b/docs/widget_gallery.md
@@ -182,7 +182,7 @@ Display and update text in a scrolling panel.
 
 [TextLog reference](./widgets/text_log.md){ .md-button .md-button--primary }
 
-```{.textual path="docs/examples/widgets/text_log.py" press="_,H,i"}
+```{.textual path="docs/examples/widgets/text_log.py" press="H,i"}
 ```
 
 ## Tree

--- a/docs/widgets/text_log.md
+++ b/docs/widgets/text_log.md
@@ -13,7 +13,7 @@ The example below shows an application showing a `TextLog` with different kinds 
 
 === "Output"
 
-    ```{.textual path="docs/examples/widgets/text_log.py" press="_,H,i"}
+    ```{.textual path="docs/examples/widgets/text_log.py" press="H,i"}
     ```
 
 === "text_log.py"

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -125,12 +125,12 @@ def test_header_render(snap_compare):
 
 def test_list_view(snap_compare):
     assert snap_compare(
-        WIDGET_EXAMPLES_DIR / "list_view.py", press=["tab", "down", "down", "up", "_"]
+        WIDGET_EXAMPLES_DIR / "list_view.py", press=["tab", "down", "down", "up"]
     )
 
 
 def test_textlog_max_lines(snap_compare):
-    assert snap_compare("snapshot_apps/textlog_max_lines.py", press=[*"abcde", "_"])
+    assert snap_compare("snapshot_apps/textlog_max_lines.py", press=[*"abcde"])
 
 
 def test_fr_units(snap_compare):
@@ -203,7 +203,7 @@ def test_order_independence(snap_compare):
 
 
 def test_order_independence_toggle(snap_compare):
-    assert snap_compare("snapshot_apps/layer_order_independence.py", press="t,_")
+    assert snap_compare("snapshot_apps/layer_order_independence.py", press="t")
 
 
 def test_columns_height(snap_compare):
@@ -218,7 +218,7 @@ def test_offsets(snap_compare):
 
 def test_nested_auto_heights(snap_compare):
     """Test refreshing widget within a auto sized container"""
-    assert snap_compare("snapshot_apps/nested_auto_heights.py", press=["1", "2", "_"])
+    assert snap_compare("snapshot_apps/nested_auto_heights.py", press=["1", "2"])
 
 
 def test_programmatic_scrollbar_gutter_change(snap_compare):
@@ -295,4 +295,4 @@ def test_focus_component_class(snap_compare):
 
 
 def test_line_api_scrollbars(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "line_api_scrollbars.py", press=["_"])
+    assert snap_compare(SNAPSHOT_APPS_DIR / "line_api_scrollbars.py")


### PR DESCRIPTION
This seeks to remove the `"_"` from the key presses of snapshots and inline runs in the documentation. The `"_"` no longer does anything, but got legacy reasons at the moment we can't actually allow `"_"` to be an input to a "faked" keypress in the docs and snapshots.

Removing these clears the way to letting `"_"` have the same status as any other character.

See #1994.
