### PR TITLE
Make textual.widgets.* event handlers private

### DIFF
--- a/src/textual/widgets/_content_switcher.py
+++ b/src/textual/widgets/_content_switcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from ..containers import Container
+from ..events import Mount
 from ..reactive import reactive
 from ..widget import Widget
 
@@ -58,7 +59,7 @@ class ContentSwitcher(Container):
         )
         self._initial = initial
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         """Perform the initial setup of the widget once the DOM is ready."""
         initial = self._initial
         with self.app.batch_update():

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -887,11 +887,11 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             return self.header_height
         return self.rows[row_key].height
 
-    async def on_styles_updated(self) -> None:
+    async def _on_styles_updated(self) -> None:
         self._clear_caches()
         self.refresh()
 
-    def on_resize(self, event: events.Resize) -> None:
+    def _on_resize(self, _: events.Resize) -> None:
         self._update_count += 1
 
     def watch_show_cursor(self, show_cursor: bool) -> None:
@@ -1364,7 +1364,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._update_count += 1
         self.refresh(layout=True)
 
-    def on_idle(self) -> None:
+    async def _on_idle(self, _: events.Idle) -> None:
         """Runs when the message pump is empty.
 
         We use this for some expensive calculations like re-computing dimensions of the
@@ -1904,7 +1904,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
         return self._render_line(y, scroll_x, scroll_x + width, self.rich_style)
 
-    def on_mouse_move(self, event: events.MouseMove):
+    def _on_mouse_move(self, event: events.MouseMove):
         """If the hover cursor is visible, display it by extracting the row
         and column metadata from the segments present in the cells."""
         self._set_hover_cursor(True)
@@ -1916,7 +1916,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             except KeyError:
                 pass
 
-    def on_leave(self, event: events.Leave) -> None:
+    def _on_leave(self, _: events.Leave) -> None:
         self._set_hover_cursor(False)
 
     def _get_fixed_offset(self) -> Spacing:
@@ -2001,7 +2001,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         elif cursor_type == "cell":
             self.refresh_coordinate(self.hover_coordinate)
 
-    def on_click(self, event: events.Click) -> None:
+    async def _on_click(self, event: events.Click) -> None:
         self._set_hover_cursor(True)
         meta = event.style.meta
         if not meta:

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Iterable
 from rich.style import Style
 from rich.text import Text, TextType
 
+from ..events import Mount
 from ..message import Message
 from ._tree import TOGGLE_STYLE, Tree, TreeNode
 
@@ -180,10 +181,10 @@ class DirectoryTree(Tree[DirEntry]):
             )
         node.expand()
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         self.load_directory(self.root)
 
-    def on_tree_node_expanded(self, event: Tree.NodeSelected) -> None:
+    def _on_tree_node_expanded(self, event: Tree.NodeSelected) -> None:
         event.stop()
         dir_entry = event.node.data
         if dir_entry is None:
@@ -194,7 +195,7 @@ class DirectoryTree(Tree[DirEntry]):
         else:
             self.post_message(self.FileSelected(dir_entry.path))
 
-    def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
+    def _on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         event.stop()
         dir_entry = event.node.data
         if dir_entry is None:

--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from rich.text import Text
 
 from ..app import RenderResult
+from ..events import Mount
 from ..reactive import Reactive
 from ..widget import Widget
 
@@ -67,7 +68,7 @@ class HeaderClock(HeaderClockSpace):
     }
     """
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         self.set_interval(1, callback=self.refresh, name=f"update header clock")
 
     def render(self) -> RenderResult:
@@ -156,10 +157,10 @@ class Header(Widget):
     def watch_tall(self, tall: bool) -> None:
         self.set_class(tall, "-tall")
 
-    def on_click(self):
+    def _on_click(self):
         self.toggle_class("-tall")
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         def set_title(title: str) -> None:
             self.query_one(HeaderTitle).text = title
 

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -12,6 +12,7 @@ from rich.text import Text
 from .. import events
 from .._segment_tools import line_crop
 from ..binding import Binding, BindingType
