### PR TITLE
Add tests for action parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## Unreleased
+
+### Fixed
+
+- Issue with parsing action strings whose arguments contained quoted closing parenthesis https://github.com/Textualize/textual/pull/2112
+- Issues with parsing action strings with tuple arguments https://github.com/Textualize/textual/pull/2112
+
 ## [0.16.0] - 2023-03-22
 
 ### Added

--- a/src/textual/actions.py
+++ b/src/textual/actions.py
@@ -6,7 +6,7 @@ import re
 from typing_extensions import Any, TypeAlias
 
 ActionParseResult: TypeAlias = "tuple[str, tuple[Any, ...]]"
-"""An action is its name and the arbitrary tuple of its parameters."""
+"""An action is its name and the arbitrary tuple of its arguments."""
 
 
 class SkipAction(Exception):
@@ -17,7 +17,47 @@ class ActionError(Exception):
     pass
 
 
-re_action_params = re.compile(r"([\w\.]+)(\(.*?\))")
+re_action_args = re.compile(r"([\w\.]+)\((.*)\)")
+
+
+def _is_single_tuple_argument(evals_to_tuple: str) -> bool:
+    """Is this tuple a single argument tuple?
+
+    If `evals_to_tuple` is such that `ast.literal_eval` evaluates it to a tuple,
+    is that because it is a comma-separated list of values, like `"1, 2, (False, 3)"`,
+    or is it because it is a single tuple, like `"(1, 2, False)"`?
+
+    If it is a single tuple, the string must start with "(", must end with ")", and after
+    removing those two parenthesis, `ast.literal_eval` must still be able to parse it
+    into the same valid tuple.
+
+    This function must also be able to handle strings like `"(1, 2), (3, 4)"`, which is
+    a 2-item tuple in a string that starts with "(" and ends with ")", but that
+    represents two arguments for our action.
+
+    Args:
+        evals_to_tuple: A string representing action arguments and that is of the type
+            `tuple` when evaluated by `ast.literal_eval`.
+
+    Returns:
+        Whether the string represents a single tuple or a space-separated list of
+            arguments.
+    """
+    if not evals_to_tuple.startswith("(") or not evals_to_tuple.endswith(")"):
+        return False
+
+    without_outer_parens = evals_to_tuple[1:-1]
+    # Short-circuit the case `evals_to_tuple == "()"` because `ast.literal_eval` will
+    # raise a SyntaxError (EOF) when evaluating `""`.
+    if not without_outer_parens:
+        return True
+
+    try:
+        ast.literal_eval(evals_to_tuple[1:-1])
+    except SyntaxError:
+        return False
+    else:
+        return True
 
 
 def parse(action: str) -> ActionParseResult:
@@ -30,22 +70,37 @@ def parse(action: str) -> ActionParseResult:
         ActionError: If the action has invalid syntax.
 
     Returns:
