### PR TITLE
Fix for `resolve_fraction_unit` zero division error (#2502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `ZeroDivisionError` in `resolve_fraction_unit` https://github.com/Textualize/textual/issues/2502
+
 ## [0.24.1] - 2023-05-08
 
 ### Fixed

--- a/src/textual/_resolve.py
+++ b/src/textual/_resolve.py
@@ -143,7 +143,7 @@ def resolve_fraction_unit(
     resolved: list[Fraction | None] = [None] * len(resolve)
     remaining_fraction = Fraction(sum(scalar.value for scalar, _, _ in resolve))
 
-    while remaining_fraction:
+    while remaining_fraction > 0:
         remaining_space_changed = False
         resolve_fraction = Fraction(remaining_space, remaining_fraction)
         for index, (scalar, min_value, max_value) in enumerate(resolve):

--- a/src/textual/_resolve.py
+++ b/src/textual/_resolve.py
@@ -143,7 +143,7 @@ def resolve_fraction_unit(
     resolved: list[Fraction | None] = [None] * len(resolve)
     remaining_fraction = Fraction(sum(scalar.value for scalar, _, _ in resolve))
 
-    while True:
+    while remaining_fraction:
         remaining_space_changed = False
         resolve_fraction = Fraction(remaining_space, remaining_fraction)
         for index, (scalar, min_value, max_value) in enumerate(resolve):
@@ -166,7 +166,7 @@ def resolve_fraction_unit(
 
     return (
         Fraction(remaining_space, remaining_fraction)
-        if remaining_space
+        if remaining_space > 0
         else Fraction(1)
     )
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -128,24 +128,17 @@ def test_resolve_fraction_unit():
 def test_resolve_issue_2502():
     """Test https://github.com/Textualize/textual/issues/2502"""
 
-    widgets_fr = [Widget() for _ in range(50)]
-    widgets_min_width = [Widget() for _ in range(50)]
-
-    for widget in widgets_fr:
-        widget.styles.width = "1fr"
-        widget.styles.min_width = 1
-
-    for widget in widgets_min_width:
-        widget.styles.width = 0
-
-    styles = (
-        widget.styles
-        for widget in chain.from_iterable(zip(widgets_fr, widgets_min_width))
-    )
+    widget = Widget()
+    widget.styles.width = "1fr"
+    widget.styles.min_width = 11
 
     assert isinstance(
         resolve_fraction_unit(
-            styles, Size(80, 24), Size(80, 24), Fraction(10), resolve_dimension="width"
+            (widget.styles,),
+            Size(80, 24),
+            Size(80, 24),
+            Fraction(10),
+            resolve_dimension="width",
         ),
         Fraction,
     )

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,4 +1,5 @@
 from fractions import Fraction
+from itertools import chain
 
 import pytest
 
@@ -122,3 +123,30 @@ def test_resolve_fraction_unit():
         Fraction(32),
         resolve_dimension="width",
     ) == Fraction(2)
+
+
+@pytest.mark.xfail(reason="https://github.com/Textualize/textual/issues/2502")
+def test_resolve_issue_2502():
+    """Test https://github.com/Textualize/textual/issues/2502"""
+
+    widgets_fr = [Widget() for _ in range(50)]
+    widgets_min_width = [Widget() for _ in range(50)]
+
+    for widget in widgets_fr:
+        widget.styles.width = "1fr"
+        widget.styles.min_width = 3
+
+    for widget in widgets_min_width:
+        widget.styles.width = 0
+
+    styles = (
+        widget.styles
+        for widget in chain.from_iterable(zip(widgets_fr, widgets_min_width))
+    )
+
+    assert isinstance(
+        resolve_fraction_unit(
+            styles, Size(80, 24), Size(80, 24), Fraction(10), resolve_dimension="width"
+        ),
+        Fraction,
+    )

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -134,7 +134,7 @@ def test_resolve_issue_2502():
 
     for widget in widgets_fr:
         widget.styles.width = "1fr"
-        widget.styles.min_width = 3
+        widget.styles.min_width = 1
 
     for widget in widgets_min_width:
         widget.styles.width = 0

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -125,7 +125,9 @@ def test_resolve_fraction_unit():
     ) == Fraction(2)
 
 
-@pytest.mark.xfail(reason="https://github.com/Textualize/textual/issues/2502")
+@pytest.mark.xfail(
+    strict=True, reason="https://github.com/Textualize/textual/issues/2502"
+)
 def test_resolve_issue_2502():
     """Test https://github.com/Textualize/textual/issues/2502"""
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -125,9 +125,6 @@ def test_resolve_fraction_unit():
     ) == Fraction(2)
 
 
-@pytest.mark.xfail(
-    strict=True, reason="https://github.com/Textualize/textual/issues/2502"
-)
 def test_resolve_issue_2502():
     """Test https://github.com/Textualize/textual/issues/2502"""
 


### PR DESCRIPTION
This will require some serious review by especially @willmcgugan (as function author) and @rodrigogiraoserrao (as maths wizard), as I'm not confident I really follow what the code is doing. However, having hand-debugged this I *think* this, or something similar, is the solution to #2502.

The approach here is that there's no point in carrying on looping around if there is no remaining fraction, and on the way out, if the remaining space has gone negative, the fallback value (`Fraction(1)`) should be used (before now it was if the remaining space was `0`, so this is in effect clamping the lower bound).