### PR TITLE
Properly indicate dependency is only required for development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ typing-extensions = "^4.4.0"
 aiohttp = { version = ">=3.8.1", optional = true }
 click = {version = ">=8.1.2", optional = true}
 msgpack = { version = ">=1.0.3", optional = true }
-mkdocs-exclude = "^1.0.2"
+mkdocs-exclude = { version = "^1.0.2", optional = true }
 
 [tool.poetry.extras]
 dev = ["aiohttp", "click", "msgpack"]


### PR DESCRIPTION
I discovered this when trying to build Textual and its dependencies in such a way that required every package to have a wheel and it stood out to me that this was unlikely to be an actual dependency.

I also found https://github.com/apenwarr/mkdocs-exclude/issues/16, it might be unmaintained