### PR TITLE
Add `TreeNode.tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added `TreeNode.tree` as a read-only public attribute https://github.com/Textualize/textual/issues/2413
+
 ## [0.22.0] - 2023-04-27
 
 ### Fixed

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -126,6 +126,11 @@ class TreeNode(Generic[TreeDataType]):
         self._updates += 1
 
     @property
+    def tree(self) -> Tree[TreeDataType]:
+        """The tree that this node is attached to."""
+        return self._tree
+
+    @property
     def children(self) -> TreeNodes[TreeDataType]:
         """The child nodes of a TreeNode."""
         return TreeNodes(self._children)


### PR DESCRIPTION
Currently, in the various TreeNode messages, and the handlers you'd write to handle them, there's no way to easily know *which* tree sent the message and so which tree the node belongs to.

This commit adds public access to the tree reference to the nodes, so that in an event handler the developer can check the tree involved in the event.

See #2413.
