### PR TITLE
Catch OSError when source code is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `!important` not applying to `overflow` https://github.com/Textualize/textual/issues/2420
 - Fixed `!important` not applying to `scrollbar-size` https://github.com/Textualize/textual/issues/2420
 - Fixed `outline-right` not being recognised https://github.com/Textualize/textual/issues/2446
+- Fixed OSError when a file system is not available https://github.com/Textualize/textual/issues/2468
 
 ### Changed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1660,7 +1660,7 @@ class App(Generic[ReturnType], DOMNode):
                     app_css_path = (
                         f"{inspect.getfile(self.__class__)}:{self.__class__.__name__}"
                     )
-                except TypeError:
+                except (TypeError, OSError):
                     app_css_path = f"{self.__class__.__name__}"
                 self.stylesheet.add_source(
                     self.CSS, path=app_css_path, is_default_css=False

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -418,7 +418,7 @@ class DOMNode(MessagePump):
             """Get a path to the DOM Node"""
             try:
                 return f"{getfile(base)}:{base.__name__}"
-            except TypeError:
+            except (TypeError, OSError):
                 return f"{base.__name__}"
 
         for tie_breaker, base in enumerate(self._node_bases):


### PR DESCRIPTION
closes #2468

with this fix, my use case works a bit more:
<img width="650" alt="image" src="https://user-images.githubusercontent.com/156560/235937786-a4c8c25f-1498-4b79-afe1-06be716fc5d2.png">


There's still an outstanding call to `getfile` but since I haven't hit this code path yet and therefore can't verify a fix, I haven't attempted it.
https://github.com/Textualize/textual/blob/c87a2b1b3731140a461b4f34bbd7b1c6de8d7e37/src/textual/_path.py#L30


**Please review the following checklist.**

- n/a Docstrings on all new or modified functions / classes 
- n/a Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
