### PR TITLE
Extend the `@on` decorator so that it will match superclasses

### DIFF
--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -138,7 +138,7 @@ class Mount(Event, bubble=False, verbose=False):
     """
 
 
-class Unmount(Mount, bubble=False, verbose=False):
+class Unmount(Event, bubble=False, verbose=False):
     """Sent when a widget is unmounted and may not longer receive messages.
 
     - [ ] Bubbles

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -578,15 +578,16 @@ class MessagePump(metaclass=_MessagePumpMeta):
             # Try decorated handlers first
             decorated_handlers = cls.__dict__.get("_decorated_handlers")
             if decorated_handlers is not None:
-                handlers = []
+                handlers: list[tuple[Callable, dict[str, tuple[SelectorSet, ...]]]] = []
                 add_handlers = handlers.extend
                 # Allow for firing of handlers bound to a message higher up
                 # the inheritance tree.
                 for check_message in type(message).__mro__:
-                    add_handlers(decorated_handlers.get(check_message, []))
-                    # If we've hit message, that's far enough.
-                    if check_message == Message:
+                    # If we've hit something that isn't derived from Message
+                    # we can give up.
+                    if not issubclass(check_message, Message):
                         break
+                    add_handlers(decorated_handlers.get(check_message, []))
                 from .widget import Widget
 
                 for method, selectors in handlers:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -582,7 +582,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 add_handlers = handlers.extend
                 # Allow for firing of handlers bound to a message higher up
                 # the inheritance tree.
-                for check_message in type(message).__mro__:
+                for check_message in message.__class__.__mro__:
                     # If we've hit something that isn't derived from Message
                     # we can give up.
                     if not issubclass(check_message, Message):

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -578,7 +578,15 @@ class MessagePump(metaclass=_MessagePumpMeta):
             # Try decorated handlers first
             decorated_handlers = cls.__dict__.get("_decorated_handlers")
             if decorated_handlers is not None:
-                handlers = decorated_handlers.get(type(message), [])
+                handlers = []
+                add_handlers = handlers.extend
+                # Allow for firing of handlers bound to a message higher up
+                # the inheritance tree.
+                for check_message in type(message).__mro__:
+                    add_handlers(decorated_handlers.get(check_message, []))
+                    # If we've hit message, that's far enough.
+                    if check_message == Message:
+                        break
                 from .widget import Widget
 
                 for method, selectors in handlers:

--- a/tests/selection_list/test_selection_messages.py
+++ b/tests/selection_list/test_selection_messages.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from textual import on
 from textual.app import App, ComposeResult
-from textual.messages import Message
 from textual.widgets import OptionList, SelectionList
 
 
@@ -24,12 +23,15 @@ class SelectionListApp(App[None]):
     def compose(self) -> ComposeResult:
         yield SelectionList[int](*[(str(n), n) for n in range(10)])
 
-    @on(OptionList.OptionHighlighted)
-    @on(OptionList.OptionSelected)
-    @on(SelectionList.SelectionHighlighted)
-    @on(SelectionList.SelectionToggled)
+    @on(OptionList.OptionMessage)
+    @on(SelectionList.SelectionMessage)
     @on(SelectionList.SelectedChanged)
-    def _record(self, event: Message) -> None:
+    def _record(
+        self,
+        event: OptionList.OptionMessage
+        | SelectionList.SelectionMessage
+        | SelectionList.SelectedChanged,
+    ) -> None:
         assert event.control == self.query_one(SelectionList)
         self.messages.append(
             (

--- a/tests/test_on.py
+++ b/tests/test_on.py
@@ -145,7 +145,7 @@ async def test_on_arbitrary_attributes() -> None:
     assert log == ["one", "two"]
 
 
-async def test_fire_on_inherited_message():
+async def test_fire_on_inherited_message() -> None:
     """Handlers should fire when descendant messages are posted."""
 
     posted: list[str] = []


### PR DESCRIPTION
This PR seeks to implement the requirement laid out in #2630. In short, the idea is that the the `@on` decorator should match a given message and any message that inherits from it. To borrow from the issue this stems from, it means that this sort of hierarchy:

```python
class PersonChanged(Message):
    ...

class PersonAdded(PersonChanged):
    ...

class PersonEdited(PersonChanged):
    ...

class PersonRemoved(PersonChanged):
    ...
```

no longer needs something like this:

```python
@on(PersonAdded)
@on(PersonEdited)
@on(PersonRemoved)
def person_changed(self, event ):
    ...
```

but can be handles something like this:

```python
@on(PersonChanged)
def person_changed(self, event ):
    ...
```

---
One other small change included in this PR is to `events.Unmount`, which used to inherit from `events.Mount`; as of this PR it inherits from `events.Event`; just like all other events. The point of this change being that a developer van safely `@on(Mount)` without needing to handle fact that `events.Unmount` would trigger the handler too.