-        Action name and parameters
+        Action name and arguments.
     """
-    params_match = re_action_params.match(action)
-    if params_match is not None:
-        action_name, action_params_str = params_match.groups()
-        try:
-            action_params = ast.literal_eval(action_params_str)
-        except Exception:
-            raise ActionError(
-                f"unable to parse {action_params_str!r} in action {action!r}"
-            )
+    args_match = re_action_args.match(action)
+    if args_match is not None:
+        action_name, action_args_str = args_match.groups()
+        if action_args_str:
+            try:
+                tentative_action_args: tuple[Any, ...] | Any = ast.literal_eval(
+                    action_args_str
+                )
+            except Exception:
+                raise ActionError(
+                    f"unable to parse {action_args_str!r} in action {action!r}"
+                )
+            else:
+                # At this point, if tentative_action_args is not a tuple, it was a
+                # single argument. If tentative_action_args IS a tuple, it may have
+                # been because the tentative_action_args was a comma-separated list
+                # of arguments, like `"1, False, (1, 2, 3)"`, or because it was a single
+                # argument tuple, like `"(1, 2, 3)"`. In the latter case,
+                # we need to convert to `((1, 2, 3),)`.
+                if isinstance(
+                    tentative_action_args, tuple
+                ) and not _is_single_tuple_argument(action_args_str):
+                    action_args = tentative_action_args
+                else:
+                    action_args = (tentative_action_args,)
+        else:
+            action_args = ()
     else:
         action_name = action
-        action_params = ()
+        action_args = ()
 
-    return (
-        action_name,
-        action_params if isinstance(action_params, tuple) else (action_params,),
-    )
+    return action_name, action_args

--- a/src/textual/actions.py
+++ b/src/textual/actions.py
@@ -20,46 +20,6 @@ class ActionError(Exception):
 re_action_args = re.compile(r"([\w\.]+)\((.*)\)")
 
 
-def _is_single_tuple_argument(evals_to_tuple: str) -> bool:
-    """Is this tuple a single argument tuple?
-
-    If `evals_to_tuple` is such that `ast.literal_eval` evaluates it to a tuple,
-    is that because it is a comma-separated list of values, like `"1, 2, (False, 3)"`,
-    or is it because it is a single tuple, like `"(1, 2, False)"`?
-
-    If it is a single tuple, the string must start with "(", must end with ")", and after
-    removing those two parenthesis, `ast.literal_eval` must still be able to parse it
-    into the same valid tuple.
-
-    This function must also be able to handle strings like `"(1, 2), (3, 4)"`, which is
-    a 2-item tuple in a string that starts with "(" and ends with ")", but that
-    represents two arguments for our action.
-
-    Args:
-        evals_to_tuple: A string representing action arguments and that is of the type
-            `tuple` when evaluated by `ast.literal_eval`.
-
-    Returns:
-        Whether the string represents a single tuple or a space-separated list of
-            arguments.
-    """
-    if not evals_to_tuple.startswith("(") or not evals_to_tuple.endswith(")"):
-        return False
-
-    without_outer_parens = evals_to_tuple[1:-1]
-    # Short-circuit the case `evals_to_tuple == "()"` because `ast.literal_eval` will
-    # raise a SyntaxError (EOF) when evaluating `""`.
-    if not without_outer_parens:
-        return True
-
-    try:
-        ast.literal_eval(evals_to_tuple[1:-1])
-    except SyntaxError:
-        return False
-    else:
-        return True
-
-
 def parse(action: str) -> ActionParseResult:
     """Parses an action string.
 
@@ -77,26 +37,14 @@ def parse(action: str) -> ActionParseResult:
         action_name, action_args_str = args_match.groups()
         if action_args_str:
             try:
-                tentative_action_args: tuple[Any, ...] | Any = ast.literal_eval(
-                    action_args_str
-                )
+                # We wrap `action_args_str` to be able to disambiguate the cases where
+                # the list of arguments is a comma-separated list of values from the
+                # case where the argument is a single tuple.
+                action_args: tuple[Any, ...] = ast.literal_eval(f"({action_args_str},)")
             except Exception:
                 raise ActionError(
                     f"unable to parse {action_args_str!r} in action {action!r}"
                 )
-            else:
-                # At this point, if tentative_action_args is not a tuple, it was a
-                # single argument. If tentative_action_args IS a tuple, it may have
-                # been because the tentative_action_args was a comma-separated list
-                # of arguments, like `"1, False, (1, 2, 3)"`, or because it was a single
-                # argument tuple, like `"(1, 2, 3)"`. In the latter case,
-                # we need to convert to `((1, 2, 3),)`.
-                if isinstance(
-                    tentative_action_args, tuple
-                ) and not _is_single_tuple_argument(action_args_str):
-                    action_args = tentative_action_args
-                else:
-                    action_args = (tentative_action_args,)
         else:
             action_args = ()
     else:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from textual.actions import ActionError, parse
