### PR TITLE
Simplify namespace for inherited messages from ToggleButton

### DIFF
--- a/src/textual/widgets/_checkbox.py
+++ b/src/textual/widgets/_checkbox.py
@@ -14,9 +14,6 @@ class Checkbox(ToggleButton):
         This message can be handled using an `on_checkbox_changed` method.
         """
 
-        # https://github.com/Textualize/textual/issues/1814
-        namespace = "checkbox"
-
         @property
         def checkbox(self) -> Checkbox:
             """The checkbox that was changed."""

--- a/src/textual/widgets/_radio_button.py
+++ b/src/textual/widgets/_radio_button.py
@@ -21,9 +21,6 @@ class RadioButton(ToggleButton):
         This message can be handled using an `on_radio_button_changed` method.
         """
 
-        # https://github.com/Textualize/textual/issues/1814
-        namespace = "radio_button"
-
         @property
         def radio_button(self) -> RadioButton:
             """The radio button that was changed."""


### PR DESCRIPTION
Related issues: #1814.
Related PRs: #2038.

Follow-up to 2038 to clean up explicit namespace declaration for the messages within the widgets that inherit from `ToggleButton`.