### PR TITLE
Fix various screenshots in the docs, broken by the addition of `AUTO_FOCUS`

### DIFF
--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -102,7 +102,7 @@ The following example shows how focus works in practice.
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/input/key03.py", press="tab,H,e,l,l,o,tab,W,o,r,l,d,!"}
+    ```{.textual path="docs/examples/guide/input/key03.py", press="H,e,l,l,o,tab,W,o,r,l,d,!"}
     ```
 
 The app splits the screen in to quarters, with a `TextLog` widget in each quarter. If you click any of the text logs, you should see that it is highlighted to show that the widget has focus. Key events will be sent to the focused widget only.

--- a/docs/guide/reactivity.md
+++ b/docs/guide/reactivity.md
@@ -87,7 +87,7 @@ Let's look at an example which illustrates this. In the following app, the value
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/reactivity/refresh01.py" press="tab,T,e,x,t,u,a,l"}
+    ```{.textual path="docs/examples/guide/reactivity/refresh01.py" press="T,e,x,t,u,a,l"}
     ```
 
 The `Name` widget has a reactive `who` attribute. When the app modifies that attribute, a refresh happens automatically.
@@ -131,7 +131,7 @@ The following example modifies "refresh01.py" so that the greeting has an automa
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/reactivity/refresh02.py" press="tab,n,a,m,e"}
+    ```{.textual path="docs/examples/guide/reactivity/refresh02.py" press="n,a,m,e"}
     ```
 
 If you type in to the input now, the greeting will expand to fit the content. If you were to set `layout=False` on the reactive attribute, you should see that the box remains the same size when you type.
@@ -191,7 +191,7 @@ The following app will display any color you type in to the input. Try it with a
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/reactivity/watch01.py" press="tab,d,a,r,k,o,r,c,h,i,d"}
+    ```{.textual path="docs/examples/guide/reactivity/watch01.py" press="d,a,r,k,o,r,c,h,i,d"}
     ```
 
 The color is parsed in `on_input_submitted` and assigned to `self.color`. Because `color` is reactive, Textual also calls `watch_color` with the old and new values.

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -583,7 +583,7 @@ Let's extend the `ByteEditor` so that clicking any of the 8 `BitSwitch` widgets 
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/compound/byte02.py" columns="90" line="30", press="tab,tab,tab,tab,enter"}
+    ```{.textual path="docs/examples/guide/compound/byte02.py" columns="90" line="30", press="tab,tab,tab,enter"}
     ```
 
 - The `BitSwitch` widget now has an `on_switch_changed` method which will handle a [`Switch.Changed`][textual.widgets.Switch.Changed] message, sent when the user clicks a switch. We use this to store the new value of the bit, and sent a new custom message, `BitSwitch.BitChanged`.
@@ -619,7 +619,7 @@ This is an example of "attributes down".
 
 === "Output"
 
-    ```{.textual path="docs/examples/guide/compound/byte03.py" columns="90" line="30", press="tab,1,0,0"}
+    ```{.textual path="docs/examples/guide/compound/byte03.py" columns="90" line="30", press="1,0,0"}
     ```
 
 - When the user edits the input, the [Input](../widgets/input.md) widget sends a `Changed` event, which we handle with `on_input_changed` by setting `self.value`, which is a reactive value we added to `ByteEditor`.

--- a/docs/widget_gallery.md
+++ b/docs/widget_gallery.md
@@ -175,7 +175,7 @@ A configurable progress bar with ETA and percentage complete.
 [ProgressBar reference](./widgets/progress_bar.md){ .md-button .md-button--primary }
 
 
-```{.textual path="docs/examples/widgets/progress_bar.py" press="tab,5,0,tab,enter"}
+```{.textual path="docs/examples/widgets/progress_bar.py" press="5,0,tab,enter"}
 ```
 
 

--- a/docs/widget_gallery.md
+++ b/docs/widget_gallery.md
@@ -89,7 +89,7 @@ A control to enter text.
 [Input reference](./widgets/input.md){ .md-button .md-button--primary }
 
 
-```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n"}
+```{.textual path="docs/examples/widgets/input.py" press="D,a,r,r,e,n"}
 ```
 
 

--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -13,7 +13,7 @@ The example below shows how you might create a simple form using two `Input` wid
 
 === "Output"
 
-    ```{.textual path="docs/examples/widgets/input.py" press="tab,D,a,r,r,e,n"}
+    ```{.textual path="docs/examples/widgets/input.py" press="D,a,r,r,e,n"}
     ```
 
 === "input.py"

--- a/docs/widgets/progress_bar.md
+++ b/docs/widgets/progress_bar.md
@@ -49,12 +49,12 @@ The example below shows a simple app with a progress bar that is keeping track o
 
 === "Output (partial funding)"
 
-    ```{.textual path="docs/examples/widgets/progress_bar.py" press="tab,1,5,enter,2,0,enter"}
+    ```{.textual path="docs/examples/widgets/progress_bar.py" press="1,5,enter,2,0,enter"}
     ```
 
 === "Output (full funding)"
 
-    ```{.textual path="docs/examples/widgets/progress_bar.py" press="tab,1,5,enter,2,0,enter,6,5,enter"}
+    ```{.textual path="docs/examples/widgets/progress_bar.py" press="1,5,enter,2,0,enter,6,5,enter"}
     ```
 
 === "progress_bar.py"


### PR DESCRIPTION
A small number of screenshots in the documentation, that used `press=` to get stuff done in the code, and which performed a <kbd>tab</kbd> to get focus to a particular control, were either different from intended or just plain not working since the addition of `AUTO_FOCUS` (because, of course, focus position was off by one from what was originally the case).

This PR fixes up all the ones I could find.

There is a question left hanging about the screenshots in the tutorial, which I've asked @willmcgugan to cast his eye over. I *think* they are likely wrong but because of the nature of them it's not obvious to me how they should look (checking the blame for `tutorial.md`, I can't see any evidence of a recent fix so it follows they must be wrong).

If the tutorial is shown to be off too that can be rolled into this, or done as a followup.

See #2720.