### PR TITLE
Fix _compositor.reflow() hidden_widgets

### DIFF
--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -361,6 +361,11 @@ class Compositor:
 
         new_widgets = map.keys()
 
+        # Newly visible widgets
+        shown_widgets = new_widgets - old_widgets
+        # Newly hidden widgets
+        hidden_widgets = self.widgets - widgets
+
         # Replace map and widgets
         self._full_map = map
         self.widgets = widgets
@@ -389,10 +394,7 @@ class Compositor:
             for widget, (region, *_) in changes
             if (widget in common_widgets and old_map[widget].region[2:] != region[2:])
         }
-        # Newly visible widgets
-        shown_widgets = new_widgets - old_widgets
-        # Newly hidden widgets
-        hidden_widgets = self.widgets - widgets
+
         return ReflowResult(
             hidden=hidden_widgets,
             shown=shown_widgets,


### PR DESCRIPTION
I think this fixes #2574.

It looks like `hidden_widgets = self.widgets - widgets` was moved to _after_ `self.widgets = widgets` in https://github.com/Textualize/textual/commit/11d10db1ab9cc723a5f12bf333d22f9b00d5e9a3#diff-3680fc293baa11cb6d4fd3f21fe9b3b0c16c36131ce36524349c1c00e2a85ca2L267-L271, so I just moved it and `shown_widgets` back.