### PR TITLE
Invalid pseudo selectors

### DIFF
--- a/src/textual/css/constants.py
+++ b/src/textual/css/constants.py
@@ -61,6 +61,14 @@ VALID_STYLE_FLAGS: Final = {
     "underline",
     "uu",
 }
+VALID_PSEUDO_CLASSES: Final = {
+    "blur",
+    "disabled",
+    "enabled",
+    "focus-within",
+    "focus",
+    "hover",
+}
 
 
 NULL_SPACING: Final = Spacing.all(0)

--- a/tests/css/test_mega_stylesheet.css
+++ b/tests/css/test_mega_stylesheet.css
@@ -140,52 +140,52 @@ A1
 
 /**********************************************************************/
 
-A:foo {}
-A:foo:bar {}
+A:focus {}
+A:focus:hover {}
 A
-:foo {}
+:focus {}
 A
-:foo:bar {}
+:focus:hover {}
 A
-:foo
-:bar {}
-A:foo-bar {}
+:focus
+:hover {}
+A:enabled {}
 A
-:foo-bar {}
+:enabled {}
 
-A :foo {}
-A :foo :bar {}
-A :foo-bar {}
+A :focus {}
+A :focus :hover {}
+A :enabled {}
 
-.A:foo {}
-.A:foo:bar {}
+.A:focus {}
+.A:focus:hover {}
 .A
-:foo {}
+:focus {}
 .A
-:foo:bar {}
+:focus:hover {}
 .A
-:foo
-:bar {}
-.A:foo-bar {}
+:focus
+:hover {}
+.A:enabled {}
 .A
-:foo-bar {}
+:enabled {}
 
-#A:foo {}
-#A:foo:bar {}
+#A:focus {}
+#A:focus:hover {}
 #A
-:foo {}
+:focus {}
 #A
-:foo:bar {}
+:focus:hover {}
 #A
-:foo
-:bar {}
-#A:foo-bar {}
+:focus
+:hover {}
+#A:enabled {}
 #A
-:foo-bar {}
+:enabled {}
 
-A1.A1.A1:foo {}
-A1.A1#A1:foo {}
-A1:foo.A1:foo#A1:foo {}
+A1.A1.A1:focus {}
+A1.A1#A1:focus {}
+A1:focus.A1:focus#A1:focus {}
 
 /**********************************************************************/
 

--- a/tests/css/test_parse.py
+++ b/tests/css/test_parse.py
@@ -1226,3 +1226,21 @@ class TestTypeNames:
             stylesheet.add_source(f"StartType {separator} 1TestType {{}}")
             with pytest.raises(TokenError):
                 stylesheet.parse()
+
+
+def test_parse_bad_psuedo_selector():
+    """Check unknown selector raises a token error."""
+
+    bad_selector = """\
+Widget:foo{
+    border: red;
+}
+    """
+
+    stylesheet = Stylesheet()
+    stylesheet.add_source(bad_selector, "foo")
+
+    with pytest.raises(TokenError) as error:
+        stylesheet.parse()
+
+    assert error.value.start == (0, 6)


### PR DESCRIPTION
Error on bad pseudo selectors.

It catches bad pseudo selectors at the tokenizer level. I could had changed the regex, but this way we can generate a helpful error.