### PR TITLE
Improving data table documentation

### DIFF
--- a/docs/examples/widgets/data_table_cursors.py
+++ b/docs/examples/widgets/data_table_cursors.py
@@ -26,6 +26,7 @@ class TableApp(App):
     def on_mount(self) -> None:
         table = self.query_one(DataTable)
         table.cursor_type = next(cursors)
+        table.zebra_stripes = True
         table.add_columns(*ROWS[0])
         table.add_rows(ROWS[1:])
 

--- a/docs/examples/widgets/data_table_cursors.py
+++ b/docs/examples/widgets/data_table_cursors.py
@@ -1,3 +1,5 @@
+from itertools import cycle
+
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable
 
@@ -14,6 +16,8 @@ ROWS = [
     (10, "Darren Burns", "Scotland", 51.84),
 ]
 
+cursors = cycle(["column", "row", "cell"])
+
 
 class TableApp(App):
     def compose(self) -> ComposeResult:
@@ -21,8 +25,13 @@ class TableApp(App):
 
     def on_mount(self) -> None:
         table = self.query_one(DataTable)
+        table.cursor_type = next(cursors)
         table.add_columns(*ROWS[0])
         table.add_rows(ROWS[1:])
+
+    def key_c(self):
+        table = self.query_one(DataTable)
+        table.cursor_type = next(cursors)
 
 
 app = TableApp()

--- a/docs/examples/widgets/data_table_fixed.py
+++ b/docs/examples/widgets/data_table_fixed.py
@@ -17,6 +17,7 @@ class TableApp(App):
         table.fixed_rows = 2
         table.fixed_columns = 1
         table.cursor_type = "row"
+        table.zebra_stripes = True
 
 
 app = TableApp()

--- a/docs/examples/widgets/data_table_fixed.py
+++ b/docs/examples/widgets/data_table_fixed.py
@@ -1,5 +1,3 @@
-from itertools import cycle
-
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable
 

--- a/docs/examples/widgets/data_table_fixed.py
+++ b/docs/examples/widgets/data_table_fixed.py
@@ -1,30 +1,22 @@
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable
 
-ROWS = [
-    ("lane", "swimmer", "country", "time"),
-    (4, "Joseph Schooling", "Singapore", 50.39),
-    (2, "Michael Phelps", "United States", 51.14),
-    (5, "Chad le Clos", "South Africa", 51.14),
-    (6, "László Cseh", "Hungary", 51.14),
-    (3, "Li Zhuhao", "China", 51.26),
-    (8, "Mehdy Metella", "France", 51.58),
-    (7, "Tom Shields", "United States", 51.73),
-    (1, "Aleksandr Sadovnikov", "Russia", 51.84),
-    (10, "Darren Burns", "Scotland", 51.84),
-]
-
 
 class TableApp(App):
+    CSS = "DataTable {height: 1fr}"
+
     def compose(self) -> ComposeResult:
         yield DataTable()
 
     def on_mount(self) -> None:
         table = self.query_one(DataTable)
-        table.add_columns(*ROWS[0])
-        table.add_rows(ROWS[1:])
+        table.focus()
+        table.add_columns("A", "B", "C")
+        for number in range(1, 100):
+            table.add_row(str(number), str(number * 2), str(number * 3))
         table.fixed_rows = 2
         table.fixed_columns = 1
+        table.cursor_type = "row"
 
 
 app = TableApp()

--- a/docs/examples/widgets/data_table_fixed.py
+++ b/docs/examples/widgets/data_table_fixed.py
@@ -1,3 +1,5 @@
+from itertools import cycle
+
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable
 
@@ -23,6 +25,8 @@ class TableApp(App):
         table = self.query_one(DataTable)
         table.add_columns(*ROWS[0])
         table.add_rows(ROWS[1:])
+        table.fixed_rows = 2
+        table.fixed_columns = 1
 
 
 app = TableApp()

