### PR TITLE
Fix retrieval mechanism for devtools port.

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -249,6 +249,8 @@ class App(Generic[ReturnType], DOMNode):
         ```
     """
 
+    _devtools: DevtoolsClient | None = None
+    """The devtools client associated with this app, if any."""
     _devtools_port: int = constants.DEFAULT_DEVTOOLS_PORT
     """Port to use if/when connecting to the devtools server.
 
@@ -371,16 +373,6 @@ class App(Generic[ReturnType], DOMNode):
         self._compose_stacks: list[list[Widget]] = []
         self._composed: list[list[Widget]] = []
 
-        self.devtools: DevtoolsClient | None = None
-        if "devtools" in self.features:
-            try:
-                from .devtools.client import DevtoolsClient
-            except ImportError:
-                # Dev dependencies not installed
-                pass
-            else:
-                self.devtools = DevtoolsClient(port=self._devtools_port)
-
         self._loop: asyncio.AbstractEventLoop | None = None
         self._return_value: ReturnType | None = None
         self._exit = False
@@ -396,6 +388,19 @@ class App(Generic[ReturnType], DOMNode):
         self._batch_count = 0
         self.set_class(self.dark, "-dark-mode")
         self.set_class(not self.dark, "-light-mode")
+
+    @property
+    def devtools(self) -> DevtoolsClient | None:
+        """The devtools associated with this app."""
+        if self._devtools is None and "devtools" in self.features:
+            try:
+                from .devtools.client import DevtoolsClient
+            except ImportError:
+                # Dev dependencies not installed
+                pass
+            else:
+                self._devtools = DevtoolsClient(port=self._devtools_port)
+        return self._devtools
 
     @property
     def workers(self) -> WorkerManager:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -29,7 +29,6 @@ from contextlib import (
 from datetime import datetime
 from functools import partial
 from pathlib import Path, PurePath
-from queue import Queue
 from time import perf_counter
 from typing import (
     TYPE_CHECKING,
@@ -248,7 +247,13 @@ class App(Generic[ReturnType], DOMNode):
         ```python
         self.app.dark = not self.app.dark  # Toggle dark mode
         ```
+    """
 
+    _devtools_port: int = constants.DEFAULT_DEVTOOLS_PORT
+    """Port to use if/when connecting to the devtools server.
+
+    You never need to set this manually. To connect to the devtools in a non-default
+    port, use the option `--port` in the command `textual run`.
     """
 
     def __init__(
@@ -374,7 +379,7 @@ class App(Generic[ReturnType], DOMNode):
                 # Dev dependencies not installed
                 pass
             else:
-                self.devtools = DevtoolsClient()
+                self.devtools = DevtoolsClient(port=self._devtools_port)
 
         self._loop: asyncio.AbstractEventLoop | None = None
         self._return_value: ReturnType | None = None

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -263,7 +263,10 @@ class App(Generic[ReturnType], DOMNode):
     _features_string: str = ""
     """A string with unparsed features for the app instance."""
     _features: frozenset[FeatureFlag] | None = None
-    """The features associated with the app instance."""
+    """The features associated with the app instance.
+
+    This must be set before running the app.
+    """
     _css_monitor: FileMonitor | None = None
     """The CSS monitor for this app, if any."""
 

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -137,7 +137,7 @@ def run_app(
     from textual.features import parse_features
 
     features = set(parse_features(os.environ.get("TEXTUAL", "")))
-    if dev:
+    if dev or port != DEFAULT_DEVTOOLS_PORT:
         features.add("debug")
         features.add("devtools")
     features_string = ",".join(sorted(features))

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -136,8 +136,6 @@ def run_app(
 
     from textual.features import parse_features
 
-    App._devtools_port = port
-
     features = set(parse_features(os.environ.get("TEXTUAL", "")))
     if dev:
         features.add("debug")
@@ -152,6 +150,8 @@ def run_app(
         console = Console(stderr=True)
         console.print(str(error))
         sys.exit(1)
+
+    app._devtools_port = port
 
     press_keys = press.split(",") if press else None
 

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-from ..constants import DEFAULT_DEVTOOLS_PORT, DEVTOOLS_PORT_ENVIRON_VARIABLE
+from ..constants import DEFAULT_DEVTOOLS_PORT
 
 try:
     import click
@@ -13,6 +13,7 @@ except ImportError:
 from importlib_metadata import version
 
 from textual._import_app import AppFail, import_app
+from textual.app import App
 from textual.pilot import Pilot
 
 
@@ -27,28 +28,23 @@ def run():
     "--port",
     "port",
     type=int,
-    default=None,
+    default=DEFAULT_DEVTOOLS_PORT,
     metavar="PORT",
     help=f"Port to use for the development mode console. Defaults to {DEFAULT_DEVTOOLS_PORT}.",
 )
 @click.option("-v", "verbose", help="Enable verbose logs.", is_flag=True)
 @click.option("-x", "--exclude", "exclude", help="Exclude log group(s)", multiple=True)
-def console(port: int | None, verbose: bool, exclude: list[str]) -> None:
+def console(port: int, verbose: bool, exclude: list[str]) -> None:
     """Launch the textual console."""
-    import os
-
     from rich.console import Console
 
     from textual.devtools.server import _run_devtools
-
-    if port is not None:
-        os.environ[DEVTOOLS_PORT_ENVIRON_VARIABLE] = str(port)
 
     console = Console()
     console.clear()
     console.show_cursor(False)
     try:
-        _run_devtools(verbose=verbose, exclude=exclude)
+        _run_devtools(verbose=verbose, exclude=exclude, port=port)
     finally:
         console.show_cursor(True)
 
@@ -97,7 +93,7 @@ def _post_run_warnings() -> None:
     "--port",
     "port",
     type=int,
-    default=None,
+    default=DEFAULT_DEVTOOLS_PORT,
     metavar="PORT",
     help=f"Port to use for the development mode console. Defaults to {DEFAULT_DEVTOOLS_PORT}.",
 )
@@ -110,7 +106,7 @@ def _post_run_warnings() -> None:
     help="Take screenshot after DELAY seconds",
 )
 def run_app(
-    import_name: str, dev: bool, port: int | None, press: str, screenshot: int | None
+    import_name: str, dev: bool, port: int, press: str, screenshot: int | None
 ) -> None:
     """Run a Textual app.
 
@@ -140,8 +136,7 @@ def run_app(
 
     from textual.features import parse_features
 
-    if port is not None:
-        os.environ[DEVTOOLS_PORT_ENVIRON_VARIABLE] = str(port)
+    App._devtools_port = port
 
     features = set(parse_features(os.environ.get("TEXTUAL", "")))
     if dev:

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -140,8 +140,8 @@ def run_app(
     if dev:
         features.add("debug")
         features.add("devtools")
+    features_string = ",".join(sorted(features))
 
-    os.environ["TEXTUAL"] = ",".join(sorted(features))
     try:
         app = import_app(import_name)
     except AppFail as error:
@@ -152,6 +152,7 @@ def run_app(
         sys.exit(1)
 
     app._devtools_port = port
+    app._features_string = features_string
 
     press_keys = press.split(",") if press else None
 

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -16,12 +16,6 @@ __all__ = ["BORDERS"]
 get_environ = os.environ.get
 
 
-DEVTOOLS_PORT_ENVIRON_VARIABLE: Final[str] = "TEXTUAL_CONSOLE_PORT"
-"""The name of the environment variable that sets the port for the devtools."""
-DEFAULT_DEVTOOLS_PORT: Final[int] = 8081
-"""The default port to use for the devtools."""
-
-
 def get_environ_bool(name: str) -> bool:
     """Check an environment variable switch.
 
@@ -35,36 +29,6 @@ def get_environ_bool(name: str) -> bool:
     return has_environ
 
 
-def get_environ_int(name: str, default: int) -> int:
-    """Retrieves an integer environment variable.
-
-    Args:
-        name: Name of environment variable.
-        default: The value to use if the value is not set, or set to something other
-            than a valid integer.
-
-    Returns:
-        The integer associated with the environment variable if it's set to a valid int
-            or the default value otherwise.
-    """
-    try:
-        return int(get_environ(name, default))
-    except ValueError:
-        return default
-
-
-def get_devtools_port() -> int:
-    """Retrieve the port to be used by the devtools.
-
-    This reads from the environment variable set in DEVTOOLS_PORT_ENVIRON_VARIABLE
-    and defaults to DEFAULT_DEVTOOLS_PORT.
-
-    Returns:
-        The port to be used.
-    """
-    return get_environ_int(DEVTOOLS_PORT_ENVIRON_VARIABLE, DEFAULT_DEVTOOLS_PORT)
-
-
 BORDERS = list(BORDER_CHARS)
 
 DEBUG: Final[bool] = get_environ_bool("TEXTUAL_DEBUG")
@@ -73,3 +37,6 @@ DRIVER: Final[str | None] = get_environ("TEXTUAL_DRIVER", None)
 
 LOG_FILE: Final[str | None] = get_environ("TEXTUAL_LOG", None)
 """A last resort log file that appends all logs, when devtools isn't working."""
+
+DEFAULT_DEVTOOLS_PORT: Final[int] = 8081
+"""The default port to use for the devtools."""

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -16,6 +16,12 @@ __all__ = ["BORDERS"]
 get_environ = os.environ.get
 
 
+DEVTOOLS_PORT_ENVIRON_VARIABLE: Final[str] = "TEXTUAL_CONSOLE_PORT"
+"""The name of the environment variable that sets the port for the devtools."""
+DEFAULT_DEVTOOLS_PORT: Final[int] = 8081
+"""The default port to use for the devtools."""
+
+
 def get_environ_bool(name: str) -> bool:
     """Check an environment variable switch.
 
@@ -47,6 +53,18 @@ def get_environ_int(name: str, default: int) -> int:
         return default
 
 
+def get_devtools_port() -> int:
+    """Retrieve the port to be used by the devtools.
+
+    This reads from the environment variable set in DEVTOOLS_PORT_ENVIRON_VARIABLE
+    and defaults to DEFAULT_DEVTOOLS_PORT.
+
+    Returns:
+        The port to be used.
+    """
+    return get_environ_int(DEVTOOLS_PORT_ENVIRON_VARIABLE, DEFAULT_DEVTOOLS_PORT)
+
+
 BORDERS = list(BORDER_CHARS)
 
 DEBUG: Final[bool] = get_environ_bool("TEXTUAL_DEBUG")
@@ -55,13 +73,3 @@ DRIVER: Final[str | None] = get_environ("TEXTUAL_DRIVER", None)
 
 LOG_FILE: Final[str | None] = get_environ("TEXTUAL_LOG", None)
 """A last resort log file that appends all logs, when devtools isn't working."""
-
-
-DEVTOOLS_PORT_ENVIRON_VARIABLE: Final[str] = "TEXTUAL_CONSOLE_PORT"
-"""The name of the environment variable that sets the port for the devtools."""
-DEFAULT_DEVTOOLS_PORT: Final[int] = 8081
-"""The default port to use for the devtools."""
-DEVTOOLS_PORT: Final[int] = get_environ_int(
-    DEVTOOLS_PORT_ENVIRON_VARIABLE, DEFAULT_DEVTOOLS_PORT
-)
-"""Constant with the port that the devtools will connect to."""

--- a/src/textual/devtools/client.py
+++ b/src/textual/devtools/client.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from rich.segment import Segment
 
 from .._log import LogGroup, LogVerbosity
-from ..constants import DEVTOOLS_PORT
+from ..constants import get_devtools_port
 
 WEBSOCKET_CONNECT_TIMEOUT = 3
 LOG_QUEUE_MAXSIZE = 512
@@ -88,12 +88,13 @@ class DevtoolsClient:
 
     Args:
         host: The host the devtools server is running on, defaults to "127.0.0.1"
-        port: The port the devtools server is accessed via, `DEVTOOLS_PORT` by default.
+        port: The port the devtools server is accessed via.
+            Uses `constants.get_devtools_port()` by default.
     """
 
     def __init__(self, host: str = "127.0.0.1", port: int | None = None) -> None:
         if port is None:
-            port = DEVTOOLS_PORT
+            port = get_devtools_port()
         self.url: str = f"ws://{host}:{port}"
         self.session: aiohttp.ClientSession | None = None
         self.log_queue_task: Task | None = None

--- a/src/textual/devtools/client.py
+++ b/src/textual/devtools/client.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from rich.segment import Segment
 
 from .._log import LogGroup, LogVerbosity
-from ..constants import get_devtools_port
+from ..constants import DEFAULT_DEVTOOLS_PORT
 
 WEBSOCKET_CONNECT_TIMEOUT = 3
 LOG_QUEUE_MAXSIZE = 512
@@ -89,12 +89,11 @@ class DevtoolsClient:
     Args:
         host: The host the devtools server is running on, defaults to "127.0.0.1"
         port: The port the devtools server is accessed via.
-            Uses `constants.get_devtools_port()` by default.
     """
 
-    def __init__(self, host: str = "127.0.0.1", port: int | None = None) -> None:
-        if port is None:
-            port = get_devtools_port()
+    def __init__(
+        self, host: str = "127.0.0.1", port: int = DEFAULT_DEVTOOLS_PORT
+    ) -> None:
         self.url: str = f"ws://{host}:{port}"
         self.session: aiohttp.ClientSession | None = None
         self.log_queue_task: Task | None = None

--- a/src/textual/devtools/server.py
+++ b/src/textual/devtools/server.py
@@ -8,7 +8,7 @@ from aiohttp.web_request import Request
 from aiohttp.web_routedef import get
 from aiohttp.web_ws import WebSocketResponse
 
-from textual.devtools.client import DEVTOOLS_PORT
+from textual.devtools.client import get_devtools_port
 from textual.devtools.service import DevtoolsService
 
 DEFAULT_SIZE_CHANGE_POLL_DELAY_SECONDS = 2
@@ -44,10 +44,12 @@ def _run_devtools(verbose: bool, exclude: list[str] | None = None) -> None:
     def noop_print(_: str) -> None:
         pass
 
+    from rich import print
+
     try:
         run_app(
             app,
-            port=DEVTOOLS_PORT,
+            port=get_devtools_port(),
             print=noop_print,
             loop=asyncio.get_event_loop(),
         )
@@ -56,7 +58,9 @@ def _run_devtools(verbose: bool, exclude: list[str] | None = None) -> None:
 
         print()
         print("[bold red]Couldn't start server")
-        print("Is there another instance of [reverse]textual console[/] running?")
+        print(
+            "Is there another instance of [reverse]textual console[/] running on this port?"
+        )
 
 
 def _make_devtools_aiohttp_app(

--- a/src/textual/devtools/server.py
+++ b/src/textual/devtools/server.py
@@ -8,8 +8,8 @@ from aiohttp.web_request import Request
 from aiohttp.web_routedef import get
 from aiohttp.web_ws import WebSocketResponse
 
-from textual.devtools.client import get_devtools_port
-from textual.devtools.service import DevtoolsService
+from ..constants import DEFAULT_DEVTOOLS_PORT
+from .service import DevtoolsService
 
 DEFAULT_SIZE_CHANGE_POLL_DELAY_SECONDS = 2
 
@@ -38,7 +38,9 @@ async def _on_startup(app: Application) -> None:
     await service.start()
 
 
-def _run_devtools(verbose: bool, exclude: list[str] | None = None) -> None:
+def _run_devtools(
+    verbose: bool, exclude: list[str] | None = None, port: int = DEFAULT_DEVTOOLS_PORT
+) -> None:
     app = _make_devtools_aiohttp_app(verbose=verbose, exclude=exclude)
 
     def noop_print(_: str) -> None:
@@ -49,7 +51,7 @@ def _run_devtools(verbose: bool, exclude: list[str] | None = None) -> None:
     try:
         run_app(
             app,
-            port=get_devtools_port(),
+            port=port,
             print=noop_print,
             loop=asyncio.get_event_loop(),
         )

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,27 +3,27 @@ from __future__ import annotations
 from textual.app import App
 
 
-def test_textual_env_var(monkeypatch):
-    monkeypatch.setenv("TEXTUAL", "")
+def test_features():
     app = App()
+    app._features_string = ""
     assert app.features == set()
     assert app.devtools is None
     assert app.debug is False
 
-    monkeypatch.setenv("TEXTUAL", "devtools")
     app = App()
+    app._features_string = "devtools"
     assert app.features == {"devtools"}
     assert app.devtools is not None
     assert app.debug is False
 
-    monkeypatch.setenv("TEXTUAL", "devtools,debug")
     app = App()
+    app._features_string = "devtools,debug"
     assert app.features == {"devtools", "debug"}
     assert app.devtools is not None
     assert app.debug is True
 
-    monkeypatch.setenv("TEXTUAL", "devtools, debug")
     app = App()
+    app._features_string = "devtools, debug"
     assert app.features == {"devtools", "debug"}
     assert app.devtools is not None
     assert app.debug is True


### PR DESCRIPTION
Defined as a static constant, the value of the devtools port is assigned before getting a chance to modify the relevant environment variable.
Make it a function, and everything works just fine.

Related PRs: https://github.com/Textualize/textual/pull/2258