### PR TITLE
Use string representation of the item to order

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1900,7 +1900,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             row: tuple[RowKey, dict[ColumnKey | str, CellType]]
         ) -> Any:
             _, row_data = row
-            result = itemgetter(*columns)(row_data)
+            result = str(itemgetter(*columns)(row_data))
             return result
 
         ordered_rows = sorted(


### PR DESCRIPTION
**Please review the following checklist.** [PENDING]

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

Following PR modifies `sort` method as part  of `DataTable` so it uses the string representation of the item when ordering.
I have a project that uses a `DataTable` and has `rich.Text` in its cells, to make use of different styles depending of the cell content, but I cannot order the table because `rich.Text` entities cannot be compared, raising a `TypeError: '<' not supported between instances of 'Text' and 'Text'`.
With this patch, `rich.Text` entities use  their plain content, the string value, so they can be compared and ordered via `DataTable.sort`.
