### PR TITLE
`DirectoryTree` "belt and braces" tweaks

### DIFF
--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -131,8 +131,9 @@ class DirectoryTree(Tree[DirEntry]):
             node: The node to add to the load queue.
         """
         assert node.data is not None
-        node.data.loaded = True
-        self._load_queue.put_nowait(node)
+        if not node.data.loaded:
+            node.data.loaded = True
+            self._load_queue.put_nowait(node)
 
     def reload(self) -> None:
         """Reload the `DirectoryTree` contents."""
@@ -351,8 +352,7 @@ class DirectoryTree(Tree[DirEntry]):
         if dir_entry is None:
             return
         if self._safe_is_dir(dir_entry.path):
-            if not dir_entry.loaded:
-                self._add_to_load_queue(event.node)
+            self._add_to_load_queue(event.node)
         else:
             self.post_message(self.FileSelected(event.node, dir_entry.path))
 

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -271,6 +271,7 @@ class DirectoryTree(Tree[DirEntry]):
             node: The Tree node to populate.
             content: The collection of `Path` objects to populate the node with.
         """
+        node.remove_children()
         for path in content:
             node.add(
                 path.name,


### PR DESCRIPTION
See #2659 and https://github.com/Textualize/frogmouth/issues/50 for context. To recap those two issues here: it's possible to get the local filesystem browser in Frogmouth to double up the entries in its `root` node. Annoyingly though it's proving impossible to recreate in a sensible way by hand, and even harder to recreate as a standalone reproducible example.

I strongly suspect that the issue does come down to one or both of these tweaks, even if I can't find a route in to forcing a reproduction.

Meanwhile though this PR does include one sensible fix, and one "let's just be *really* sure" safety measure.