### PR TITLE
Make `textual.containers` `1fr` in meaningful dimensions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unrelased
 
+### Added
+
+- Added `ProgressBar` widget https://github.com/Textualize/textual/pull/2333
+
 ### Changed
 
 - All `textual.containers` are now `1fr` in relevant dimensions by default
@@ -32,7 +36,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `ScrollView` now inherits from `ScrollableContainer` rather than `Widget` https://github.com/Textualize/textual/issues/2332
 - Containers no longer inherit any bindings from `Widget` https://github.com/Textualize/textual/issues/2331
 - Added `ScrollableContainer`; a container class that binds the common navigation keys to scroll actions (see also above breaking change) https://github.com/Textualize/textual/issues/2332
-- Added `ProgressBar` widget https://github.com/Textualize/textual/pull/2333
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- All `textual.containers` are now `1fr` in relevant dimensions by default
+- All `textual.containers` are now `1fr` in relevant dimensions by default https://github.com/Textualize/textual/pull/2386
 
 ## [0.21.0] - 2023-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unrelased
+
+### Changed
+
+- All `textual.containers` are now `1fr` in relevant dimensions by default
+
 ## [0.21.0] - 2023-04-26
 
 ### Changed

--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -18,6 +18,8 @@ class Container(Widget):
 
     DEFAULT_CSS = """
     Container {
+        width: 1fr;
+        height: 1fr;
         layout: vertical;
         overflow: hidden hidden;
     }
@@ -29,6 +31,8 @@ class ScrollableContainer(Widget, inherit_bindings=False):
 
     DEFAULT_CSS = """
     ScrollableContainer {
+        width: 1fr;
+        height: 1fr;
         layout: vertical;
         overflow: auto auto;
     }
@@ -64,6 +68,8 @@ class Vertical(Widget, inherit_bindings=False):
 
     DEFAULT_CSS = """
     Vertical {
+        width: 1fr;
+        height: 1fr;
         layout: vertical;
         overflow: hidden hidden;
     }
@@ -87,6 +93,8 @@ class Horizontal(Widget, inherit_bindings=False):
 
     DEFAULT_CSS = """
     Horizontal {
+        width: 1fr;
+        height: 1fr;
         layout: horizontal;
         overflow: hidden hidden;
     }
@@ -134,6 +142,8 @@ class Grid(Widget, inherit_bindings=False):
 
     DEFAULT_CSS = """
     Grid {
+        width: 1fr;
+        height: 1fr;
         layout: grid;
     }
     """

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -258,7 +258,7 @@ class ProgressBar(Widget, can_focus=False):
     """A progress bar widget."""
 
     DEFAULT_CSS = """
-    Horizontal {
+    ProgressBar > Horizontal {
         width: auto;
         height: auto;
     }


### PR DESCRIPTION
An unintended consequence of changes made to containers in v0.21.0 (#2377) is something like #2385; so this PR sort of rolls that change back, and solidifies how containers are styled by default in respect to their width and height. Where appropriate the dimensions will be `1fr`.

Also includes a wee tweak to `ProgressBar` to ensure its `DEFAULT_CSS` styling of `Vertical` isn't quite so greedy (noticed because without this the `ProgressBar` snapshot tests all failed when the main purpose of this PR was introduced).

Note that, as a followup to this, as identified by @darrenburns, we will need to think about revamping the layout section of the manual as it's a little out of date in respect to how containers work now (and what's available).