### PR TITLE
Make `!important` apply to rules that have "sub-rules"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed `!important` not applying to `border` https://github.com/Textualize/textual/issues/2420
+- Fixed `!important` not applying to `outline` https://github.com/Textualize/textual/issues/2420
 
 ## [0.22.3] - 2023-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed `!important` not applying to `align` https://github.com/Textualize/textual/issues/2420
 - Fixed `!important` not applying to `border` https://github.com/Textualize/textual/issues/2420
+- Fixed `!important` not applying to `content-align` https://github.com/Textualize/textual/issues/2420
 - Fixed `!important` not applying to `outline` https://github.com/Textualize/textual/issues/2420
+- Fixed `!important` not applying to `overflow` https://github.com/Textualize/textual/issues/2420
+- Fixed `!important` not applying to `scrollbar-size` https://github.com/Textualize/textual/issues/2420
 - Fixed `outline-right` not being recognised https://github.com/Textualize/textual/issues/2446
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `!important` not applying to `border` https://github.com/Textualize/textual/issues/2420
 - Fixed `!important` not applying to `outline` https://github.com/Textualize/textual/issues/2420
+- Fixed `outline-right` not being recognised https://github.com/Textualize/textual/issues/2446
 
 ## [0.22.3] - 2023-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `!important` not applying to `border` https://github.com/Textualize/textual/issues/2420
 
 ## [0.22.3] - 2023-04-29
 

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -486,6 +486,16 @@ class StylesBuilder:
         rules = self.styles._rules
         rules["border_top"] = rules["border_right"] = border
         rules["border_bottom"] = rules["border_left"] = border
+        # If border is marked as important...
+        if "border" in self.styles.important:
+            # ...border alone at this depth isn't really a thing, only
+            # border edges (that's to say, border gets expanded out to all 4
+            # edges). So we remove "border" as important and mark all the
+            # edges as important.
+            self.styles.important.remove("border")
+            self.styles.important.update(
+                f"border_{edge}" for edge in ("top", "left", "bottom", "right")
+            )
 
     def process_border_top(self, name: str, tokens: list[Token]) -> None:
         self._process_border_edge("top", name, tokens)

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -526,6 +526,7 @@ class StylesBuilder:
         rules = self.styles._rules
         rules["outline_top"] = rules["outline_right"] = border
         rules["outline_bottom"] = rules["outline_left"] = border
+        self._distribute_edge_importance("outline")
 
     def process_outline_top(self, name: str, tokens: list[Token]) -> None:
         self._process_outline("top", name, tokens)

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -811,7 +811,7 @@ class StylesBuilder:
         self.styles._rules[f"{name}_horizontal"] = token_horizontal.value  # type: ignore
         self.styles._rules[f"{name}_vertical"] = token_vertical.value  # type: ignore
 
-        self._distribute_importance("align", ("horizontal", "vertical"))
+        self._distribute_importance(name, ("horizontal", "vertical"))
 
     def process_align_horizontal(self, name: str, tokens: list[Token]) -> None:
         try:

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -881,6 +881,7 @@ class StylesBuilder:
                 scrollbar_size_error(name, token2)
             self.styles._rules["scrollbar_size_horizontal"] = horizontal
             self.styles._rules["scrollbar_size_vertical"] = vertical
+            self._distribute_importance("scrollbar_size", ("horizontal", "vertical"))
 
     def process_scrollbar_size_vertical(self, name: str, tokens: list[Token]) -> None:
         if not tokens:

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -811,6 +811,8 @@ class StylesBuilder:
         self.styles._rules[f"{name}_horizontal"] = token_horizontal.value  # type: ignore
         self.styles._rules[f"{name}_vertical"] = token_vertical.value  # type: ignore
 
+        self._distribute_importance("align", ("horizontal", "vertical"))
+
     def process_align_horizontal(self, name: str, tokens: list[Token]) -> None:
         try:
             value = self._process_enum(name, tokens, VALID_ALIGN_HORIZONTAL)

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -321,6 +321,7 @@ class StylesBuilder:
         )
         rules["overflow_x"] = cast(Overflow, overflow_x)
         rules["overflow_y"] = cast(Overflow, overflow_y)
