### PR TITLE
faster focus within

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [0.22.2] - 2023-04-29
 
 ### Added
 
 - Added `TreeNode.tree` as a read-only public attribute https://github.com/Textualize/textual/issues/2413
+
+### Fixed
+
+- Fixed superfluous style updates for focus-within pseudo-selector
 
 ## [0.22.1] - 2023-04-28
 
@@ -833,6 +837,8 @@ https://textual.textualize.io/blog/2022/11/08/version-040/#version-040
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
 
+[0.22.2]: https://github.com/Textualize/textual/compare/v0.22.1...v0.22.2
+[0.22.1]: https://github.com/Textualize/textual/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Textualize/textual/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/Textualize/textual/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/Textualize/textual/compare/v0.20.0...v0.20.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "0.22.1"
+version = "0.22.2"
 homepage = "https://github.com/Textualize/textual"
 description = "Modern Text User Interface framework"
 authors = ["Will McGugan <will@textualize.io>"]

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1226,7 +1226,7 @@ class App(Generic[ReturnType], DOMNode):
         """
         return self.screen.get_child_by_type(expect_type)
 
-    def update_styles(self, node: DOMNode | None = None) -> None:
+    def update_styles(self, node: DOMNode) -> None:
         """Immediately update the styles of this node and all descendant nodes.
 
         Should be called whenever CSS classes / pseudo classes change.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3076,20 +3076,22 @@ class Widget(DOMNode):
     def _on_focus(self, event: events.Focus) -> None:
         self.has_focus = True
         self.refresh()
+        for widget in reversed(self.ancestors_with_self):
+            if widget._has_focus_within:
+                widget._update_styles()
+                break
+
         self.post_message(events.DescendantFocus())
 
     def _on_blur(self, event: events.Blur) -> None:
         self.has_focus = False
         self.refresh()
+        for widget in reversed(self.ancestors_with_self):
+            if widget._has_focus_within:
+                widget._update_styles()
+                break
+
         self.post_message(events.DescendantBlur())
-
-    def _on_descendant_blur(self, event: events.DescendantBlur) -> None:
-        if self._has_focus_within:
-            self._update_styles()
-
-    def _on_descendant_focus(self, event: events.DescendantBlur) -> None:
-        if self._has_focus_within:
-            self._update_styles()
 
     def _on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
         if event.ctrl or event.shift:


### PR DESCRIPTION
The mechanism to refresh styles when the `focus-within` state changes was doing way more work than required. The root cause of slow tabs in Frogmouth.