### PR TITLE
Fix a typo in the `OptionList` messages list

### DIFF
--- a/docs/widgets/option_list.md
+++ b/docs/widgets/option_list.md
@@ -87,7 +87,7 @@ tables](https://rich.readthedocs.io/en/latest/tables.html):
 
 ## Messages
 
-- [OptionList.OptionHighlight][textual.widgets.OptionList.OptionHighlighted]
+- [OptionList.OptionHighlighted][textual.widgets.OptionList.OptionHighlighted]
 - [OptionList.OptionSelected][textual.widgets.OptionList.OptionSelected]
 
 Both of the messages above inherit from the common base [`OptionList`][textual.widgets.OptionList.OptionMessage], so refer to its documentation to see what attributes are available.


### PR DESCRIPTION
Noticed this one why passing by.