### PR TITLE
Assorted tweaks to `Input`

### DIFF
--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -400,12 +400,7 @@ class Input(Widget, can_focus=True):
         if self.cursor_blink:
             self.blink_timer.reset()
 
-        # Do key bindings first
-        if await self.handle_key(event):
-            event.prevent_default()
-            event.stop()
-            return
-        elif event.is_printable:
+        if event.is_printable:
             event.stop()
             assert event.character is not None
             self.insert_text_at_cursor(event.character)

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -299,7 +299,7 @@ class Input(Widget, can_focus=True):
         else:
             self.view_position = self.view_position
 
-    async def watch_value(self, value: str) -> None:
+    async def _watch_value(self, value: str) -> None:
         self._suggestion = ""
         if self.suggester and value:
             self.run_worker(self.suggester._get_suggestion(self, value))

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -282,7 +282,7 @@ class Input(Widget, can_focus=True):
         new_view_position = max(0, min(view_position, self.cursor_width - width))
         return new_view_position
 
-    def watch_cursor_position(self, cursor_position: int) -> None:
+    def _watch_cursor_position(self) -> None:
         width = self.content_size.width
         if width == 0:
             # If the input has no width the view position can't be elsewhere.


### PR DESCRIPTION
A followup to #2737 where, while I was in the code, I saw a couple of things that could be cleaned up (in terms of taking on newer approaches we've adopted) and also the chance to eliminate what very much looks like a wee bit of dead code (#2742).

On the latter point, as mentioned in the linked issue that I'd made as reminder for myself, all evidence suggests that that code was handling a situation that seems to no longer be possible in Textual (seeing keys bound to an action in an `on_key` handler). Removing this code makes zero difference to the `Input` unit tests, and hand-testing (in the demo for example, where we have plain and also password inputs) shows zero ill-effects too.

The other tweak here is to make the watchers "private". Once #2708 lands there's likely a couple of similar changes can be made elsewhere here too.