### PR TITLE
Move responsibility for writing in to driver

### DIFF
--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -94,11 +94,15 @@ class LayoutUpdate:
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
+        return self.iter_segments()
+
+    def iter_segments(self) -> Iterable[Segment]:
+        """Get an iterable of segments."""
         x = self.region.x
         new_line = Segment.line()
         move_to = Control.move_to
         for last, (y, line) in loop_last(enumerate(self.strips, self.region.y)):
-            yield move_to(x, y)
+            yield move_to(x, y).segment
             yield from line
             if not last:
                 yield new_line
@@ -131,6 +135,10 @@ class ChopsUpdate:
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
+        return self.iter_segments()
+
+    def iter_segments(self) -> Iterable[Segment]:
+        """Get an iterable of segments."""
         move_to = Control.move_to
         new_line = Segment.line()
         chops = self.chops
@@ -150,7 +158,7 @@ class ChopsUpdate:
                     continue
 
                 if x2 > x >= x1 and end <= x2:
-                    yield move_to(x, y)
+                    yield move_to(x, y).segment
                     yield from strip
                     continue
 
@@ -159,12 +167,12 @@ class ChopsUpdate:
                     for segment in iter_segments:
                         next_x = x + _cell_len(segment.text)
                         if next_x > x1:
-                            yield move_to(x, y)
+                            yield move_to(x, y).segment
                             yield segment
                             break
                         x = next_x
                 else:
-                    yield move_to(x, y)
+                    yield move_to(x, y).segment
                 if end <= x2:
                     yield from iter_segments
                 else:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -259,6 +259,7 @@ class App(Generic[ReturnType], DOMNode):
             emoji=False,
             legacy_windows=False,
             _environ=environ,
