### PR TITLE
Add support for "returning" a result value from screens.

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1402,7 +1402,9 @@ class App(Generic[ReturnType], DOMNode):
             self.screen.post_message(events.ScreenSuspend())
             self.screen.refresh()
         next_screen, await_mount = self._get_screen(screen)
-        next_screen._push_result_callback(self.screen, callback)
+        next_screen._push_result_callback(
+            self.screen if self._screen_stack else None, callback
+        )
         self._screen_stack.append(next_screen)
         next_screen.post_message(events.ScreenResume())
         self.log.system(f"{self.screen} is current (PUSHED)")

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -92,7 +92,7 @@ from .keys import (
 from .messages import CallbackType
 from .reactive import Reactive
 from .renderables.blank import Blank
-from .screen import Screen, ScreenResultCallbackType
+from .screen import Screen, ScreenResultCallbackType, ScreenResultType
 from .widget import AwaitMount, Widget
 
 if TYPE_CHECKING:
@@ -1380,13 +1380,18 @@ class App(Generic[ReturnType], DOMNode):
         return screen
 
     def push_screen(
-        self, screen: Screen | str, callback: ScreenResultCallbackType | None = None
+        self,
+        screen: Screen[ScreenResultType] | str,
+        callback: ScreenResultCallbackType[ScreenResultType] | None = None,
     ) -> AwaitMount:
         """Push a new [screen](/guide/screens) on the screen stack, making it the current screen.
 
         Args:
             screen: A Screen instance or the name of an installed screen.
+            callback: An optional callback function that is called if the screen is dismissed with a result.
 
+        Returns:
+            An awaitable that awaits the mounting of the screen and its children.
         """
         if not isinstance(screen, (Screen, str)):
             raise TypeError(
@@ -1397,7 +1402,7 @@ class App(Generic[ReturnType], DOMNode):
             self.screen.post_message(events.ScreenSuspend())
             self.screen.refresh()
         next_screen, await_mount = self._get_screen(screen)
-        next_screen._result_callback = callback
+        next_screen._push_result_callback(self.screen, callback)
         self._screen_stack.append(next_screen)
         next_screen.post_message(events.ScreenResume())
         self.log.system(f"{self.screen} is current (PUSHED)")
@@ -1496,6 +1501,7 @@ class App(Generic[ReturnType], DOMNode):
                 "Can't pop screen; there must be at least one screen on the stack"
             )
         previous_screen = self._replace_screen(screen_stack.pop())
+        previous_screen._pop_result_callback()
         self.screen._screen_resized(self.size)
         self.screen.post_message(events.ScreenResume())
         self.log.system(f"{self.screen} is active")

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1392,7 +1392,7 @@ class App(Generic[ReturnType], DOMNode):
             callback: An optional callback function that is called if the screen is dismissed with a result.
 
         Returns:
-            An awaitable that awaits the mounting of the screen and its children.
+            An optional awaitable that awaits the mounting of the screen and its children.
         """
         if not isinstance(screen, (Screen, str)):
             raise TypeError(

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -92,7 +92,7 @@ from .keys import (
 from .messages import CallbackType
 from .reactive import Reactive
 from .renderables.blank import Blank
-from .screen import Screen
+from .screen import Screen, ScreenResultCallbackType
 from .widget import AwaitMount, Widget
 
 if TYPE_CHECKING:
@@ -1379,7 +1379,9 @@ class App(Generic[ReturnType], DOMNode):
             self.log.system(f"{screen} REMOVED")
         return screen
 
-    def push_screen(self, screen: Screen | str) -> AwaitMount:
+    def push_screen(
+        self, screen: Screen | str, callback: ScreenResultCallbackType | None = None
+    ) -> AwaitMount:
         """Push a new [screen](/guide/screens) on the screen stack, making it the current screen.
 
         Args:
@@ -1395,6 +1397,7 @@ class App(Generic[ReturnType], DOMNode):
             self.screen.post_message(events.ScreenSuspend())
             self.screen.refresh()
         next_screen, await_mount = self._get_screen(screen)
+        next_screen._result_callback = callback
         self._screen_stack.append(next_screen)
         next_screen.post_message(events.ScreenResume())
         self.log.system(f"{self.screen} is current (PUSHED)")

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1423,7 +1423,8 @@ class App(Generic[ReturnType], DOMNode):
                 f"switch_screen requires a Screen instance or str; not {screen!r}"
             )
         if self.screen is not screen:
