### PR TITLE
Refactor Message.control and Tree Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## Unreleased
+
+### Changed
+
+- `Message.control` is now a property instead of a class variable. https://github.com/Textualize/textual/issues/2528
+- `Tree` and `DirectoryTree` Messages no longer accept a `tree` parameter, using `self.node.tree` instead. https://github.com/Textualize/textual/issues/2529
+
 ## [0.25.0] - 2023-05-17
 
 ### Changed

--- a/src/textual/_on.py
+++ b/src/textual/_on.py
@@ -65,7 +65,7 @@ def on(
     parsed_selectors: dict[str, tuple[SelectorSet, ...]] = {}
     for attribute, css_selector in selectors.items():
         if attribute == "control":
-            if message_type.control is None:
+            if message_type.control == Message.control:
                 raise OnDecoratorError(
                     "The message class must have a 'control' to match with the on decorator"
                 )

--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -42,7 +42,6 @@ class Message:
     verbose: ClassVar[bool] = False  # Message is verbose
     no_dispatch: ClassVar[bool] = False  # Message may not be handled by client code
     namespace: ClassVar[str] = ""  # Namespace to disambiguate messages
-    control: Widget | None = None
 
     def __init__(self) -> None:
         self.__post_init__()
@@ -78,6 +77,11 @@ class Message:
             cls.no_dispatch = no_dispatch
         if namespace is not None:
             cls.namespace = namespace
+
+    @property
+    def control(self) -> Widget | None:
+        """The widget associated with this message, or None by default."""
+        return None
 
     @property
     def is_forwarded(self) -> bool:

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -66,9 +66,7 @@ class DirectoryTree(Tree[DirEntry]):
         `DirectoryTree` or in a parent widget in the DOM.
         """
 
-        def __init__(
-            self, tree: DirectoryTree, node: TreeNode[DirEntry], path: Path
-        ) -> None:
+        def __init__(self, node: TreeNode[DirEntry], path: Path) -> None:
             """Initialise the FileSelected object.
 
             Args:
@@ -76,21 +74,15 @@ class DirectoryTree(Tree[DirEntry]):
                 path: The path of the file that was selected.
             """
             super().__init__()
-            self.tree: DirectoryTree = tree
-            """The `DirectoryTree` that had a file selected."""
             self.node: TreeNode[DirEntry] = node
             """The tree node of the file that was selected."""
             self.path: Path = path
             """The path of the file that was selected."""
 
         @property
-        def control(self) -> DirectoryTree:
-            """The `DirectoryTree` that had a file selected.
-
-            This is an alias for [`FileSelected.tree`][textual.widgets.DirectoryTree.FileSelected.tree]
-            which is used by the [`on`][textual.on] decorator.
-            """
-            return self.tree
+        def control(self) -> Tree[DirEntry]:
+            """The `Tree` that had a file selected."""
+            return self.node.tree
 
     path: var[str | Path] = var["str | Path"](Path("."), init=False, always_update=True)
     """The path that is the root of the directory tree.

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -350,7 +350,7 @@ class DirectoryTree(Tree[DirEntry]):
             if not dir_entry.loaded:
                 self._add_to_load_queue(event.node)
         else:
-            self.post_message(self.FileSelected(self, event.node, dir_entry.path))
+            self.post_message(self.FileSelected(event.node, dir_entry.path))
 
     def _on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         event.stop()
@@ -358,4 +358,4 @@ class DirectoryTree(Tree[DirEntry]):
         if dir_entry is None:
             return
         if not self._safe_is_dir(dir_entry.path):
-            self.post_message(self.FileSelected(self, event.node, dir_entry.path))
+            self.post_message(self.FileSelected(event.node, dir_entry.path))

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -226,19 +226,22 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         """Posted when the select value was changed.
 
         This message can be handled using a `on_select_changed` method.
-
         """
 
-        def __init__(self, control: Select, value: SelectType | None) -> None:
+        def __init__(self, widget: Select, value: SelectType | None) -> None:
             """
             Initialize the Changed message.
-
             """
             super().__init__()
-            self.control = control
-            """The select control."""
+            self.widget = widget
+            """The select widget."""
             self.value = value
             """The value of the Select when it changed."""
+
+        @property
+        def control(self) -> Select:
+            """The Select that sent the message."""
+            return self.widget
 
     def __init__(
         self,

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -228,12 +228,12 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         This message can be handled using a `on_select_changed` method.
         """
 
-        def __init__(self, widget: Select, value: SelectType | None) -> None:
+        def __init__(self, select: Select, value: SelectType | None) -> None:
             """
             Initialize the Changed message.
             """
             super().__init__()
-            self.widget = widget
+            self.select = select
             """The select widget."""
             self.value = value
             """The value of the Select when it changed."""
@@ -241,7 +241,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         @property
         def control(self) -> Select:
             """The Select that sent the message."""
-            return self.widget
+            return self.select
 
     def __init__(
         self,

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -207,7 +207,7 @@ class TreeNode(Generic[TreeDataType]):
         """
         self._expanded = True
         self._updates += 1
-        self._tree.post_message(Tree.NodeExpanded(self._tree, self))
+        self._tree.post_message(Tree.NodeExpanded(self))
         if expand_all:
             for child in self.children:
                 child._expand(expand_all)
@@ -240,7 +240,7 @@ class TreeNode(Generic[TreeDataType]):
         """
         self._expanded = False
         self._updates += 1
-        self._tree.post_message(Tree.NodeCollapsed(self._tree, self))
+        self._tree.post_message(Tree.NodeCollapsed(self))
         if collapse_all:
             for child in self.children:
                 child._collapse(collapse_all)
@@ -873,7 +873,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             node._selected = True
             self._cursor_node = node
             if previous_node != node:
-                self.post_message(self.NodeHighlighted(self, node))
+                self.post_message(self.NodeHighlighted(node))
         else:
             self._cursor_node = None
 
@@ -1204,7 +1204,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
 
         Note:
             If `auto_expand` is `True` use of this action on a non-leaf node
-            will cause both an expand/collapse event to occour, as well as a
+            will cause both an expand/collapse event to occur, as well as a
             selected event.
         """
         try:
@@ -1215,4 +1215,4 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             node = line.path[-1]
             if self.auto_expand:
                 self._toggle_node(node)
-            self.post_message(self.NodeSelected(self, node))
+            self.post_message(self.NodeSelected(node))

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -514,23 +514,15 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         parent node in the DOM.
         """
 
-        def __init__(
-            self, tree: Tree[EventTreeDataType], node: TreeNode[EventTreeDataType]
-        ) -> None:
-            self.tree = tree
-            """The tree that sent the message."""
+        def __init__(self, node: TreeNode[EventTreeDataType]) -> None:
             self.node: TreeNode[EventTreeDataType] = node
             """The node that was collapsed."""
             super().__init__()
 
         @property
         def control(self) -> Tree[EventTreeDataType]:
-            """The tree that sent the message.
-
-            This is an alias for [`NodeCollapsed.tree`][textual.widgets.Tree.NodeCollapsed.tree]
-            and is used by the [`on`][textual.on] decorator.
-            """
-            return self.tree
+            """The tree that sent the message."""
+            return self.node.tree
 
     class NodeExpanded(Generic[EventTreeDataType], Message, bubble=True):
         """Event sent when a node is expanded.
@@ -539,23 +531,15 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         parent node in the DOM.
         """
 
-        def __init__(
-            self, tree: Tree[EventTreeDataType], node: TreeNode[EventTreeDataType]
-        ) -> None:
-            self.tree = tree
-            """The tree that sent the message."""
+        def __init__(self, node: TreeNode[EventTreeDataType]) -> None:
             self.node: TreeNode[EventTreeDataType] = node
             """The node that was expanded."""
             super().__init__()
 
         @property
         def control(self) -> Tree[EventTreeDataType]:
-            """The tree that sent the message.
-
-            This is an alias for [`NodeExpanded.tree`][textual.widgets.Tree.NodeExpanded.tree]
-            and is used by the [`on`][textual.on] decorator.
-            """
-            return self.tree
+            """The tree that sent the message."""
+            return self.node.tree
 
     class NodeHighlighted(Generic[EventTreeDataType], Message, bubble=True):
         """Event sent when a node is highlighted.
@@ -564,23 +548,15 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         parent node in the DOM.
         """
 
-        def __init__(
-            self, tree: Tree[EventTreeDataType], node: TreeNode[EventTreeDataType]
-        ) -> None:
-            self.tree = tree
-            """The tree that sent the message."""
+        def __init__(self, node: TreeNode[EventTreeDataType]) -> None:
             self.node: TreeNode[EventTreeDataType] = node
             """The node that was highlighted."""
             super().__init__()
 
         @property
         def control(self) -> Tree[EventTreeDataType]:
-            """The tree that sent the message.
-
-            This is an alias for [`NodeHighlighted.tree`][textual.widgets.Tree.NodeHighlighted.tree]
-            and is used by the [`on`][textual.on] decorator.
-            """
-            return self.tree
+            """The tree that sent the message."""
+            return self.node.tree
 
     class NodeSelected(Generic[EventTreeDataType], Message, bubble=True):
         """Event sent when a node is selected.
@@ -589,23 +565,15 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         parent node in the DOM.
         """
 
-        def __init__(
-            self, tree: Tree[EventTreeDataType], node: TreeNode[EventTreeDataType]
-        ) -> None:
-            self.tree = tree
-            """The tree that sent the message."""
+        def __init__(self, node: TreeNode[EventTreeDataType]) -> None:
             self.node: TreeNode[EventTreeDataType] = node
             """The node that was selected."""
             super().__init__()
 
         @property
         def control(self) -> Tree[EventTreeDataType]:
-            """The tree that sent the message.
-
-            This is an alias for [`NodeSelected.tree`][textual.widgets.Tree.NodeSelected.tree]
-            and is used by the [`on`][textual.on] decorator.
-            """
-            return self.tree
+            """The tree that sent the message."""
+            return self.node.tree
 
     def __init__(
         self,


### PR DESCRIPTION
An attempt to address #2528 and #2529 as suggested by @davep.

- Changed `Message.control` to a property
- Removed the `tree` parameter from:
  - `Tree.NodeCollapsed`
  - `Tree.NodeExpanded`
  - `Tree.NodeHighlighted`
  - `Tree.NodeSelected`
  - `DirectoryTree.FileSelected`
- Changed the above's `control` to return `self.node.tree`.

I was not entirely following what changes needed to be made to the `@on` decorator, but I believe the rest is there. Additionally, I was getting a type error for `DirectoryTree.FileSelected.control` because `self.node.tree` is a `Tree[DirEntry]` vs a `DirectoryTree`. Not sure if that matters so I wanted to raise it here.

Hope this helps, happy to get it finished with a little more guidance.