+            force_terminal=True,
         )
         self._workers = WorkerManager(self)
         self.error_console = Console(markup=False, stderr=True)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -171,6 +171,19 @@ CSSPathType = Union[
 CallThreadReturnType = TypeVar("CallThreadReturnType")
 
 
+class _NullFile:
+    """A file-like where writes go nowhere."""
+
+    def write(self, text: str) -> None:
+        pass
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return True
+
+
 @rich.repr.auto
 class App(Generic[ReturnType], DOMNode):
     """The base class for Textual Applications.
@@ -253,7 +266,7 @@ class App(Generic[ReturnType], DOMNode):
             self._filter = Monochrome()
 
         self.console = Console(
-            file=sys.__stdout__,
+            file=_NullFile(),
             markup=True,
             highlight=False,
             emoji=False,
@@ -822,6 +835,7 @@ class App(Generic[ReturnType], DOMNode):
         """
         assert self._driver is not None, "App must be running"
         width, height = self.size
+
         console = Console(
             width=width,
             height=height,

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -542,18 +542,6 @@ class App(Generic[ReturnType], DOMNode):
 
         return namespace_binding_map
 
-    @property
-    def driver(self) -> Driver:
-        """The Textual driver.
-
-        Warning:
-
-            Here be dragons! The driver object is not something most apps will use directly
-
-        """
-        assert self._driver is not None
-        return self._driver
-
     def _set_active(self) -> None:
         """Set this app to be the currently active app."""
         active_app.set(self)
@@ -1724,7 +1712,6 @@ class App(Generic[ReturnType], DOMNode):
 
                 finally:
                     driver.stop_application_mode()
-                    driver.close()
         except Exception as error:
             self._handle_exception(error)
 
@@ -1945,7 +1932,7 @@ class App(Generic[ReturnType], DOMNode):
             await self._disconnect_devtools()
 
         if self._driver is not None:
-            self.driver.flush()
+            self._driver.close()
 
         self._print_error_renderables()
 
@@ -1997,10 +1984,10 @@ class App(Generic[ReturnType], DOMNode):
                     except Exception as error:
                         self._handle_exception(error)
                     else:
-                        self.driver.write(terminal_sequence)
+                        self._driver.write(terminal_sequence)
                 finally:
                     self._end_update()
-                self.driver.flush()
+                self._driver.flush()
         finally:
             self.post_display_hook()
 
@@ -2493,9 +2480,9 @@ class App(Generic[ReturnType], DOMNode):
         self._sync_available = True
 
     def _begin_update(self) -> None:
-        if self._sync_available:
-            self.driver.write(SYNC_START)
+        if self._sync_available and self._driver is not None:
+            self._driver.write(SYNC_START)
 
     def _end_update(self) -> None:
-        if self._sync_available:
-            self.driver.write(SYNC_END)
+        if self._sync_available and self._driver is not None:
+            self._driver.write(SYNC_END)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -95,7 +95,7 @@ from .screen import Screen
 from .widget import AwaitMount, Widget
 
 if TYPE_CHECKING:
-    from typing_extensions import Coroutine, Final, TypeAlias
+    from typing_extensions import Coroutine, TypeAlias
 
     from .devtools.client import DevtoolsClient
     from .pilot import Pilot
@@ -830,6 +830,7 @@ class App(Generic[ReturnType], DOMNode):
             color_system="truecolor",
             record=True,
             legacy_windows=False,
+            safe_box=False,
         )
         screen_render = self.screen._compositor.render_update(
             full=True, screen_stack=self.app._background_screens

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -260,6 +260,7 @@ class App(Generic[ReturnType], DOMNode):
             legacy_windows=False,
             _environ=environ,
             force_terminal=True,
+            safe_box=False,
         )
         self._workers = WorkerManager(self)
         self.error_console = Console(markup=False, stderr=True)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1979,7 +1979,11 @@ class App(Generic[ReturnType], DOMNode):
                 self._begin_update()
                 try:
                     try:
-                        segments = console.render(renderable)
+                        segments = (
+                            renderable.iter_segments()
+                            if hasattr(renderable, "iter_segments")
+                            else console.render(renderable)
+                        )
                         terminal_sequence = console._render_buffer(segments)
                     except Exception as error:
                         self._handle_exception(error)

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -128,3 +128,6 @@ class Driver(ABC):
     @abstractmethod
     def stop_application_mode(self) -> None:
         """Stop application mode, restore state."""
+
+    def close(self) -> None:
+        """Perform any final cleanup."""

--- a/src/textual/drivers/_writer_thread.py
+++ b/src/textual/drivers/_writer_thread.py
@@ -30,7 +30,7 @@ class WriterThread(threading.Thread):
         """Pretend to be a terminal.
 
         Returns:
-            True if this is a tty.
+            True.
         """
         return True
 

--- a/src/textual/drivers/_writer_thread.py
+++ b/src/textual/drivers/_writer_thread.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import threading
+from queue import Queue
+from typing import IO
+
+from typing_extensions import Final
+
+MAX_QUEUED_WRITES: Final[int] = 30
+
+
+class WriterThread(threading.Thread):
+    """A thread / file-like to do writes to stdout in the background."""
+
+    def __init__(self, file: IO[str]) -> None:
+        super().__init__(daemon=True)
+        self._queue: Queue[str | None] = Queue(MAX_QUEUED_WRITES)
+        self._file = file
+
+    def write(self, text: str) -> None:
+        """Write text. Text will be enqueued for writing.
+
+        Args:
+            text: Text to write to the file.
+        """
+        self._queue.put(text)
+
+    def isatty(self) -> bool:
+        """Pretend to be a terminal.
+
+        Returns:
+            True if this is a tty.
+        """
+        return True
+
+    def fileno(self) -> int:
+        """Get file handle number.
+
+        Returns:
+            File number of proxied file.
+        """
+        return self._file.fileno()
+
+    def flush(self) -> None:
+        """Flush the file (a no-op, because flush is done in the thread)."""
+        return
+
+    def run(self) -> None:
+        """Run the thread."""
+        write = self._file.write
+        flush = self._file.flush
+        get = self._queue.get
+        qsize = self._queue.qsize
+        # Read from the queue, write to the file.
+        # Flush when there is a break.
+        while True:
+            text: str | None = get()
+            if text is None:
+                break
+            write(text)
+            if qsize() == 0:
+                flush()
+        flush()
+
+    def stop(self) -> None:
+        """Stop the thread, and block until it finished."""
+        self._queue.put(None)
+        self.join()


### PR DESCRIPTION
Previously the App was writing to `console.file` directly. This update write to the Driver object, which will benefit textual-serve which needs to intercept these writes.

- Adds a Driver.close method, to allow stop_application_mode and start_application_mode to be called more than once in a future update.
- The WriterThread object has been moved out of app, in to the drivers.
- Updating the console is now a little simpler (and faster) as a side effect.