-            self._replace_screen(self._screen_stack.pop())
+            previous_screen = self._replace_screen(self._screen_stack.pop())
+            previous_screen._pop_result_callback()
             next_screen, await_mount = self._get_screen(screen)
             self._screen_stack.append(next_screen)
             self.screen.post_message(events.ScreenResume())

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -57,7 +57,7 @@ class ResultCallback(Generic[ScreenResultType]):
 
     def __init__(
         self,
-        requester: Widget,
+        requester: Widget | None,
         callback: ScreenResultCallbackType[ScreenResultType] | None,
     ) -> None:
         """Initialise the result callback object.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -66,7 +66,7 @@ class ResultCallback(Generic[ScreenResultType]):
             requester: The object making a request for the callback.
             callback: The callback function.
         """
-        self.requester: Widget = requester
+        self.requester: Widget | None = requester
         """The object in the DOM that requested the callback."""
         self.callback: ScreenResultCallbackType | None = callback
         """The callback function."""
@@ -78,9 +78,9 @@ class ResultCallback(Generic[ScreenResultType]):
             result: The result to pass to the callback.
 
         Note:
-            If the callback is `None` this will be a no-op.
+            If the requested or the callback are `None` this will be a no-op.
         """
-        if self.callback is not None:
+        if self.requester is not None and self.callback is not None:
             self.requester.call_next(self.callback, result)
 
 
@@ -501,7 +501,7 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _push_result_callback(
         self,
-        requester: Widget,
+        requester: Widget | None,
         callback: ScreenResultCallbackType[ScreenResultType] | None,
     ) -> None:
         """Add a result callback to the screen.


### PR DESCRIPTION
This is still in the "let's see if we like this approach" stage, although I think @willmcgugan and myself are liking this approach. Testing and review of these changes is highly encouraged. Beyond docstrings there are no documentation changes at the moment. This will need a slight reworking of the `Screen` guide so it's better that we're happy with the approach and the code before we write this up fully.

Please review without worrying about documentation for now.

This PR seeks to satisfy #2267 and does take the suggested callback approach. The alternative was to go with a "use messages" story that, while working well, places more work on the developer using Textual and potentially results in more boilerplate.

Changes of note here are:

- Much like with `App`, a `Screen` can now be typed. The type signifies the type of the result that it will "return".
- `App.push_screen` has acquired a `callback` parameter. If provided the callback function should be a function that takes a single argument, that is the type of the type given to the screen being pushed.
- `Screen` has acquired a new method called `dismiss`. This is a thin wrapper around `App.pop_screen`. Called with no parameter it performs the same as if `App.pop_screen` were called. If called with a parameter the callback provided with `App.push_screen` is called and then the screen is popped.
- `Screen` has also acquired an `action_dismiss` method to allow for easy dismissal of a screen from within an action.

Other things to keep in mind:

- A callback can optionally be awaitable.
- Because any given instance of a screen can end up on the screen stack multiple times, the result callback hook is done as a stack.

As an illustration of how this might be used, here's a small program that uses a `ModalScreen` to ask the user a question and then act on their answer:

```python
from textual.app import App, ComposeResult
from textual.containers import Horizontal, Vertical
from textual.screen import ModalScreen
from textual.widgets import Header, Footer, OptionList, Button, Label


class AyeNaw(ModalScreen[bool]):
    DEFAULT_CSS = """
    AyeNaw {
        align: center middle;
    }

    AyeNaw > Vertical {
        background: $secondary;
        width: auto;
        height: auto;
        border: thick $primary;
        padding: 2 4;
    }

    AyeNaw > Vertical > * {
        width: auto;
        height: auto;
    }

    AyeNaw > Vertical > Label {
        padding-bottom: 2;
    }

    AyeNaw > Vertical > Horizontal {
        align: right middle;
    }

    AyeNaw Button {
        margin-left: 2;
    }
    """

    def compose(self) -> ComposeResult:
        with Vertical():
            yield Label("Well, what do you think?")
            with Horizontal():
                yield Button("Aye!", id="aye")
                yield Button("Naw!", id="naw")

    def on_button_pressed(self, event: Button.Pressed) -> None:
        self.dismiss(result=event.button.id == "aye")


class ScreenResultExampleApp(App[None]):
    BINDINGS = [
        ("question_mark", "ask", "Ask a question"),
    ]

    def compose(self) -> ComposeResult:
        yield Header()
        yield OptionList()
        yield Footer()

    def accept_answer(self, answer: bool) -> None:
        self.query_one(OptionList).add_option(
            f"Computer said {'[green]Aye' if answer else '[red]Naw'}[/]"
        )

    def action_ask(self) -> None:
        self.push_screen(AyeNaw(), callback=self.accept_answer)


if __name__ == "__main__":
    ScreenResultExampleApp().run()
```

https://user-images.githubusercontent.com/28237/232797119-2b711c08-a2ab-43be-817d-a36db64f995a.mov
