### PR TITLE
Fix clearing an OptionList

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -630,6 +630,13 @@ class OptionList(ScrollView, can_focus=True):
         self.highlighted = None
         self._mouse_hovering_over = None
         self.virtual_size = Size(self.scrollable_content_region.width, 0)
+        # TODO: See https://github.com/Textualize/textual/issues/2582 -- it
+        # should not be necessary to do this like this here; ideally here in
+        # clear_options it would be a forced refresh, and also in a
+        # `on_show` it would be the same (which, I think, would actually
+        # solve the problem we're seeing). But, until such a time as we get
+        # to the bottom of 2582... this seems to delay the refresh enough
+        # that things fall into place.
         self._request_content_tracking_refresh()
         return self
 

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -631,7 +631,7 @@ class OptionList(ScrollView, can_focus=True):
         self.highlighted = None
         self._mouse_hovering_over = None
         self.virtual_size = Size(self.scrollable_content_region.width, 0)
-        self.refresh()
+        self._request_content_tracking_refresh()
         return self
 
     def _set_option_disabled(self, index: int, disabled: bool) -> Self:

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -627,7 +627,6 @@ class OptionList(ScrollView, can_focus=True):
         """
         self._contents.clear()
         self._options.clear()
-        self._refresh_content_tracking(force=True)
         self.highlighted = None
         self._mouse_hovering_over = None
         self.virtual_size = Size(self.scrollable_content_region.width, 0)

--- a/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots.ambr
@@ -22706,6 +22706,169 @@
   
   '''
 # ---
+# name: test_select_rebuild
+  '''
+  <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+      <!-- Generated with Rich https://www.textualize.io -->
+      <style>
+  
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Regular"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+          font-style: normal;
+          font-weight: 400;
+      }
+      @font-face {
+          font-family: "Fira Code";
+          src: local("FiraCode-Bold"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+          font-style: bold;
+          font-weight: 700;
+      }
+  
+      .terminal-330554958-matrix {
+          font-family: Fira Code, monospace;
+          font-size: 20px;
+          line-height: 24.4px;
+          font-variant-east-asian: full-width;
+      }
+  
+      .terminal-330554958-title {
+          font-size: 18px;
+          font-weight: bold;
+          font-family: arial;
+      }
+  
+      .terminal-330554958-r1 { fill: #1e1e1e }
+  .terminal-330554958-r2 { fill: #0178d4 }
+  .terminal-330554958-r3 { fill: #c5c8c6 }
+  .terminal-330554958-r4 { fill: #787878 }
+  .terminal-330554958-r5 { fill: #a8a8a8 }
+  .terminal-330554958-r6 { fill: #121212 }
+  .terminal-330554958-r7 { fill: #ddedf9;font-weight: bold }
+  .terminal-330554958-r8 { fill: #85beea;font-weight: bold }
+  .terminal-330554958-r9 { fill: #e2e3e3 }
+  .terminal-330554958-r10 { fill: #e1e1e1 }
+      </style>
+  
+      <defs>
+      <clipPath id="terminal-330554958-clip-terminal">
+        <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+      </clipPath>
+      <clipPath id="terminal-330554958-line-0">
+      <rect x="0" y="1.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-1">
+      <rect x="0" y="25.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-2">
+      <rect x="0" y="50.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-3">
+      <rect x="0" y="74.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-4">
+      <rect x="0" y="99.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-5">
+      <rect x="0" y="123.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-6">
+      <rect x="0" y="147.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-7">
+      <rect x="0" y="172.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-8">
+      <rect x="0" y="196.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-9">
+      <rect x="0" y="221.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-10">
+      <rect x="0" y="245.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-11">
+      <rect x="0" y="269.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-12">
+      <rect x="0" y="294.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-13">
+      <rect x="0" y="318.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-14">
+      <rect x="0" y="343.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-15">
+      <rect x="0" y="367.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-16">
+      <rect x="0" y="391.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-17">
+      <rect x="0" y="416.3" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-18">
+      <rect x="0" y="440.7" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-19">
+      <rect x="0" y="465.1" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-20">
+      <rect x="0" y="489.5" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-21">
+      <rect x="0" y="513.9" width="976" height="24.65"/>
+              </clipPath>
+  <clipPath id="terminal-330554958-line-22">
+      <rect x="0" y="538.3" width="976" height="24.65"/>
+              </clipPath>
+      </defs>
+  
+      <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-330554958-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">SelectRebuildApp</text>
+              <g transform="translate(26,22)">
+              <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+              <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+              <circle cx="44" cy="0" r="7" fill="#28c840"/>
+              </g>
+          
+      <g transform="translate(9, 41)" clip-path="url(#terminal-330554958-clip-terminal)">
+      <rect fill="#0178d4" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="1.5" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="36.6" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="109.8" y="25.9" width="805.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="915" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="927.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="939.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="12.2" y="50.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="74.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="195.2" y="74.7" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="24.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="109.8" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="195.2" y="99.1" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="939.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="85.4" y="123.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="195.2" y="123.5" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="147.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="109.8" y="147.9" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="61" y="172.3" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="196.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="85.4" y="196.7" width="854" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="221.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="85.4" y="221.1" width="854" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="245.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="85.4" y="245.5" width="854" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="269.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="73.2" y="269.9" width="866.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="24.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="36.6" y="294.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="134.2" y="294.3" width="805.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="939.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="951.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="12.2" y="318.7" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="963.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+      <g class="terminal-330554958-matrix">
+      <text class="terminal-330554958-r1" x="0" y="20" textLength="12.2" clip-path="url(#terminal-330554958-line-0)">▊</text><text class="terminal-330554958-r2" x="12.2" y="20" textLength="951.6" clip-path="url(#terminal-330554958-line-0)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-330554958-r2" x="963.8" y="20" textLength="12.2" clip-path="url(#terminal-330554958-line-0)">▎</text><text class="terminal-330554958-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-330554958-line-0)">
+  </text><text class="terminal-330554958-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-330554958-line-1)">▊</text><text class="terminal-330554958-r4" x="36.6" y="44.4" textLength="73.2" clip-path="url(#terminal-330554958-line-1)">Select</text><text class="terminal-330554958-r5" x="927.2" y="44.4" textLength="12.2" clip-path="url(#terminal-330554958-line-1)">▲</text><text class="terminal-330554958-r2" x="963.8" y="44.4" textLength="12.2" clip-path="url(#terminal-330554958-line-1)">▎</text><text class="terminal-330554958-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-330554958-line-1)">
+  </text><text class="terminal-330554958-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-330554958-line-2)">▊</text><text class="terminal-330554958-r2" x="12.2" y="68.8" textLength="951.6" clip-path="url(#terminal-330554958-line-2)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-330554958-r2" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-330554958-line-2)">▎</text><text class="terminal-330554958-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-330554958-line-2)">
+  </text><text class="terminal-330554958-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-330554958-line-3)">▊</text><text class="terminal-330554958-r6" x="12.2" y="93.2" textLength="183" clip-path="url(#terminal-330554958-line-3)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-330554958-r6" x="195.2" y="93.2" textLength="768.6" clip-path="url(#terminal-330554958-line-3)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-330554958-r6" x="963.8" y="93.2" textLength="12.2" clip-path="url(#terminal-330554958-line-3)">▎</text><text class="terminal-330554958-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-330554958-line-3)">
+  </text><text class="terminal-330554958-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-330554958-line-4)">▊</text><text class="terminal-330554958-r8" x="36.6" y="117.6" textLength="73.2" clip-path="url(#terminal-330554958-line-4)">Select</text><text class="terminal-330554958-r6" x="963.8" y="117.6" textLength="12.2" clip-path="url(#terminal-330554958-line-4)">▎</text><text class="terminal-330554958-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-330554958-line-4)">
+  </text><text class="terminal-330554958-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-330554958-line-5)">▊</text><text class="terminal-330554958-r9" x="36.6" y="142" textLength="48.8" clip-path="url(#terminal-330554958-line-5)">This</text><text class="terminal-330554958-r6" x="963.8" y="142" textLength="12.2" clip-path="url(#terminal-330554958-line-5)">▎</text><text class="terminal-330554958-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-330554958-line-5)">
+  </text><text class="terminal-330554958-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-330554958-line-6)">▊</text><text class="terminal-330554958-r9" x="36.6" y="166.4" textLength="73.2" clip-path="url(#terminal-330554958-line-6)">Should</text><text class="terminal-330554958-r6" x="963.8" y="166.4" textLength="12.2" clip-path="url(#terminal-330554958-line-6)">▎</text><text class="terminal-330554958-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-330554958-line-6)">
+  </text><text class="terminal-330554958-r1" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-330554958-line-7)">▊</text><text class="terminal-330554958-r9" x="36.6" y="190.8" textLength="24.4" clip-path="url(#terminal-330554958-line-7)">Be</text><text class="terminal-330554958-r6" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-330554958-line-7)">▎</text><text class="terminal-330554958-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-330554958-line-7)">
+  </text><text class="terminal-330554958-r1" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-330554958-line-8)">▊</text><text class="terminal-330554958-r9" x="36.6" y="215.2" textLength="48.8" clip-path="url(#terminal-330554958-line-8)">What</text><text class="terminal-330554958-r6" x="963.8" y="215.2" textLength="12.2" clip-path="url(#terminal-330554958-line-8)">▎</text><text class="terminal-330554958-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-330554958-line-8)">
+  </text><text class="terminal-330554958-r1" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-330554958-line-9)">▊</text><text class="terminal-330554958-r9" x="36.6" y="239.6" textLength="48.8" clip-path="url(#terminal-330554958-line-9)">Goes</text><text class="terminal-330554958-r6" x="963.8" y="239.6" textLength="12.2" clip-path="url(#terminal-330554958-line-9)">▎</text><text class="terminal-330554958-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-330554958-line-9)">
+  </text><text class="terminal-330554958-r1" x="0" y="264" textLength="12.2" clip-path="url(#terminal-330554958-line-10)">▊</text><text class="terminal-330554958-r9" x="36.6" y="264" textLength="48.8" clip-path="url(#terminal-330554958-line-10)">Into</text><text class="terminal-330554958-r6" x="963.8" y="264" textLength="12.2" clip-path="url(#terminal-330554958-line-10)">▎</text><text class="terminal-330554958-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-330554958-line-10)">
+  </text><text class="terminal-330554958-r1" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-330554958-line-11)">▊</text><text class="terminal-330554958-r9" x="36.6" y="288.4" textLength="36.6" clip-path="url(#terminal-330554958-line-11)">The</text><text class="terminal-330554958-r6" x="963.8" y="288.4" textLength="12.2" clip-path="url(#terminal-330554958-line-11)">▎</text><text class="terminal-330554958-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-330554958-line-11)">
+  </text><text class="terminal-330554958-r1" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-330554958-line-12)">▊</text><text class="terminal-330554958-r9" x="36.6" y="312.8" textLength="97.6" clip-path="url(#terminal-330554958-line-12)">Snapshit</text><text class="terminal-330554958-r6" x="963.8" y="312.8" textLength="12.2" clip-path="url(#terminal-330554958-line-12)">▎</text><text class="terminal-330554958-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-330554958-line-12)">
+  </text><text class="terminal-330554958-r1" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-330554958-line-13)">▊</text><text class="terminal-330554958-r6" x="12.2" y="337.2" textLength="951.6" clip-path="url(#terminal-330554958-line-13)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-330554958-r6" x="963.8" y="337.2" textLength="12.2" clip-path="url(#terminal-330554958-line-13)">▎</text><text class="terminal-330554958-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-330554958-line-13)">
+  </text><text class="terminal-330554958-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-330554958-line-14)">
+  </text><text class="terminal-330554958-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-330554958-line-15)">
+  </text><text class="terminal-330554958-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-330554958-line-16)">
+  </text><text class="terminal-330554958-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-330554958-line-17)">
+  </text><text class="terminal-330554958-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-330554958-line-18)">
+  </text><text class="terminal-330554958-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-330554958-line-19)">
+  </text><text class="terminal-330554958-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-330554958-line-20)">
+  </text><text class="terminal-330554958-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-330554958-line-21)">
+  </text><text class="terminal-330554958-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-330554958-line-22)">
+  </text>
+      </g>
+      </g>
+  </svg>
+  
+  '''
+# ---
 # name: test_switches
   '''
   <svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">

--- a/tests/snapshot_tests/snapshot_apps/select_rebuild.py
+++ b/tests/snapshot_tests/snapshot_apps/select_rebuild.py
@@ -1,0 +1,21 @@
+"""Test https://github.com/Textualize/textual/issues/2557"""
+
+from textual.app import App, ComposeResult
+from textual.widgets import Select, Button
+
+
+class SelectRebuildApp(App[None]):
+
+    def compose(self) -> ComposeResult:
+        yield Select[int]((("1", 1), ("2", 2)))
+        yield Button("Rebuild")
+
+    def on_button_pressed(self):
+        self.query_one(Select).set_options((
+            ("This", 0), ("Should", 1), ("Be", 2),
+            ("What", 3), ("Goes", 4), ("Into",5),
+            ("The", 6), ("Snapshit", 7)
+        ))
+
+if __name__ == "__main__":
+    SelectRebuildApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -493,3 +493,12 @@ def test_quickly_change_tabs(snap_compare):
 def test_fr_unit_with_min(snap_compare):
     # https://github.com/Textualize/textual/issues/2378
     assert snap_compare(SNAPSHOT_APPS_DIR / "fr_with_min.py")
+
+
+def test_select_rebuild(snap_compare):
+    # https://github.com/Textualize/textual/issues/2557
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "select_rebuild.py",
+        press=["tab", "space", "escape", "tab", "enter", "tab", "space"]
+    )
+


### PR DESCRIPTION
See #2557, credit to Will: https://github.com/Textualize/textual/issues/2557#issuecomment-1546883815

After a diversion into #2574 and #2582, with the obvious need to dive into the latter much deeper, we're going with this fix for the moment. I don't think it's *the* fix here, but it's for sure a fix that works for now and this should get a revisit if and when #2582 gets a deep dive.

Long story short: because of the nature of how `Select` works, most of the times that the content refresh happens the `OptionList` has no size. No size means it's impossible to calculate the content as the `width` is needed to know how many lines is needed for each prompt. The obvious fix here would be to add `_on_show` to `OptionList` and refresh the content, much like it does with `_on_resize`; however I'm not seeing the expected events happen when it's used within `Select`.

This fix delays the refresh until there is size for the widget, having the desired effect, albeit not in the most ideal way.