### PR TITLE
print after stopping writer thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed container not resizing when a widget is removed https://github.com/Textualize/textual/issues/2007
 - Fixes issue where the horizontal scrollbar would be incorrectly enabled https://github.com/Textualize/textual/pull/2024
+- Fixes for tracebacks not appearing on exit https://github.com/Textualize/textual/issues/2027
 
 ### Added
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1827,12 +1827,13 @@ class App(Generic[ReturnType], DOMNode):
 
         await self._dispatch_message(events.Unmount())
 
-        self._print_error_renderables()
         if self.devtools is not None and self.devtools.is_connected:
             await self._disconnect_devtools()
 
         if self._writer_thread is not None:
             self._writer_thread.stop()
+
+        self._print_error_renderables()
 
     async def _on_exit_app(self) -> None:
         self._begin_batch()  # Prevent repaint / layout while shutting down


### PR DESCRIPTION
Possible fix for https://github.com/Textualize/textual/issues/2027

Unable to reproduce the original error, but it look possible that the error is printed before the exit application mode escape sequences have been written.