### PR TITLE
implement single line comments

### DIFF
--- a/examples/calculator.css
+++ b/examples/calculator.css
@@ -2,7 +2,7 @@ Screen {
     overflow: auto;
 }
 
-#calculator {    
+#calculator {
     layout: grid;
     grid-size: 4;
     grid-gutter: 1 2;

--- a/src/textual/css/tokenize.py
+++ b/src/textual/css/tokenize.py
@@ -16,6 +16,7 @@ HEX_COLOR = r"\#[0-9a-fA-F]{8}|\#[0-9a-fA-F]{6}|\#[0-9a-fA-F]{4}|\#[0-9a-fA-F]{3
 RGB_COLOR = rf"rgb{OPEN_BRACE}{DECIMAL}{COMMA}{DECIMAL}{COMMA}{DECIMAL}{CLOSE_BRACE}|rgba{OPEN_BRACE}{DECIMAL}{COMMA}{DECIMAL}{COMMA}{DECIMAL}{COMMA}{DECIMAL}{CLOSE_BRACE}"
 HSL_COLOR = rf"hsl{OPEN_BRACE}{DECIMAL}{COMMA}{PERCENT}{COMMA}{PERCENT}{CLOSE_BRACE}|hsla{OPEN_BRACE}{DECIMAL}{COMMA}{PERCENT}{COMMA}{PERCENT}{COMMA}{DECIMAL}{CLOSE_BRACE}"
 
+COMMENT_LINE = r"\# .*$"
 COMMENT_START = r"\/\*"
 SCALAR = rf"{DECIMAL}(?:fr|%|w|h|vw|vh)"
 DURATION = r"\d+\.?\d*(?:ms|s)"
@@ -46,6 +47,7 @@ DECLARATION_VALUES = {
 expect_root_scope = Expect(
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     selector_start_id=r"\#" + IDENTIFIER,
     selector_start_class=r"\." + IDENTIFIER,
     selector_start_universal=r"\*",
@@ -59,6 +61,7 @@ expect_variable_name_continue = Expect(
     variable_value_end=r"\n|;",
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     **DECLARATION_VALUES,
 ).expect_eof(True)
 
@@ -71,6 +74,7 @@ expect_comment_end = Expect(
 expect_selector_continue = Expect(
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     pseudo_class=r"\:[a-zA-Z_-]+",
     selector_id=r"\#[a-zA-Z_\-][a-zA-Z0-9_\-]*",
     selector_class=r"\.[a-zA-Z_\-][a-zA-Z0-9_\-]*",
@@ -86,6 +90,7 @@ expect_selector_continue = Expect(
 expect_declaration = Expect(
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     declaration_name=r"[a-zA-Z_\-]+\:",
     declaration_set_end=r"\}",
 )
@@ -93,6 +98,7 @@ expect_declaration = Expect(
 expect_declaration_solo = Expect(
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     declaration_name=r"[a-zA-Z_\-]+\:",
     declaration_set_end=r"\}",
 ).expect_eof(True)
@@ -103,6 +109,7 @@ expect_declaration_content = Expect(
     declaration_end=r";",
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     **DECLARATION_VALUES,
     important=r"\!important",
     comma=",",
@@ -113,6 +120,7 @@ expect_declaration_content_solo = Expect(
     declaration_end=r";",
     whitespace=r"\s+",
     comment_start=COMMENT_START,
+    comment_line=COMMENT_LINE,
     **DECLARATION_VALUES,
     important=r"\!important",
     comma=",",
@@ -157,7 +165,9 @@ class TokenizerState:
         while True:
             token = get_token(expect)
             name = token.name
-            if name == "comment_start":
+            if name == "comment_line":
+                continue
+            elif name == "comment_start":
                 tokenizer.skip_to(expect_comment_end)
                 continue
             elif name == "eof":

--- a/tests/css/test_tokenize.py
+++ b/tests/css/test_tokenize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from textual.css.parse import parse
 from textual.css.tokenize import tokenize
 from textual.css.tokenizer import Token, TokenError
 
@@ -173,6 +174,127 @@ def test_variable_declaration_multiple_values():
             referenced_by=None,
         ),
     ]
+
+
+def test_single_line_comment():
+    css = """\
+# Ignored
+#foo { # Ignored
+    color: red; # Also ignored
+} # Nada"""
+    # Check the css parses
+    # list(parse(css, "<foo>"))
+    result = list(tokenize(css, ""))
+
+    print(result)
+    expected = [
+        Token(
+            name="whitespace",
+            value="\n",
+            path="",
+            code=css,
+            location=(0, 9),
+        ),
+        Token(
+            name="selector_start_id",
+            value="#foo",
+            path="",
+            code=css,
+            location=(1, 0),
+        ),
+        Token(
+            name="whitespace",
+            value=" ",
+            path="",
+            code=css,
+            location=(1, 4),
+        ),
+        Token(
+            name="declaration_set_start",
+            value="{",
+            path="",
+            code=css,
+            location=(1, 5),
+        ),
+        Token(
+            name="whitespace",
+            value=" ",
+            path="",
+            code=css,
+            location=(1, 6),
+        ),
+        Token(
+            name="whitespace",
+            value="\n",
+            path="",
+            code=css,
+            location=(1, 16),
+        ),
+        Token(
+            name="whitespace",
+            value="    ",
+            path="",
+            code=css,
+            location=(2, 0),
+        ),
+        Token(
+            name="declaration_name",
+            value="color:",
+            path="",
+            code=css,
+            location=(2, 4),
+        ),
+        Token(
+            name="whitespace",
+            value=" ",
+            path="",
+            code=css,
+            location=(2, 10),
+        ),
+        Token(
+            name="token",
+            value="red",
+            path="",
+            code=css,
+            location=(2, 11),
+        ),
+        Token(
+            name="declaration_end",
+            value=";",
+            path="",
+            code=css,
+            location=(2, 14),
+        ),
+        Token(
+            name="whitespace",
+            value=" ",
+            path="",
+            code=css,
+            location=(2, 15),
+        ),
+        Token(
+            name="whitespace",
+            value="\n",
+            path="",
+            code=css,
+            location=(2, 30),
+        ),
+        Token(
+            name="declaration_set_end",
+            value="}",
+            path="",
+            code=css,
+            location=(3, 0),
+        ),
+        Token(
+            name="whitespace",
+            value=" ",
+            path="",
+            code=css,
+            location=(3, 1),
+        ),
+    ]
+    assert result == expected
 
 
 def test_variable_declaration_comment_ignored():


### PR DESCRIPTION
Implements single line comments.

Commenting out CSS in code is a pain. VSCode doesn't know know to use css comment syntax, and comments with a `#` which is invalid CSS.

This PR breaks with the syntax of CSS to add single line comments which start with a `#` followed by a space, and then to the end of the line.

Note the space after the `#` makes it a comment, otherwise IDs would become comments.

This is a bit of an experiment. Want to see if there are any unintended consiquences.