### PR TITLE
Allow setting (sub)title of any type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## Unrealeased
+
+### Changed
+
+- App `title` and `sub_title` attributes can be set to any type https://github.com/Textualize/textual/issues/2521
+
+
 ## [0.24.1] - 2023-05-08
 
 ### Fixed

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -409,9 +409,11 @@ class App(Generic[ReturnType], DOMNode):
         self.set_class(not self.dark, "-light-mode")
 
     def validate_title(self, title: Any) -> str:
+        """Make sure the title is set to a string."""
         return str(title)
 
     def validate_sub_title(self, sub_title: Any) -> str:
+        """Make sure the sub-title is set to a string."""
         return str(sub_title)
 
     @property

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -316,6 +316,7 @@ class App(Generic[ReturnType], DOMNode):
         the name of the app if it doesn't.
 
         Assign a new value to this attribute to change the title.
+        The new value is always converted to string.
         """
 
         self.sub_title = self.SUB_TITLE if self.SUB_TITLE is not None else ""
@@ -328,6 +329,7 @@ class App(Generic[ReturnType], DOMNode):
         the file being worker on.
 
         Assign a new value to this attribute to change the sub-title.
+        The new value is always converted to string.
         """
 
         self._logger = Logger(self._log)
@@ -405,6 +407,12 @@ class App(Generic[ReturnType], DOMNode):
         self._batch_count = 0
         self.set_class(self.dark, "-dark-mode")
         self.set_class(not self.dark, "-light-mode")
+
+    def validate_title(self, title: Any) -> str:
+        return str(title)
+
+    def validate_sub_title(self, sub_title: Any) -> str:
+        return str(sub_title)
 
     @property
     def workers(self) -> WorkerManager:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,3 +36,33 @@ async def test_hover_update_styles():
         # We've hovered, so ensure the pseudoclass is present and background changed
         assert button.pseudo_classes == {"enabled", "hover"}
         assert button.styles.background != initial_background
+
+
+def test_setting_title():
+    app = MyApp()
+    app.title = None
+    assert app.title == "None"
+
+    app.title = ""
+    assert app.title == ""
+
+    app.title = 0.125
+    assert app.title == "0.125"
+
+    app.title = [True, False, 2]
+    assert app.title == "[True, False, 2]"
+
+
+def test_setting_sub_title():
+    app = MyApp()
+    app.sub_title = None
+    assert app.sub_title == "None"
+
+    app.sub_title = ""
+    assert app.sub_title == ""
+
+    app.sub_title = 0.125
+    assert app.sub_title == "0.125"
+
+    app.sub_title = [True, False, 2]
+    assert app.sub_title == "[True, False, 2]"


### PR DESCRIPTION
This will close #2521.

App `title` and `sub_title` can now be set to values of arbitrary types but are always converted to strings.