### PR TITLE
Ensure an app's CSS refresh updates all screens in the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed dark mode toggles in a "child" screen not updating a "parent" screen https://github.com/Textualize/textual/issues/1999
+
 ## [0.20.1] - 2023-04-18
 
 ### Fix

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1986,6 +1986,12 @@ class App(Generic[ReturnType], DOMNode):
         stylesheet.reparse()
         stylesheet.update(self.app, animate=animate)
         self.screen._refresh_layout(self.size, full=True)
+        # The other screens in the stack will need to know about some style
+        # changes, as a final pass let's check in on every screen that isn't
+        # the current one and update them too.
+        for screen in self.screen_stack:
+            if screen != self.screen:
+                stylesheet.update(screen, animate=animate)
 
     def _display(self, screen: Screen, renderable: RenderableType | None) -> None:
         """Display a renderable within a sync.


### PR DESCRIPTION
Mainly to address #1999 (dark mode toggles in a "child" screen not updating the "parent" screen). In turn also fixes what happens when making CSS changes in a situation where the frontmost screen has a transparent background.