### PR TITLE
Import `Sparkline` from a non-internal location

### DIFF
--- a/docs/examples/widgets/sparkline.py
+++ b/docs/examples/widgets/sparkline.py
@@ -2,7 +2,7 @@ import random
 from statistics import mean
 
 from textual.app import App, ComposeResult
-from textual.widgets._sparkline import Sparkline
+from textual.widgets import Sparkline
 
 random.seed(73)
 data = [random.expovariate(1 / 3) for _ in range(1000)]

--- a/docs/examples/widgets/sparkline_basic.py
+++ b/docs/examples/widgets/sparkline_basic.py
@@ -1,5 +1,5 @@
 from textual.app import App, ComposeResult
-from textual.widgets._sparkline import Sparkline
+from textual.widgets import Sparkline
 
 data = [1, 2, 2, 1, 1, 4, 3, 1, 1, 8, 8, 2]  # (1)!
 

--- a/docs/examples/widgets/sparkline_colors.py
+++ b/docs/examples/widgets/sparkline_colors.py
@@ -1,7 +1,7 @@
 from math import sin
 
 from textual.app import App, ComposeResult
-from textual.widgets._sparkline import Sparkline
+from textual.widgets import Sparkline
 
 
 class SparklineColorsApp(App[None]):


### PR DESCRIPTION
Updates the Sparkline examples within the documentation so that the `Sparkline` widget is imported in a way that developers working with Textual should.
