### PR TITLE
Fix the examples for the `ContentSwitcher` widget

### DIFF
--- a/docs/widgets/content_switcher.md
+++ b/docs/widgets/content_switcher.md
@@ -41,7 +41,7 @@ between the different views.
 
 When the user presses the "Markdown" button the view is switched:
 
-```{.textual path="docs/examples/widgets/content_switcher.py" lines="40" press="tab,tab,enter"}
+```{.textual path="docs/examples/widgets/content_switcher.py" lines="40" press="tab,enter"}
 ```
 
 ## Reactive Attributes


### PR DESCRIPTION
See #2718. The problem is that the work done on #2527 and related PRs has changed the starting position of focus, which means that any code example that has key presses in them that start out by tabbing to a control will be off by one.
