### PR TITLE
Revisit allowing building the docs without access to "Material for MkDocs Insiders"

### DIFF
--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -67,9 +67,6 @@ plugins:
     default_handler: python
     handlers:
       python:
-        import:
-          - https://docs.python.org/3/objects.inv
-          - https://rich.readthedocs.io/en/stable/objects.inv
         options:
           show_signature_annotations: false
           separate_signature: true

--- a/mkdocs-offline.yml
+++ b/mkdocs-offline.yml
@@ -2,7 +2,6 @@ INHERIT: mkdocs-common.yml
 
 plugins:
   offline:
-  privacy:
   exclude:
     glob:
       - "**/_template.md"

--- a/mkdocs-online.yml
+++ b/mkdocs-online.yml
@@ -14,3 +14,9 @@ plugins:
       - categories
       - release
       - tags
+  mkdocstrings:
+    handlers:
+      python:
+        import:
+          - https://docs.python.org/3/objects.inv
+          - https://rich.readthedocs.io/en/stable/objects.inv


### PR DESCRIPTION
This is a follow-on PR from #1726, which aimed to satisfy #631. Since that PR #2629 and #2639 have arisen; likely the same issue, or at least massively-overlapping.

The main changes in this PR include:

- Removal of [the `privacy` plugin](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#built-in-privacy-plugin), which is only available to "Insiders". Without this change anyone wishing to build the Textual documentation for themselves would have to be a "Material for MkDocs Insider".
- Removal of interlinking to the Python and Rich documentation for Python and Rich types from the common configuration, placing it instead in the "online" configuration. The downloading of the `.inv` files would result in an error when building the documentation while offline so this solves that.

With #2629 in mind specifically: we may want to have a think about what "building from scratch" means and who we have in mind when we say this. For the Textualize team, with access the "Insiders", this should never be a problem as long as the correct "Material for MkDocs" setup is in place; if that's the case then `make docs-serve` should work out of the box.

For people downloading the Textual source and wanting to build or work on the docs, they will need to use the `offline` targets in the `Makefile`. At the moment this isn't especially obvious so as a subsequent bit of work to this PR, perhaps there's some things to think about:

- Perhaps building in a non-Textualize context should be the default?
- Perhaps there should be a "How To" document that's about how to get a development environment up and running, including how to locally build or locally serve the documentation?
- Both?

Meanwhile though, with this PR in place, as long as someone uses either `make docs-serve-offline` or `make docs-build-offline`, they should be able to work with the docs.

**NOTE:** The privacy plugin was originally used to reduce the number of external resources used by the documentation (fonts and, I think, some stylesheets). With it removed those external resources of course remain external. This means that if someone builds the offline docs and then actually uses them offline, there will be a degraded experience, mainly relating to the fonts used in diagrams and screenshots.

Here's some examples of the offline docs being viewed without an Internet connection:

<img width="1337" alt="Screenshot 2023-05-29 at 08 35 45" src="https://github.com/Textualize/textual/assets/28237/04d2b377-e143-432b-bb4b-e1345649a438">

<img width="1337" alt="Screenshot 2023-05-29 at 08 36 51" src="https://github.com/Textualize/textual/assets/28237/3df9738b-5fbb-4176-b627-d3a1265d2aa9">

<img width="1337" alt="Screenshot 2023-05-29 at 08 36 27" src="https://github.com/Textualize/textual/assets/28237/41cd620a-e4d7-4e52-b3b8-7f7269dad64c">
