### PR TITLE
Fix docstring for `DOMNode.set_classes`

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1123,7 +1123,8 @@ class DOMNode(MessagePump):
         """Replace all classes.
 
         Args:
-            A string contain space separated classes, or an iterable of class names.
+            classes: A string containing space separated classes, or an
+                iterable of class names.
 
         Returns:
             Self.


### PR DESCRIPTION
The argument in the Args list was missing its name; also fixes a typo too.
