### PR TITLE
Prevent reactive-watcher loop in Tabs / TabbedContent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed order styles are applied in DataTable - allows combining of renderable styles and component classes https://github.com/Textualize/textual/pull/2272
 - Fix empty ListView preventing bindings from firing https://github.com/Textualize/textual/pull/2281
 - Fixed `active_message_pump.get` sometimes resulting in a `LookupError` https://github.com/Textualize/textual/issues/2301
+- Fixed issue arising when active tab was changed too quickly in succession https://github.com/Textualize/textual/pull/2305
 
 
 ## [0.19.1] - 2023-04-10

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -120,6 +120,8 @@ class TabbedContent(Widget):
 
     @active.setter
     def active(self, active: str) -> None:
+        if not active:
+            raise ValueError("'active' tab must not be empty string.")
         self.get_child_by_type(Tabs).active = active
 
     def compose(self) -> ComposeResult:

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -71,27 +71,6 @@ class TabPane(Widget):
         )
 
 
-class _ActiveTabProxyDescriptor:
-    """Descriptor to proxy the attribute `active` from `Tabs` to the `TabbedContent`.
-
-    For the rationale that prompted the implementation of this descriptor, refer to
-    https://github.com/Textualize/textual/issues/2229 and, in particular, this comment:
-    https://github.com/Textualize/textual/issues/2229#issuecomment-1511636895.
-    """
-
-    def __get__(
-        self, obj: TabbedContent, objtype: type[TabbedContent] | None = None
-    ) -> str:
-        """Get the active tab by proxy."""
-        return obj.get_child_by_type(Tabs).active
-
-    def __set__(self, obj: TabbedContent, active: str) -> None:
-        """Set the active tab by proxy."""
-        if not active:
-            raise ValueError("'active' tab must not be empty string.")
-        obj.get_child_by_type(Tabs).active = active
-
-
 class TabbedContent(Widget):
     """A container with associated tabs to toggle content visibility."""
 
