### PR TITLE
Fix App.BINDINGS type

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -71,7 +71,7 @@ from ._wait import wait_for_idle
 from ._worker_manager import WorkerManager
 from .actions import ActionParseResult, SkipAction
 from .await_remove import AwaitRemove
-from .binding import Binding, _Bindings
+from .binding import Binding, _Bindings, BindingType
 from .css.query import NoMatches
 from .css.stylesheet import Stylesheet
 from .design import ColorSystem
@@ -230,7 +230,9 @@ class App(Generic[ReturnType], DOMNode):
     To update the sub-title while the app is running, you can set the [sub_title][textual.app.App.sub_title] attribute.
     """
 
-    BINDINGS = [Binding("ctrl+c", "quit", "Quit", show=False, priority=True)]
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("ctrl+c", "quit", "Quit", show=False, priority=True)
+    ]
 
     title: Reactive[str] = Reactive("", compute=False)
     sub_title: Reactive[str] = Reactive("", compute=False)


### PR DESCRIPTION
The implicit type was creating mypy errors when defining bindings with tuples. For example:

    class MyApp(App):
        BINDINGS = [("q", "quit", "Quit")]

Would give the error:

    error: List item 0 has incompatible type "Tuple[str, str, str]"; expected "Binding"  [list-item]