### PR TITLE
Add `DataTable.move_cursor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - The DataTable cursor is now scrolled into view when the cursor coordinate is changed programmatically https://github.com/Textualize/textual/issues/2459
 
+
+### Added
+
+- Method `DataTable.move_cursor` https://github.com/Textualize/textual/issues/2472
+
 ## [0.23.0] - 2023-05-03
 
 ### Fixed

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -955,7 +955,9 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             elif self.cursor_type == "column":
                 self.refresh_column(old_coordinate.column)
                 self._highlight_column(new_coordinate.column)
-            self._scroll_cursor_into_view()
+            # If the coordinate was changed via `move_cursor`, give priority to its
+            # scrolling because it may be animated.
+            self.call_next(self._scroll_cursor_into_view)
 
     def move_cursor(
         self,

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -2113,7 +2113,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             self.cursor_coordinate = Coordinate(
                 row_index + rows_to_scroll - 1, column_index
             )
-            self._scroll_cursor_into_view()
         else:
             super().action_page_down()
 
@@ -2137,7 +2136,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             self.cursor_coordinate = Coordinate(
                 row_index - rows_to_scroll + 1, column_index
             )
-            self._scroll_cursor_into_view()
         else:
             super().action_page_up()
 
@@ -2148,7 +2146,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "row"):
             row_index, column_index = self.cursor_coordinate
             self.cursor_coordinate = Coordinate(0, column_index)
-            self._scroll_cursor_into_view()
         else:
             super().action_scroll_home()
 
@@ -2159,7 +2156,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "row"):
             row_index, column_index = self.cursor_coordinate
             self.cursor_coordinate = Coordinate(self.row_count - 1, column_index)
-            self._scroll_cursor_into_view()
         else:
             super().action_scroll_end()
 
@@ -2168,7 +2164,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         cursor_type = self.cursor_type
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "row"):
             self.cursor_coordinate = self.cursor_coordinate.up()
-            self._scroll_cursor_into_view()
         else:
             # If the cursor doesn't move up (e.g. column cursor can't go up),
             # then ensure that we instead scroll the DataTable.
@@ -2179,7 +2174,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         cursor_type = self.cursor_type
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "row"):
             self.cursor_coordinate = self.cursor_coordinate.down()
-            self._scroll_cursor_into_view()
         else:
             super().action_scroll_down()
 
@@ -2187,8 +2181,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._set_hover_cursor(False)
         cursor_type = self.cursor_type
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "column"):
-            self.cursor_coordinate = self.cursor_coordinate.right()
-            self._scroll_cursor_into_view(animate=True)
+            self.move_cursor(self.cursor_coordinate.right(), animate=True)
         else:
             super().action_scroll_right()
 
@@ -2196,8 +2189,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._set_hover_cursor(False)
         cursor_type = self.cursor_type
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "column"):
-            self.cursor_coordinate = self.cursor_coordinate.left()
-            self._scroll_cursor_into_view(animate=True)
+            self.move_cursor(self.cursor_coordinate.left(), animate=True)
         else:
             super().action_scroll_left()
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -961,7 +961,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
     def move_cursor(
         self,
-        coordinate: Coordinate | None = None,
         *,
         row: int | None = None,
         column: int | None = None,
@@ -969,47 +968,26 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
     ) -> None:
         """Move the cursor to the given position.
 
-        The new cursor position can be specified as a coordinate or you can specify
-        only the new row/column for the cursor.
-        Specifying a coordinate is mutually exclusive with specifying either a new
-        row or new column.
-
         Example:
             ```py
             datatable = app.query_one(DataTable)
-            datatable.move_cursor(Coordinate(5, 7))
-            # datatable.cursor_coordinate == Coordinate(5, 7)
-            datatable.move_cursor(row=3)
-            # datatable.cursor_coordinate == Coordinate(3, 7)
             datatable.move_cursor(row=4, column=6)
             # datatable.cursor_coordinate == Coordinate(4, 6)