--- a/docs/examples/widgets/data_table_labels.py
+++ b/docs/examples/widgets/data_table_labels.py
@@ -1,0 +1,34 @@
+from rich.text import Text
+
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+ROWS = [
+    ("lane", "swimmer", "country", "time"),
+    (4, "Joseph Schooling", "Singapore", 50.39),
+    (2, "Michael Phelps", "United States", 51.14),
+    (5, "Chad le Clos", "South Africa", 51.14),
+    (6, "László Cseh", "Hungary", 51.14),
+    (3, "Li Zhuhao", "China", 51.26),
+    (8, "Mehdy Metella", "France", 51.58),
+    (7, "Tom Shields", "United States", 51.73),
+    (1, "Aleksandr Sadovnikov", "Russia", 51.84),
+    (10, "Darren Burns", "Scotland", 51.84),
+]
+
+
+class TableApp(App):
+    def compose(self) -> ComposeResult:
+        yield DataTable()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.add_columns(*ROWS[0])
+        for number, row in enumerate(ROWS[1:], start=1):
+            label = Text(str(number), style="#B0FC38 italic")
+            table.add_row(*row, label=label)
+
+
+app = TableApp()
+if __name__ == "__main__":
+    app.run()

--- a/docs/examples/widgets/data_table_renderables.py
+++ b/docs/examples/widgets/data_table_renderables.py
@@ -1,0 +1,37 @@
+from rich.text import Text
+
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+ROWS = [
+    ("lane", "swimmer", "country", "time"),
+    (4, "Joseph Schooling", "Singapore", 50.39),
+    (2, "Michael Phelps", "United States", 51.14),
+    (5, "Chad le Clos", "South Africa", 51.14),
+    (6, "László Cseh", "Hungary", 51.14),
+    (3, "Li Zhuhao", "China", 51.26),
+    (8, "Mehdy Metella", "France", 51.58),
+    (7, "Tom Shields", "United States", 51.73),
+    (1, "Aleksandr Sadovnikov", "Russia", 51.84),
+    (10, "Darren Burns", "Scotland", 51.84),
+]
+
+
+class TableApp(App):
+    def compose(self) -> ComposeResult:
+        yield DataTable()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.add_columns(*ROWS[0])
+        for row in ROWS[1:]:
+            # Adding styled and justified `Text` objects instead of plain strings.
+            styled_row = [
+                Text(str(cell), style="italic #03AC13", justify="right") for cell in row
+            ]
+            table.add_row(*styled_row)
+
+
+app = TableApp()
+if __name__ == "__main__":
+    app.run()

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -5,9 +5,11 @@ A table widget optimized for displaying a lot of data.
 - [x] Focusable
 - [ ] Container
 
-## Example
+## Adding data
 
-The example below populates a table with CSV data.
+The following example shows how to fill a table with data.
+First, we use [add_columns][textual.widgets.DataTable.add_rows] to include the `lane`, `swimmer`, `country`, and `time` columns in the table.
+After that, we use the [add_rows][textual.widgets.DataTable.add_rows] method to insert the rows into the table.
 
 === "Output"
 
@@ -20,10 +22,78 @@ The example below populates a table with CSV data.
     --8<-- "docs/examples/widgets/data_table.py"
     ```
 
+## Keys
+
+When adding a row to the table, you can supply a _key_ to [add_row][textual.widgets.DataTable.add_row], which is a unique identifier for that row.
+If you don't supply a key, Textual will generate one for you and return it from `add_row`.
+This key can later be used to reference the row, regardless of its current position in the table (rows
+can change location due to sorting) - they are a stable reference to data within the table.
+When working with data from a database for example, you make wish to set the row `key` to the primary key of the data to ensure uniqueness.
+The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
+
+## Cursors
+
+Three types of cursor are supported: `cell`, `row`, and `column`.
+Change the cursor type by assigning to the `cursor_type` reactive attribute.
+
+=== "Column Cursor"
+
+    ```{.textual path="docs/examples/widgets/data_table_cursors.py"}
+    ```
+
+=== "Row Cursor"
+
+    ```{.textual path="docs/examples/widgets/data_table_cursors.py" press="c"}
+    ```
+
+=== "Cell Cursor"
+
+    ```{.textual path="docs/examples/widgets/data_table_cursors.py" press="c,c"}
+    ```
+
+=== "data_table_cursors.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/data_table_cursors.py"
+    ```
+
+You can change the position of the cursor using the arrow keys, ++page-up++, ++page-down++, ++home++ and ++end++,
+or by assigning to the `cursor_coordinate` reactive attribute.
+
+## Removing data
+
+To remove all data in the table, use the [clear][textual.widgets.DataTable.clear] method.
+To remove individual rows, use [remove_row][textual.widgets.DataTable.remove_row].
+The `remove_row` method accepts a `key` argument, which identifies the row to be removed.
+
+## Fixed data
+
+You can fix a number of rows and columns in place, keeping them pinned to the top and left of the table respectively.
+To do this, assign an integer to the `fixed_rows` or `fixed_columns` reactive attributes of the `DataTable`.
+
+=== "Fixed data"
+
+    ```{.textual path="docs/examples/widgets/data_table_fixed.py"}
+    ```
+
+=== "data_table_fixed.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/data_table_fixed.py"
+    ```
+
+## Sorting
+
+The `DataTable` can be sorted using the [sort][textual.widgets.DataTable.sort] method.
+In order to sort your data by a column, you must have supplied a `key` to the `add_column` method
+when you added it.
+You can then pass this key to the sort method to sort by that column.
+Additionally, you can pass multiple keys to break ties.
+
 ## Reactive Attributes
 
 | Name                | Type                                        | Default            | Description                                           |
-| ------------------- | ------------------------------------------- | ------------------ | ----------------------------------------------------- |
+|---------------------|---------------------------------------------|--------------------|-------------------------------------------------------|
 | `show_header`       | `bool`                                      | `True`             | Show the table header                                 |
 | `fixed_rows`        | `int`                                       | `0`                | Number of fixed rows (rows which do not scroll)       |
 | `fixed_columns`     | `int`                                       | `0`                | Number of fixed columns (columns which do not scroll) |

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -24,7 +24,7 @@ After that, we use the [add_rows][textual.widgets.DataTable.add_rows] method to 
     --8<-- "docs/examples/widgets/data_table.py"
     ```
 
