### PR TITLE
Simplify driver

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -507,12 +507,12 @@ class App(Generic[ReturnType], DOMNode):
 
     @property
     def debug(self) -> bool:
-        """bool: Is debug mode is enabled?"""
+        """Is debug mode is enabled?"""
         return "debug" in self.features
 
     @property
     def is_headless(self) -> bool:
-        """bool: Is the app running in 'headless' mode?"""
+        """Is the driver running in 'headless' mode?"""
         return False if self._driver is None else self._driver.is_headless
 
     @property

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -507,7 +507,7 @@ class App(Generic[ReturnType], DOMNode):
 
     @property
     def debug(self) -> bool:
-        """Is debug mode is enabled?"""
+        """Is debug mode enabled?"""
         return "debug" in self.features
 
     @property

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1619,7 +1619,9 @@ class App(Generic[ReturnType], DOMNode):
                 "type[Driver]",
                 HeadlessDriver if headless else self.driver_class,
             )
-            driver = self._driver = driver_class(self.console, self, size=terminal_size)
+            driver = self._driver = driver_class(
+                self.console.file, self, size=terminal_size
+            )
 
             if not self._exit:
                 driver.start_application_mode()

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 from . import _time, events
 from ._types import MessageTarget
@@ -15,13 +15,13 @@ if TYPE_CHECKING:
 class Driver(ABC):
     def __init__(
         self,
-        console: "Console",
+        file: IO[str],
         target: "MessageTarget",
         *,
         debug: bool = False,
         size: tuple[int, int] | None = None,
     ) -> None:
-        self.console = console
+        self._file = file
         self._target = target
         self._debug = debug
         self._size = size
@@ -86,6 +86,13 @@ class Driver(ABC):
         ):
             click_event = events.Click.from_event(event)
             self.send_event(click_event)
+
+    def flush(self) -> None:
+        pass
+
+    @abstractmethod
+    def write(self, data: str) -> None:
+        ...
 
     @abstractmethod
     def start_application_mode(self) -> None:

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -25,8 +25,8 @@ class Driver(ABC):
         Args:
             file: A file-like object open for writing unicode.
             target: The message target (expected to be the app).
-            debug: Enabled debug mode. Defaults to False.
-            size: Initial size of the terminal or None to detect. Defaults to None.
+            debug: Enabled debug mode.
+            size: Initial size of the terminal or `None` to detect.
         """
         self._file = file
         self._target = target

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
-from typing import IO, TYPE_CHECKING
+from typing import IO
 
 from . import _time, events
 from ._types import MessageTarget

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -8,11 +8,10 @@ from . import _time, events
 from ._types import MessageTarget
 from .events import MouseUp
 
-if TYPE_CHECKING:
-    from rich.console import Console
-
 
 class Driver(ABC):
+    """A base class for drivers."""
+
     def __init__(
         self,
         file: IO[str],
@@ -21,6 +20,14 @@ class Driver(ABC):
         debug: bool = False,
         size: tuple[int, int] | None = None,
     ) -> None:
+        """Initialize a driver.
+
+        Args:
+            file: A file-like object open for writing unicode.
+            target: The message target (expected to be the app).
+            debug: Enabled debug mode. Defaults to False.
+            size: Initial size of the terminal or None to detect. Defaults to None.
+        """
         self._file = file
         self._target = target
         self._debug = debug
@@ -32,16 +39,25 @@ class Driver(ABC):
 
     @property
     def is_headless(self) -> bool:
-        """Check if the driver is 'headless'"""
+        """Is the driver 'headless' (no output)?"""
         return False
 
     def send_event(self, event: events.Event) -> None:
+        """Send an event to the target app.
+
+        Args:
+            event: An event.
+        """
         asyncio.run_coroutine_threadsafe(
             self._target._post_message(event), loop=self._loop
         )
 
     def process_event(self, event: events.Event) -> None:
-        """Performs some additional processing of events."""
+        """Perform additional processing on an event, prior to sending.
+
+        Args:
+            event: An event to send.
+        """
         event._set_sender(self._target)
         if isinstance(event, events.MouseDown):
             self._mouse_down_time = event.time
@@ -88,20 +104,24 @@ class Driver(ABC):
             self.send_event(click_event)
 
     def flush(self) -> None:
-        pass
+        """Flush any buffered data."""
 
     @abstractmethod
     def write(self, data: str) -> None:
-        ...
+        """Write data to the output device.
+
+        Args:
+            data: Raw data.
+        """
 
     @abstractmethod
     def start_application_mode(self) -> None:
-        ...
+        """Start application mode."""
 
     @abstractmethod
     def disable_input(self) -> None:
-        ...
+        """Disable further input."""
 
     @abstractmethod
     def stop_application_mode(self) -> None:
-        ...
+        """Stop application mode, restore state."""

--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -34,12 +34,19 @@ class HeadlessDriver(Driver):
         return width, height
 
     def write(self, data: str) -> None:
-        pass
+        """Write data to the output device.
+
+        Args:
+            data: Raw data.
+        """
+        # Nothing to write as this is a headless driver.
 
     def start_application_mode(self) -> None:
+        """Start application mode."""
         loop = asyncio.get_running_loop()
 
-        def send_size_event():
+        def send_size_event() -> None:
+            """Send first resize event."""
             terminal_size = self._get_terminal_size()
             width, height = terminal_size
             textual_size = Size(width, height)
@@ -52,7 +59,8 @@ class HeadlessDriver(Driver):
         send_size_event()
 
     def disable_input(self) -> None:
-        pass
+        """Start application mode."""
 
     def stop_application_mode(self) -> None:
-        pass
+        """Stop application mode, restore state."""
+        # Nothing to do

--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -12,6 +12,7 @@ class HeadlessDriver(Driver):
 
     @property
     def is_headless(self) -> bool:
+        """Is the driver running in 'headless' mode?"""
         return True
 
     def _get_terminal_size(self) -> tuple[int, int]:

--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -32,6 +32,9 @@ class HeadlessDriver(Driver):
         height = height or 25
         return width, height
 
+    def write(self, data: str) -> None:
+        pass
+
     def start_application_mode(self) -> None:
         loop = asyncio.get_running_loop()
 

--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -59,7 +59,7 @@ class HeadlessDriver(Driver):
         send_size_event()
 
     def disable_input(self) -> None:
-        """Start application mode."""
+        """Disable further input."""
 
     def stop_application_mode(self) -> None:
         """Stop application mode, restore state."""

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -9,7 +9,7 @@ import termios
 import tty
 from codecs import getincrementaldecoder
 from threading import Event, Thread
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, Any
 
 import rich.repr
 
@@ -32,6 +32,14 @@ class LinuxDriver(Driver):
         debug: bool = False,
         size: tuple[int, int] | None = None,
     ) -> None:
+        """Initialize a driver.
+
+        Args:
+            file: A file-like object open for writing unicode.
+            target: The message target (expected to be the app).
+            debug: Enabled debug mode. Defaults to False.
+            size: Initial size of the terminal or None to detect. Defaults to None.
+        """
         super().__init__(file, target, debug=debug, size=size)
         self._file = file
         self.fileno = sys.stdin.fileno()

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -185,6 +185,7 @@ class LinuxDriver(Driver):
         )
 
     def disable_input(self) -> None:
+        """Disable further input."""
         try:
             if not self.exit_event.is_set():
                 signal.signal(signal.SIGWINCH, signal.SIG_DFL)

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -37,8 +37,8 @@ class LinuxDriver(Driver):
         Args:
             file: A file-like object open for writing unicode.
             target: The message target (expected to be the app).
-            debug: Enabled debug mode. Defaults to False.
-            size: Initial size of the terminal or None to detect. Defaults to None.
+            debug: Enabled debug mode.
+            size: Initial size of the terminal or `None` to detect.
         """
         super().__init__(file, target, debug=debug, size=size)
         self._file = file

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -51,10 +51,10 @@ class LinuxDriver(Driver):
         yield "debug", self._debug
 
     def _get_terminal_size(self) -> tuple[int, int]:
