### PR TITLE
Export button variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed signature of Driver. Technically a breaking change, but unlikely to affect anyone.
 - Breaking change: Timer.start is now private, and returns No
 - A clicked tab will now be scrolled to the center of its tab container https://github.com/Textualize/textual/pull/2276
+- `ButtonVariant` is now exported from `textual.widgets.button` https://github.com/Textualize/textual/issues/2264
 
 ### Added
 

--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -31,11 +31,11 @@ Clicking any of the non-disabled buttons in the example app below will result in
 
 ## Reactive Attributes
 
-| Name       | Type   | Default     | Description                                                                                                                       |
-| ---------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `label`    | `str`  | `""`        | The text that appears inside the button.                                                                                          |
-| `variant`  | `str`  | `"default"` | Semantic styling variant. One of `default`, `primary`, `success`, `warning`, `error`.                                             |
-| `disabled` | `bool` | `False`     | Whether the button is disabled or not. Disabled buttons cannot be focused or clicked, and are styled in a way that suggests this. |
+| Name       | Type            | Default     | Description                                                                                                                       |
+|------------|-----------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `label`    | `str`           | `""`        | The text that appears inside the button.                                                                                          |
+| `variant`  | `ButtonVariant` | `"default"` | Semantic styling variant. One of `default`, `primary`, `success`, `warning`, `error`.                                             |
+| `disabled` | `bool`          | `False`     | Whether the button is disabled or not. Disabled buttons cannot be focused or clicked, and are styled in a way that suggests this. |
 
 ## Messages
 
@@ -51,3 +51,8 @@ Clicking any of the non-disabled buttons in the example app below will result in
 ::: textual.widgets.Button
     options:
       heading_level: 2
+
+::: textual.widgets.button
+    options:
+      show_root_heading: true
+      show_root_toc_entry: true

--- a/src/textual/widgets/button.py
+++ b/src/textual/widgets/button.py
@@ -1,0 +1,3 @@
+from ._button import ButtonVariant
+
+__all__ = ["ButtonVariant"]


### PR DESCRIPTION
Makes `ButtonVariant` a public type. See #2264.

I'm not sure I've *quite* got the documentation change spot on -- seems the way we're documenting widgets has changed a lot in the last week (I'm aware that changes took place, I just wasn't aware of the underlying nature of the changes) and I'm still trying to work out how to document a very specific type.

Anyway, this makes `ButtonVariant` public so third party code can reference it without needing to import from a "private" module.