### PR TITLE
fix for code browser type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.24.1] - 2023-05-08
+
+### Fixed
+
+- Fix TypeError in code browser
+
 ## [0.24.0] - 2023-05-08
 
 ### Fixed
@@ -928,6 +934,7 @@ https://textual.textualize.io/blog/2022/11/08/version-040/#version-040
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
 
+[0.24.1]: https://github.com/Textualize/textual/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/Textualize/textual/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/Textualize/textual/compare/v0.22.3...v0.23.0
 [0.22.3]: https://github.com/Textualize/textual/compare/v0.22.2...v0.22.3

--- a/examples/code_browser.py
+++ b/examples/code_browser.py
@@ -54,7 +54,7 @@ class CodeBrowser(App):
         code_view = self.query_one("#code", Static)
         try:
             syntax = Syntax.from_path(
-                event.path,
+                str(event.path),
                 line_numbers=True,
                 word_wrap=False,
                 indent_guides=True,
@@ -66,7 +66,7 @@ class CodeBrowser(App):
         else:
             code_view.update(syntax)
             self.query_one("#code-view").scroll_home(animate=False)
-            self.sub_title = event.path
+            self.sub_title = str(event.path)
 
     def action_toggle_files(self) -> None:
         """Called in response to key binding."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "0.24.0"
+version = "0.24.1"
 homepage = "https://github.com/Textualize/textual"
 description = "Modern Text User Interface framework"
 authors = ["Will McGugan <will@textualize.io>"]

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -261,7 +261,7 @@ class DirectoryTree(Tree[DirEntry]):
             if not dir_entry.loaded:
                 self._load_directory(event.node)
         else:
-            self.post_message(self.FileSelected(event.node, dir_entry.path))
+            self.post_message(self.FileSelected(self, event.node, dir_entry.path))
 
     def _on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         event.stop()
@@ -269,4 +269,4 @@ class DirectoryTree(Tree[DirEntry]):
         if dir_entry is None:
             return
         if not dir_entry.path.is_dir():
-            self.post_message(self.FileSelected(event.node, dir_entry.path))
+            self.post_message(self.FileSelected(self, event.node, dir_entry.path))


### PR DESCRIPTION
Fix path related issue with code_browser.py, related to the change to use Pathlib in DirectoryTree

`FileSelected` also grew an argument for the tree, which wasn't updated.