### PR TITLE
Fix Select reactives table layout

### DIFF
--- a/docs/widgets/select.md
+++ b/docs/widgets/select.md
@@ -66,10 +66,10 @@ The following example presents a `Select` with a number of options.
 ## Reactive attributes
 
 
-| Name       | Type                 | Default | Description                         |
-| ---------- | -------------------- | ------- | ----------------------------------- |
-| `expanded` | `bool`               | `False` | True to expand the options overlay. |
-| `value`    | `SelectType \| None` | `None`  | Current value of the Select.        |
+| Name       | Type                   | Default | Description                         |
+|------------|------------------------|---------|-------------------------------------|
+| `expanded` | `bool`                 | `False` | True to expand the options overlay. |
+| `value`    | `SelectType` \| `None` | `None`  | Current value of the Select.        |
 
 
 ## Bindings


### PR DESCRIPTION
The escaped `|` wasn't being rendered correctly as it was inside back-ticks. Noticed it while passing by.
