### PR TITLE
fix(markdown): add formatter to render ordered lists correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ textual = "textual.cli.cli:run"
 python = "^3.7"
 rich = ">12.6.0"
 markdown-it-py = {extras = ["plugins", "linkify"], version = "^2.1.0"}
+mdformat-gfm = "^0.3.5"
 #rich = {path="../rich", develop=true}
 importlib-metadata = "^4.11.3"
 typing-extensions = "^4.4.0"

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path, PurePath
 from typing import Iterable
 
+import mdformat
 from markdown_it import MarkdownIt
 from rich.style import Style
 from rich.syntax import Syntax
@@ -581,7 +582,15 @@ class Markdown(Widget):
 
         table_of_contents: TableOfContentsType = []
 
-        for token in parser.parse(markdown):
+        # Parse a formatted version of the markdown.
+        # This ensures that ordered lists will be rendered correctly
+        # by applying consecutive numbering.
+        formatted_markdown: str = mdformat.text(
+            markdown,
+            options={"number": True},
+        )
+
+        for token in parser.parse(formatted_markdown):
             if token.type == "heading_open":
                 block_id += 1
                 stack.append(HEADINGS[token.tag](id=f"block{block_id}"))


### PR DESCRIPTION
### Description

Parse a `mdformat` formatted version of the markdown. This ensures that ordered lists will be rendered correctly by applying consecutive numbering using the `"number": True` option.

This adds the dependency `mdformat-gfm` for [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/) support.

### Related Issue

Fixes #2002 

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
