### PR TITLE
Delete Reactive.var.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Keybinding <kbd>right</kbd> in `Input` is also used to accept a suggestion if the cursor is at the end of the input https://github.com/Textualize/textual/pull/2604
 - `Input.__init__` now accepts a `suggester` attribute for completion suggestions https://github.com/Textualize/textual/pull/2604
 - Using `switch_screen` to switch to the currently active screen is now a no-op https://github.com/Textualize/textual/pull/2692
+- Breaking change: removed `reactive.py::Reactive.var` in favor of `reactive.py::var` https://github.com/Textualize/textual/pull/2709/
 
 ### Removed
 
 - `Placeholder.reset_color_cycle`
 - Removed `Widget.reset_focus` (now called `Widget.blur`) https://github.com/Textualize/textual/issues/2642
-- Removed `reactive.py::Reactive.var` in favor of `reactive.py::var` https://github.com/Textualize/textual/pull/2709/
 
 ## [0.26.0] - 2023-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Placeholder.reset_color_cycle`
 - Removed `Widget.reset_focus` (now called `Widget.blur`) https://github.com/Textualize/textual/issues/2642
-
+- Removed `reactive.py::Reactive.var` in favor of `reactive.py::var` https://github.com/Textualize/textual/pull/2709/
 
 ## [0.26.0] - 2023-05-20
 

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -72,23 +72,6 @@ class Reactive(Generic[ReactiveType]):
         yield "always_update", self._always_update
         yield "compute", self._run_compute
 
-    @classmethod
-    def var(
-        cls,
-        default: ReactiveType | Callable[[], ReactiveType],
-        always_update: bool = False,
-    ) -> Reactive:
-        """A reactive variable that doesn't update or layout.
-
-        Args:
-            default: A default value or callable that returns a default.
-            always_update: Call watchers even when the new value equals the old value.
-
-        Returns:
-            A Reactive descriptor.
-        """
-        return cls(default, layout=False, repaint=False, init=False)
-
     def _initialize_reactive(self, obj: Reactable, name: str) -> None:
         """Initialized a reactive attribute on an object.
 


### PR DESCRIPTION
Closes #2706.

Deletes `Reactive.var` in favour of `var`.