### PR TITLE
Include `widgets.option_list.Option` in the docs

### DIFF
--- a/docs/widgets/option_list.md
+++ b/docs/widgets/option_list.md
@@ -115,3 +115,8 @@ The option list provides the following component classes:
 ::: textual.widgets.OptionList
     options:
       heading_level: 2
+
+
+::: textual.widgets.option_list.Option
+    options:
+      heading_level: 2


### PR DESCRIPTION
Noticed this in passing; possibly dropped by accident when the widgets were removed form the API section of the docs?
