### PR TITLE
enable console markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Textual will not render strings within renderables (such as tables) as Console Markup by default. You wrap wrap your text with rich.Text() if you want the original behavior. https://github.com/Textualize/textual/issues/2120
+- Textual will now render strings within renderables (such as tables) as Console Markup by default. You can wrap your text with rich.Text() if you want the original behavior. https://github.com/Textualize/textual/issues/2120
 
 ## [0.16.0] - 2023-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Textual will not render strings within renderables (such as tables) as Console Markup by default. You wrap wrap your text with rich.Text() if you want the original behavior. https://github.com/Textualize/textual/issues/2120
+
 ## [0.16.0] - 2023-03-22
 
 ### Added

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -319,7 +319,7 @@ class App(Generic[ReturnType], DOMNode):
 
         self.console = Console(
             file=file,
-            markup=False,
+            markup=True,
             highlight=False,
             emoji=False,
             legacy_windows=False,

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -18553,6 +18553,166 @@
   
   '''
 # ---
+# name: test_table_markup
+  '''
+  <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+      <!-- Generated with Rich https://www.textualize.io -->
+      <style>
+  
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Regular"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+          font-style: normal;
+          font-weight: 400;
+      }
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Bold"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+          font-style: bold;
+          font-weight: 700;
+      }
+  
+      .terminal-2727430444-matrix {
+          font-family: Fira Code, monospace;
+          font-size: 20px;
+          line-height: 24.4px;
+          font-variant-east-asian: full-width;
+      }
+  
+      .terminal-2727430444-title {
+          font-size: 18px;
+          font-weight: bold;
+          font-family: arial;
+      }
+  
+      .terminal-2727430444-r1 { fill: #e1e1e1 }
+  .terminal-2727430444-r2 { fill: #c5c8c6 }
+  .terminal-2727430444-r3 { fill: #e1e1e1;font-weight: bold }
+  .terminal-2727430444-r4 { fill: #98a84b;font-weight: bold;font-style: italic; }
+  .terminal-2727430444-r5 { fill: #98729f;font-weight: bold }
+  .terminal-2727430444-r6 { fill: #e1e1e1;font-style: italic; }
+  .terminal-2727430444-r7 { fill: #e1e1e1;text-decoration: underline; }
+      </style>
+  
+      <defs>
+      <clipPath id="terminal-2727430444-clip-terminal">
+        <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+      </clipPath>
+      <clipPath id="terminal-2727430444-line-0">
+      <rect x="0" y="1.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-1">
+      <rect x="0" y="25.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-2">
+      <rect x="0" y="50.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-3">
+      <rect x="0" y="74.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-4">
+      <rect x="0" y="99.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-5">
+      <rect x="0" y="123.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-6">
+      <rect x="0" y="147.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-7">
+      <rect x="0" y="172.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-8">
+      <rect x="0" y="196.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-9">
+      <rect x="0" y="221.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-10">
+      <rect x="0" y="245.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-11">
+      <rect x="0" y="269.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-12">
+      <rect x="0" y="294.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-13">
+      <rect x="0" y="318.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-14">
+      <rect x="0" y="343.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-15">
+      <rect x="0" y="367.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-16">
+      <rect x="0" y="391.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-17">
+      <rect x="0" y="416.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-18">
+      <rect x="0" y="440.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-19">
+      <rect x="0" y="465.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-20">
+      <rect x="0" y="489.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-21">
+      <rect x="0" y="513.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2727430444-line-22">
+      <rect x="0" y="538.3" width="976" height="24.65"/>
+              </clipPath>
+      </defs>
+  
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-2727430444-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">TableStaticApp</text>
+              <g transform="translate(26,22)">
+              <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+              <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+              <circle cx="44" cy="0" r="7" fill="#28c840"/>
+              </g>
+          
+      <g transform="translate(9, 41)" clip-path="url(#terminal-2727430444-clip-terminal)">
+      <rect fill="#1e1e1e" x="0" y="1.5" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="451.4" y="1.5" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="12.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="61" y="25.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="183" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="207.4" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="280.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="292.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="305" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="317.2" y="25.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="427" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="451.4" y="25.9" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="451.4" y="50.3" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="97.6" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="183" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="207.4" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="280.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="292.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="305" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="317.2" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="427" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="439.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="451.4" y="74.7" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="451.4" y="99.1" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-2727430444-matrix">
+      <text class="terminal-2727430444-r1" x="0" y="20" textLength="451.4" clip-path="url(#terminal-2727430444-line-0)">┏━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┓</text><text class="terminal-2727430444-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2727430444-line-0)">
+  </text><text class="terminal-2727430444-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-1)">┃</text><text class="terminal-2727430444-r4" x="24.4" y="44.4" textLength="36.6" clip-path="url(#terminal-2727430444-line-1)">Foo</text><text class="terminal-2727430444-r1" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-1)">┃</text><text class="terminal-2727430444-r3" x="207.4" y="44.4" textLength="73.2" clip-path="url(#terminal-2727430444-line-1)">Bar&#160;&#160;&#160;</text><text class="terminal-2727430444-r1" x="292.8" y="44.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-1)">┃</text><text class="terminal-2727430444-r3" x="317.2" y="44.4" textLength="109.8" clip-path="url(#terminal-2727430444-line-1)">baz&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2727430444-r1" x="439.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-1)">┃</text><text class="terminal-2727430444-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-1)">
+  </text><text class="terminal-2727430444-r1" x="0" y="68.8" textLength="451.4" clip-path="url(#terminal-2727430444-line-2)">┡━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━┩</text><text class="terminal-2727430444-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2727430444-line-2)">
+  </text><text class="terminal-2727430444-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-3)">│</text><text class="terminal-2727430444-r1" x="24.4" y="93.2" textLength="73.2" clip-path="url(#terminal-2727430444-line-3)">Hello&#160;</text><text class="terminal-2727430444-r5" x="97.6" y="93.2" textLength="73.2" clip-path="url(#terminal-2727430444-line-3)">World!</text><text class="terminal-2727430444-r1" x="183" y="93.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-3)">│</text><text class="terminal-2727430444-r6" x="207.4" y="93.2" textLength="73.2" clip-path="url(#terminal-2727430444-line-3)">Italic</text><text class="terminal-2727430444-r1" x="292.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-3)">│</text><text class="terminal-2727430444-r7" x="317.2" y="93.2" textLength="109.8" clip-path="url(#terminal-2727430444-line-3)">Underline</text><text class="terminal-2727430444-r1" x="439.2" y="93.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-3)">│</text><text class="terminal-2727430444-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-3)">
+  </text><text class="terminal-2727430444-r1" x="0" y="117.6" textLength="451.4" clip-path="url(#terminal-2727430444-line-4)">└──────────────┴────────┴───────────┘</text><text class="terminal-2727430444-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2727430444-line-4)">
+  </text><text class="terminal-2727430444-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2727430444-line-5)">
+  </text><text class="terminal-2727430444-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-6)">
+  </text><text class="terminal-2727430444-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2727430444-line-7)">
+  </text><text class="terminal-2727430444-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-8)">
+  </text><text class="terminal-2727430444-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2727430444-line-9)">
+  </text><text class="terminal-2727430444-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2727430444-line-10)">
+  </text><text class="terminal-2727430444-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-11)">
+  </text><text class="terminal-2727430444-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2727430444-line-12)">
+  </text><text class="terminal-2727430444-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-13)">
+  </text><text class="terminal-2727430444-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2727430444-line-14)">
+  </text><text class="terminal-2727430444-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2727430444-line-15)">
+  </text><text class="terminal-2727430444-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-16)">
+  </text><text class="terminal-2727430444-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2727430444-line-17)">
+  </text><text class="terminal-2727430444-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2727430444-line-18)">
+  </text><text class="terminal-2727430444-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2727430444-line-19)">
+  </text><text class="terminal-2727430444-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2727430444-line-20)">
+  </text><text class="terminal-2727430444-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2727430444-line-21)">
+  </text><text class="terminal-2727430444-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2727430444-line-22)">
+  </text>
+      </g>
+      </g>
+  </svg>
+  
+  '''
+# ---
 # name: test_textlog_max_lines
   '''
   <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">

--- a/tests/snapshot_tests/snapshot_apps/table_markup.py
+++ b/tests/snapshot_tests/snapshot_apps/table_markup.py
@@ -1,0 +1,16 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from rich.table import Table
+
+
+class TableStaticApp(App):
+    def compose(self) -> ComposeResult:
+        table = Table("[i green]Foo", "Bar", "baz")
+        table.add_row("Hello [bold magenta]World!", "[i]Italic", "[u]Underline")
+        yield Static(table)
+
+
+if __name__ == "__main__":
+    app = TableStaticApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -319,3 +319,7 @@ def test_remove_with_auto_height(snap_compare):
 
 def test_auto_table(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "auto-table.py", terminal_size=(120, 40))
+
+
+def test_table_markup(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "table_markup.py")


### PR DESCRIPTION
Enable console markup in renderables.

Previously if you returned a table with strings, those strings would not process markup. This re-enables that markup, so if a cell has "[b]Hello" it will be rendered in bold.