### PR TITLE
Update poetry-core requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,5 +83,5 @@ markers = [
 ]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Related issues: #2562

I was searching for a poetry command that would demonstrate the fix for pre-1.2.0 versions (i.e., the `pyproject.toml` dependency would be discovered first and the command would bail) but it always seems to hit the group error first.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
