### PR TITLE
Extend `OptionList` testing

### DIFF
--- a/tests/option_list/test_option_list_disabled.py
+++ b/tests/option_list/test_option_list_disabled.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from textual.app import App, ComposeResult
 from textual.widgets import OptionList
-from textual.widgets.option_list import Option
+from textual.widgets.option_list import Option, OptionDoesNotExist
 
 
 class OptionListApp(App[None]):
@@ -78,3 +80,31 @@ async def test_disabled_to_enabled_via_id() -> None:
             assert option_list.get_option(str(n)).disabled is True
             option_list.enable_option(str(n))
             assert option_list.get_option(str(n)).disabled is False
+
+
+async def test_disable_invalid_id() -> None:
+    """Disabling an option via an ID that does not exist should throw an error."""
+    async with OptionListApp(True).run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).disable_option("does-not-exist")
+
+
+async def test_disable_invalid_index() -> None:
+    """Disabling an option via an index that does not exist should throw an error."""
+    async with OptionListApp(True).run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).disable_option_at_index(4242)
+
+
+async def test_enable_invalid_id() -> None:
+    """Disabling an option via an ID that does not exist should throw an error."""
+    async with OptionListApp(False).run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).enable_option("does-not-exist")
+
+
+async def test_enable_invalid_index() -> None:
+    """Disabling an option via an index that does not exist should throw an error."""
+    async with OptionListApp(False).run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).enable_option_at_index(4242)

--- a/tests/option_list/test_option_removal.py
+++ b/tests/option_list/test_option_removal.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from textual.app import App, ComposeResult
 from textual.widgets import OptionList
-from textual.widgets.option_list import Option
+from textual.widgets.option_list import Option, OptionDoesNotExist
 
 
 class OptionListApp(App[None]):
@@ -83,3 +85,17 @@ async def test_remove_all_options_via_id() -> None:
         option_list.remove_option("1")
         assert option_list.option_count == 0
         assert option_list.highlighted is None
+
+
+async def test_remove_invalid_id() -> None:
+    """Attempting to remove an option ID that doesn't exist should raise an exception."""
+    async with OptionListApp().run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).remove_option("does-not-exist")
+
+
+async def test_remove_invalid_index() -> None:
+    """Attempting to remove an option index that doesn't exist should raise an exception."""
+    async with OptionListApp().run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).remove_option_at_index(23)


### PR DESCRIPTION
Some of the changes in response to the review of the `OptionList` PR resulted in its coverage dropping a wee bit. This gets it back to where it was.