### PR TITLE
pass through unprocessed args

### DIFF
--- a/src/textual/_resolve.py
+++ b/src/textual/_resolve.py
@@ -109,12 +109,12 @@ def resolve_box_models(
     box_models: list[BoxModel | None] = [
         (
             None
-            if dimension is not None and dimension.is_fraction
+            if _dimension is not None and _dimension.is_fraction
             else widget._get_box_model(
                 size, viewport_size, fraction_width, fraction_height
             )
         )
-        for (dimension, widget) in zip(dimensions, widgets)
+        for (_dimension, widget) in zip(dimensions, widgets)
     ]
 
     if dimension == "width":

--- a/src/textual/_wait.py
+++ b/src/textual/_wait.py
@@ -2,7 +2,7 @@ from asyncio import sleep
 from time import monotonic, process_time
 
 SLEEP_GRANULARITY: float = 1 / 50
-SLEEP_IDLE: float = SLEEP_GRANULARITY / 100.0
+SLEEP_IDLE: float = SLEEP_GRANULARITY / 20.0
 
 
 async def wait_for_idle(

--- a/src/textual/_wait.py
+++ b/src/textual/_wait.py
@@ -2,7 +2,7 @@ from asyncio import sleep
 from time import monotonic, process_time
 
 SLEEP_GRANULARITY: float = 1 / 50
-SLEEP_IDLE: float = SLEEP_GRANULARITY / 10.0
+SLEEP_IDLE: float = SLEEP_GRANULARITY / 100.0
 
 
 async def wait_for_idle(

--- a/src/textual/cli/_run.py
+++ b/src/textual/cli/_run.py
@@ -10,13 +10,9 @@ from __future__ import annotations
 
 import importlib
 import os
-import platform
 import sys
 from string import Template
 from typing import NoReturn, Sequence
-
-WINDOWS = platform.system() == "Windows"
-"""True if we're running on Windows."""
 
 EXEC_SCRIPT = Template(
     """\

--- a/src/textual/cli/_run.py
+++ b/src/textual/cli/_run.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 import importlib
 import os
 import platform
-import shlex
 import sys
 from string import Template
-from typing import NoReturn
+from typing import NoReturn, Sequence
 
 WINDOWS = platform.system() == "Windows"
 """True if we're running on Windows."""
@@ -38,7 +37,9 @@ class ExecImportError(Exception):
     """Raised if a Python import is invalid."""
 
 
-def run_app(command_args: str, environment: dict[str, str] | None = None) -> None:
+def run_app(
+    import_name: str, args: Sequence[str], environment: dict[str, str] | None = None
+) -> None:
     """Run a textual app.
 
     Note:
@@ -48,7 +49,6 @@ def run_app(command_args: str, environment: dict[str, str] | None = None) -> Non
         command_args: Arguments to pass to the Textual app.
         environment: Environment variables, or None to use current process.
     """
-    import_name, *args = shlex.split(command_args, posix=not WINDOWS)
     if environment is None:
         app_environment = dict(os.environ)
     else:
@@ -91,7 +91,7 @@ def _flush() -> None:
     sys.stdout.flush()
 
 
-def exec_python(args: list[str], environment: dict[str, str]) -> NoReturn:
+def exec_python(args: Sequence[str], environment: dict[str, str]) -> NoReturn:
     """Execute a Python script.
 
     Args:
@@ -102,7 +102,9 @@ def exec_python(args: list[str], environment: dict[str, str]) -> NoReturn:
     os.execvpe(sys.executable, ["python", *args], environment)
 
 
-def exec_command(command: str, environment: dict[str, str]) -> NoReturn:
+def exec_command(
+    command: str, args: Sequence[str], environment: dict[str, str]
+) -> NoReturn:
     """Execute a command with the given environment.
 
     Args:
@@ -110,7 +112,6 @@ def exec_command(command: str, environment: dict[str, str]) -> NoReturn:
         environment: Environment variables.
     """
     _flush()
-    command, *args = shlex.split(command, posix=not WINDOWS)
     os.execvpe(command, [command, *args], environment)
 
 
@@ -134,7 +135,7 @@ def check_import(module_name: str, app_name: str) -> bool:
 
 
 def exec_import(
-    import_name: str, args: list[str], environment: dict[str, str]
+    import_name: str, args: Sequence[str], environment: dict[str, str]
 ) -> NoReturn:
     """Import and execute an app.
 

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import shlex
 import sys
 
@@ -13,6 +14,9 @@ except ImportError:
     sys.exit(1)
 
 from importlib_metadata import version
+
+WINDOWS = platform.system() == "Windows"
+"""True if we're running on Windows."""
 
 
 @click.group()
@@ -190,7 +194,7 @@ def _run_app(
 
     _pre_run_warnings()
 
-    import_name, *args = [*shlex.split(import_name), *extra_args]
+    import_name, *args = [*shlex.split(import_name, posix=not WINDOWS), *extra_args]
 
     if command:
         exec_command(import_name, args, environment)

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import sys
 
 from ..constants import DEVTOOLS_PORT
@@ -156,14 +157,14 @@ def _run_app(
 
         textual run module.foo:MyApp
 
-    If you are running a file and want to pass command line arguments, wrap the filename and arguments
-    in quotes:
+    Add the --dev switch to enable the textual console.
 
-        textual run "foo.py arg --option"
+        textual run --dev foo.py
 
     Use the -c switch to run a command that launches a Textual app.
 
         textual run -c textual colors
+
     """
 
     import os
@@ -189,10 +190,12 @@ def _run_app(
 
     _pre_run_warnings()
 
+    import_name, *args = [*shlex.split(import_name), *extra_args]
+
     if command:
-        exec_command(import_name, extra_args, environment)
+        exec_command(import_name, args, environment)
     else:
-        run_app(import_name, extra_args, environment)
+        run_app(import_name, args, environment)
 
 
 @run.command("borders")

--- a/src/textual/cli/cli.py
+++ b/src/textual/cli/cli.py
@@ -129,12 +129,14 @@ def _pre_run_warnings() -> None:
     help="Show any return value on exit.",
     is_flag=True,
 )
+@click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 def _run_app(
     import_name: str,
     dev: bool,
     port: int | None,
     press: str | None,
     screenshot: int | None,
+    extra_args: tuple[str],
     command: bool = False,
     show_return: bool = False,
 ) -> None:
@@ -161,7 +163,7 @@ def _run_app(
 
     Use the -c switch to run a command that launches a Textual app.
 
-        textual run -c "textual colors"
+        textual run -c textual colors
     """
 
     import os
@@ -188,9 +190,9 @@ def _run_app(
     _pre_run_warnings()
 
     if command:
-        exec_command(import_name, environment)
+        exec_command(import_name, extra_args, environment)
     else:
-        run_app(import_name, environment)
+        run_app(import_name, extra_args, environment)
 
 
 @run.command("borders")

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -139,20 +139,22 @@ class Pilot(Generic[ReturnType]):
             delay: Seconds to pause, or None to wait for cpu idle.
         """
         # These sleep zeros, are to force asyncio to give up a time-slice,
-        self.app.screen._on_timer_update()  # Force one last repaint
         if delay is None:
             await wait_for_idle(0)
         else:
             await asyncio.sleep(delay)
+        self.app.screen._on_timer_update()
 
     async def wait_for_animation(self) -> None:
         """Wait for any current animation to complete."""
         await self._app.animator.wait_for_idle()
+        self.app.screen._on_timer_update()
 
     async def wait_for_scheduled_animations(self) -> None:
         """Wait for any current and scheduled animations to complete."""
         await self._app.animator.wait_until_complete()
         await wait_for_idle()
+        self.app.screen._on_timer_update()
 
     async def exit(self, result: ReturnType) -> None:
         """Exit the app with the given result.

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -65,6 +65,7 @@ class Pilot(Generic[ReturnType]):
         """
         if keys:
             await self._app._press_keys(keys)
+            self.app.screen._on_timer_update()
 
     async def click(
         self,

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -65,7 +65,6 @@ class Pilot(Generic[ReturnType]):
         """
         if keys:
             await self._app._press_keys(keys)
-            self.app.screen._on_timer_update()
 
     async def click(
         self,
@@ -140,22 +139,20 @@ class Pilot(Generic[ReturnType]):
             delay: Seconds to pause, or None to wait for cpu idle.
         """
         # These sleep zeros, are to force asyncio to give up a time-slice,
+        self.app.screen._on_timer_update()  # Force one last repaint
         if delay is None:
             await wait_for_idle(0)
         else:
             await asyncio.sleep(delay)
-        self.app.screen._on_timer_update()
 
     async def wait_for_animation(self) -> None:
         """Wait for any current animation to complete."""
         await self._app.animator.wait_for_idle()
-        self.app.screen._on_timer_update()
 
     async def wait_for_scheduled_animations(self) -> None:
         """Wait for any current and scheduled animations to complete."""
         await self._app.animator.wait_until_complete()
         await wait_for_idle()
-        self.app.screen._on_timer_update()
 
     async def exit(self, result: ReturnType) -> None:
         """Exit the app with the given result.


### PR DESCRIPTION
Uses a feature of Click to pass through "unprocessed arguments".

Prevuously if you want to run a command you would have to quote everything

```
textual run -c "python -m textual"
```

Now, you can omit the quotes:

```
textual run -c python -m textual
```