### PR TITLE
Fix a typo in the typing example in the SelectionList docs

### DIFF
--- a/docs/widgets/selection_list.md
+++ b/docs/widgets/selection_list.md
@@ -18,7 +18,7 @@ follows:
 
 ```python
 selections = [("First", 1), ("Second", 2)]
-my_selection_list: SelectionList[int] =  SelectionList(selections)
+my_selection_list: SelectionList[int] =  SelectionList(*selections)
 ```
 
 !!! note


### PR DESCRIPTION
See #2727.
