### PR TITLE
Tidy builtin actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Breaking change: `Container` no longer shows required scrollbars by default https://github.com/Textualize/textual/issues/2361
 - Breaking change: `VerticalScroll` no longer shows a required horizontal scrollbar by default
 - Breaking change: `HorizontalScroll` no longer shows a required vertical scrollbar by default
+- Breaking change: Renamed `App.action_add_class_` to `App.action_add_class`
+- Breaking change: Renamed `App.action_remove_class_` to `App.action_remove_class`
 
 ### Added
 

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -126,9 +126,18 @@ In the previous example if you wanted a link to set the background on the app ra
 
 Textual supports the following builtin actions which are defined on the app.
 
+- [action_add_class][textual.app.App.action_add_class]
+- [action_back][textual.app.App.action_back]
 - [action_bell][textual.app.App.action_bell]
-- [action_push_screen][textual.app.App.action_push_screen]
+- [action_check_bindings][textual.app.App.action_check_bindings]
+- [action_focus][textual.app.App.action_focus]
+- [action_focus_next][textual.app.App.action_focus_next]
+- [action_focus_previous][textual.app.App.action_focus_previous]
 - [action_pop_screen][textual.app.App.action_pop_screen]
-- [action_switch_screen][textual.app.App.action_switch_screen]
+- [action_push_screen][textual.app.App.action_push_screen]
+- [action_quit][textual.app.App.action_quit]
+- [action_remove_class][textual.app.App.action_remove_class]
 - [action_screenshot][textual.app.App.action_screenshot]
+- [action_switch_screen][textual.app.App.action_switch_screen]
+- [action_toggle_class][textual.app.App.action_toggle_class]
 - [action_toggle_dark][textual.app.App.action_toggle_dark]

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2483,7 +2483,7 @@ class App(Generic[ReturnType], DOMNode):
         """
         self.screen.query(selector).add_class(class_name)
 
-    async def action_remove_class_(self, selector: str, class_name: str) -> None:
+    async def action_remove_class(self, selector: str, class_name: str) -> None:
         """An [action](/guide/actions) to remove a CSS class from the selected widget.
 
         Args:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2411,7 +2411,11 @@ class App(Generic[ReturnType], DOMNode):
         self._unregister(root)
 
     async def action_check_bindings(self, key: str) -> None:
-        """An [action](/guide/actions) to handle a key press using the binding system."""
+        """An [action](/guide/actions) to handle a key press using the binding system.
+
+        Args:
+            key: The key to process.
+        """
         if not await self.check_bindings(key, priority=True):
             await self.check_bindings(key, priority=False)
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2462,7 +2462,13 @@ class App(Generic[ReturnType], DOMNode):
         self.pop_screen()
 
     async def action_back(self) -> None:
-        """An [action](/guide/actions) to go back to the previous screen (pop the current screen)."""
+        """An [action](/guide/actions) to go back to the previous screen (pop the current screen).
+
+        Note:
+            If there is no screen to go back to, this is a non-operation (in
+            other words it's safe to call even if there are no other screens
+            on the stack.)
+        """
         try:
             self.pop_screen()
         except ScreenStackError:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2474,7 +2474,7 @@ class App(Generic[ReturnType], DOMNode):
         except ScreenStackError:
             pass
 
-    async def action_add_class_(self, selector: str, class_name: str) -> None:
+    async def action_add_class(self, selector: str, class_name: str) -> None:
         """An [action](/guide/actions) to add a CSS class to the selected widget.
 
         Args:


### PR DESCRIPTION
Quick visit to the builtin actions list in the docs, to add some missing ones.

Also, while doing so, renamed `action_add_class_` to `action_add_class` and `action_remove_class_` to `action_remove_class` -- there was some discussion as to why they were named with the tailing underscore and no actual reason could be thought of; most likely a typo.

I've searched the code for mention of those actions and can't find any, so making this change while marking them in the changelog as breaking changes because it could affect anyone who has used those names in their apps.