### PR TITLE
remove markup, simplify repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Placeholder` now sets its color cycle per app https://github.com/Textualize/textual/issues/2590
 - Footer now clears key highlight regardless of whether it's in the active screen or not https://github.com/Textualize/textual/issues/2606
-- The default repr no longer displays classes and pseudo-classes (to reduce noise in logs). Add them to your rich_repr method if needed. https://github.com/Textualize/textual/pull/2623
+- The default Widget repr no longer displays classes and pseudo-classes (to reduce noise in logs). Add them to your `__rich_repr__` method if needed. https://github.com/Textualize/textual/pull/2623
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Placeholder` now sets its color cycle per app https://github.com/Textualize/textual/issues/2590
 - Footer now clears key highlight regardless of whether it's in the active screen or not https://github.com/Textualize/textual/issues/2606
+- The default repr no longer displays classes and pseudo-classes (to reduce noise in logs). Add them to your rich_repr method if needed. https://github.com/Textualize/textual/pull/2623
 
 ### Removed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -71,7 +71,7 @@ from ._wait import wait_for_idle
 from ._worker_manager import WorkerManager
 from .actions import ActionParseResult, SkipAction
 from .await_remove import AwaitRemove
-from .binding import Binding, _Bindings, BindingType
+from .binding import Binding, BindingType, _Bindings
 from .css.query import NoMatches
 from .css.stylesheet import Stylesheet
 from .design import ColorSystem
@@ -1853,7 +1853,7 @@ class App(Generic[ReturnType], DOMNode):
 
         if self.css_monitor:
             self.set_interval(0.25, self.css_monitor, name="css monitor")
-            self.log.system("[b green]STARTED[/]", self.css_monitor)
+            self.log.system("STARTED", self.css_monitor)
 
         async def run_process_messages():
             """The main message loop, invoke below."""
@@ -2713,7 +2713,7 @@ class App(Generic[ReturnType], DOMNode):
     def _on_terminal_supports_synchronized_output(
         self, message: messages.TerminalSupportsSynchronizedOutput
     ) -> None:
-        log.system("[b green]SynchronizedOutput mode is supported")
+        log.system("SynchronizedOutput mode is supported")
         self._sync_available = True
 
     def _begin_update(self) -> None:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -35,9 +35,6 @@ if TYPE_CHECKING:
 class Event(Message):
     """The base class for all events."""
 
-    def __rich_repr__(self) -> rich.repr.Result:
-        yield from ()
-
 
 @rich.repr.auto
 class Callback(Event, bubble=False, verbose=True):

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2532,11 +2532,6 @@ class Widget(DOMNode):
         yield "id", self.id, None
         if self.name:
             yield "name", self.name
-        if self.classes:
-            yield "classes", set(self.classes)
-        pseudo_classes = self.pseudo_classes
-        if pseudo_classes:
-            yield "pseudo_classes", set(pseudo_classes)
 
     def _get_scrollable_region(self, region: Region) -> Region:
         """Adjusts the Widget region to accommodate scrollbars.


### PR DESCRIPTION
- Remove markup from log statements (no longer supported)
- Simplified widget default repr by removing classes an psuedo-classes. 99% of the time it is noise.