### PR TITLE
Attempt to narrow CI/test trigger to just code changes

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,11 @@
 name: Test Textual module
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - '**.pyi'
+      - '**.css'
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,6 +6,9 @@ on:
       - '**.py'
       - '**.pyi'
       - '**.css'
+      - '**.ambr'
+      - '**.lock'
+      - 'Makefile'
 
 jobs:
   build:

--- a/src/textual/__main__.py
+++ b/src/textual/__main__.py
@@ -1,5 +1,3 @@
-# Ignore this. This is just a forced change to a Python file.
-
 from .demo import DemoApp
 
 if __name__ == "__main__":

--- a/src/textual/__main__.py
+++ b/src/textual/__main__.py
@@ -1,3 +1,5 @@
+# Ignore this. This is just a forced change to a Python file.
+
 from .demo import DemoApp
 
 if __name__ == "__main__":


### PR DESCRIPTION
Looking at [the GitHib docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) I *think* this might be the approach to take. Consider this an experimental change that will very likely get rolled back.

The thinking here is that we *don't* run testing on a PR unless one of the following things have happened in that PR:

- A `py` file has been modified.
- A `pyi` file has been modified.
- A `css` file has been modified.
- The snapshot data has been modified.
- The lock file has been modified.
- The `Makefile` has been modified.

See #2404

I suggest we give this a spin and see if it works out; if not it should be very simple to back this out.

---
One thing to keep in mind and keep an eye out for (it should be obvious): the ability to merge is normally down to having an approval and passing tests; so is having no test fail the same as passing tests?