### PR TITLE
fix(app): explicitly check if action_target is none

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2149,7 +2149,9 @@ class App(Generic[ReturnType], DOMNode):
             action_target = getattr(self, destination)
             implicit_destination = True
         else:
-            action_target = default_namespace or self
+            action_target = default_namespace
+            if action_target is None:
+                action_target = self
             action_name = target
 
         handled = await self._dispatch_action(action_target, action_name, params)


### PR DESCRIPTION
Fixes #2265 by explicitly checking if `action_target` is None.

Thanks again to @davep for his help with this issue.





