### PR TITLE
remove arrangement spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Issue with parsing action strings whose arguments contained quoted closing parenthesis https://github.com/Textualize/textual/pull/2112
 - Issues with parsing action strings with tuple arguments https://github.com/Textualize/textual/pull/2112
 - Fix for tabs not invalidating https://github.com/Textualize/textual/issues/2125
+- Fixed scrollbar layers issue https://github.com/Textualize/textual/issues/1358
 
 ### Changed
 

--- a/src/textual/_arrange.py
+++ b/src/textual/_arrange.py
@@ -128,4 +128,4 @@ def arrange(
 
         placements.extend(layout_placements)
 
-    return DockArrangeResult(placements, arrange_widgets, scroll_spacing)
+    return DockArrangeResult(placements, arrange_widgets)

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -484,7 +484,6 @@ class Compositor:
                     # Arrange the layout
                     arrange_result = widget._arrange(child_region.size)
                     arranged_widgets = arrange_result.widgets
-                    spacing = arrange_result.spacing
                     widgets.update(arranged_widgets)
 
                     if visible_only:
@@ -513,9 +512,7 @@ class Compositor:
                         if fixed:
                             widget_region = sub_region + placement_offset
                         else:
-                            total_region = total_region.union(
-                                sub_region.grow(spacing + margin)
-                            )
+                            total_region = total_region.union(sub_region.grow(margin))
                             widget_region = sub_region + placement_scroll_offset
 
                         widget_order = order + (

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -21,8 +21,6 @@ class DockArrangeResult:
     """A `WidgetPlacement` for every widget to describe it's location on screen."""
     widgets: set[Widget]
     """A set of widgets in the arrangement."""
-    spacing: Spacing
-    """Shared spacing around the widgets."""
 
     _spatial_map: SpatialMap[WidgetPlacement] | None = None
     """A Spatial map to query widget placements."""
@@ -113,7 +111,7 @@ class Layout(ABC):
         else:
             # Use a size of 0, 0 to ignore relative sizes, since those are flexible anyway
             arrangement = widget._arrange(Size(0, 0))
-            return arrangement.total_region.right + arrangement.spacing.right
+            return arrangement.total_region.right
         return width
 
     def get_content_height(
@@ -135,5 +133,5 @@ class Layout(ABC):
         else:
             # Use a height of zero to ignore relative heights
             arrangement = widget._arrange(Size(width, 0))
-            height = arrangement.total_region.bottom + arrangement.spacing.bottom
+            height = arrangement.total_region.bottom
         return height

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -15508,6 +15508,165 @@
   
   '''
 # ---
+# name: test_layer_fix
+  '''
+  <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+      <!-- Generated with Rich https://www.textualize.io -->
+      <style>
+  
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Regular"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+          font-style: normal;
+          font-weight: 400;
+      }
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Bold"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+          font-style: bold;
+          font-weight: 700;
+      }
+  
+      .terminal-1675990519-matrix {
+          font-family: Fira Code, monospace;
+          font-size: 20px;
+          line-height: 24.4px;
+          font-variant-east-asian: full-width;
+      }
+  
+      .terminal-1675990519-title {
+          font-size: 18px;
+          font-weight: bold;
+          font-family: arial;
+      }
+  
+      .terminal-1675990519-r1 { fill: #c5c8c6 }
+  .terminal-1675990519-r2 { fill: #e3e3e3 }
+  .terminal-1675990519-r3 { fill: #e1e1e1 }
+  .terminal-1675990519-r4 { fill: #ff0000 }
+  .terminal-1675990519-r5 { fill: #dde8f3;font-weight: bold }
+  .terminal-1675990519-r6 { fill: #ddedf9 }
+      </style>
+  
+      <defs>
+      <clipPath id="terminal-1675990519-clip-terminal">
+        <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+      </clipPath>
+      <clipPath id="terminal-1675990519-line-0">
+      <rect x="0" y="1.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-1">
+      <rect x="0" y="25.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-2">
+      <rect x="0" y="50.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-3">
+      <rect x="0" y="74.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-4">
+      <rect x="0" y="99.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-5">
+      <rect x="0" y="123.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-6">
+      <rect x="0" y="147.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-7">
+      <rect x="0" y="172.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-8">
+      <rect x="0" y="196.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-9">
+      <rect x="0" y="221.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-10">
+      <rect x="0" y="245.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-11">
+      <rect x="0" y="269.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-12">
+      <rect x="0" y="294.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-13">
+      <rect x="0" y="318.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-14">
+      <rect x="0" y="343.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-15">
+      <rect x="0" y="367.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-16">
+      <rect x="0" y="391.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-17">
+      <rect x="0" y="416.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-18">
+      <rect x="0" y="440.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-19">
+      <rect x="0" y="465.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-20">
+      <rect x="0" y="489.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-21">
+      <rect x="0" y="513.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-1675990519-line-22">
+      <rect x="0" y="538.3" width="976" height="24.65"/>
+              </clipPath>
+      </defs>
+  
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-1675990519-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">DialogIssueApp</text>
+              <g transform="translate(26,22)">
+              <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+              <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+              <circle cx="44" cy="0" r="7" fill="#28c840"/>
+              </g>
+          
+      <g transform="translate(9, 41)" clip-path="url(#terminal-1675990519-clip-terminal)">
+      <rect fill="#282828" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="12.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="24.4" y="1.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="97.6" y="1.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="390.4" y="1.5" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="561.2" y="1.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="866.2" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#282828" x="963.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="147.9" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="147.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="172.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="172.3" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="172.3" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="196.7" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="196.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="221.1" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="221.1" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="245.5" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="245.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="269.9" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="269.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="294.3" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="294.3" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="318.7" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="318.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="343.1" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="343.1" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="367.5" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="367.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="391.9" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="391.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="416.3" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="416.3" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="440.7" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="732" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="744.2" y="440.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0053aa" x="0" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="562.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="268.4" y="562.7" width="707.6" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-1675990519-matrix">
+      <text class="terminal-1675990519-r2" x="12.2" y="20" textLength="12.2" clip-path="url(#terminal-1675990519-line-0)">⭘</text><text class="terminal-1675990519-r2" x="390.4" y="20" textLength="170.8" clip-path="url(#terminal-1675990519-line-0)">DialogIssueApp</text><text class="terminal-1675990519-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1675990519-line-0)">
+  </text><text class="terminal-1675990519-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-1)">
+  </text><text class="terminal-1675990519-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-2)">
+  </text><text class="terminal-1675990519-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-3)">
+  </text><text class="terminal-1675990519-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-4)">
+  </text><text class="terminal-1675990519-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1675990519-line-5)">
+  </text><text class="terminal-1675990519-r4" x="244" y="166.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-6)">╭</text><text class="terminal-1675990519-r4" x="256.2" y="166.4" textLength="475.8" clip-path="url(#terminal-1675990519-line-6)">───────────────────────────────────────</text><text class="terminal-1675990519-r4" x="732" y="166.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-6)">╮</text><text class="terminal-1675990519-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-6)">
+  </text><text class="terminal-1675990519-r4" x="244" y="190.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-7)">│</text><text class="terminal-1675990519-r4" x="732" y="190.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-7)">│</text><text class="terminal-1675990519-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-7)">
+  </text><text class="terminal-1675990519-r4" x="244" y="215.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-8)">│</text><text class="terminal-1675990519-r4" x="732" y="215.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-8)">│</text><text class="terminal-1675990519-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-8)">
+  </text><text class="terminal-1675990519-r4" x="244" y="239.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-9)">│</text><text class="terminal-1675990519-r4" x="732" y="239.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-9)">│</text><text class="terminal-1675990519-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-9)">
+  </text><text class="terminal-1675990519-r4" x="244" y="264" textLength="12.2" clip-path="url(#terminal-1675990519-line-10)">│</text><text class="terminal-1675990519-r4" x="732" y="264" textLength="12.2" clip-path="url(#terminal-1675990519-line-10)">│</text><text class="terminal-1675990519-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1675990519-line-10)">
+  </text><text class="terminal-1675990519-r4" x="244" y="288.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-11)">│</text><text class="terminal-1675990519-r4" x="732" y="288.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-11)">│</text><text class="terminal-1675990519-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-11)">
+  </text><text class="terminal-1675990519-r4" x="244" y="312.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-12)">│</text><text class="terminal-1675990519-r3" x="256.2" y="312.8" textLength="475.8" clip-path="url(#terminal-1675990519-line-12)">This&#160;should&#160;not&#160;cause&#160;a&#160;scrollbar&#160;to&#160;ap</text><text class="terminal-1675990519-r4" x="732" y="312.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-12)">│</text><text class="terminal-1675990519-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-12)">
+  </text><text class="terminal-1675990519-r4" x="244" y="337.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-13)">│</text><text class="terminal-1675990519-r4" x="732" y="337.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-13)">│</text><text class="terminal-1675990519-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-13)">
+  </text><text class="terminal-1675990519-r4" x="244" y="361.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-14)">│</text><text class="terminal-1675990519-r4" x="732" y="361.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-14)">│</text><text class="terminal-1675990519-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-14)">
+  </text><text class="terminal-1675990519-r4" x="244" y="386" textLength="12.2" clip-path="url(#terminal-1675990519-line-15)">│</text><text class="terminal-1675990519-r4" x="732" y="386" textLength="12.2" clip-path="url(#terminal-1675990519-line-15)">│</text><text class="terminal-1675990519-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1675990519-line-15)">
+  </text><text class="terminal-1675990519-r4" x="244" y="410.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-16)">│</text><text class="terminal-1675990519-r4" x="732" y="410.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-16)">│</text><text class="terminal-1675990519-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-16)">
+  </text><text class="terminal-1675990519-r4" x="244" y="434.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-17)">│</text><text class="terminal-1675990519-r4" x="732" y="434.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-17)">│</text><text class="terminal-1675990519-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-17)">
+  </text><text class="terminal-1675990519-r4" x="244" y="459.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-18)">╰</text><text class="terminal-1675990519-r4" x="256.2" y="459.2" textLength="475.8" clip-path="url(#terminal-1675990519-line-18)">───────────────────────────────────────</text><text class="terminal-1675990519-r4" x="732" y="459.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-18)">╯</text><text class="terminal-1675990519-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1675990519-line-18)">
+  </text><text class="terminal-1675990519-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1675990519-line-19)">
+  </text><text class="terminal-1675990519-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1675990519-line-20)">
+  </text><text class="terminal-1675990519-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1675990519-line-21)">
+  </text><text class="terminal-1675990519-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1675990519-line-22)">
+  </text><text class="terminal-1675990519-r5" x="0" y="581.2" textLength="36.6" clip-path="url(#terminal-1675990519-line-23)">&#160;D&#160;</text><text class="terminal-1675990519-r6" x="36.6" y="581.2" textLength="231.8" clip-path="url(#terminal-1675990519-line-23)">&#160;Toggle&#160;the&#160;dialog&#160;</text>
+      </g>
+      </g>
+  </svg>
+  
+  '''
+# ---
 # name: test_layers
   '''
   <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">

--- a/tests/snapshot_tests/snapshot_apps/layer_fix.py
+++ b/tests/snapshot_tests/snapshot_apps/layer_fix.py
@@ -1,0 +1,48 @@
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Header, Footer, Label
+from textual.binding import Binding
+
+
+class Dialog(Vertical):
+    def compose(self) -> ComposeResult:
+        """Compose the child widgets."""
+        yield Label("This should not cause a scrollbar to appear")
+
+
+class DialogIssueApp(App[None]):
+    CSS = """
+    Screen {
+        layers: base dialog;
+    }
+
+    .hidden {
+        display: none;
+    }
+
+    Dialog {
+        align: center middle;
+        border: round red;
+        width: 50%;
+        height: 50%;
+        layer: dialog;
+        offset: 50% 50%;
+    }
+    """
+
+    BINDINGS = [
+        Binding("d", "dialog", "Toggle the dialog"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Vertical()
+        yield Dialog(classes="hidden")
+        yield Footer()
+
+    def action_dialog(self) -> None:
+        self.query_one(Dialog).toggle_class("hidden")
+
+
+if __name__ == "__main__":
+    DialogIssueApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -343,4 +343,5 @@ def test_scrollbar_thumb_height(snap_compare):
 
 
 def test_layer_fix(snap_compare):
+    # Check https://github.com/Textualize/textual/issues/1358
     assert snap_compare(SNAPSHOT_APPS_DIR / "layer_fix.py", press=["d"])

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -340,3 +340,7 @@ def test_scrollbar_thumb_height(snap_compare):
     assert snap_compare(
         SNAPSHOT_APPS_DIR / "scrollbar_thumb_height.py",
     )
+
+
+def test_layer_fix(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "layer_fix.py", press=["d"])

--- a/tests/test_arrange.py
+++ b/tests/test_arrange.py
@@ -12,7 +12,6 @@ def test_arrange_empty():
     result = arrange(container, [], Size(80, 24), Size(80, 24))
     assert result.placements == []
     assert result.widgets == set()
-    assert result.spacing == Spacing(0, 0, 0, 0)
 
 
 def test_arrange_dock_top():
@@ -31,7 +30,6 @@ def test_arrange_dock_top():
         WidgetPlacement(Region(0, 1, 80, 23), Spacing(), child, order=0, fixed=False),
     ]
     assert result.widgets == {child, header}
-    assert result.spacing == Spacing(1, 0, 0, 0)
 
 
 def test_arrange_dock_left():
@@ -49,7 +47,6 @@ def test_arrange_dock_left():
         WidgetPlacement(Region(10, 0, 70, 24), Spacing(), child, order=0, fixed=False),
     ]
     assert result.widgets == {child, header}
-    assert result.spacing == Spacing(0, 0, 0, 10)
 
 
 def test_arrange_dock_right():
@@ -67,7 +64,6 @@ def test_arrange_dock_right():
         WidgetPlacement(Region(0, 0, 70, 24), Spacing(), child, order=0, fixed=False),
     ]
     assert result.widgets == {child, header}
-    assert result.spacing == Spacing(0, 10, 0, 0)
 
 
 def test_arrange_dock_bottom():
@@ -85,7 +81,6 @@ def test_arrange_dock_bottom():
         WidgetPlacement(Region(0, 0, 80, 23), Spacing(), child, order=0, fixed=False),
     ]
     assert result.widgets == {child, header}
-    assert result.spacing == Spacing(0, 0, 1, 0)
 
 
 def test_arrange_dock_badly():


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/1358

The `spacing` attribute on `DockArrangeResult` was throwing off calculations.

Fortunately it doesn't seem to be required at all. Removing it only broke tests that explicitly checked it. I think it was superseded by a calculation done in `arrange`.