### PR TITLE
Include more missing things from the OptionList

### DIFF
--- a/docs/widgets/option_list.md
+++ b/docs/widgets/option_list.md
@@ -117,6 +117,6 @@ The option list provides the following component classes:
       heading_level: 2
 
 
-::: textual.widgets.option_list.Option
+::: textual.widgets.option_list
     options:
       heading_level: 2


### PR DESCRIPTION
While working on the SelectionList documentation I've noticed that even more things have got lost from the docs relating to OptionList, likely lost when widgets were removed from the API section of the docs.

This drags more OptionList-related types into the docs, thus providing more links.

Follows on from #2640.
