### PR TITLE
implement dim fix

### DIFF
--- a/src/textual/_styles_cache.py
+++ b/src/textual/_styles_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from sys import intern
-from typing import TYPE_CHECKING, Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence
 
 from rich.console import Console
 from rich.segment import Segment
@@ -139,7 +139,7 @@ class StylesCache:
             content_size=widget.content_region.size,
             padding=styles.padding,
             crop=crop,
-            filter=widget.app._filter,
+            filters=widget.app._filters,
         )
         if widget.auto_links:
             hover_style = widget.hover_style
@@ -170,7 +170,7 @@ class StylesCache:
         content_size: Size | None = None,
         padding: Spacing | None = None,
         crop: Region | None = None,
-        filter: LineFilter | None = None,
+        filters: Sequence[LineFilter] | None = None,
     ) -> list[Strip]:
         """Render a widget content plus CSS styles.
 
@@ -186,7 +186,7 @@ class StylesCache:
             content_size: Size of content or None to assume full size.
             padding: Override padding from Styles, or None to use styles.padding.
             crop: Region to crop to.
-            filter: Additional post-processing for the segments.
+            filters: Additional post-processing for the segments.
 
         Returns:
             Rendered lines.
@@ -225,8 +225,9 @@ class StylesCache:
                 self._cache[y] = strip
             else:
                 strip = self._cache[y]
-            if filter:
-                strip = strip.apply_filter(filter)
+            if filters:
+                for filter in filters:
+                    strip = strip.apply_filter(filter, background)
             add_strip(strip)
         self._dirty_lines.difference_update(crop.line_range)
 

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -54,7 +54,7 @@ DEBUG: Final[bool] = get_environ_bool("TEXTUAL_DEBUG")
 DRIVER: Final[str | None] = get_environ("TEXTUAL_DRIVER", None)
 
 FILTERS: Final[str] = get_environ("TEXTUAL_FILTERS", "")
-"""A list of filters to apply to renderabels."""
+"""A list of filters to apply to renderables."""
 
 LOG_FILE: Final[str | None] = get_environ("TEXTUAL_LOG", None)
 """A last resort log file that appends all logs, when devtools isn't working."""

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -53,6 +53,8 @@ DEBUG: Final[bool] = get_environ_bool("TEXTUAL_DEBUG")
 
 DRIVER: Final[str | None] = get_environ("TEXTUAL_DRIVER", None)
 
+FILTERS: Final[str] = get_environ("TEXTUAL_FILTERS", "")
+
 LOG_FILE: Final[str | None] = get_environ("TEXTUAL_LOG", None)
 """A last resort log file that appends all logs, when devtools isn't working."""
 

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -54,6 +54,7 @@ DEBUG: Final[bool] = get_environ_bool("TEXTUAL_DEBUG")
 DRIVER: Final[str | None] = get_environ("TEXTUAL_DRIVER", None)
 
 FILTERS: Final[str] = get_environ("TEXTUAL_FILTERS", "")
+"""A list of filters to apply to renderabels."""
 
 LOG_FILE: Final[str | None] = get_environ("TEXTUAL_LOG", None)
 """A last resort log file that appends all logs, when devtools isn't working."""

--- a/src/textual/filter.py
+++ b/src/textual/filter.py
@@ -89,7 +89,7 @@ def dim_color(background: RichColor, color: RichColor, factor: float) -> RichCol
     Returns:
         New dimmer color.
     """
-    red1, green1, blue1 = background.get_truecolor(foreground=True)
+    red1, green1, blue1 = background.get_truecolor(foreground=False)
     red2, green2, blue2 = color.get_truecolor(foreground=True)
 
     return RichColor.from_rgb(

--- a/src/textual/filter.py
+++ b/src/textual/filter.py
@@ -99,6 +99,9 @@ def dim_color(background: RichColor, color: RichColor, factor: float) -> RichCol
     )
 
 
+DEFAULT_COLOR = RichColor.default()
+
+
 @lru_cache(1024)
 def dim_style(style: Style, background: Color, factor: float) -> Style:
     """Replace dim attribute with a dim color.
@@ -117,9 +120,9 @@ def dim_style(style: Style, background: Color, factor: float) -> Style:
                 (
                     background.rich_color
                     if style.bgcolor.is_default
-                    else (style.bgcolor or RichColor.default())
+                    else (style.bgcolor or DEFAULT_COLOR)
                 ),
-                style.color or RichColor.default(),
+                style.color or DEFAULT_COLOR,
                 factor,
             ),
             None,

--- a/src/textual/filter.py
+++ b/src/textual/filter.py
@@ -20,6 +20,7 @@ class LineFilter(ABC):
 
         Args:
             segments: A list of segments.
+            background: The background color.
 
         Returns:
             A new list of segments.
@@ -59,6 +60,7 @@ class Monochrome(LineFilter):
 
         Args:
             segments: A list of segments.
+            background: The background color.
 
         Returns:
             A new list of segments.
@@ -142,6 +144,7 @@ class DimFilter(LineFilter):
 
         Args:
             segments: A list of segments.