-        """Detect the terminal size
+        """Detect the terminal size.
 
         Returns:
-            The size of the terminal as a tuple of (WIDTH, HEIGHT)
+            The size of the terminal as a tuple of (WIDTH, HEIGHT).
         """
         width: int | None = 80
         height: int | None = 25

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -208,7 +208,7 @@ class LinuxDriver(Driver):
             pass
 
     def stop_application_mode(self) -> None:
-        """Disable further input."""
+        """Stop application mode, restore state."""
         self._disable_bracketed_paste()
         self.disable_input()
 

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -21,6 +21,14 @@ class WindowsDriver(Driver):
         debug: bool = False,
         size: tuple[int, int] | None = None,
     ) -> None:
+        """Initialize a driver.
+
+        Args:
+            file: A file-like object open for writing unicode.
+            target: The message target (expected to be the app).
+            debug: Enabled debug mode.
+            size: Initial size of the terminal or `None` to detect.
+        """
         super().__init__(file, target, debug=debug, size=size)
 
         self.exit_event = Event()

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from threading import Event, Thread
-from typing import IO, TYPE_CHECKING, Callable
+from typing import IO, Callable
 
 from .._context import active_app
 from .._types import MessageTarget

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -28,9 +28,15 @@ class WindowsDriver(Driver):
         self._restore_console: Callable[[], None] | None = None
 
     def write(self, data: str) -> None:
+        """Write data to the output device.
+
+        Args:
+            data: Raw data.
+        """
         self._file.write(data)
 
     def _enable_mouse_support(self) -> None:
+        """Enable reporting of mouse events."""
         write = self.write
         write("\x1b[?1000h")  # SET_VT200_MOUSE
         write("\x1b[?1003h")  # SET_ANY_EVENT_MOUSE
@@ -39,6 +45,7 @@ class WindowsDriver(Driver):
         self.flush()
 
     def _disable_mouse_support(self) -> None:
+        """Disable reporting of mouse events."""
         write = self.write
         write("\x1b[?1000l")
         write("\x1b[?1003l")
@@ -55,6 +62,7 @@ class WindowsDriver(Driver):
         self.write("\x1b[?2004l")
 
     def start_application_mode(self) -> None:
+        """Start application mode."""
         loop = asyncio.get_running_loop()
 
         self._restore_console = win32.enable_application_mode()
@@ -73,6 +81,7 @@ class WindowsDriver(Driver):
         self._event_thread.start()
 
     def disable_input(self) -> None:
+        """Disable further input."""
         try:
             if not self.exit_event.is_set():
                 self._disable_mouse_support()
@@ -86,6 +95,7 @@ class WindowsDriver(Driver):
             pass
 
     def stop_application_mode(self) -> None:
+        """Stop application mode, restore state."""
         self._disable_bracketed_paste()
         self.disable_input()
         if self._restore_console:

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -91,5 +91,6 @@ class WindowsDriver(Driver):
         if self._restore_console:
             self._restore_console()
 
+        # Disable alt screen, show cursor
         self.write("\x1b[?1049l" + "\x1b[?25h")
         self.flush()


### PR DESCRIPTION
Simplifies the structure of the driver. The base class now doesn't require a Console, only a file.

This is because textual-serve will set a "virtual" driver of sorts, which doesn't have a Console per se.

Also added a bunch of docstrings.