### PR TITLE
Fix border rendering issue.

### DIFF
--- a/src/textual/_border.py
+++ b/src/textual/_border.py
@@ -327,6 +327,8 @@ def render_border_label(
         return
 
     text_label = Text.from_markup(label)
+    if not text_label.cell_len:
+        return
     text_label.truncate(width - cells_reserved, overflow="ellipsis")
     segments = text_label.render(console)
 

--- a/tests/test_border.py
+++ b/tests/test_border.py
@@ -175,6 +175,33 @@ def test_render_border_label_wide_plain(label: str):
     assert original_text == Segment(label, _EMPTY_STYLE)
 
 
+@pytest.mark.parametrize(
+    "label",
+    [
+        "[b][/]",
+        "[i b][/]",
+        "[white on red][/]",
+        "[blue]",
+    ],
+)
+def test_render_border_empty_text_with_markup(label: str):
+    """Test label rendering if there is no text but some markup."""
+    assert [] == list(
+        render_border_label(
+            label,
+            True,
+            "round",
+            999,
+            _EMPTY_STYLE,
+            _EMPTY_STYLE,
+            _EMPTY_STYLE,
+            _WIDE_CONSOLE,
+            True,
+            True,
+        )
+    )
+
+
 def test_render_border_label():
     """Test label rendering with styling, with and without overflow."""
 


### PR DESCRIPTION
When a border label was empty but contained markup, the padding was still being rendered and the label would end up with some weird blank spaces.

Added tests and fixed the issue.