### PR TITLE
Fix light mode plain text in non-syntax code blocks in Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - All `textual.containers` are now `1fr` in relevant dimensions by default https://github.com/Textualize/textual/pull/2386
 
+### Fixed
+
+- Fixed plain text in Markdown code blocks with no syntax being difficult to read https://github.com/Textualize/textual/issues/2400
+
 ## [0.21.0] - 2023-04-26
 
 ### Changed

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -476,6 +476,7 @@ class MarkdownFence(MarkdownBlock):
         width: 100%;
         height: auto;
         max-height: 20;
+        color: rgb(210,210,210);
     }
 
     MarkdownFence > * {


### PR DESCRIPTION
Bit of a workaround at the moment; ideally longer-term we'll go with something less hard-coded.

See #2400
