### PR TITLE
Fix a copy/pasteo in an option list docstring

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -753,7 +753,7 @@ class OptionList(ScrollView, can_focus=True):
         """Get the option with the given ID.
 
         Args:
-            index: The ID of the option to get.
+            option_id: The ID of the option to get.
 
         Returns:
             The option at with the ID.


### PR DESCRIPTION
Just a simple typo copy/pasteo error I noticed in passing.