-To add rows and columns one-at-a-time, use [add_row][textual.widgets.DataTable.add_row] and [add_column][textual.widgets.DataTable.add_column].
+To add a single row or column use [add_row][textual.widgets.DataTable.add_row] and [add_column][textual.widgets.DataTable.add_column], respectively.
 
 #### Styling and justifying cells
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -61,7 +61,7 @@ a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.
 
 ### Cursors
 
-You can retrieve the current coordinate of the cursor from the `cursor_coordinate` reactive attribute.
+The coordinate of the cursor is exposed via the `cursor_coordinate` reactive attribute.
 Three types of cursor are supported: `cell`, `row`, and `column`.
 Change the cursor type by assigning to the `cursor_type` reactive attribute.
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -50,7 +50,7 @@ If you don't supply a key, Textual will generate one for you and return it from 
 This key can later be used to reference the row, regardless of its current position in the table.
 
 When working with data from a database, for example, you may wish to set the row `key` to the primary key of the data to ensure uniqueness.
-The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
+The method [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
 
 Keys are important because cells in a data table can change location due to factors like row deletion and sorting.
 Thus, using keys instead of coordinates allows us to refer to data without worrying about its current location in the table.

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -44,7 +44,8 @@ Cells can contain more than just plain strings - [Rich](https://rich.readthedocs
 
 ### Keys
 
-When adding a row to the table, you can supply a _key_ to [add_row][textual.widgets.DataTable.add_row], which is a unique identifier for that row.
+When adding a row to the table, you can supply a _key_ to [add_row][textual.widgets.DataTable.add_row].
+A key is a unique identifier for that row.
 If you don't supply a key, Textual will generate one for you and return it from `add_row`.
 This key can later be used to reference the row, regardless of its current position in the table.
 
@@ -52,7 +53,7 @@ When working with data from a database for example, you make wish to set the row
 The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
 
 Keys are important because cells in a data table can change location due factors like row deletion and sorting.
-Thus, using keys instead of coordinates allows us to refer to data without worrying changing coordinates.
+Thus, using keys instead of coordinates allows us to refer to data without worrying about its current location in the table.
 
 Sometimes you wish to perform an operation on a cell/row/column based solely on coordinates, without regard for the data that is currently visible at those coordinates.
 In these cases you can make use of the [coordinate_to_cell_key][textual.widgets.DataTable.coordinate_to_cell_key] method to convert

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -40,6 +40,7 @@ a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.
 
 ## Cursors
 
+You can retrieve the current coordinate of the cursor from the `cursor_coordinate` reactive attribute.
 Three types of cursor are supported: `cell`, `row`, and `column`.
 Change the cursor type by assigning to the `cursor_type` reactive attribute.
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -114,7 +114,7 @@ To do this, assign an integer to the `fixed_rows` or `fixed_columns` reactive at
 
 === "Fixed data"
 
-    ```{.textual path="docs/examples/widgets/data_table_fixed.py"}
+    ```{.textual path="docs/examples/widgets/data_table_fixed.py" press="end"}
     ```
 
 === "data_table_fixed.py"

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -52,7 +52,7 @@ This key can later be used to reference the row, regardless of its current posit
 When working with data from a database, for example, you may wish to set the row `key` to the primary key of the data to ensure uniqueness.
 The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
 
-Keys are important because cells in a data table can change location due factors like row deletion and sorting.
+Keys are important because cells in a data table can change location due to factors like row deletion and sorting.
 Thus, using keys instead of coordinates allows us to refer to data without worrying about its current location in the table.
 
 If you want to change the table based solely on coordinates, you can use the [coordinate_to_cell_key][textual.widgets.DataTable.coordinate_to_cell_key] method to convert a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -55,9 +55,7 @@ The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argu
 Keys are important because cells in a data table can change location due factors like row deletion and sorting.
 Thus, using keys instead of coordinates allows us to refer to data without worrying about its current location in the table.
 
-Sometimes you wish to perform an operation on a cell/row/column based solely on coordinates, without regard for the data that is currently visible at those coordinates.
-In these cases you can make use of the [coordinate_to_cell_key][textual.widgets.DataTable.coordinate_to_cell_key] method to convert
-a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.
+If you want to change the table based solely on coordinates, you can use the [coordinate_to_cell_key][textual.widgets.DataTable.coordinate_to_cell_key] method to convert a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.
 
 ### Cursors
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -5,7 +5,9 @@ A table widget optimized for displaying a lot of data.
 - [x] Focusable
 - [ ] Container
 
-## Adding data
+## Guide
+
+### Adding data
 
 The following example shows how to fill a table with data.
 First, we use [add_columns][textual.widgets.DataTable.add_rows] to include the `lane`, `swimmer`, `country`, and `time` columns in the table.
@@ -22,7 +24,12 @@ After that, we use the [add_rows][textual.widgets.DataTable.add_rows] method to 
     --8<-- "docs/examples/widgets/data_table.py"
     ```
 
-## Keys
+To add rows and columns one-at-a-time, use [add_row][textual.widgets.DataTable.add_row] and [add_column][textual.widgets.DataTable.add_column].
+
+Note that `DataTable` cells can contain more than just plain strings - Rich renderables such as `Text` are also supported,
+and this is a common way to apply simple styles to the text in a cell.
+
+### Keys
 
 When adding a row to the table, you can supply a _key_ to [add_row][textual.widgets.DataTable.add_row], which is a unique identifier for that row.
 If you don't supply a key, Textual will generate one for you and return it from `add_row`.
@@ -38,7 +45,7 @@ Sometimes you wish to perform an operation on a cell/row/column based solely on 
 In these cases you can make use of the [coordinate_to_cell_key][textual.widgets.DataTable.coordinate_to_cell_key] method to convert
 a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.
 
-## Cursors
+### Cursors
 
 You can retrieve the current coordinate of the cursor from the `cursor_coordinate` reactive attribute.
 Three types of cursor are supported: `cell`, `row`, and `column`.
@@ -68,11 +75,11 @@ Change the cursor type by assigning to the `cursor_type` reactive attribute.
 You can change the position of the cursor using the arrow keys, ++page-up++, ++page-down++, ++home++ and ++end++,
 or by assigning to the `cursor_coordinate` reactive attribute.
 
-## Updating data
+### Updating data
 
 Cells can be updated in the `DataTable` by using the [update_cell][textual.widgets.DataTable.update_cell] and [update_cell_at][textual.widgets.DataTable.update_cell_at] methods.
 
-## Removing data
+### Removing data
 
 To remove all data in the table, use the [clear][textual.widgets.DataTable.clear] method.
 To remove individual rows, use [remove_row][textual.widgets.DataTable.remove_row].
@@ -88,7 +95,7 @@ row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
 table.remove_row(row_key)
 ```
 
-## Fixed data
+### Fixed data
 
 You can fix a number of rows and columns in place, keeping them pinned to the top and left of the table respectively.
 To do this, assign an integer to the `fixed_rows` or `fixed_columns` reactive attributes of the `DataTable`.
@@ -108,7 +115,7 @@ In the example above, we set `fixed_rows` to `2`, and `fixed_columns` to `1`,
 meaning the first two rows and the leftmost column do not scroll - they always remain
 visible as you scroll through the data table.
 
-## Sorting
+### Sorting
 
 The `DataTable` can be sorted using the [sort][textual.widgets.DataTable.sort] method.
 In order to sort your data by a column, you must have supplied a `key` to the `add_column` method

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -26,10 +26,17 @@ After that, we use the [add_rows][textual.widgets.DataTable.add_rows] method to 
 
 When adding a row to the table, you can supply a _key_ to [add_row][textual.widgets.DataTable.add_row], which is a unique identifier for that row.
 If you don't supply a key, Textual will generate one for you and return it from `add_row`.
-This key can later be used to reference the row, regardless of its current position in the table (rows
-can change location due to sorting) - they are a stable reference to data within the table.
+This key can later be used to reference the row, regardless of its current position in the table.
+
 When working with data from a database for example, you make wish to set the row `key` to the primary key of the data to ensure uniqueness.
 The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
+
+Keys are important because cells in a data table can change location due factors like row deletion and sorting.
+Thus, using keys instead of coordinates allows us to refer to data without worrying changing coordinates.
+
+Sometimes you wish to perform an operation on a cell/row/column based solely on coordinates, without regard for the data that is currently visible at those coordinates.
+In these cases you can make use of the [coordinate_to_cell_key][textual.widgets.DataTable.coordinate_to_cell_key] method to convert
+a coordinate to a _cell key_, which is a `(row_key, column_key)` pair.
 
 ## Cursors
 
@@ -60,11 +67,25 @@ Change the cursor type by assigning to the `cursor_type` reactive attribute.
 You can change the position of the cursor using the arrow keys, ++page-up++, ++page-down++, ++home++ and ++end++,
 or by assigning to the `cursor_coordinate` reactive attribute.
 
+## Updating data
+
+Cells can be updated in the `DataTable` by using the [update_cell][textual.widgets.DataTable.update_cell] and [update_cell_at][textual.widgets.DataTable.update_cell_at] methods.
+
 ## Removing data
 
 To remove all data in the table, use the [clear][textual.widgets.DataTable.clear] method.
 To remove individual rows, use [remove_row][textual.widgets.DataTable.remove_row].
 The `remove_row` method accepts a `key` argument, which identifies the row to be removed.
+
+If you wish to remove the row below the cursor in the `DataTable`, use `coordinate_to_cell_key` to get the row key of
+the row under the current `cursor_coordinate`, then supply this key to `remove_row`:
+
+```python
+# Get the keys for the row and column under the cursor.
+row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+# Supply the row key to `remove_row` to delete the row.
+table.remove_row(row_key)
+```
 
 ## Fixed data
 
@@ -82,13 +103,17 @@ To do this, assign an integer to the `fixed_rows` or `fixed_columns` reactive at
     --8<-- "docs/examples/widgets/data_table_fixed.py"
     ```
 
+In the example above, we set `fixed_rows` to `2`, and `fixed_columns` to `1`,
+meaning the first two rows and the leftmost column do not scroll - they always remain
+visible as you scroll through the data table.
+
 ## Sorting
 
 The `DataTable` can be sorted using the [sort][textual.widgets.DataTable.sort] method.
 In order to sort your data by a column, you must have supplied a `key` to the `add_column` method
 when you added it.
-You can then pass this key to the sort method to sort by that column.
-Additionally, you can pass multiple keys to break ties.
+You can then pass this key to the `sort` method to sort by that column.
+Additionally, you can sort by multiple columns by passing multiple keys to `sort`.
 
 ## Reactive Attributes
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -137,7 +137,7 @@ Additionally, you can sort by multiple columns by passing multiple keys to `sort
 
 ### Labelled rows
 
-A "label" can be attached to rows using the [add_row][textual.widgets.DataTable.add_row] method.
+A "label" can be attached to a row using the [add_row][textual.widgets.DataTable.add_row] method.
 This will add an extra column to the left of the table which the cursor cannot interact with.
 This column is similar to the leftmost column in a spreadsheet containing the row numbers.
 The example below shows how to attach simple numbered labels to rows.

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -137,11 +137,30 @@ when you added it.
 You can then pass this key to the `sort` method to sort by that column.
 Additionally, you can sort by multiple columns by passing multiple keys to `sort`.
 
+### Labelled rows
+
+A "label" can be attached to rows using the [add_row][textual.widgets.DataTable.add_row] method.
+This will add an extra column to the left of the table which the cursor cannot interact with.
+This column is similar to the leftmost column in a spreadsheet containing the row numbers.
+The example below shows how to attach simple numbered labels to rows.
+
+=== "Labelled rows"
+
+    ```{.textual path="docs/examples/widgets/data_table_labels.py"}
+    ```
+
+=== "data_table_labels.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/data_table_labels.py"
+    ```
+
 ## Reactive Attributes
 
 | Name                | Type                                        | Default            | Description                                           |
 |---------------------|---------------------------------------------|--------------------|-------------------------------------------------------|
 | `show_header`       | `bool`                                      | `True`             | Show the table header                                 |
+| `show_row_labels`   | `bool`                                      | `True`             | Show the row labels (if applicable)                   |
 | `fixed_rows`        | `int`                                       | `0`                | Number of fixed rows (rows which do not scroll)       |
 | `fixed_columns`     | `int`                                       | `0`                | Number of fixed columns (columns which do not scroll) |
 | `zebra_stripes`     | `bool`                                      | `False`            | Display alternating colors on rows                    |
@@ -160,6 +179,7 @@ Additionally, you can sort by multiple columns by passing multiple keys to `sort
 - [DataTable.ColumnHighlighted][textual.widgets.DataTable.ColumnHighlighted]
 - [DataTable.ColumnSelected][textual.widgets.DataTable.ColumnSelected]
 - [DataTable.HeaderSelected][textual.widgets.DataTable.HeaderSelected]
+- [DataTable.RowLabelSelected][textual.widgets.DataTable.RowLabelSelected]
 
 ## Bindings
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -60,7 +60,7 @@ If you want to change the table based solely on coordinates, you can use the [co
 ### Cursors
 
 The coordinate of the cursor is exposed via the `cursor_coordinate` reactive attribute.
-Three types of cursor are supported: `cell`, `row`, and `column`.
+Three types of cursors are supported: `cell`, `row`, and `column`.
 Change the cursor type by assigning to the `cursor_type` reactive attribute.
 
 === "Column Cursor"

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -26,8 +26,21 @@ After that, we use the [add_rows][textual.widgets.DataTable.add_rows] method to 
 
 To add rows and columns one-at-a-time, use [add_row][textual.widgets.DataTable.add_row] and [add_column][textual.widgets.DataTable.add_column].
 
-Note that `DataTable` cells can contain more than just plain strings - Rich renderables such as `Text` are also supported,
-and this is a common way to apply simple styles to the text in a cell.
+#### Styling and justifying cells
+
+Cells can contain more than just plain strings - [Rich](https://rich.readthedocs.io/en/stable/introduction.html) renderables such as [`Text`](https://rich.readthedocs.io/en/stable/text.html?highlight=Text#rich-text) are also supported.
+`Text` objects provide an easy way to style and justify cell content:
+
+=== "Output"
+
+    ```{.textual path="docs/examples/widgets/data_table_renderables.py"}
+    ```
+
+=== "data_table_renderables.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/data_table_renderables.py"
+    ```
 
 ### Keys
 

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -49,7 +49,7 @@ A key is a unique identifier for that row.
 If you don't supply a key, Textual will generate one for you and return it from `add_row`.
 This key can later be used to reference the row, regardless of its current position in the table.
 
-When working with data from a database for example, you make wish to set the row `key` to the primary key of the data to ensure uniqueness.
+When working with data from a database, for example, you may wish to set the row `key` to the primary key of the data to ensure uniqueness.
 The [add_column][textual.widgets.DataTable.add_column] also accepts a `key` argument and works similarly.
 
 Keys are important because cells in a data table can change location due factors like row deletion and sorting.


### PR DESCRIPTION
There were a few features and concepts of the DataTable that were pretty difficult to discover and understand, as they are referenced in docstrings in a way that assumes prior knowledge.

The DataTable widget docs now include a guide at the top, which show off some of the features of the table that I suspect many people don't even realise exist. It also shows how to achieve several things which I see asked regularly.