### PR TITLE
Fix TabbedContent __init__ signature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The DataTable cursor is now scrolled into view when the cursor coordinate is changed programmatically https://github.com/Textualize/textual/issues/2459
 - run_worker exclusive parameter is now `False` by default https://github.com/Textualize/textual/pull/2470
 - Added `always_update` as an optional argument for `reactive.var`
+- `TabbedContent` now takes kwargs `id`, `name`, `classes`, and `disabled`, upon initialization, like other widgets https://github.com/Textualize/textual/pull/2497
 
 ## [0.23.0] - 2023-05-03
 

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -103,17 +103,29 @@ class TabbedContent(Widget):
             yield self.tabbed_content
             yield self.tab
 
-    def __init__(self, *titles: TextType, initial: str = "") -> None:
+    def __init__(
+        self,
+        *titles: TextType,
+        initial: str = "",
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
+    ):
         """Initialize a TabbedContent widgets.
 
         Args:
             *titles: Positional argument will be used as title.
             initial: The id of the initial tab, or empty string to select the first tab.
+            name: The name of the button.
+            id: The ID of the button in the DOM.
+            classes: The CSS classes of the button.
+            disabled: Whether the button is disabled or not.
         """
         self.titles = [self.render_str(title) for title in titles]
         self._tab_content: list[Widget] = []
         self._initial = initial
-        super().__init__()
+        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
 
     def validate_active(self, active: str) -> str:
         """It doesn't make sense for `active` to be an empty string.


### PR DESCRIPTION
This fixes the signature of `TabbedContent.__init__` so that it is initialised like any other widget.

Of course, this PR only makes sense under the assumption that these `kwargs` were missing due to our oversight in implementing and reviewing `TabbedContent`.