### PR TITLE
Finish off `ContentSwitcher` unit testing

### DIFF
--- a/docs/widgets/selection_list.md
+++ b/docs/widgets/selection_list.md
@@ -18,7 +18,7 @@ follows:
 
 ```python
 selections = [("First", 1), ("Second", 2)]
-my_selection_list: SelectionList[int] =  SelectionList(selections)
+my_selection_list: SelectionList[int] =  SelectionList(*selections)
 ```
 
 !!! note

--- a/tests/test_content_switcher.py
+++ b/tests/test_content_switcher.py
@@ -26,6 +26,7 @@ async def test_no_initial_display() -> None:
         assert all(
             not child.display for child in pilot.app.query_one(ContentSwitcher).children
         )
+        assert pilot.app.query_one(ContentSwitcher).visible_content is None
 
 
 async def test_initial_display() -> None:
@@ -34,6 +35,9 @@ async def test_initial_display() -> None:
         assert pilot.app.query_one(ContentSwitcher).current == "w3"
         for child in pilot.app.query_one(ContentSwitcher).children:
             assert child.display is (child.id == "w3")
+        assert pilot.app.query_one(
+            ContentSwitcher
+        ).visible_content is pilot.app.query_one("#w3")
 
 
 async def test_no_initial_display_then_set() -> None:
@@ -43,10 +47,14 @@ async def test_no_initial_display_then_set() -> None:
         assert all(
             not child.display for child in pilot.app.query_one(ContentSwitcher).children
         )
+        assert pilot.app.query_one(ContentSwitcher).visible_content is None
         pilot.app.query_one(ContentSwitcher).current = "w3"
         assert pilot.app.query_one(ContentSwitcher).current == "w3"
         for child in pilot.app.query_one(ContentSwitcher).children:
             assert child.display is (child.id == "w3")
+        assert pilot.app.query_one(
+            ContentSwitcher
+        ).visible_content is pilot.app.query_one("#w3")
 
 
 async def test_initial_display_then_change() -> None:
@@ -55,10 +63,16 @@ async def test_initial_display_then_change() -> None:
         assert pilot.app.query_one(ContentSwitcher).current == "w3"
         for child in pilot.app.query_one(ContentSwitcher).children:
             assert child.display is (child.id == "w3")
+        assert pilot.app.query_one(
+            ContentSwitcher
+        ).visible_content is pilot.app.query_one("#w3")
         pilot.app.query_one(ContentSwitcher).current = "w2"
         assert pilot.app.query_one(ContentSwitcher).current == "w2"
         for child in pilot.app.query_one(ContentSwitcher).children:
             assert child.display is (child.id == "w2")
+        assert pilot.app.query_one(
+            ContentSwitcher
+        ).visible_content is pilot.app.query_one("#w2")
 
 
 async def test_initial_display_then_hide() -> None:


### PR DESCRIPTION
Looks like `visible_content` might have been added later, and wasn't added to unit tests for `ContentSwitcher`. This covers that also.

---
Note the spurious change to the `SelectionList` docs in here too. Over the weekend I did the 1 character correction in #2728 but managed to do it on my fork's `main` rather than in a branch of its own; so for the moment my `main` is ahead of upstream. (╯°□°）╯︵ ┻━┻ 

Should resolve itself once #2728 is merged.