@@ -103,9 +82,6 @@ class TabbedContent(Widget):
         height: auto;
     }
     """
-
-    active = _ActiveTabProxyDescriptor()
-    """The ID of the active tab, or empty string if none are active."""
 
     class TabActivated(Message):
         """Posted when the active tab changes."""
@@ -136,6 +112,15 @@ class TabbedContent(Widget):
         self._tab_content: list[Widget] = []
         self._initial = initial
         super().__init__()
+
+    @property
+    def active(self) -> str:
+        """The ID of the active tab, or empty string if none are active."""
+        return self.get_child_by_type(Tabs).active
+
+    @active.setter
+    def active(self, active: str) -> None:
+        self.get_child_by_type(Tabs).active = active
 
     def compose(self) -> ComposeResult:
         """Compose the tabbed content."""

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -19676,6 +19676,171 @@
   
   '''
 # ---
+# name: test_quickly_change_tabs
+  '''
+  <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+      <!-- Generated with Rich https://www.textualize.io -->
+      <style>
+  
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Regular"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+          font-style: normal;
+          font-weight: 400;
+      }
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Bold"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+          font-style: bold;
+          font-weight: 700;
+      }
+  
+      .terminal-2212491683-matrix {
+          font-family: Fira Code, monospace;
+          font-size: 20px;
+          line-height: 24.4px;
+          font-variant-east-asian: full-width;
+      }
+  
+      .terminal-2212491683-title {
+          font-size: 18px;
+          font-weight: bold;
+          font-family: arial;
+      }
+  
+      .terminal-2212491683-r1 { fill: #c5c8c6 }
+  .terminal-2212491683-r2 { fill: #737373 }
+  .terminal-2212491683-r3 { fill: #e1e1e1;font-weight: bold }
+  .terminal-2212491683-r4 { fill: #323232 }
+  .terminal-2212491683-r5 { fill: #0178d4 }
+  .terminal-2212491683-r6 { fill: #e2e3e3 }
+  .terminal-2212491683-r7 { fill: #1a1000;font-weight: bold }
+  .terminal-2212491683-r8 { fill: #008139 }
+  .terminal-2212491683-r9 { fill: #919497;font-weight: bold }
+  .terminal-2212491683-r10 { fill: #14191f }
+  .terminal-2212491683-r11 { fill: #e2e3e3;font-weight: bold }
+  .terminal-2212491683-r12 { fill: #e1e1e1 }
+      </style>
+  
+      <defs>
+      <clipPath id="terminal-2212491683-clip-terminal">
+        <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+      </clipPath>
+      <clipPath id="terminal-2212491683-line-0">
+      <rect x="0" y="1.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-1">
+      <rect x="0" y="25.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-2">
+      <rect x="0" y="50.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-3">
+      <rect x="0" y="74.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-4">
+      <rect x="0" y="99.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-5">
+      <rect x="0" y="123.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-6">
+      <rect x="0" y="147.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-7">
+      <rect x="0" y="172.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-8">
+      <rect x="0" y="196.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-9">
+      <rect x="0" y="221.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-10">
+      <rect x="0" y="245.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-11">
+      <rect x="0" y="269.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-12">
+      <rect x="0" y="294.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-13">
+      <rect x="0" y="318.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-14">
+      <rect x="0" y="343.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-15">
+      <rect x="0" y="367.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-16">
+      <rect x="0" y="391.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-17">
+      <rect x="0" y="416.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-18">
+      <rect x="0" y="440.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-19">
+      <rect x="0" y="465.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-20">
+      <rect x="0" y="489.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-21">
+      <rect x="0" y="513.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-2212491683-line-22">
+      <rect x="0" y="538.3" width="976" height="24.65"/>
+              </clipPath>
+      </defs>
+  
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-2212491683-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">QuicklyChangeTabsApp</text>
+              <g transform="translate(26,22)">
+              <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+              <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+              <circle cx="44" cy="0" r="7" fill="#28c840"/>
+              </g>
+          
+      <g transform="translate(9, 41)" clip-path="url(#terminal-2212491683-clip-terminal)">
+      <rect fill="#1e1e1e" x="0" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="1.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="61" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="97.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="134.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="25.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="158.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="50.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#cf7e00" x="61" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="85.4" y="99.1" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="927.2" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="158.6" y="123.5" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="927.2" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="147.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="147.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="158.6" y="147.9" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="927.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="172.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="172.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="195.2" y="172.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="196.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="196.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="196.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="244" y="196.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="221.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="221.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="221.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="268.4" y="221.1" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="245.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="245.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="317.2" y="245.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="269.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="269.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="269.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="170.8" y="269.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="294.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="294.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="294.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="195.2" y="294.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="318.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="318.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="318.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="244" y="318.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-2212491683-matrix">
+      <text class="terminal-2212491683-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2212491683-line-0)">
+  </text><text class="terminal-2212491683-r2" x="24.4" y="44.4" textLength="36.6" clip-path="url(#terminal-2212491683-line-1)">one</text><text class="terminal-2212491683-r2" x="97.6" y="44.4" textLength="36.6" clip-path="url(#terminal-2212491683-line-1)">two</text><text class="terminal-2212491683-r3" x="170.8" y="44.4" textLength="61" clip-path="url(#terminal-2212491683-line-1)">three</text><text class="terminal-2212491683-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-1)">
+  </text><text class="terminal-2212491683-r4" x="0" y="68.8" textLength="158.6" clip-path="url(#terminal-2212491683-line-2)">━━━━━━━━━━━━━</text><text class="terminal-2212491683-r4" x="158.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-2)">╸</text><text class="terminal-2212491683-r5" x="170.8" y="68.8" textLength="61" clip-path="url(#terminal-2212491683-line-2)">━━━━━</text><text class="terminal-2212491683-r4" x="231.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-2)">╺</text><text class="terminal-2212491683-r4" x="244" y="68.8" textLength="732" clip-path="url(#terminal-2212491683-line-2)">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</text><text class="terminal-2212491683-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-2)">
+  </text><text class="terminal-2212491683-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-3)">
+  </text><text class="terminal-2212491683-r6" x="24.4" y="117.6" textLength="24.4" clip-path="url(#terminal-2212491683-line-4)">📂&#160;</text><text class="terminal-2212491683-r7" x="61" y="117.6" textLength="24.4" clip-path="url(#terminal-2212491683-line-4)">./</text><text class="terminal-2212491683-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-4)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="142" textLength="48.8" clip-path="url(#terminal-2212491683-line-5)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="142" textLength="24.4" clip-path="url(#terminal-2212491683-line-5)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="142" textLength="48.8" clip-path="url(#terminal-2212491683-line-5)">.faq</text><text class="terminal-2212491683-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2212491683-line-5)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="166.4" textLength="48.8" clip-path="url(#terminal-2212491683-line-6)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="166.4" textLength="24.4" clip-path="url(#terminal-2212491683-line-6)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="166.4" textLength="48.8" clip-path="url(#terminal-2212491683-line-6)">.git</text><text class="terminal-2212491683-r10" x="927.2" y="166.4" textLength="24.4" clip-path="url(#terminal-2212491683-line-6)">▄▄</text><text class="terminal-2212491683-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-6)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="190.8" textLength="48.8" clip-path="url(#terminal-2212491683-line-7)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="190.8" textLength="24.4" clip-path="url(#terminal-2212491683-line-7)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="190.8" textLength="85.4" clip-path="url(#terminal-2212491683-line-7)">.github</text><text class="terminal-2212491683-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-7)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="215.2" textLength="48.8" clip-path="url(#terminal-2212491683-line-8)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-2212491683-line-8)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="215.2" textLength="134.2" clip-path="url(#terminal-2212491683-line-8)">.mypy_cache</text><text class="terminal-2212491683-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-8)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="239.6" textLength="48.8" clip-path="url(#terminal-2212491683-line-9)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="239.6" textLength="24.4" clip-path="url(#terminal-2212491683-line-9)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="239.6" textLength="158.6" clip-path="url(#terminal-2212491683-line-9)">.pytest_cache</text><text class="terminal-2212491683-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-9)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="264" textLength="48.8" clip-path="url(#terminal-2212491683-line-10)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="264" textLength="24.4" clip-path="url(#terminal-2212491683-line-10)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="264" textLength="207.4" clip-path="url(#terminal-2212491683-line-10)">.screenshot_cache</text><text class="terminal-2212491683-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2212491683-line-10)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="288.4" textLength="48.8" clip-path="url(#terminal-2212491683-line-11)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-2212491683-line-11)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="288.4" textLength="61" clip-path="url(#terminal-2212491683-line-11)">.venv</text><text class="terminal-2212491683-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-11)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="312.8" textLength="48.8" clip-path="url(#terminal-2212491683-line-12)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="312.8" textLength="24.4" clip-path="url(#terminal-2212491683-line-12)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="312.8" textLength="85.4" clip-path="url(#terminal-2212491683-line-12)">.vscode</text><text class="terminal-2212491683-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-12)">
+  </text><text class="terminal-2212491683-r8" x="24.4" y="337.2" textLength="48.8" clip-path="url(#terminal-2212491683-line-13)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-2212491683-line-13)">📁&#160;</text><text class="terminal-2212491683-r11" x="109.8" y="337.2" textLength="134.2" clip-path="url(#terminal-2212491683-line-13)">__pycache__</text><text class="terminal-2212491683-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-13)">
+  </text><text class="terminal-2212491683-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-14)">
+  </text><text class="terminal-2212491683-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2212491683-line-15)">
+  </text><text class="terminal-2212491683-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-16)">
+  </text><text class="terminal-2212491683-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-17)">
+  </text><text class="terminal-2212491683-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-18)">
+  </text><text class="terminal-2212491683-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-19)">
+  </text><text class="terminal-2212491683-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2212491683-line-20)">
+  </text><text class="terminal-2212491683-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-21)">
+  </text><text class="terminal-2212491683-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-22)">
+  </text>
+      </g>
+      </g>
+  </svg>
+  
+  '''
+# ---
 # name: test_radio_button_example
   '''
   <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -19699,141 +19699,135 @@
           font-weight: 700;
       }
   
-      .terminal-2212491683-matrix {
+      .terminal-1586716314-matrix {
           font-family: Fira Code, monospace;
           font-size: 20px;
           line-height: 24.4px;
           font-variant-east-asian: full-width;
       }
   
-      .terminal-2212491683-title {
+      .terminal-1586716314-title {
           font-size: 18px;
           font-weight: bold;
           font-family: arial;
       }
   
-      .terminal-2212491683-r1 { fill: #c5c8c6 }
-  .terminal-2212491683-r2 { fill: #737373 }
-  .terminal-2212491683-r3 { fill: #e1e1e1;font-weight: bold }
-  .terminal-2212491683-r4 { fill: #323232 }
-  .terminal-2212491683-r5 { fill: #0178d4 }
-  .terminal-2212491683-r6 { fill: #e2e3e3 }
-  .terminal-2212491683-r7 { fill: #1a1000;font-weight: bold }
-  .terminal-2212491683-r8 { fill: #008139 }
-  .terminal-2212491683-r9 { fill: #919497;font-weight: bold }
-  .terminal-2212491683-r10 { fill: #14191f }
-  .terminal-2212491683-r11 { fill: #e2e3e3;font-weight: bold }
-  .terminal-2212491683-r12 { fill: #e1e1e1 }
+      .terminal-1586716314-r1 { fill: #c5c8c6 }
+  .terminal-1586716314-r2 { fill: #737373 }
+  .terminal-1586716314-r3 { fill: #e1e1e1;font-weight: bold }
+  .terminal-1586716314-r4 { fill: #323232 }
+  .terminal-1586716314-r5 { fill: #0178d4 }
+  .terminal-1586716314-r6 { fill: #e1e1e1 }
       </style>
   
       <defs>
-      <clipPath id="terminal-2212491683-clip-terminal">
+      <clipPath id="terminal-1586716314-clip-terminal">
         <rect x="0" y="0" width="975.0" height="584.5999999999999" />
       </clipPath>
-      <clipPath id="terminal-2212491683-line-0">
+      <clipPath id="terminal-1586716314-line-0">
       <rect x="0" y="1.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-1">
+  <clipPath id="terminal-1586716314-line-1">
       <rect x="0" y="25.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-2">
+  <clipPath id="terminal-1586716314-line-2">
       <rect x="0" y="50.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-3">
+  <clipPath id="terminal-1586716314-line-3">
       <rect x="0" y="74.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-4">
+  <clipPath id="terminal-1586716314-line-4">
       <rect x="0" y="99.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-5">
+  <clipPath id="terminal-1586716314-line-5">
       <rect x="0" y="123.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-6">
+  <clipPath id="terminal-1586716314-line-6">
       <rect x="0" y="147.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-7">
+  <clipPath id="terminal-1586716314-line-7">
       <rect x="0" y="172.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-8">
+  <clipPath id="terminal-1586716314-line-8">
       <rect x="0" y="196.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-9">
+  <clipPath id="terminal-1586716314-line-9">
       <rect x="0" y="221.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-10">
+  <clipPath id="terminal-1586716314-line-10">
       <rect x="0" y="245.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-11">
+  <clipPath id="terminal-1586716314-line-11">
       <rect x="0" y="269.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-12">
+  <clipPath id="terminal-1586716314-line-12">
       <rect x="0" y="294.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-13">
+  <clipPath id="terminal-1586716314-line-13">
       <rect x="0" y="318.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-14">
+  <clipPath id="terminal-1586716314-line-14">
       <rect x="0" y="343.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-15">
+  <clipPath id="terminal-1586716314-line-15">
       <rect x="0" y="367.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-16">
+  <clipPath id="terminal-1586716314-line-16">
       <rect x="0" y="391.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-17">
+  <clipPath id="terminal-1586716314-line-17">
       <rect x="0" y="416.3" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-18">
+  <clipPath id="terminal-1586716314-line-18">
       <rect x="0" y="440.7" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-19">
+  <clipPath id="terminal-1586716314-line-19">
       <rect x="0" y="465.1" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-20">
+  <clipPath id="terminal-1586716314-line-20">
       <rect x="0" y="489.5" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-21">
+  <clipPath id="terminal-1586716314-line-21">
       <rect x="0" y="513.9" width="976" height="24.65"/>
               </clipPath>
-  <clipPath id="terminal-2212491683-line-22">
+  <clipPath id="terminal-1586716314-line-22">
       <rect x="0" y="538.3" width="976" height="24.65"/>
               </clipPath>
       </defs>
   
-      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-2212491683-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">QuicklyChangeTabsApp</text>
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-1586716314-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">QuicklyChangeTabsApp</text>
               <g transform="translate(26,22)">
               <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
               <circle cx="22" cy="0" r="7" fill="#febc2e"/>
               <circle cx="44" cy="0" r="7" fill="#28c840"/>
               </g>
           
-      <g transform="translate(9, 41)" clip-path="url(#terminal-2212491683-clip-terminal)">
-      <rect fill="#1e1e1e" x="0" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="1.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="61" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="97.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="134.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="25.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="158.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="50.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#cf7e00" x="61" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="85.4" y="99.1" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="927.2" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="158.6" y="123.5" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="927.2" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="147.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="147.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="158.6" y="147.9" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#23568b" x="927.2" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="172.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="172.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="195.2" y="172.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="196.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="196.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="196.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="244" y="196.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="221.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="221.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="221.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="268.4" y="221.1" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="245.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="245.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="317.2" y="245.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="269.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="269.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="269.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="170.8" y="269.9" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="294.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="294.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="294.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="195.2" y="294.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="318.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="318.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="318.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="244" y="318.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14191f" x="927.2" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-      <g class="terminal-2212491683-matrix">
-      <text class="terminal-2212491683-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2212491683-line-0)">
-  </text><text class="terminal-2212491683-r2" x="24.4" y="44.4" textLength="36.6" clip-path="url(#terminal-2212491683-line-1)">one</text><text class="terminal-2212491683-r2" x="97.6" y="44.4" textLength="36.6" clip-path="url(#terminal-2212491683-line-1)">two</text><text class="terminal-2212491683-r3" x="170.8" y="44.4" textLength="61" clip-path="url(#terminal-2212491683-line-1)">three</text><text class="terminal-2212491683-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-1)">
-  </text><text class="terminal-2212491683-r4" x="0" y="68.8" textLength="158.6" clip-path="url(#terminal-2212491683-line-2)">━━━━━━━━━━━━━</text><text class="terminal-2212491683-r4" x="158.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-2)">╸</text><text class="terminal-2212491683-r5" x="170.8" y="68.8" textLength="61" clip-path="url(#terminal-2212491683-line-2)">━━━━━</text><text class="terminal-2212491683-r4" x="231.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-2)">╺</text><text class="terminal-2212491683-r4" x="244" y="68.8" textLength="732" clip-path="url(#terminal-2212491683-line-2)">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</text><text class="terminal-2212491683-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-2)">
-  </text><text class="terminal-2212491683-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-3)">
-  </text><text class="terminal-2212491683-r6" x="24.4" y="117.6" textLength="24.4" clip-path="url(#terminal-2212491683-line-4)">📂&#160;</text><text class="terminal-2212491683-r7" x="61" y="117.6" textLength="24.4" clip-path="url(#terminal-2212491683-line-4)">./</text><text class="terminal-2212491683-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-4)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="142" textLength="48.8" clip-path="url(#terminal-2212491683-line-5)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="142" textLength="24.4" clip-path="url(#terminal-2212491683-line-5)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="142" textLength="48.8" clip-path="url(#terminal-2212491683-line-5)">.faq</text><text class="terminal-2212491683-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2212491683-line-5)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="166.4" textLength="48.8" clip-path="url(#terminal-2212491683-line-6)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="166.4" textLength="24.4" clip-path="url(#terminal-2212491683-line-6)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="166.4" textLength="48.8" clip-path="url(#terminal-2212491683-line-6)">.git</text><text class="terminal-2212491683-r10" x="927.2" y="166.4" textLength="24.4" clip-path="url(#terminal-2212491683-line-6)">▄▄</text><text class="terminal-2212491683-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-6)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="190.8" textLength="48.8" clip-path="url(#terminal-2212491683-line-7)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="190.8" textLength="24.4" clip-path="url(#terminal-2212491683-line-7)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="190.8" textLength="85.4" clip-path="url(#terminal-2212491683-line-7)">.github</text><text class="terminal-2212491683-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-7)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="215.2" textLength="48.8" clip-path="url(#terminal-2212491683-line-8)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="215.2" textLength="24.4" clip-path="url(#terminal-2212491683-line-8)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="215.2" textLength="134.2" clip-path="url(#terminal-2212491683-line-8)">.mypy_cache</text><text class="terminal-2212491683-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-8)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="239.6" textLength="48.8" clip-path="url(#terminal-2212491683-line-9)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="239.6" textLength="24.4" clip-path="url(#terminal-2212491683-line-9)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="239.6" textLength="158.6" clip-path="url(#terminal-2212491683-line-9)">.pytest_cache</text><text class="terminal-2212491683-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-9)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="264" textLength="48.8" clip-path="url(#terminal-2212491683-line-10)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="264" textLength="24.4" clip-path="url(#terminal-2212491683-line-10)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="264" textLength="207.4" clip-path="url(#terminal-2212491683-line-10)">.screenshot_cache</text><text class="terminal-2212491683-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2212491683-line-10)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="288.4" textLength="48.8" clip-path="url(#terminal-2212491683-line-11)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="288.4" textLength="24.4" clip-path="url(#terminal-2212491683-line-11)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="288.4" textLength="61" clip-path="url(#terminal-2212491683-line-11)">.venv</text><text class="terminal-2212491683-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-11)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="312.8" textLength="48.8" clip-path="url(#terminal-2212491683-line-12)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="312.8" textLength="24.4" clip-path="url(#terminal-2212491683-line-12)">📁&#160;</text><text class="terminal-2212491683-r9" x="109.8" y="312.8" textLength="85.4" clip-path="url(#terminal-2212491683-line-12)">.vscode</text><text class="terminal-2212491683-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-12)">
-  </text><text class="terminal-2212491683-r8" x="24.4" y="337.2" textLength="48.8" clip-path="url(#terminal-2212491683-line-13)">├──&#160;</text><text class="terminal-2212491683-r6" x="73.2" y="337.2" textLength="24.4" clip-path="url(#terminal-2212491683-line-13)">📁&#160;</text><text class="terminal-2212491683-r11" x="109.8" y="337.2" textLength="134.2" clip-path="url(#terminal-2212491683-line-13)">__pycache__</text><text class="terminal-2212491683-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-13)">
-  </text><text class="terminal-2212491683-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-14)">
-  </text><text class="terminal-2212491683-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2212491683-line-15)">
-  </text><text class="terminal-2212491683-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-16)">
-  </text><text class="terminal-2212491683-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-17)">
-  </text><text class="terminal-2212491683-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2212491683-line-18)">
-  </text><text class="terminal-2212491683-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2212491683-line-19)">
-  </text><text class="terminal-2212491683-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2212491683-line-20)">
-  </text><text class="terminal-2212491683-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2212491683-line-21)">
-  </text><text class="terminal-2212491683-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2212491683-line-22)">
+      <g transform="translate(9, 41)" clip-path="url(#terminal-1586716314-clip-terminal)">
+      <rect fill="#1e1e1e" x="0" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="1.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="61" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="73.2" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="97.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="134.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="25.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="50.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="158.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="170.8" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="244" y="50.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="24.4" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="99.1" width="866.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-1586716314-matrix">
+      <text class="terminal-1586716314-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1586716314-line-0)">
+  </text><text class="terminal-1586716314-r2" x="24.4" y="44.4" textLength="36.6" clip-path="url(#terminal-1586716314-line-1)">one</text><text class="terminal-1586716314-r2" x="97.6" y="44.4" textLength="36.6" clip-path="url(#terminal-1586716314-line-1)">two</text><text class="terminal-1586716314-r3" x="170.8" y="44.4" textLength="61" clip-path="url(#terminal-1586716314-line-1)">three</text><text class="terminal-1586716314-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1586716314-line-1)">
+  </text><text class="terminal-1586716314-r4" x="0" y="68.8" textLength="158.6" clip-path="url(#terminal-1586716314-line-2)">━━━━━━━━━━━━━</text><text class="terminal-1586716314-r4" x="158.6" y="68.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-2)">╸</text><text class="terminal-1586716314-r5" x="170.8" y="68.8" textLength="61" clip-path="url(#terminal-1586716314-line-2)">━━━━━</text><text class="terminal-1586716314-r4" x="231.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-2)">╺</text><text class="terminal-1586716314-r4" x="244" y="68.8" textLength="732" clip-path="url(#terminal-1586716314-line-2)">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</text><text class="terminal-1586716314-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-2)">
+  </text><text class="terminal-1586716314-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1586716314-line-3)">
+  </text><text class="terminal-1586716314-r6" x="24.4" y="117.6" textLength="61" clip-path="url(#terminal-1586716314-line-4)">three</text><text class="terminal-1586716314-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1586716314-line-4)">
+  </text><text class="terminal-1586716314-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1586716314-line-5)">
+  </text><text class="terminal-1586716314-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1586716314-line-6)">
+  </text><text class="terminal-1586716314-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-7)">
+  </text><text class="terminal-1586716314-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1586716314-line-8)">
+  </text><text class="terminal-1586716314-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1586716314-line-9)">
+  </text><text class="terminal-1586716314-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1586716314-line-10)">
+  </text><text class="terminal-1586716314-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1586716314-line-11)">
+  </text><text class="terminal-1586716314-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-12)">
+  </text><text class="terminal-1586716314-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1586716314-line-13)">
+  </text><text class="terminal-1586716314-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1586716314-line-14)">
+  </text><text class="terminal-1586716314-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1586716314-line-15)">
+  </text><text class="terminal-1586716314-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1586716314-line-16)">
+  </text><text class="terminal-1586716314-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-17)">
+  </text><text class="terminal-1586716314-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1586716314-line-18)">
+  </text><text class="terminal-1586716314-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1586716314-line-19)">
+  </text><text class="terminal-1586716314-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1586716314-line-20)">
+  </text><text class="terminal-1586716314-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1586716314-line-21)">
+  </text><text class="terminal-1586716314-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1586716314-line-22)">
   </text>
       </g>
       </g>

--- a/tests/snapshot_tests/snapshot_apps/quickly_change_tabs.py
+++ b/tests/snapshot_tests/snapshot_apps/quickly_change_tabs.py
@@ -1,22 +1,17 @@
 """Regression test for https://github.com/Textualize/textual/issues/2229."""
 from textual.app import App, ComposeResult
