### PR TITLE
Ensure reflow reflows non-visible widgets, fix scroll_to_center issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed zero division error https://github.com/Textualize/textual/issues/2673
+- Fix `scroll_to_center` when there were nested layers out of view (Compositor full_map not populated fully) https://github.com/Textualize/textual/pull/2684
 
 ### Added
 

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -266,7 +266,6 @@ class Compositor:
 
     def __init__(self) -> None:
         # A mapping of Widget on to its "render location" (absolute position / depth)
-
         self._full_map: CompositorMap = {}
         self._full_map_invalidated = True
         self._visible_map: CompositorMap | None = None
@@ -358,7 +357,7 @@ class Compositor:
         old_map = self._full_map
         old_widgets = old_map.keys()
 
-        map, widgets = self._arrange_root(parent, size)
+        map, widgets = self._arrange_root(parent, size, visible_only=False)
 
         new_widgets = map.keys()
 
@@ -1021,11 +1020,12 @@ class Compositor:
         return StripRenderable(self.render_strips())
 
     def update_widgets(self, widgets: set[Widget]) -> None:
-        """Update a given widget in the composition.
+        """Update the given widgets in the composition.
 
         Args:
             widgets: Set of Widgets to update.
         """
+
         # If there are any *new* widgets we need to invalidate the full map
         if not self._full_map_invalidated and not widgets.issubset(
             self.visible_widgets.keys()

--- a/tests/snapshot_tests/snapshot_apps/scroll_to_center.py
+++ b/tests/snapshot_tests/snapshot_apps/scroll_to_center.py
@@ -5,32 +5,33 @@ from textual.widgets import Label
 
 class MyApp(App[None]):
     CSS = """
-    VerticalScroll, HorizontalScroll {
+    VerticalScroll {
         border: round $primary;
     }
     #vertical {
         height: 21;
     }
     HorizontalScroll {
+        border: round $secondary;
         height: auto;
+    }
+    Label {
+        height: auto;
+        width: auto;
     }
     """
 
     def compose(self) -> ComposeResult:
-        with VerticalScroll():
-            yield Label(("SPAM\n" * 205)[:-1])
-            with VerticalScroll():
-                yield Label(("SPAM\n" * 53)[:-1])
-                with VerticalScroll(id="vertical"):
-                    yield Label(("SPAM\n" * 78)[:-1])
-                    with HorizontalScroll():
-                        yield Label(("v\n" * 17)[:-1])
-                        yield Label("@" * 302)
-                        yield Label("[red]>>bullseye<<[/red]", id="bullseye")
-                        yield Label("@" * 99)
-                    yield Label(("SPAM\n" * 49)[:-1])
-                yield Label(("SPAM\n" * 51)[:-1])
-            yield Label(("SPAM\n" * 59)[:-1])
+        yield Label(("SPAM\n" * 53)[:-1])
+        with VerticalScroll(id="vertical"):
+            yield Label(("SPAM\n" * 78)[:-1])
+            with HorizontalScroll():
+                yield Label(("v\n" * 17)[:-1])
+                yield Label("@" * 302)
+                yield Label("[red]>>bullseye<<[/red]", id="bullseye")
+                yield Label("@" * 99)
+            yield Label(("SPAM\n" * 49)[:-1])
+        yield Label(("SPAM\n" * 51)[:-1])
 
     def key_s(self) -> None:
         self.screen.scroll_to_center(self.query_one("#bullseye"))

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -518,9 +518,6 @@ def test_scroll_visible(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "scroll_visible.py", press=["t"])
 
 
-@pytest.mark.xfail(
-    reason="Unpredictable while https://github.com/Textualize/textual/issues/2254 is open."
-)
 def test_scroll_to_center(snap_compare):
     # READ THIS IF THIS TEST FAILS:
     # While https://github.com/Textualize/textual/issues/2254 is open, the snapshot


### PR DESCRIPTION
Closes #2268 
Closes #2254 

When `reflow` was called, we were only reflowing visible widgets. This was preventing widgets that were not visible from being added into `full_map`.

`reflow_visible` was explicitly passing `visible_only=True` to `arrange_root`, but that was actually already the default value. `reflow` was not passing `visible_only` at all, so it was defaulting to `True`.

This broke `scroll_to_center`, because widgets that were scrolled out of view were not present in the compositors full map.

With this change, the `_full_map` is now fully populated by `reflow`, and `scroll_to_center` works as expected.

<img width="846" alt="image" src="https://github.com/Textualize/textual/assets/5740731/9b1e59f7-dc3b-450b-b63b-d1bf14f2603d">

I've removed the `xfail` the `scroll_to_center` snapshot test and it seems to pass consistently now.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
