### PR TITLE
Fix a crash when `DirectoryTree` starts out anywhere other than `.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Fixed crash when creating a `DirectoryTree` starting anywhere other than `.`
+
 ### Changed
 
 - The DataTable cursor is now scrolled into view when the cursor coordinate is changed programmatically https://github.com/Textualize/textual/issues/2459

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -103,7 +103,6 @@ class DirectoryTree(Tree[DirEntry]):
             classes: A space-separated list of classes, or None for no classes.
             disabled: Whether the directory tree is disabled or not.
         """
-        self.path = path
         super().__init__(
             str(path),
             data=DirEntry(Path(path)),
@@ -112,6 +111,7 @@ class DirectoryTree(Tree[DirEntry]):
             classes=classes,
             disabled=disabled,
         )
+        self.path = path
 
     def reload(self) -> None:
         """Reload the `DirectoryTree` contents."""


### PR DESCRIPTION
A hangover from the previous `DirectoryTree`, where setting the path didn't matter. This now sets it *after* calling `Tree`'s `__init__`, thus ensuring the line cache and other related things have been created.
