### PR TITLE
Improve `OptionList` test coverage

### DIFF
--- a/tests/option_list/test_option_list_mouse_hover.py
+++ b/tests/option_list/test_option_list_mouse_hover.py
@@ -13,7 +13,9 @@ class OptionListApp(App[None]):
 
     def compose(self) -> ComposeResult:
         yield Label("Something else to hover over")
-        yield OptionList(*[Option(str(n), id=str(n)) for n in range(10)])
+        yield OptionList(
+            *[Option(str(n), id=str(n), disabled=n == 3) for n in range(10)]
+        )
 
 
 async def test_no_hover() -> None:
@@ -38,6 +40,18 @@ async def test_hover_no_highlight() -> None:
         await pilot.hover(OptionList, Offset(1, 1))
         option_list = pilot.app.query_one(OptionList)
         assert option_list._mouse_hovering_over == 1
+        assert option_list._mouse_hovering_over != option_list.highlighted
+
+
+async def test_hover_disabled() -> None:
+    """The mouse hover value should react to the mouse hover over a disabled option."""
+    async with OptionListApp().run_test() as pilot:
+        await pilot.hover(OptionList, Offset(1, 3))
+        option_list = pilot.app.query_one(OptionList)
+        assert option_list._mouse_hovering_over == 3
+        assert option_list.get_option_at_index(
+            option_list._mouse_hovering_over
+        ).disabled
         assert option_list._mouse_hovering_over != option_list.highlighted
 
 

--- a/tests/option_list/test_option_messages.py
+++ b/tests/option_list/test_option_messages.py
@@ -20,6 +20,7 @@ class OptionListApp(App[None]):
 
     def _record(self, event: OptionList.OptionMessage) -> None:
         assert isinstance(event.option_id, str)
+        assert event.option_list is event.control
         self.messages.append(
             (event.__class__.__name__, event.option_id, event.option_index)
         )


### PR DESCRIPTION
~~Almost 100%, but that last line is going to need changes to `snap_compare` so that we can pilot/mouse things for snapshot tests.~~

Got this to 100% via a slightly different route/test. Sadly I can't get this to work via snapshot tests as it looks like `Pilot.hover` doesn't quite tickle `_mouse_move` in the way you'd expect.