### PR TITLE
State version of widget addition in docs.

### DIFF
--- a/docs/widgets/_template.md
+++ b/docs/widgets/_template.md
@@ -1,5 +1,7 @@
 # Widget
 
+!!! tip "Added in version x.y.z"
+
 Widget description.
 
 - [ ] Focusable

--- a/docs/widgets/checkbox.md
+++ b/docs/widgets/checkbox.md
@@ -1,5 +1,7 @@
 # Checkbox
 
+!!! tip "Added in version 0.13.0"
+
 A simple checkbox widget which stores a boolean value.
 
 - [x] Focusable

--- a/docs/widgets/content_switcher.md
+++ b/docs/widgets/content_switcher.md
@@ -1,5 +1,7 @@
 # ContentSwitcher
 
+!!! tip "Added in version 0.14.0"
+
 A widget for containing and switching display between multiple child
 widgets.
 

--- a/docs/widgets/label.md
+++ b/docs/widgets/label.md
@@ -1,5 +1,7 @@
 # Label
 
+!!! tip "Added in version 0.5.0"
+
 A widget which displays static text, but which can also contain more complex Rich renderables.
 
 - [ ] Focusable

--- a/docs/widgets/list_item.md
+++ b/docs/widgets/list_item.md
@@ -1,5 +1,7 @@
 # ListItem
 
+!!! tip "Added in version 0.5.0"
+
 `ListItem` is the type of the elements in a `ListView`.
 
 - [ ] Focusable

--- a/docs/widgets/list_view.md
+++ b/docs/widgets/list_view.md
@@ -1,5 +1,7 @@
 # ListView
 
+!!! tip "Added in version 0.5.0"
+
 Displays a vertical list of `ListItem`s which can be highlighted and selected.
 Supports keyboard navigation.
 

--- a/docs/widgets/loading_indicator.md
+++ b/docs/widgets/loading_indicator.md
@@ -1,5 +1,7 @@
 # LoadingIndicator
 
+!!! tip "Added in version 0.15.0"
+
 Displays pulsating dots to indicate when data is being loaded.
 
 - [ ] Focusable

--- a/docs/widgets/markdown.md
+++ b/docs/widgets/markdown.md
@@ -1,5 +1,7 @@
 # Markdown
 
+!!! tip "Added in version 0.11.0"
+
 A widget to display a Markdown document.
 
 - [x] Focusable

--- a/docs/widgets/markdown_viewer.md
+++ b/docs/widgets/markdown_viewer.md
@@ -1,5 +1,7 @@
 # MarkdownViewer
 
+!!! tip "Added in version 0.11.0"
+
 A Widget to display Markdown content with an optional Table of Contents.
 
 - [x] Focusable

--- a/docs/widgets/placeholder.md
+++ b/docs/widgets/placeholder.md
@@ -1,5 +1,6 @@
 # Placeholder
 
+!!! tip "Added in version 0.6.0"
 
 A widget that is meant to have no complex functionality.
 Use the placeholder widget when studying the layout of your app before having to develop your custom widgets.

--- a/docs/widgets/radiobutton.md
+++ b/docs/widgets/radiobutton.md
@@ -1,5 +1,7 @@
 # RadioButton
 
+!!! tip "Added in version 0.13.0"
+
 A simple radio button which stores a boolean value.
 
 - [x] Focusable

--- a/docs/widgets/radioset.md
+++ b/docs/widgets/radioset.md
@@ -1,5 +1,7 @@
 # RadioSet
 
+!!! tip "Added in version 0.13.0"
+
 A container widget that groups [`RadioButton`](./radiobutton.md)s together.
 
 - [ ] Focusable

--- a/docs/widgets/tabbed_content.md
+++ b/docs/widgets/tabbed_content.md
@@ -1,5 +1,7 @@
 # TabbedContent
 
+!!! tip "Added in version 0.16.0"
+
 Switch between mutually exclusive content panes via a row of tabs.
 
 - [x] Focusable

--- a/docs/widgets/tabs.md
+++ b/docs/widgets/tabs.md
@@ -1,5 +1,7 @@
 # Tabs
 
+!!! tip "Added in version 0.15.0"
+
 Displays a number of tab headers which may be activated with a click or navigated with cursor keys.
 
 - [x] Focusable

--- a/docs/widgets/tree.md
+++ b/docs/widgets/tree.md
@@ -1,5 +1,7 @@
 # Tree
 
+!!! tip "Added in version 0.6.0"
+
 A tree control widget.
 
 - [x] Focusable


### PR DESCRIPTION
 - I had to guess the version in which ListView and ListItem were added because it isn't mentioned in the changelog.
  The first commits are from 7/8th of November when 0.4 was released and the corresponding blog post didn't mention ListView/ListItem, so I guessed 0.5 which was a couple of weeks after.

 - Widgets that have been around "forever" didn't get an admonition (`Button`, `Input`, `Header`, `Footer`, ...)

 - Renamed/rebuilt widgets didn't get an admonition (`DirectoryTree`, `Switch`)

 - I only added the admonition to the reference page, not the API page.

Related issues: #2133