### PR TITLE
Leave footer when pushing modal screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `Placeholder` now sets its color cycle per app https://github.com/Textualize/textual/issues/2590
+- Footer now clears key highlight regardless of whether it's in the active screen or not https://github.com/Textualize/textual/issues/2606
 
 ### Removed
 

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -79,8 +79,7 @@ class Footer(Widget):
 
     def _on_leave(self, _: events.Leave) -> None:
         """Clear any highlight when the mouse leaves the widget"""
-        if self.screen.is_current:
-            self.highlight_key = None
+        self.highlight_key = None
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield from super().__rich_repr__()

--- a/tests/test_footer.py
+++ b/tests/test_footer.py
@@ -1,0 +1,28 @@
+from textual.app import App, ComposeResult
+from textual.geometry import Offset
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Label
+
+
+async def test_footer_highlight_when_pushing_modal():
+    """Regression test for https://github.com/Textualize/textual/issues/2606"""
+
+    class MyModalScreen(ModalScreen):
+        def compose(self) -> ComposeResult:
+            yield Label("apple")
+
+    class MyApp(App[None]):
+        BINDINGS = [("a", "p", "push")]
+
+        def compose(self) -> ComposeResult:
+            yield Footer()
+
+        def action_p(self):
+            self.push_screen(MyModalScreen())
+
+    app = MyApp()
+    async with app.run_test(size=(80, 2)) as pilot:
+        await pilot.hover(None, Offset(0, 1))
+        await pilot.click(None, Offset(0, 1))
+        assert isinstance(app.screen, MyModalScreen)
+        assert app.screen_stack[0].query_one(Footer).highlight_key is None


### PR DESCRIPTION
This closes #2606.

The original issue suggests calling `_set_mouse_over(None)` when pushing the screen.
This is already done.
The issue was that by the time we get to `_on_leave` inside the footer, the modal screen is already in the stack.
This changes the implementation of `_on_leave` so that the footer loses focus even if it's not at the top of the stack.

Alternatively, I can change the implementation so that it loses focus if the only screens on top of the footer screen are modals.