+
+
+@pytest.mark.parametrize(
+    ("action_string", "expected_name", "expected_arguments"),
+    [
+        ("spam", "spam", ()),
+        ("hypothetical_action()", "hypothetical_action", ()),
+        ("another_action(1)", "another_action", (1,)),
+        ("foo(True, False)", "foo", (True, False)),
+        ("foo.bar.baz(3, 3.15, 'Python')", "foo.bar.baz", (3, 3.15, "Python")),
+        ("m1234.n5678(None, [1, 2])", "m1234.n5678", (None, [1, 2])),
+    ],
+)
+def test_parse_action(
+    action_string: str, expected_name: str, expected_arguments: tuple[Any]
+) -> None:
+    action_name, action_arguments = parse(action_string)
+    assert action_name == expected_name
+    assert action_arguments == expected_arguments
+
+
+@pytest.mark.parametrize(
+    ("action_string", "expected_arguments"),
+    [
+        ("f()", ()),
+        ("f(())", ((),)),
+        ("f((1, 2, 3))", ((1, 2, 3),)),
+        ("f((1, 2, 3), (1, 2, 3))", ((1, 2, 3), (1, 2, 3))),
+        ("f(((1, 2), (), None), 0)", (((1, 2), (), None), 0)),
+        ("f((((((1))))))", (1,)),
+        ("f(((((((((1, 2)))))))))", ((1, 2),)),
+        ("f((1, 2), (3, 4))", ((1, 2), (3, 4))),
+        ("f((((((1, 2), (3, 4))))))", (((1, 2), (3, 4)),)),
+    ],
+)
+def test_nested_and_convoluted_tuple_arguments(
+    action_string: str, expected_arguments: tuple[Any]
+) -> None:
+    """Test that tuple arguments are parsed correctly."""
+    _, args = parse(action_string)
+    assert args == expected_arguments
+
+
+@pytest.mark.parametrize(
+    ["action_string", "expected_arguments"],
+    [
+        ("f('')", ("",)),
+        ('f("")', ("",)),
+        ("f('''''')", ("",)),
+        ('f("""""")', ("",)),
+        ("f('(')", ("(",)),
+        ("f(')')", (")",)),
+        ("f('f()')", ("f()",)),
+    ],
+)
+def test_parse_action_nested_special_character_arguments(
+    action_string: str, expected_arguments: tuple[Any]
+) -> None:
+    """Test that special characters nested in strings are handled correctly.
+
+    See: https://github.com/Textualize/textual/issues/2088
+    """
+    _, args = parse(action_string)
+    assert args == expected_arguments
+
+
+@pytest.mark.parametrize(
+    "action_string",
+    [
+        "foo(,,,,,)",
+        "bar(1 2 3 4 5)",
+        "baz.spam(Tru, Fals, in)",
+        "ham(not)",
+        "cheese((((()",
+    ],
+)
+def test_parse_action_raises_error(action_string: str) -> None:
+    with pytest.raises(ActionError):
+        parse(action_string)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -56,7 +56,7 @@ def test_nested_and_convoluted_tuple_arguments(
         ("f('''''')", ("",)),
         ('f("""""")', ("",)),
         ("f('(')", ("(",)),
-        ("f(')')", (")",)),
+        ("f(')')", (")",)),  # Regression test for #2088
         ("f('f()')", ("f()",)),
     ],
 )
@@ -65,7 +65,7 @@ def test_parse_action_nested_special_character_arguments(
 ) -> None:
     """Test that special characters nested in strings are handled correctly.
 
-    See: https://github.com/Textualize/textual/issues/2088
+    See also: https://github.com/Textualize/textual/issues/2088
     """
     _, args = parse(action_string)
     assert args == expected_arguments


### PR DESCRIPTION
This will close #2088.

This also uncovered a couple of more nuanced bugs that I have fixed in this PR and that are covered by tests.
These have to do with the previous way in which we decided if we should wrap the parsed parameters into another tuple or not.

It is easier to see the issue than to explain it.
The REPL session below uses  the "current" tip of `main`, e15805b93bbd2a4b2e321b0c0accba23bf198b86, _**after**_ changing the regex to `r"([\w\.]+)(\(.*\))"` as suggested by Dave in the linked issue to allow using `)` in the arguments.

```pycon
>>>  _, args = parse("f((1, 2, 3))")
>>> args
(1, 2, 3)
```

This is wrong! The result should be `((1, 2, 3),)`, a 1-item tuple with the tuple `(1, 2, 3)` inside it.

The returned action arguments must be "a tuple with all arguments".
Hence, if the only argument is a tuple, then we must return a 1-item tuple with that argument tuple inside it.
Previously, we would return the tuple itself, as if it were a collection of arguments.

To tackle this, we tweak the regex (so that the action arguments group doesn't capture the outer () from the function call) and add an auxiliary function that determines if a given string that parses as a tuple is a single tuple argument or not to cover all edge cases.
