### PR TITLE
Rework `RadioSet` so it no longer leans on the DOM for state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### [Fixed]
+
+- `RadioSet` is now far less likely to report `pressed_button` as `None` https://github.com/Textualize/textual/issues/2203
+
 ## [0.17.3] - 2023-04-02
 
 ### [Fixed]

--- a/src/textual/widgets/_radio_set.py
+++ b/src/textual/widgets/_radio_set.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from rich.repr import Result
+import rich.repr
 
 from ..containers import Container
 from ..message import Message
@@ -30,6 +30,7 @@ class RadioSet(Container):
     }
     """
 
+    @rich.repr.auto
     class Changed(Message, bubble=True):
         """Posted when the pressed button in the set changes.
 
@@ -50,7 +51,7 @@ class RadioSet(Container):
             self.index = radio_set.pressed_index
             """The index of the `RadioButton` that was pressed to make the change."""
 
-        def __rich_repr__(self) -> Result:
+        def __rich_repr__(self) -> rich.repr.Result:
             yield "radio_set", self.radio_set
             yield "pressed", self.pressed
             yield "index", self.index

--- a/src/textual/widgets/_radio_set.py
+++ b/src/textual/widgets/_radio_set.py
@@ -78,8 +78,6 @@ class RadioSet(Container):
             it.
         """
         self._pressed_button: RadioButton | None = None
-        """Keeps track of which radio button is pressed."""
-        self._buttons: list[RadioButton] = []
         """Holds the radio buttons we're responsible for."""
         super().__init__(
             *[
@@ -95,18 +93,12 @@ class RadioSet(Container):
     def on_mount(self) -> None:
         """Perform some processing once mounted in the DOM."""
 
-        # Get the collection of buttons we're directly responsible for. We
-        # do this in here rather than in __init__ because someone might be
-        # composing the RadioSet using it as a context manager; point being
-        # there won't be any buttons being passed to __init__.
-        self._buttons = list(self.query(RadioButton))
-
         # It's possible for the user to pass in a collection of radio
         # buttons, with more than one set to on; they shouldn't, but we
         # can't stop them. So here we check for that and, for want of a
         # better approach, we keep the first one on and turn all the others
         # off.
-        switched_on = [button for button in self._buttons if button.value]
+        switched_on = [button for button in self.query(RadioButton) if button.value]
         with self.prevent(RadioButton.Changed):
             for button in switched_on[1:]:
                 button.value = False

--- a/tests/toggles/test_radioset.py
+++ b/tests/toggles/test_radioset.py
@@ -39,8 +39,8 @@ async def test_radio_sets_initial_state():
 async def test_radio_sets_toggle():
     """Test the status of the radio sets after they've been toggled."""
     async with RadioSetApp().run_test() as pilot:
-        pilot.app.query_one("#from_buttons", RadioSet)._buttons[0].toggle()
-        pilot.app.query_one("#from_strings", RadioSet)._buttons[2].toggle()
+        pilot.app.query_one("#from_buttons", RadioSet)._nodes[0].toggle()
+        pilot.app.query_one("#from_strings", RadioSet)._nodes[2].toggle()
         await pilot.pause()
         assert pilot.app.query_one("#from_buttons", RadioSet).pressed_index == 0
         assert pilot.app.query_one("#from_buttons", RadioSet).pressed_button is not None


### PR DESCRIPTION
See #2202 and subsequently #2203. While unable to reproduce locally, it does look like there are some environments where it was possible for a `RadioSet` to briefly appear to have two buttons pressed, which in turn would result in `pressed_button` evaluating to `None`.

This PR changes the internals of `RadioSet` so that it no longer uses the DOM to track state, which should remove the issue.