+        self._distribute_importance("overflow", ("x", "y"))
 
     def process_overflow_x(self, name: str, tokens: list[Token]) -> None:
         self.styles._rules["overflow_x"] = cast(

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -531,7 +531,7 @@ class StylesBuilder:
     def process_outline_top(self, name: str, tokens: list[Token]) -> None:
         self._process_outline("top", name, tokens)
 
-    def process_parse_border_right(self, name: str, tokens: list[Token]) -> None:
+    def process_outline_right(self, name: str, tokens: list[Token]) -> None:
         self._process_outline("right", name, tokens)
 
     def process_outline_bottom(self, name: str, tokens: list[Token]) -> None:

--- a/tests/test_style_importance.py
+++ b/tests/test_style_importance.py
@@ -1,0 +1,102 @@
+from textual.app import App, ComposeResult
+from textual.color import Color
+from textual.containers import Container
+from textual.css.scalar import Scalar, ScalarOffset
+
+
+class StyleApp(App[None]):
+    CSS = """
+    Container {
+        border: round green !important;
+        outline: round green !important;
+        align: right bottom !important;
+        content-align: right bottom !important;
+        offset: 17 23 !important;
+        overflow: hidden hidden !important;
+        padding: 10 20 30 40 !important;
+        scrollbar-size: 23 42 !important;
+    }
+
+    Container.more-specific {
+        border: solid red;
+        outline: solid red;
+        align: center middle;
+        content-align: center middle;
+        offset: 0 0;
+        overflow: scroll scroll;
+        padding: 1 2 3 4;
+        scrollbar-size: 1 2;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Container(classes="more-specific")
+
+
+async def test_border_importance():
+    """Border without sides should support !important"""
+    async with StyleApp().run_test() as pilot:
+        border = pilot.app.query_one(Container).styles.border
+        desired = ("round", Color.parse("green"))
+        assert border.top == desired
+        assert border.left == desired
+        assert border.bottom == desired
+        assert border.right == desired
+
+
+async def test_outline_importance():
+    """Outline without sides should support !important"""
+    async with StyleApp().run_test() as pilot:
+        outline = pilot.app.query_one(Container).styles.outline
+        desired = ("round", Color.parse("green"))
+        assert outline.top == desired
+        assert outline.left == desired
+        assert outline.bottom == desired
+        assert outline.right == desired
+
+
+async def test_align_importance():
+    """Align without direction should support !important"""
+    async with StyleApp().run_test() as pilot:
+        assert pilot.app.query_one(Container).styles.align == ("right", "bottom")
+
+
+async def test_content_align_importance():
+    """Content align without direction should support !important"""
+    async with StyleApp().run_test() as pilot:
+        assert pilot.app.query_one(Container).styles.content_align == (
+            "right",
+            "bottom",
+        )
+
+
+async def test_offset_importance():
+    """Offset without direction should support !important"""
+    async with StyleApp().run_test() as pilot:
+        assert pilot.app.query_one(Container).styles.offset == ScalarOffset.from_offset(
+            (17, 23)
+        )
+
+
+async def test_overflow_importance():
+    """Overflow without direction should support !important"""
+    async with StyleApp().run_test() as pilot:
+        assert pilot.app.query_one(Container).styles.overflow_x == "hidden"
+        assert pilot.app.query_one(Container).styles.overflow_y == "hidden"
+
+
+async def test_padding_importance():
+    """Padding without sides should support !important"""
+    async with StyleApp().run_test() as pilot:
+        padding = pilot.app.query_one(Container).styles.padding
+        assert padding.top == 10
+        assert padding.left == 40
+        assert padding.bottom == 30
+        assert padding.right == 20
+
+
+async def test_scrollbar_size_importance():
+    """Scrollbar size without direction should support !important"""
+    async with StyleApp().run_test() as pilot:
+        assert pilot.app.query_one(Container).styles.scrollbar_size_horizontal == 23
+        assert pilot.app.query_one(Container).styles.scrollbar_size_vertical == 42


### PR DESCRIPTION
This PR fixes things so that `!important` applies to all sides/directions/etc, when it is applied to the whole rule. In other words this:

```python
border: solid red !important;
```

never came through as important, but this did:

```python
border-top: solid red !important;
```

This fixes that issue. The issue was found to exist for the following styles:

- `border`
- `outline`
- `align`
- `content-align`
- `overflow`
- `scrollbar-size`

See #2420.

Also includes a wee fix for #2446 too, which I noticed in the code as I was researching the fix for the above.