-            datatable.move_cursor(Coordinate(0, 0), row=3)  # RuntimeError
+            datatable.move_cursor(row=3)
+            # datatable.cursor_coordinate == Coordinate(3, 6)
             ```
 
         Args:
-            coordinate: The new coordinate to move the cursor to.
             row: The new row to move the cursor to.
             column: The new column to move the cursor to.
             animate: Whether to animate the change of coordinates.
-
-        Raises:
-            RuntimeError: If the parameter `coordinate` is specified together with any
-                of `row` or `column`, or if no new position is specified.
         """
-        if coordinate is not None and (row is not None or column is not None):
-            raise RuntimeError("Can't specify `coordinate` and `row`/`column`.")
-        if coordinate is None and row is None and column is None:
-            raise RuntimeError("You must specify a new position to move the cursor to.")
-
-        if coordinate is not None:
-            destination = coordinate
-        else:
-            cursor_row, cursor_column = self.cursor_coordinate
-            if row is not None:
-                cursor_row = row
-            if column is not None:
-                cursor_column = column
-            destination = Coordinate(cursor_row, cursor_column)
+        cursor_row, cursor_column = self.cursor_coordinate
+        if row is not None:
+            cursor_row = row
+        if column is not None:
+            cursor_column = column
+        destination = Coordinate(cursor_row, cursor_column)
         self.cursor_coordinate = destination
         self._scroll_cursor_into_view(animate=animate)
 
@@ -2181,7 +2159,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._set_hover_cursor(False)
         cursor_type = self.cursor_type
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "column"):
-            self.move_cursor(self.cursor_coordinate.right(), animate=True)
+            self.cursor_coordinate = self.cursor_coordinate.right()
+            self._scroll_cursor_into_view(animate=True)
         else:
             super().action_scroll_right()
 
@@ -2189,7 +2168,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._set_hover_cursor(False)
         cursor_type = self.cursor_type
         if self.show_cursor and (cursor_type == "cell" or cursor_type == "column"):
-            self.move_cursor(self.cursor_coordinate.left(), animate=True)
+            self.cursor_coordinate = self.cursor_coordinate.left()
+            self._scroll_cursor_into_view(animate=True)
         else:
             super().action_scroll_left()
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -309,6 +309,11 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
     cursor_coordinate: Reactive[Coordinate] = Reactive(
         Coordinate(0, 0), repaint=False, always_update=True
     )
+    """Current cursor [`Coordinate`][textual.coordinate.Coordinate].
+
+    This can be set programmatically or changed via the method
+    [`move_cursor`][textual.widgets.DataTable.move_cursor].
+    """
     hover_coordinate: Reactive[Coordinate] = Reactive(
         Coordinate(0, 0), repaint=False, always_update=True
     )
@@ -951,6 +956,60 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                 self.refresh_column(old_coordinate.column)
                 self._highlight_column(new_coordinate.column)
             self._scroll_cursor_into_view()
+
+    def move_cursor(
+        self,
+        coordinate: Coordinate | None = None,
+        *,
+        row: int | None = None,
+        column: int | None = None,
+        animate: bool = False,
+    ) -> None:
+        """Move the cursor to the given position.
+
+        The new cursor position can be specified as a coordinate or you can specify
+        only the new row/column for the cursor.
+        Specifying a coordinate is mutually exclusive with specifying either a new
+        row or new column.
+
+        Example:
+            ```py
+            datatable = app.query_one(DataTable)
+            datatable.move_cursor(Coordinate(5, 7))
+            # datatable.cursor_coordinate == Coordinate(5, 7)
+            datatable.move_cursor(row=3)
+            # datatable.cursor_coordinate == Coordinate(3, 7)
+            datatable.move_cursor(row=4, column=6)
+            # datatable.cursor_coordinate == Coordinate(4, 6)
+            datatable.move_cursor(Coordinate(0, 0), row=3)  # RuntimeError
+            ```
+
+        Args:
+            coordinate: The new coordinate to move the cursor to.
+            row: The new row to move the cursor to.
+            column: The new column to move the cursor to.
+            animate: Whether to animate the change of coordinates.
+
+        Raises:
+            RuntimeError: If the parameter `coordinate` is specified together with any
+                of `row` or `column`, or if no new position is specified.
+        """
+        if coordinate is not None and (row is not None or column is not None):
+            raise RuntimeError("Can't specify `coordinate` and `row`/`column`.")
+        if coordinate is None and row is None and column is None:
+            raise RuntimeError("You must specify a new position to move the cursor to.")
+
+        if coordinate is not None:
+            destination = coordinate
+        else:
+            cursor_row, cursor_column = self.cursor_coordinate
+            if row is not None:
+                cursor_row = row
+            if column is not None:
+                cursor_column = column
+            destination = Coordinate(cursor_row, cursor_column)
+        self.cursor_coordinate = destination
+        self._scroll_cursor_into_view(animate=animate)
 
     def _highlight_coordinate(self, coordinate: Coordinate) -> None:
         """Apply highlighting to the cell at the coordinate, and post event."""

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -1021,28 +1021,9 @@ async def test_move_cursor():
         table.add_columns(*"These are some columns in your nice table".split())
         table.add_rows(["These are some columns in your nice table".split()] * 10)
 
-        table.move_cursor(Coordinate(5, 7))
-        assert table.cursor_coordinate == Coordinate(5, 7)
-        table.move_cursor(row=3)
-        assert table.cursor_coordinate == Coordinate(3, 7)
         table.move_cursor(row=4, column=6)
         assert table.cursor_coordinate == Coordinate(4, 6)
+        table.move_cursor(row=3)
+        assert table.cursor_coordinate == Coordinate(3, 6)
         table.move_cursor(column=3)
-        assert table.cursor_coordinate == Coordinate(4, 3)
-
-
-async def test_move_cursor_raises_error():
-    app = DataTableApp()
-
-    async with app.run_test():
-        table = app.query_one(DataTable)
-        table.add_columns(*"These are some columns in your nice table".split())
-        table.add_rows(["These are some columns in your nice table".split()] * 10)
-
-        coordinate = Coordinate(0, 0)
-        with pytest.raises(RuntimeError):
-            table.move_cursor(coordinate, row=1)
-        with pytest.raises(RuntimeError):
-            table.move_cursor(coordinate, column=1)
-        with pytest.raises(RuntimeError):
-            table.move_cursor(coordinate, row=1, column=1)
+        assert table.cursor_coordinate == Coordinate(3, 3)


### PR DESCRIPTION
This will add the method `DataTable.move_cursor`.
This also fixes the animation you get when going left/right in a data table.

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

Closes #2471.
Closes #2472.