+            background: The background color.
 
         Returns:
             A new list of segments.
@@ -165,11 +168,26 @@ class DimFilter(LineFilter):
 
 
 class ANSIToTruecolor(LineFilter):
+    """Convert an ANSI colors to their truecolor equivalents."""
+
     def __init__(self, terminal_theme: TerminalTheme):
+        """Initialise filter.
+
+        Args:
+            terminal_theme: A rich terminal theme.
+        """
         self.terminal_theme = terminal_theme
 
     @lru_cache(1024)
     def truecolor_style(self, style: Style) -> Style:
+        """Replace system colors with truecolor equivalent.
+
+        Args:
+            style: Style to apply truecolor filter to.
+
+        Returns:
+            New style.
+        """
         terminal_theme = self.terminal_theme
         color = style.color
         if color is not None and color.is_system_defined:
@@ -184,6 +202,15 @@ class ANSIToTruecolor(LineFilter):
         return style + Style.from_color(color, bgcolor)
 
     def apply(self, segments: list[Segment], background: Color) -> list[Segment]:
+        """Transform a list of segments.
+
+        Args:
+            segments: A list of segments.
+            background: The background color.
+
+        Returns:
+            A new list of segments.
+        """
         _Segment = Segment
         truecolor_style = self.truecolor_style
 

--- a/src/textual/filter.py
+++ b/src/textual/filter.py
@@ -171,7 +171,7 @@ class DimFilter(LineFilter):
 
 
 class ANSIToTruecolor(LineFilter):
-    """Convert an ANSI colors to their truecolor equivalents."""
+    """Convert ANSI colors to their truecolor equivalents."""
 
     def __init__(self, terminal_theme: TerminalTheme):
         """Initialise filter.

--- a/src/textual/filter.py
+++ b/src/textual/filter.py
@@ -89,8 +89,8 @@ def dim_color(background: RichColor, color: RichColor, factor: float) -> RichCol
     Returns:
         New dimmer color.
     """
-    red1, green1, blue1 = background.get_truecolor(foreground=False)
-    red2, green2, blue2 = color.get_truecolor(foreground=True)
+    red1, green1, blue1 = background.triplet
+    red2, green2, blue2 = color.triplet
 
     return RichColor.from_rgb(
         red1 + (red2 - red1) * factor,

--- a/src/textual/strip.py
+++ b/src/textual/strip.py
@@ -18,6 +18,7 @@ from rich.style import Style, StyleType
 
 from ._cache import FIFOCache
 from ._segment_tools import index_to_cell_position
+from .color import Color
 from .constants import DEBUG
 from .filter import LineFilter
 
@@ -265,7 +266,7 @@ class Strip:
         )
         return line
 
-    def apply_filter(self, filter: LineFilter) -> Strip:
+    def apply_filter(self, filter: LineFilter, background: Color) -> Strip:
         """Apply a filter to all segments in the strip.
 
         Args:
@@ -274,7 +275,7 @@ class Strip:
         Returns:
             A new Strip.
         """
-        return Strip(filter.apply(self._segments), self._cell_length)
+        return Strip(filter.apply(self._segments, background), self._cell_length)
 
     def style_links(self, link_id: str, link_style: Style) -> Strip:
         """Apply a style to Segments with the given link_id.

--- a/tests/test_line_filter.py
+++ b/tests/test_line_filter.py
@@ -1,6 +1,7 @@
 from rich.segment import Segment
 from rich.style import Style
 
+from textual.color import Color
 from textual.filter import DimFilter
 
 
@@ -11,7 +12,7 @@ def test_dim_apply():
 
     segments = [Segment("Hello, World!", Style.parse("dim #ffffff on #0000ff"))]
 
-    dimmed_segments = dim_filter.apply(segments)
+    dimmed_segments = dim_filter.apply(segments, Color(0, 0, 0))
 
     expected = [Segment("Hello, World!", Style.parse("not dim #7f7fff on #0000ff"))]
 

--- a/tests/test_strip.py
+++ b/tests/test_strip.py
@@ -3,6 +3,7 @@ from rich.segment import Segment
 from rich.style import Style
 
 from textual._segment_tools import NoCellPositionForIndex
+from textual.color import Color
 from textual.filter import Monochrome
 from textual.strip import Strip
 
@@ -102,7 +103,7 @@ def test_apply_filter():
     expected = Strip([Segment("foo", Style.parse("#1b1b1b"))])
     print(repr(strip))
     print(repr(expected))
-    assert strip.apply_filter(Monochrome()) == expected
+    assert strip.apply_filter(Monochrome(), Color(0, 0, 0)) == expected
 
 
 def test_style_links():


### PR DESCRIPTION
Another step towards fixing the "dim" bug with xterm.js.

In order to calculate the dim color, we need to know the terminal colors. We can't auto-detect them, so I have forced them to use the "dimmed monokai" theme.

- There's a new `TEXTUAL_FILTERS` env var which can be used to insert filters. 
- More than one filter may be applied.