### PR TITLE
Scroll to center when tab is clicked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Changed signature of Driver. Technically a breaking change, but unlikely to affect anyone.
 - Breaking change: Timer.start is now private, and returns No
+- A clicked tab will now be scrolled to the center of its tab container https://github.com/Textualize/textual/pull/2276
 
 ### Added
 
 - Added `DataTable.remove_row` method https://github.com/Textualize/textual/pull/2253
-- `Widget.scroll_to_center` now scrolls the widget to the center of the screen https://github.com/Textualize/textual/pull/2255
+- `Widget.scroll_to_center` method to scroll children to the center of container widget https://github.com/Textualize/textual/pull/2255 and https://github.com/Textualize/textual/pull/2276
 - Added `TabActivated` message to `TabbedContent` https://github.com/Textualize/textual/pull/2260
 
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2475,6 +2475,7 @@ class Widget(DOMNode):
 
     def scroll_to_center(
         self,
+        widget: Widget,
         animate: bool = True,
         *,
         speed: float | None = None,
@@ -2493,8 +2494,8 @@ class Widget(DOMNode):
         """
 
         self.call_after_refresh(
-            self.screen._scroll_to_center_of,
-            widget=self,
+            self._scroll_to_center_of,
+            widget=widget,
             animate=animate,
             speed=speed,
             duration=duration,

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -449,7 +449,7 @@ class Tabs(Widget, can_focus=True):
         self.query("#tabs-list Tab.-active").remove_class("-active")
         tab.add_class("-active")
         self.active = tab.id or ""
-        self.query_one("#tabs-scroll").scroll_to_widget(tab, force=True)
+        self.query_one("#tabs-scroll").scroll_to_center(tab, force=True)
 
     def _on_underline_clicked(self, event: Underline.Clicked) -> None:
         """The underline was clicked.
@@ -471,7 +471,7 @@ class Tabs(Widget, can_focus=True):
         """Scroll the active tab into view."""
         if self.active_tab:
             try:
-                self.query_one("#tabs-scroll").scroll_to_widget(
+                self.query_one("#tabs-scroll").scroll_to_center(
                     self.active_tab, force=True
                 )
             except NoMatches:

--- a/tests/snapshot_tests/snapshot_apps/scroll_to_center.py
+++ b/tests/snapshot_tests/snapshot_apps/scroll_to_center.py
@@ -33,7 +33,7 @@ class MyApp(App[None]):
             yield Label(("SPAM\n" * 59)[:-1])
 
     def key_s(self) -> None:
-        self.query_one("#bullseye").scroll_to_center()
+        self.screen.scroll_to_center(self.query_one("#bullseye"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes the intended behaviour of `scroll_to_center` and uses it when a tab is clicked.
This will close #2256 

Video demo below. On the left, scrolls to view. On the right, scrolls to center.


https://user-images.githubusercontent.com/5621605/231719994-ce5f0284-9bce-433b-8219-5bc421223556.mov

