### PR TITLE
Have `Container` *not* show scrollbars by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `textual run` execs apps in a new context.
+- Breaking change: `Container` no longer shows required scrollbars by default https://github.com/Textualize/textual/issues/2361
+- Breaking change: `VerticalScroll` no longer shows a required horizontal scrollbar by default
+- Breaking change: `HorizontalScroll` no longer shows a required vertical scrollbar by default
 
 ### Added
 

--- a/docs/examples/styles/scrollbar_size.py
+++ b/docs/examples/styles/scrollbar_size.py
@@ -1,5 +1,5 @@
 from textual.app import App
-from textual.containers import Container
+from textual.containers import ScrollableContainer
 from textual.widgets import Label
 
 TEXT = """I must not fear.
@@ -14,7 +14,7 @@ Where the fear has gone there will be nothing. Only I will remain.
 
 class ScrollbarApp(App):
     def compose(self):
-        yield Container(Label(TEXT * 5), classes="panel")
+        yield ScrollableContainer(Label(TEXT * 5), classes="panel")
 
 
 app = ScrollbarApp(css_path="scrollbar_size.css")

--- a/docs/examples/styles/scrollbar_size2.css
+++ b/docs/examples/styles/scrollbar_size2.css
@@ -1,4 +1,4 @@
-Container {
+ScrollableContainer {
     width: 1fr;
 }
 

--- a/docs/examples/styles/scrollbar_size2.py
+++ b/docs/examples/styles/scrollbar_size2.py
@@ -1,5 +1,5 @@
 from textual.app import App
-from textual.containers import Horizontal, Container
+from textual.containers import Horizontal, ScrollableContainer
 from textual.widgets import Label
 
 TEXT = """I must not fear.
@@ -15,10 +15,12 @@ Where the fear has gone there will be nothing. Only I will remain.
 class ScrollbarApp(App):
     def compose(self):
         yield Horizontal(
-            Container(Label(TEXT * 5), id="v1"),
-            Container(Label(TEXT * 5), id="v2"),
-            Container(Label(TEXT * 5), id="v3"),
+            ScrollableContainer(Label(TEXT * 5), id="v1"),
+            ScrollableContainer(Label(TEXT * 5), id="v2"),
+            ScrollableContainer(Label(TEXT * 5), id="v3"),
         )
 
 
 app = ScrollbarApp(css_path="scrollbar_size2.css")
+if __name__ == "__main__":
+    app.run()

--- a/docs/examples/styles/scrollbars.css
+++ b/docs/examples/styles/scrollbars.css
@@ -9,6 +9,6 @@ Label {
     scrollbar-corner-color: blue;
 }
 
-Horizontal > Container {
+Horizontal > ScrollableContainer {
     width: 50%;
 }

--- a/docs/examples/styles/scrollbars.py
+++ b/docs/examples/styles/scrollbars.py
@@ -1,5 +1,5 @@
 from textual.app import App
-from textual.containers import Horizontal, Container
+from textual.containers import Horizontal, ScrollableContainer
 from textual.widgets import Label
 
 TEXT = """I must not fear.
@@ -15,9 +15,11 @@ Where the fear has gone there will be nothing. Only I will remain.
 class ScrollbarApp(App):
     def compose(self):
         yield Horizontal(
-            Container(Label(TEXT * 10)),
-            Container(Label(TEXT * 10), classes="right"),
+            ScrollableContainer(Label(TEXT * 10)),
+            ScrollableContainer(Label(TEXT * 10), classes="right"),
         )
 
 
 app = ScrollbarApp(css_path="scrollbars.css")
+if __name__ == "__main__":
+    app.run()

--- a/docs/examples/widgets/content_switcher.py
+++ b/docs/examples/widgets/content_switcher.py
@@ -1,5 +1,7 @@
+from rich.align import VerticalCenter
+
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
+from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Button, ContentSwitcher, DataTable, Markdown
 
 MARKDOWN_EXAMPLE = """# Three Flavours Cornetto
@@ -37,7 +39,8 @@ class ContentSwitcherApp(App[None]):
 
         with ContentSwitcher(initial="data-table"):  # (4)!
             yield DataTable(id="data-table")
-            yield Markdown(MARKDOWN_EXAMPLE, id="markdown")
+            with VerticalScroll(id="markdown"):
+                yield Markdown(MARKDOWN_EXAMPLE)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.query_one(ContentSwitcher).current = event.button.id  # (5)!

--- a/src/textual/cli/previews/easing.py
+++ b/src/textual/cli/previews/easing.py
@@ -79,7 +79,7 @@ class EasingApp(App):
                 yield duration_input
             with Horizontal():
                 yield self.animated_bar
-                yield Container(self.opacity_widget, id="other")
+                yield VerticalScroll(self.opacity_widget, id="other")
             yield Footer()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -77,6 +77,7 @@ class VerticalScroll(ScrollableContainer, can_focus=True):
     VerticalScroll {
         width: 1fr;
         layout: vertical;
+        overflow-x: hidden;
         overflow-y: auto;
     }
     """

--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -101,6 +101,7 @@ class HorizontalScroll(ScrollableContainer, can_focus=True):
     HorizontalScroll {
         height: 1fr;
         layout: horizontal;
+        overflow-y: hidden;
         overflow-x: auto;
     }
     """

--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -18,13 +18,20 @@ class Container(Widget):
     Container {
         height: 1fr;
         layout: vertical;
-        overflow: auto;
+        overflow: hidden hidden;
     }
     """
 
 
 class ScrollableContainer(Widget, inherit_bindings=False):
     """Base container widget that binds navigation keys for scrolling."""
+
+    DEFAULT_CSS = """
+    ScrollableContainer {
+        layout: vertical;
+        overflow: auto auto;
+    }
+    """
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("up", "scroll_up", "Scroll Up", show=False),

--- a/tests/snapshot_tests/snapshot_apps/auto-table.py
+++ b/tests/snapshot_tests/snapshot_apps/auto-table.py
@@ -2,7 +2,7 @@ from os import urandom
 from random import randrange
 
 from textual.app import App
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container, Horizontal, ScrollableContainer, Vertical
 from textual.screen import Screen
 from textual.widgets import DataTable, Header, Label
 
@@ -109,7 +109,7 @@ class Rendering(LabeledBox):
 
         super().__init__(
             "",
-            Container(
+            ScrollableContainer(
                 Horizontal(self.__info, id="issue-info"),
                 Horizontal(*[Status(str(i)) for i in range(4)], id="statuses-box"),
                 id="issues-box",


### PR DESCRIPTION
This PR seeks to satisfy #2361, having `Container` hide scrollbars by default, encouraging the use of `ScrollableContainer` (and of course `HorizontalScroll` and `VerticalScroll`) when that's a requirement. It also updates `HorizontalScroll` and `VerticalScroll` to hide the opposing scrollbar by default.

All affected tests are updated too.

**NOTE:** As reflected by the need to change tests, this is a breaking change (albeit one that likely won't affect too many applications).