### PR TITLE
Change how to determine whether a message needs an updated namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Pilot.click` not correctly creating the mouse events https://github.com/Textualize/textual/issues/2022
 - Fixes issue where the horizontal scrollbar would be incorrectly enabled https://github.com/Textualize/textual/pull/2024
 - Fixes for tracebacks not appearing on exit https://github.com/Textualize/textual/issues/2027
+- Fixed how the namespace for messages is calculated to facilitate inheriting messages https://github.com/Textualize/textual/issues/1814
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## Unreleased
+
+### Fixed
+
+- Fixed how the namespace for messages is calculated to facilitate inheriting messages https://github.com/Textualize/textual/issues/1814
+
 ## [0.15.0] - 2023-03-13
 
 ### Fixed
@@ -14,7 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Pilot.click` not correctly creating the mouse events https://github.com/Textualize/textual/issues/2022
 - Fixes issue where the horizontal scrollbar would be incorrectly enabled https://github.com/Textualize/textual/pull/2024
 - Fixes for tracebacks not appearing on exit https://github.com/Textualize/textual/issues/2027
-- Fixed how the namespace for messages is calculated to facilitate inheriting messages https://github.com/Textualize/textual/issues/1814
 
 ### Added
 

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -62,7 +62,7 @@ class MessagePumpMeta(type):
         isclass = inspect.isclass
         for value in class_dict.values():
             if isclass(value) and issubclass(value, Message):
-                if not value.namespace:
+                if "namespace" not in value.__dict__:
                     value.namespace = namespace
         class_obj = super().__new__(cls, name, bases, class_dict, **kwargs)
         return class_obj

--- a/tests/test_message_handling.py
+++ b/tests/test_message_handling.py
@@ -1,0 +1,45 @@
+from textual.app import App, ComposeResult
+from textual.message import Message
+from textual.widget import Widget
+
+
+async def test_message_inheritance_namespace():
+    """Inherited messages get their correct namespaces.
+
+    Regression test for https://github.com/Textualize/textual/issues/1814.
+    """
+
+    class BaseWidget(Widget):
+        class Fired(Message):
+            pass
+
+        def trigger(self) -> None:
+            self.post_message(self.Fired())
+
+    class Left(BaseWidget):
+        class Fired(BaseWidget.Fired):
+            pass
+
+    class Right(BaseWidget):
+        class Fired(BaseWidget.Fired):
+            pass
+
+    handlers_called = []
+
+    class MessageInheritanceApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Left()
+            yield Right()
+
+        def on_left_fired(self):
+            handlers_called.append("left")
+
+        def on_right_fired(self):
+            handlers_called.append("right")
+
+    app = MessageInheritanceApp()
+    async with app.run_test():
+        app.query_one(Left).trigger()
+        app.query_one(Right).trigger()
+
+    assert handlers_called == ["left", "right"]


### PR DESCRIPTION
This will fix #1814.

The fix is very similar to what we do to allow inheriting of bindings, component classes, default CSS, etc.