### PR TITLE
Allow serving docs without MkDocs Insider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ docs-serve: clean-screenshot-cache docs-online-nav
 	$(run) mkdocs serve --config-file mkdocs-nav-online.yml
 	rm -f mkdocs-nav-online.yml
 
+.PHONY: docs-serve-offline
+docs-serve-offline: clean-screenshot-cache docs-offline-nav
+	$(run) mkdocs serve --config-file mkdocs-nav-offline.yml
+	rm -f mkdocs-nav-offline.yml
+
 .PHONY: docs-build
 docs-build: docs-online-nav
 	$(run) mkdocs build --config-file mkdocs-nav-online.yml


### PR DESCRIPTION
This is the cousin make rule that was missing so that people can serve the docs without access to the Insiders version of MkDocs.