### PR TITLE
Remove duplicated setting of `height` for `Select`

### DIFF
--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -185,10 +185,6 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         border: tall $accent;
     }
 
-    Select {
-        height: auto;
-    }
-
     Select > SelectOverlay {
         width: 1fr;
         display: none;


### PR DESCRIPTION
Just removes a duplicated rule I noticed while reading over the code for something else.