### PR TITLE
[WIP] widgets: new "TextArea" widget

### DIFF
--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -37,6 +37,7 @@ if typing.TYPE_CHECKING:
     from ._text_log import TextLog
     from ._tree import Tree
     from ._welcome import Welcome
+    from ._text_area import TextArea
 
 
 __all__ = [
@@ -70,6 +71,7 @@ __all__ = [
     "TextLog",
     "Tree",
     "Welcome",
+    "TextArea",
 ]
 
 _WIDGETS_LAZY_LOADING_CACHE: dict[str, type[Widget]] = {}

--- a/src/textual/widgets/__init__.pyi
+++ b/src/textual/widgets/__init__.pyi
@@ -29,3 +29,4 @@ from ._tabs import Tabs as Tabs
 from ._text_log import TextLog as TextLog
 from ._tree import Tree as Tree
 from ._welcome import Welcome as Welcome
+from ._text_area import TextArea as TextArea

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -285,7 +285,7 @@ class TextArea(ScrollView, can_focus=True):
             text: New text to insert.
         """
         self._buffer.insert(self.cursor_offset, text)
-        self.action_cursor_right()
+        self.cursor_x += len(text)
 
     async def _on_key(self, event: events.Key) -> None:
         # Do key bindings first

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -112,7 +112,7 @@ class _TextAreaRenderable:
             return
         self.textarea.styles.background = bgcolor.name
 
-# FIXME: cursor jumping between odd lines (in terms of length)
+
 # TODO: document code :)
 # TODO: possibility to pass `pygments.lexer.Lexer` with "lexer"
 # TODO: possibility to pass the theme for syntax highlighting
@@ -156,6 +156,15 @@ class TextArea(ScrollView, can_focus=True):
     def compute_cursor_offset(self) -> Offset:
         return Offset(self.cursor_x, self.cursor_y)
 
+    def watch_cursor_offset(
+        self, previous_cursor_offset: Offset, cursor_offset: Offset
+    ) -> None:
+        previous_cursor_x, _ = previous_cursor_offset
+        _, cursor_y = cursor_offset
+        line_length = self._buffer.get_line_length(cursor_y)
+        if previous_cursor_x > line_length:
+            self.cursor_x = line_length
+
     def validate_cursor_x(self, cursor_x: int) -> int:
         if cursor_x < 0:
             return 0
@@ -191,7 +200,6 @@ class TextArea(ScrollView, can_focus=True):
             self.action_cursor_up()
             self.cursor_x = above_line_length
             return
-
         if self.cursor_x:
             self.action_cursor_left()
             self._buffer.remove_char(self.cursor_offset)

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import os
+from typing import ClassVar, FrozenSet, List, Tuple, Union
+
+from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+from rich.segment import Segment
+from rich.style import Style
+from rich.syntax import DEFAULT_THEME, Syntax
+
+from .. import events
+from .._segment_tools import line_crop
+from ..binding import Binding, BindingType
+from ..geometry import Offset, Size
+from ..reactive import reactive
+from ..scroll_view import ScrollView
+
+
+class _Buffer:
+    def __init__(self) -> None:
+        self._lines = [[]]
+
+    def get_line_length(self, y: int) -> int:
+        return len(self._lines[y])
+
+    @property
+    def max_y(self) -> int:
+        return len(self._lines)
+
+    @property
+    def max_x(self) -> int:
+        if not self.max_y:
+            return 0
+        return max(len(line) for line in self._lines)
+
+    @property
+    def max_xy(self) -> Tuple[int, int]:
+        return (self.max_x, self.max_y)
+
+    def write(self, cursor_pad_at_lines: Union[FrozenSet[int], None] = None) -> str:
+        lines: List[str] = []
+        has_cursor_pads = cursor_pad_at_lines is not None
+        for index, line in enumerate(self._lines):
+            line = "".join(line)
+            if has_cursor_pads and index in cursor_pad_at_lines:
+                line += " "
+            lines.append(line)
+        return os.linesep.join(lines)
+
+    def insert(self, position: Offset, text: str) -> None:
+        x, y = position
+        if text == os.linesep:
+            line = self._lines[y][x:]
+            self._lines.insert(y + 1, line)
+            del self._lines[y][x:]
+            return
+        self._lines[y].insert(x, text)
+
+    def remove_char(self, position: Offset) -> None:
+        x, y = position
+        del self._lines[y][x]
+
+    def remove_linebreak(self, y: int) -> None:
+        line = self._lines[y]
+        self._lines[y - 1] += line
+        del self._lines[y]
+
+
+class _TextAreaRenderable:
+    """Render the TextArea content"""
+
+    def __init__(self, textarea: TextArea) -> None:
+        self.textarea = textarea
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        textarea = self.textarea
+
+        options.max_width = textarea._buffer.max_x + 1
+        options.height = textarea._buffer.max_y
+
+        lines_with_cursors = frozenset({textarea.cursor_offset.y})
+        written_buffer = textarea._buffer.write(lines_with_cursors)
+        syntax = Syntax(written_buffer, "python")
+        cursor_style = self.textarea.get_component_rich_style("textarea--cursor")
+
+        self._set_background(syntax)
+        self._set_cursor(textarea.cursor_offset, syntax, cursor_style)
+
+        scroll_x, scroll_y = textarea.scroll_offset
+        lines = console.render_lines(syntax, options)
+        lines = lines[scroll_y:]
+        for line in lines:
+            line = line_crop(
+                line,
+                scroll_x,
+                scroll_x + textarea.size.width,
+                Segment.get_line_length(line),
+            )
+            line.append(Segment.line())
+            yield from line
+
+    def _set_cursor(self, position: Offset, syntax: Syntax, style: Style) -> None:
+        x, y = position
+        y += 1
+        syntax.stylize_range(style, (y, x), (y, x + 1))
+
+    def _set_background(self, syntax: Syntax) -> None:
+        bgcolor = syntax.get_theme(DEFAULT_THEME).get_background_style().bgcolor
+        if bgcolor is None:
+            return
+        self.textarea.styles.background = bgcolor.name
+
+
+# FIXME: cursor jumping between odd lines (in terms of length)
+# TODO: implement tab (\t) support
+class TextArea(ScrollView, can_focus=True):
+    BINDINGS: ClassVar[List[BindingType]] = [
+        Binding("left", "cursor_left", "cursor left"),
+        Binding("right", "cursor_right", "cursor right"),
+        Binding("up", "cursor_up", "cursor up"),
+        Binding("down", "cursor_down", "cursor down"),
+        Binding("backspace", "remove_left", "remove left"),
+        Binding("enter", "insert_linebreak_at_cursor", "insert linebreak"),
+    ]
+
+    COMPONENT_CLASSES: ClassVar[set[str]] = {"textarea--cursor"}
+
+    DEFAULT_CSS = """
+    TextArea>.textarea--cursor {
+        background: white;
+        color: black;
+    }
+    """
+    cursor_offset: reactive[Offset] = reactive(Offset(0, 0))
+    cursor_x: reactive[int] = reactive(0)
+    cursor_y: reactive[int] = reactive(0)
+
+    def __init__(self) -> None:
+        self._buffer = _Buffer()
+        super().__init__()
+
+    def compute_cursor_offset(self) -> Offset:
+        return Offset(self.cursor_x, self.cursor_y)
+
+    def validate_cursor_x(self, cursor_x: int) -> int:
+        if cursor_x < 0:
+            return 0
+        line_length = self._buffer.get_line_length(self.cursor_y)
+        if cursor_x > line_length:
+            return line_length
+        return cursor_x
+
+    def validate_cursor_y(self, cursor_y: int) -> int:
+        if cursor_y < 0:
+            return 0
+        last_line = self._buffer.max_y - 1
+        if cursor_y > last_line:
+            return last_line
+        return cursor_y
+
+    def action_cursor_left(self) -> None:
+        self.cursor_x -= 1
+
+    def action_cursor_right(self) -> None:
+        self.cursor_x += 1
+
+    def action_cursor_up(self) -> None:
+        self.cursor_y -= 1
+
+    def action_cursor_down(self) -> None:
+        self.cursor_y += 1
+
+    def action_remove_left(self) -> None:
+        if not self.cursor_x and self.cursor_y:
+            above_line_length = self._buffer.get_line_length(self.cursor_y - 1)
+            self._buffer.remove_linebreak(self.cursor_y)
+            self.action_cursor_up()
+            self.cursor_x = above_line_length
+            return
+
+        if self.cursor_x:
+            self.action_cursor_left()
+            self._buffer.remove_char(self.cursor_offset)
+
+    def action_insert_linebreak_at_cursor(self) -> None:
+        self._buffer.insert(self.cursor_offset, os.linesep)
+        self.action_cursor_down()
+        self.cursor_x = 0
+
+    def render(self) -> RenderableType:
+        max_x, max_y = self._buffer.max_xy
+        self.virtual_size = Size(max_x, max_y)
+        return _TextAreaRenderable(self)
+
+    def insert_text_at_cursor(self, text: str) -> None:
+        self._buffer.insert(self.cursor_offset, text)
+        self.action_cursor_right()
+
+    async def _on_key(self, event: events.Key) -> None:
+        # Do key bindings first
+        if await self.handle_key(event):
+            event.prevent_default()
+            event.stop()
+            return
+        if event.is_printable:
+            event.stop()
+            assert event.character is not None
+            self.insert_text_at_cursor(event.character)
+            event.prevent_default()

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -121,19 +121,13 @@ class _TextAreaRenderable:
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        def set_cursor(position: Offset, syntax: Syntax, style: Style):
-            x, y = position
-            y += 1
-            syntax.stylize_range(style, (y, x), (y, x + 1))
-
         textarea = self.textarea
         lines_with_cursors = frozenset({textarea.cursor_offset.y})
         written_buffer = textarea._buffer.write(lines_with_cursors)
         syntax = Syntax(written_buffer, textarea._lexer)
-        cursor_style = self.textarea.get_component_rich_style("textarea--cursor")
 
         self._set_background(syntax)
-        set_cursor(textarea.cursor_offset, syntax, cursor_style)
+        self._set_cursor(textarea.cursor_offset, syntax)
 
         options.max_width = textarea._buffer.max_x + 1
         options.height = textarea._buffer.max_y
@@ -156,6 +150,12 @@ class _TextAreaRenderable:
         if bgcolor is None:
             return
         self.textarea.styles.background = bgcolor.name
+
+    def _set_cursor(self, position: Offset, syntax: Syntax):
+        x, y = position
+        y += 1
+        cursor_style = self.textarea.get_component_rich_style("textarea--cursor")
+        syntax.stylize_range(cursor_style, (y, x), (y, x + 1))
 
 
 # TODO: document code

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -105,7 +105,7 @@ class _Buffer:
 
     def delete_linebreak(self, y: int) -> None:
         """
-        Merge into the line at y above and delete the line at y.
+        Merge line at y into the line at y above and delete the line at y.
 
         Args:
             y: The line number.

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -158,7 +158,8 @@ class _TextAreaRenderable:
         self.textarea.styles.background = bgcolor.name
 
 
-# TODO: document code :)
+# TODO: document code
+# TODO: write tests
 # TODO: possibility to pass `pygments.lexer.Lexer` with "lexer" argument
 # TODO: possibility to pass the theme for syntax highlighting
 # TODO: implement tab (\t) support

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -82,7 +82,7 @@ class _TextAreaRenderable:
 
         lines_with_cursors = frozenset({textarea.cursor_offset.y})
         written_buffer = textarea._buffer.write(lines_with_cursors)
-        syntax = Syntax(written_buffer, "python")
+        syntax = Syntax(written_buffer, textarea._lexer)
         cursor_style = self.textarea.get_component_rich_style("textarea--cursor")
 
         self._set_background(syntax)
@@ -133,13 +133,22 @@ class TextArea(ScrollView, can_focus=True):
         color: black;
     }
     """
+
     cursor_offset: reactive[Offset] = reactive(Offset(0, 0))
     cursor_x: reactive[int] = reactive(0)
     cursor_y: reactive[int] = reactive(0)
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        lexer: str | None = None,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        self._lexer = lexer or ""
         self._buffer = _Buffer()
-        super().__init__()
+        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
 
     def compute_cursor_offset(self) -> Offset:
         return Offset(self.cursor_x, self.cursor_y)

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -194,6 +194,7 @@ class TextArea(ScrollView, can_focus=True):
         self.cursor_y += 1
 
     def action_remove_left(self) -> None:
+        # TODO: refactor of removing linebreak into "watch_cursor_offset"?
         if not self.cursor_x and self.cursor_y:
             above_line_length = self._buffer.get_line_length(self.cursor_y - 1)
             self._buffer.remove_linebreak(self.cursor_y)

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -5,7 +5,6 @@ from typing import ClassVar, FrozenSet, List, Tuple, Union
 
 from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
 from rich.segment import Segment
-from rich.style import Style
 from rich.syntax import DEFAULT_THEME, Syntax
 
 from .. import events

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -112,9 +112,11 @@ class _TextAreaRenderable:
             return
         self.textarea.styles.background = bgcolor.name
 
-
 # FIXME: cursor jumping between odd lines (in terms of length)
+# TODO: possibility to pass `pygments.lexer.Lexer` with "lexer"
+# TODO: possibility to pass the theme for syntax highlighting
 # TODO: implement tab (\t) support
+# TODO: implement multiple cursors
 class TextArea(ScrollView, can_focus=True):
     BINDINGS: ClassVar[List[BindingType]] = [
         Binding("left", "cursor_left", "cursor left"),

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -157,7 +157,6 @@ class _TextAreaRenderable:
         syntax.stylize_range(cursor_style, (y, x), (y, x + 1))
 
 
-# TODO: document code
 # TODO: write tests
 # TODO: possibility to pass `pygments.lexer.Lexer` with "lexer" argument
 # TODO: possibility to pass the theme for syntax highlighting

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -53,6 +53,10 @@ class _Buffer:
 
     @property
     def max_xy(self) -> Tuple[int, int]:
+        """
+        Returns:
+            Length of the longest line and number of the lines (max_x, max_y)
+        """
         return (self.max_x, self.max_y)
 
     def write(self, cursor_pad_at_lines: Union[FrozenSet[int], None] = None) -> str:

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -17,18 +17,37 @@ from ..scroll_view import ScrollView
 
 
 class _Buffer:
+    """
+    A buffer.
+    """
+
     def __init__(self) -> None:
         self._lines = [[]]
 
     def get_line_length(self, y: int) -> int:
+        """
+        Args:
+            y: The line number.
+
+        Returns:
+            Length of line at y.
+        """
         return len(self._lines[y])
 
     @property
     def max_y(self) -> int:
+        """
+        Returns:
+            Number of the lines.
+        """
         return len(self._lines)
 
     @property
     def max_x(self) -> int:
+        """
+        Returns:
+            Length of the longest line.
+        """
         if not self.max_y:
             return 0
         return max(len(line) for line in self._lines)
@@ -38,7 +57,16 @@ class _Buffer:
         return (self.max_x, self.max_y)
 
     def write(self, cursor_pad_at_lines: Union[FrozenSet[int], None] = None) -> str:
-        lines: List[str] = []
+        """
+        Write out the buffer.
+
+        Args:
+            cursor_pad_at_lines: Cursor pad at line numbers.
+
+        Returns:
+            The written buffer
+        """
+        lines = []
         has_cursor_pads = cursor_pad_at_lines is not None
         for index, line in enumerate(self._lines):
             line = "".join(line)
@@ -48,6 +76,12 @@ class _Buffer:
         return os.linesep.join(lines)
 
     def insert(self, position: Offset, text: str) -> None:
+        """
+        Insert the text at position.
+
+        Args:
+            text: New text to insert.
+        """
         x, y = position
         if text == os.linesep:
             line = self._lines[y][x:]
@@ -56,11 +90,23 @@ class _Buffer:
             return
         self._lines[y].insert(x, text)
 
-    def remove_char(self, position: Offset) -> None:
+    def delete_char(self, position: Offset) -> None:
+        """
+        Delete the character at position.
+
+        Args:
+            position: Position of the charcater
+        """
         x, y = position
         del self._lines[y][x]
 
-    def remove_linebreak(self, y: int) -> None:
+    def delete_linebreak(self, y: int) -> None:
+        """
+        Merge into the line at y above and delete the line at y.
+
+        Args:
+            y: The line number.
+        """
         line = self._lines[y]
         self._lines[y - 1] += line
         del self._lines[y]
@@ -75,21 +121,25 @@ class _TextAreaRenderable:
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
+        def set_cursor(position: Offset, syntax: Syntax, style: Style):
+            x, y = position
+            y += 1
+            syntax.stylize_range(style, (y, x), (y, x + 1))
+
         textarea = self.textarea
-
-        options.max_width = textarea._buffer.max_x + 1
-        options.height = textarea._buffer.max_y
-
         lines_with_cursors = frozenset({textarea.cursor_offset.y})
         written_buffer = textarea._buffer.write(lines_with_cursors)
         syntax = Syntax(written_buffer, textarea._lexer)
         cursor_style = self.textarea.get_component_rich_style("textarea--cursor")
 
         self._set_background(syntax)
-        self._set_cursor(textarea.cursor_offset, syntax, cursor_style)
+        set_cursor(textarea.cursor_offset, syntax, cursor_style)
 
-        scroll_x, scroll_y = textarea.scroll_offset
+        options.max_width = textarea._buffer.max_x + 1
+        options.height = textarea._buffer.max_y
+
         lines = console.render_lines(syntax, options)
+        scroll_x, scroll_y = textarea.scroll_offset
         lines = lines[scroll_y:]
         for line in lines:
             line = line_crop(
@@ -101,11 +151,6 @@ class _TextAreaRenderable:
             line.append(Segment.line())
             yield from line
 
-    def _set_cursor(self, position: Offset, syntax: Syntax, style: Style) -> None:
-        x, y = position
-        y += 1
-        syntax.stylize_range(style, (y, x), (y, x + 1))
-
     def _set_background(self, syntax: Syntax) -> None:
         bgcolor = syntax.get_theme(DEFAULT_THEME).get_background_style().bgcolor
         if bgcolor is None:
@@ -114,21 +159,40 @@ class _TextAreaRenderable:
 
 
 # TODO: document code :)
-# TODO: possibility to pass `pygments.lexer.Lexer` with "lexer"
+# TODO: possibility to pass `pygments.lexer.Lexer` with "lexer" argument
 # TODO: possibility to pass the theme for syntax highlighting
 # TODO: implement tab (\t) support
 # TODO: implement multiple cursors
 class TextArea(ScrollView, can_focus=True):
+    """
+    A multi-line input widget.
+    """
+
     BINDINGS: ClassVar[List[BindingType]] = [
         Binding("left", "cursor_left", "cursor left"),
         Binding("right", "cursor_right", "cursor right"),
         Binding("up", "cursor_up", "cursor up"),
         Binding("down", "cursor_down", "cursor down"),
-        Binding("backspace", "remove_left", "remove left"),
+        Binding("backspace", "delete_left", "delete left"),
         Binding("enter", "insert_linebreak_at_cursor", "insert linebreak"),
     ]
+    """
+    | Key(s) | Description |
+    | :- | :- |
+    | left | Move the cursor one character left. |
+    | right | Move the cursor one character right. |
+    | up | Move the cursor one line up. |
+    | down | Move the cursor one line down. |
+    | backspace | Delete the character to the left of the cursor. |
+    | enter | Do a linebreak. |
+    """
 
     COMPONENT_CLASSES: ClassVar[set[str]] = {"textarea--cursor"}
+    """
+    | Class | Description |
+    | :- | :- |
+    | `textarea--cursor` | Target the cursor. |
+    """
 
     DEFAULT_CSS = """
     TextArea>.textarea--cursor {
@@ -193,17 +257,16 @@ class TextArea(ScrollView, can_focus=True):
     def action_cursor_down(self) -> None:
         self.cursor_y += 1
 
-    def action_remove_left(self) -> None:
-        # TODO: refactor of removing linebreak into "watch_cursor_offset"?
+    def action_delete_left(self) -> None:
         if not self.cursor_x and self.cursor_y:
             above_line_length = self._buffer.get_line_length(self.cursor_y - 1)
-            self._buffer.remove_linebreak(self.cursor_y)
+            self._buffer.delete_linebreak(self.cursor_y)
             self.action_cursor_up()
             self.cursor_x = above_line_length
             return
         if self.cursor_x:
             self.action_cursor_left()
-            self._buffer.remove_char(self.cursor_offset)
+            self._buffer.delete_char(self.cursor_offset)
 
     def action_insert_linebreak_at_cursor(self) -> None:
         self._buffer.insert(self.cursor_offset, os.linesep)

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -279,6 +279,11 @@ class TextArea(ScrollView, can_focus=True):
         return _TextAreaRenderable(self)
 
     def insert_text_at_cursor(self, text: str) -> None:
+        """Insert new text at the cursor, move the cursor to the end of the new text.
+
+        Args:
+            text: New text to insert.
+        """
         self._buffer.insert(self.cursor_offset, text)
         self.action_cursor_right()
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -113,6 +113,7 @@ class _TextAreaRenderable:
         self.textarea.styles.background = bgcolor.name
 
 # FIXME: cursor jumping between odd lines (in terms of length)
+# TODO: document code :)
 # TODO: possibility to pass `pygments.lexer.Lexer` with "lexer"
 # TODO: possibility to pass the theme for syntax highlighting
 # TODO: implement tab (\t) support


### PR DESCRIPTION
**Note:**
- the following widget is still in the early stages of development and is **far** from being ready for production
- feel free to request/make changes to improve the code.

### Description
Compared to the "Input" widget, the "TextArea" widget makes it possible to edit text on multiple lines.

So far the widget offers:
- a cursor that can be moved vertically and horizontally
- the insertion of characters (including line breaks)
- character deletion (including line breaks)
- syntax highlighting using `Syntax` from `rich.syntax`.
- horizontal and vertical scrolling when the text goes out of the bounds of the screen

here a [demo](https://discord.com/channels/1026214085173461072/1033752599112994867/1110264382421745745) :slightly_smiling_face: 