### PR TITLE
fix for remove nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed borders not rendering correctly. https://github.com/Textualize/textual/pull/2074
+- Fix for error when removing nodes. https://github.com/Textualize/textual/issues/2079
 
 ### Changed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2174,11 +2174,14 @@ class App(Generic[ReturnType], DOMNode):
             for child in widget._nodes:
                 push(child)
 
-    def _remove_nodes(self, widgets: list[Widget], parent: DOMNode) -> AwaitRemove:
+    def _remove_nodes(
+        self, widgets: list[Widget], parent: DOMNode | None
+    ) -> AwaitRemove:
         """Remove nodes from DOM, and return an awaitable that awaits cleanup.
 
         Args:
             widgets: List of nodes to remove.
+            parent: Parent node of widgets, or None for no parent.
 
         Returns:
             Awaitable that returns when the nodes have been fully removed.
@@ -2197,7 +2200,7 @@ class App(Generic[ReturnType], DOMNode):
                 await self._prune_nodes(widgets)
             finally:
                 finished_event.set()
-                if parent.styles.auto_dimensions:
+                if parent is not None and parent.styles.auto_dimensions:
                     parent.refresh(layout=True)
 
         removed_widgets = self._detach_from_dom(widgets)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -181,3 +181,20 @@ async def test_remove():
         await pilot.press("r")
         await pilot.pause()
     assert app.return_value == 123
+
+
+# Regression test for https://github.com/Textualize/textual/issues/2079
+async def test_remove_unmounted():
+    mounted = False
+
+    class RemoveApp(App):
+        def on_mount(self):
+            nonlocal mounted
+            label = Label()
+            label.remove()
+            mounted = True
+
+    app = RemoveApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert mounted


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/2079

Bit of an edge case. Calling `remove` on a widget that was never mounted.