### PR TITLE
Remove unused import from widget.py

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -16,7 +16,6 @@ from typing import (
     ClassVar,
     Collection,
     Generator,
-    Generic,
     Iterable,
     NamedTuple,
     Sequence,


### PR DESCRIPTION
Just removing an unused import I noticed while passing by.