### PR TITLE
Allow paths when creating 'DirectoryTree'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Tabs widget now sends Tabs.Cleared when there is no active tab.
 - Breaking change: changed default behaviour of `Vertical` (see `VerticalScroll`) https://github.com/Textualize/textual/issues/1957
 - The default `overflow` style for `Horizontal` was changed to `hidden hidden` https://github.com/Textualize/textual/issues/1957
+- `DirectoryTree` also accepts `pathlib.Path` objects as the path to list https://github.com/Textualize/textual/issues/1438
 
 ### Removed
 

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -90,11 +90,11 @@ class DirectoryTree(Tree[DirEntry]):
         classes: str | None = None,
         disabled: bool = False,
     ) -> None:
-        path = os.fspath(path)
-        self.path = path
+        str_path = os.fspath(path)
+        self.path = str_path
         super().__init__(
-            path,
-            data=DirEntry(path, True),
+            str_path,
+            data=DirEntry(str_path, True),
             name=name,
             id=id,
             classes=classes,

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
@@ -7,14 +8,13 @@ from typing import ClassVar
 from rich.style import Style
 from rich.text import Text, TextType
 
-from .._types import MessageTarget
 from ..message import Message
 from ._tree import TOGGLE_STYLE, Tree, TreeNode
 
 
 @dataclass
 class DirEntry:
-    """Attaches directory information ot a node."""
+    """Attaches directory information to a node."""
 
     path: str
     is_dir: bool
@@ -26,9 +26,9 @@ class DirectoryTree(Tree[DirEntry]):
 
     Args:
         path: Path to directory.
-        name: The name of the widget, or None for no name. Defaults to None.
-        id: The ID of the widget in the DOM, or None for no ID. Defaults to None.
-        classes: A space-separated list of classes, or None for no classes. Defaults to None.
+        name: The name of the widget, or None for no name.
+        id: The ID of the widget in the DOM, or None for no ID.
+        classes: A space-separated list of classes, or None for no classes.
         disabled: Whether the directory tree is disabled or not.
     """
 
@@ -83,13 +83,14 @@ class DirectoryTree(Tree[DirEntry]):
 
     def __init__(
         self,
-        path: str,
+        path: str | Path,
         *,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
         disabled: bool = False,
     ) -> None:
+        path = os.fspath(path)
         self.path = path
         super().__init__(
             path,


### PR DESCRIPTION
This will close #1438.

This felt like a no-brainer given that we can support `pathlib.Path` (which makes _a lot_ of sense) without needing to modify the inner workings by letting everything stay a string.
It would've taken longer to ask if it made sense to implement this than to just wait for this PR to get accepted/closed.