+from ..events import Blur, Focus, Mount
 from ..geometry import Size
 from ..message import Message
 from ..reactive import reactive
@@ -299,22 +300,22 @@ class Input(Widget, can_focus=True):
         """Toggle visibility of cursor."""
         self._cursor_visible = not self._cursor_visible
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         self.blink_timer = self.set_interval(
             0.5,
             self._toggle_cursor,
             pause=not (self.cursor_blink and self.has_focus),
         )
 
-    def on_blur(self) -> None:
+    def _on_blur(self, _: Blur) -> None:
         self.blink_timer.pause()
 
-    def on_focus(self) -> None:
+    def _on_focus(self, _: Focus) -> None:
         self.cursor_position = len(self.value)
         if self.cursor_blink:
             self.blink_timer.resume()
 
-    async def on_key(self, event: events.Key) -> None:
+    async def _on_key(self, event: events.Key) -> None:
         self._cursor_visible = True
         if self.cursor_blink:
             self.blink_timer.reset()
@@ -330,12 +331,12 @@ class Input(Widget, can_focus=True):
             self.insert_text_at_cursor(event.character)
             event.prevent_default()
 
-    def on_paste(self, event: events.Paste) -> None:
+    def _on_paste(self, event: events.Paste) -> None:
         line = event.text.splitlines()[0]
         self.insert_text_at_cursor(line)
         event.stop()
 
-    def on_click(self, event: events.Click) -> None:
+    async def _on_click(self, event: events.Click) -> None:
         offset = event.get_content_offset(self)
         if offset is None:
             return

--- a/src/textual/widgets/_list_item.py
+++ b/src/textual/widgets/_list_item.py
@@ -47,7 +47,7 @@ class ListItem(Widget, can_focus=False):
             self.item = item
             super().__init__()
 
-    def on_click(self, event: events.Click) -> None:
+    async def _on_click(self, _: events.Click) -> None:
         self.post_message(self._ChildClicked(self))
 
     def watch_highlighted(self, value: bool) -> None:

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -5,6 +5,7 @@ from typing import ClassVar, Optional
 from textual.await_remove import AwaitRemove
 from textual.binding import Binding, BindingType
 from textual.containers import VerticalScroll
+from textual.events import Mount
 from textual.geometry import clamp
 from textual.message import Message
 from textual.reactive import reactive
@@ -93,7 +94,7 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
         )
         self._index = initial_index
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         """Ensure the ListView is fully-settled after mounting."""
         self.index = self._index
 
@@ -196,7 +197,7 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
             return
         self.index -= 1
 
-    def on_list_item__child_clicked(self, event: ListItem._ChildClicked) -> None:
+    def _on_list_item__child_clicked(self, event: ListItem._ChildClicked) -> None:
         self.focus()
         self.index = self._nodes.index(event.item)
         self.post_message(self.Selected(self, event.item))

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -7,6 +7,7 @@ from rich.style import Style
 from rich.text import Text
 
 from ..color import Gradient
+from ..events import Mount
 from ..widget import Widget
 
 