-from textual.widgets import TabbedContent, TabPane, Tabs, DirectoryTree
+from textual.widgets import TabbedContent, TabPane, Tabs, Label
 
 
 class QuicklyChangeTabsApp(App[None]):
-    CSS = """
-    DirectoryTree {
-        min-height: 10;
-    }"""
-
     def compose(self) -> ComposeResult:
         with TabbedContent():
             with TabPane("one"):
-                yield DirectoryTree("./")
+                yield Label("one")
             with TabPane("two"):
-                yield DirectoryTree("./")
+                yield Label("two")
             with TabPane("three", id="three"):
-                yield DirectoryTree("./")
+                yield Label("three")
 
     def key_p(self) -> None:
         self.query_one(Tabs).action_next_tab()

--- a/tests/snapshot_tests/snapshot_apps/quickly_change_tabs.py
+++ b/tests/snapshot_tests/snapshot_apps/quickly_change_tabs.py
@@ -1,0 +1,29 @@
+"""Regression test for https://github.com/Textualize/textual/issues/2229."""
+from textual.app import App, ComposeResult
+from textual.widgets import TabbedContent, TabPane, Tabs, DirectoryTree
+
+
+class QuicklyChangeTabsApp(App[None]):
+    CSS = """
+    DirectoryTree {
+        min-height: 10;
+    }"""
+
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            with TabPane("one"):
+                yield DirectoryTree("./")
+            with TabPane("two"):
+                yield DirectoryTree("./")
+            with TabPane("three", id="three"):
+                yield DirectoryTree("./")
+
+    def key_p(self) -> None:
+        self.query_one(Tabs).action_next_tab()
+        self.query_one(Tabs).action_next_tab()
+
+
+app = QuicklyChangeTabsApp()
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -429,3 +429,8 @@ def test_scroll_to_center(snap_compare):
     # scrolled so that the red string >>bullseye<< is centered on the screen.
     # When this snapshot "breaks" because #2254 is fixed, this snapshot can be updated.
     assert snap_compare(SNAPSHOT_APPS_DIR / "scroll_to_center.py", press=["s"])
+
+
+def test_quickly_change_tabs(snap_compare):
+    # https://github.com/Textualize/textual/issues/2229
+    assert snap_compare(SNAPSHOT_APPS_DIR / "quickly_change_tabs.py", press=["p"])


### PR DESCRIPTION
This will close #2229.
See [this comment](https://github.com/Textualize/textual/issues/2229#issuecomment-1511636895) wherein for an explanation of the issue.

We use a descriptor to proxy the attribute `active` from `Tabs` to `TabbedContent` without having to keep it in sync in two different places.