### PR TITLE
Add (currently xfailing) tests for private reactive validation and compute methods

### DIFF
--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -435,3 +435,27 @@ async def test_public_and_private_validate() -> None:
         pilot.app.counter += 1
         assert calls["private"] is True
         assert calls["public"] is True
+
+
+async def test_public_and_private_compute() -> None:
+    """If a reactive/var has public and private compute both should get called."""
+
+    calls: dict[str, bool] = {"private": False, "public": False}
+
+    class PrivateComputeTest(App):
+        counter = var(0, init=False)
+
+        def compute_counter(self) -> int:
+            calls["public"] = True
+            return 23
+
+        def _compute_counter(self) -> int:
+            calls["private"] = True
+            return 42
+
+    async with PrivateComputeTest().run_test() as pilot:
+        assert calls["private"] is False
+        assert calls["public"] is False
+        _ = pilot.app.counter
+        assert calls["private"] is True
+        assert calls["public"] is True

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -413,3 +413,25 @@ async def test_public_and_private_watch() -> None:
         pilot.app.counter += 1
         assert calls["private"] is True
         assert calls["public"] is True
+
+
+async def test_public_and_private_validate() -> None:
+    """If a reactive/var has public and private validate both should get called."""
+
+    calls: dict[str, bool] = {"private": False, "public": False}
+
+    class PrivateValidateTest(App):
+        counter = var(0, init=False)
+
+        def validate_counter(self, _: int) -> None:
+            calls["public"] = True
+
+        def _validate_counter(self, _: int) -> None:
+            calls["private"] = True
+
+    async with PrivateValidateTest().run_test() as pilot:
+        assert calls["private"] is False
+        assert calls["public"] is False
+        pilot.app.counter += 1
+        assert calls["private"] is True
+        assert calls["public"] is True

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -415,6 +415,7 @@ async def test_public_and_private_watch() -> None:
         assert calls["public"] is True
 
 
+@pytest.mark.xfail(reason="https://github.com/Textualize/textual/issues/2539")
 async def test_public_and_private_validate() -> None:
     """If a reactive/var has public and private validate both should get called."""
 
@@ -437,6 +438,7 @@ async def test_public_and_private_validate() -> None:
         assert calls["public"] is True
 
 
+@pytest.mark.xfail(reason="https://github.com/Textualize/textual/issues/2539")
 async def test_public_and_private_compute() -> None:
     """If a reactive/var has public and private compute both should get called."""
 


### PR DESCRIPTION
As a check for the state of #2539 this PR adds a pair of tests. I suspect the final form of these will be different in that I'm not sure it actually makes sense to support calling both a public ***and*** private validation or compute method. However, adding these as xfailing tests for now as a reminder that this should be decided and resolved.