@@ -22,7 +23,7 @@ class LoadingIndicator(Widget):
     }
     """
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         self._start_time = time()
         self.auto_refresh = 1 / 16
 

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -13,6 +13,7 @@ from typing_extensions import TypeAlias
 
 from ..app import ComposeResult
 from ..containers import Horizontal, VerticalScroll
+from ..events import Mount
 from ..message import Message
 from ..reactive import reactive, var
 from ..widget import Widget
@@ -587,7 +588,7 @@ class Markdown(Widget):
             self.href: str = href
             """The link that was selected."""
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         if self._markdown is not None:
             self.update(self._markdown)
 
@@ -801,7 +802,7 @@ class MarkdownTableOfContents(Widget, can_focus_children=True):
                     node = node.add(NUMERALS[level], expand=True)
             node.add_leaf(f"[dim]{NUMERALS[level]}[/] {name}", {"block_id": block_id})
 
-    async def on_tree_node_selected(self, message: Tree.NodeSelected) -> None:
+    async def _on_tree_node_selected(self, message: Tree.NodeSelected) -> None:
         node_data = message.node.data
         if node_data is not None:
             await self._post_message(
@@ -872,7 +873,7 @@ class MarkdownViewer(VerticalScroll, can_focus=True, can_focus_children=True):
         """The table of contents widget"""
         return self.query_one(MarkdownTableOfContents)
 
-    async def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         if self._markdown is not None:
             self.document.update(self._markdown)
 
@@ -890,7 +891,7 @@ class MarkdownViewer(VerticalScroll, can_focus=True, can_focus_children=True):
         if self.navigator.forward():
             await self.document.load(self.navigator.location)
 
-    async def on_markdown_link_clicked(self, message: Markdown.LinkClicked) -> None:
+    async def _on_markdown_link_clicked(self, message: Markdown.LinkClicked) -> None:
         message.stop()
         await self.go(message.href)
 
@@ -901,7 +902,7 @@ class MarkdownViewer(VerticalScroll, can_focus=True, can_focus_children=True):
         yield MarkdownTableOfContents()
         yield Markdown(parser_factory=self._parser_factory)
 
-    def on_markdown_table_of_contents_updated(
+    def _on_markdown_table_of_contents_updated(
         self, message: Markdown.TableOfContentsUpdated
     ) -> None:
         self.query_one(
@@ -909,7 +910,7 @@ class MarkdownViewer(VerticalScroll, can_focus=True, can_focus_children=True):
         ).table_of_contents = message.table_of_contents
         message.stop()
 
-    def on_markdown_table_of_contents_selected(
+    def _on_markdown_table_of_contents_selected(
         self, message: Markdown.TableOfContentsSelected
     ) -> None:
         block_selector = f"#{message.block_id}"

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -16,7 +16,7 @@ from rich.style import Style
 from typing_extensions import Literal, Self, TypeAlias
 
 from ..binding import Binding, BindingType
-from ..events import Click, MouseMove
+from ..events import Click, Idle, Leave, MouseMove
 from ..geometry import Region, Size
 from ..message import Message
 from ..reactive import reactive
@@ -363,7 +363,7 @@ class OptionList(ScrollView, can_focus=True):
         self._needs_to_scroll_to_highlight = rescroll_to_highlight
         self.check_idle()
 
-    def on_idle(self) -> None:
+    async def _on_idle(self, _: Idle) -> None:
         """Perform content tracking data refresh when idle."""
         self._refresh_content_tracking()
         if self._needs_to_scroll_to_highlight:
@@ -380,11 +380,11 @@ class OptionList(ScrollView, can_focus=True):
         """
         self._request_content_tracking_refresh()
 
-    def on_resize(self) -> None:
+    def _on_resize(self) -> None:
         """Refresh the layout of the renderables in the list when resized."""
         self._request_content_tracking_refresh(rescroll_to_highlight=True)
 
-    def on_mouse_move(self, event: MouseMove) -> None:
+    def _on_mouse_move(self, event: MouseMove) -> None:
         """React to the mouse moving.
 
         Args:
@@ -392,11 +392,11 @@ class OptionList(ScrollView, can_focus=True):
         """
         self._mouse_hovering_over = event.style.meta.get("option")
 
-    def on_leave(self) -> None:
+    def _on_leave(self, _: Leave) -> None:
         """React to the mouse leaving the widget."""
         self._mouse_hovering_over = None
 
-    def on_click(self, event: Click) -> None:
+    async def _on_click(self, event: Click) -> None:
         """React to the mouse being clicked on an item.
 
         Args:

--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -156,11 +156,11 @@ class Placeholder(Widget):
             )
         return variant
 
-    def on_click(self) -> None:
+    async def _on_click(self, _: events.Click) -> None:
         """Click handler to cycle through the placeholder variants."""
         self.cycle_variant()
 
-    def on_resize(self, event: events.Resize) -> None:
+    def _on_resize(self, event: events.Resize) -> None:
         """Update the placeholder "size" variant with the new placeholder size."""
         self._renderables["size"] = self._SIZE_RENDER_TEMPLATE.format(*event.size)
         if self.variant == "size":

--- a/src/textual/widgets/_radio_set.py
+++ b/src/textual/widgets/_radio_set.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import rich.repr
 
 from ..containers import Container
+from ..events import Mount
 from ..message import Message
 from ._radio_button import RadioButton
 
@@ -91,7 +92,7 @@ class RadioSet(Container):
             disabled=disabled,
         )
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         """Perform some processing once mounted in the DOM."""
 
         # It's possible for the user to pass in a collection of radio
@@ -108,7 +109,7 @@ class RadioSet(Container):
         if switched_on:
             self._pressed_button = switched_on[0]
 
-    def on_radio_button_changed(self, event: RadioButton.Changed) -> None:
+    def _on_radio_button_changed(self, event: RadioButton.Changed) -> None:
         """Respond to the value of a button in the set being changed.
 
         Args:

--- a/src/textual/widgets/_switch.py
+++ b/src/textual/widgets/_switch.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar
 from rich.console import RenderableType
 
 from ..binding import Binding, BindingType
+from ..events import Click
 from ..geometry import Size
 from ..message import Message
 from ..reactive import reactive
@@ -153,7 +154,7 @@ class Switch(Widget, can_focus=True):
     def get_content_height(self, container: Size, viewport: Size, width: int) -> int:
         return 1
 
-    def on_click(self) -> None:
+    async def _on_click(self, _: Click) -> None:
         """Toggle the state of the switch."""
         self.toggle()
 

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -11,6 +11,7 @@ from ..app import ComposeResult, RenderResult
 from ..binding import Binding, BindingType
 from ..containers import Container, Horizontal, Vertical
 from ..css.query import NoMatches
+from ..events import Mount
 from ..geometry import Offset
 from ..message import Message
 from ..reactive import reactive
@@ -73,7 +74,7 @@ class Underline(Widget):
             background_style=Style.from_color(bar_style.bgcolor),
         )
 
-    def on_click(self, event: events.Click):
+    def _on_click(self, event: events.Click):
         """Catch clicks, so that the underline can activate the tabs."""
         event.stop()
         self.post_message(self.Clicked(event.screen_offset))
@@ -379,7 +380,7 @@ class Tabs(Widget, can_focus=True):
         except NoMatches:
             return None
 
-    def on_mount(self) -> None:
+    def _on_mount(self, _: Mount) -> None:
         """Make the first tab active."""
         if self._first_active is not None:
             self.active = self._first_active

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -12,6 +12,7 @@ from rich.text import Text, TextType
 
 from ..app import RenderResult
 from ..binding import Binding, BindingType
+from ..events import Click
 from ..geometry import Size
 from ..message import Message
 from ..reactive import reactive
@@ -220,7 +221,7 @@ class ToggleButton(Static, can_focus=True):
         """
         self.toggle()
 
-    def on_click(self) -> None:
+    async def _on_click(self, _: Click) -> None:
         """Toggle the value of the widget when clicked with the mouse."""
         self.toggle()
 


### PR DESCRIPTION
To help declutter the documentation for widgets this PR makes any public event handlers within our own widgets private (see #2324). From now on we should also make an effort to always use private event handlers for any new widgets.

Small change of note, that hopefully isn't going to be an issue: in one or two situations, simply to hush type checking, a non-async handler has had to be made async because the version in `Widget` it was overriding was async. In testing here (both unit testing and hand-testing) no issues became apparent.