### PR TITLE
Screen css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - The devtools console now confirms when CSS files have been successfully loaded after a previous error https://github.com/Textualize/textual/pull/2716
+- Class variable `CSS` to screens https://github.com/Textualize/textual/issues/2137
+- Class variable `CSS_PATH` to screens https://github.com/Textualize/textual/issues/2137
 
 ### Fixed
 

--- a/src/textual/_path.py
+++ b/src/textual/_path.py
@@ -2,6 +2,34 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path, PurePath
+from typing import List, Union
+
+from typing_extensions import TypeAlias
+
+CSSPathType: TypeAlias = Union[
+    str,
+    PurePath,
+    List[Union[str, PurePath]],
+]
+"""Valid ways of specifying paths to CSS files."""
+
+
+class CSSPathError(Exception):
+    """Raised when supplied CSS path(s) are invalid."""
+
+
+def _css_path_type_as_list(css_path: CSSPathType) -> list[PurePath]:
+    paths: list[PurePath] = []
+    if isinstance(css_path, str):
+        paths = [Path(css_path)]
+    elif isinstance(css_path, PurePath):
+        paths = [css_path]
+    elif isinstance(css_path, list):
+        paths = [Path(path) for path in css_path]
+    else:
+        raise CSSPathError("Expected a str, Path or list[str | Path] for the CSS_PATH.")
+
+    return paths
 
 
 def _make_path_object_relative(path: str | PurePath, obj: object) -> Path:

--- a/src/textual/_types.py
+++ b/src/textual/_types.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Pattern, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Union
 
-from typing_extensions import Protocol, runtime_checkable
+from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from .message import Message

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -27,7 +27,7 @@ from contextlib import (
 )
 from datetime import datetime
 from functools import partial
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from time import perf_counter
 from typing import (
     TYPE_CHECKING,
@@ -67,7 +67,7 @@ from ._compositor import CompositorUpdate
 from ._context import active_app, active_message_pump
 from ._context import message_hook as message_hook_context_var
 from ._event_broker import NoHandler, extract_handler_actions
-from ._path import _make_path_object_relative
+from ._path import CSSPathType, _css_path_type_as_list, _make_path_object_relative
 from ._wait import wait_for_idle
 from ._worker_manager import WorkerManager
 from .actions import ActionParseResult, SkipAction
@@ -175,10 +175,6 @@ class UnknownModeError(ModeError):
 
 class ActiveModeError(ModeError):
     """Raised when attempting to remove the currently active mode."""
-
-
-class CssPathError(Exception):
-    """Raised when supplied CSS path(s) are invalid."""
 
 
 ReturnType = TypeVar("ReturnType")
@@ -402,32 +398,15 @@ class App(Generic[ReturnType], DOMNode):
         self.stylesheet = Stylesheet(variables=self.get_css_variables())
 
         css_path = css_path or self.CSS_PATH
-        if css_path is not None:
-            # When value(s) are supplied for CSS_PATH, we normalise them to a list of Paths.
-            css_paths: List[PurePath]
-            if isinstance(css_path, str):
-                css_paths = [Path(css_path)]
-            elif isinstance(css_path, PurePath):
-                css_paths = [css_path]
-            elif isinstance(css_path, list):
-                css_paths = []
-                for path in css_path:
-                    css_paths.append(
-                        Path(path) if isinstance(path, str) else path,
-                    )
-            else:
-                raise CssPathError(
-                    "Expected a str, Path or list[str | Path] for the CSS_PATH."
-                )
-
-            # We want the CSS path to be resolved from the location of the App subclass
-            css_paths = [
-                _make_path_object_relative(css_path, self) for css_path in css_paths
-            ]
-        else:
-            css_paths = []
-
+        css_paths = [
+            _make_path_object_relative(css_path, self)
+            for css_path in (
+                _css_path_type_as_list(css_path) if css_path is not None else []
+            )
+        ]
         self.css_path = css_paths
+        self._css_screens_loaded: WeakSet[Screen[Any]] = WeakSet()
+
         self._registry: WeakSet[DOMNode] = WeakSet()
 
         # Sensitivity on X is double the sensitivity on Y to account for
@@ -1424,7 +1403,11 @@ class App(Generic[ReturnType], DOMNode):
             else:
                 screen, _ = self._get_screen(self.MODES[mode])
             stack.append(screen)
-        self._screen_stacks[mode] = [screen]
+
+            if screen not in self._css_screens_loaded:
+                self._load_screen_css(screen)
+
+        self._screen_stacks[mode] = stack
 
     def switch_mode(self, mode: str) -> None:
         """Switch to a given mode.
@@ -1558,6 +1541,32 @@ class App(Generic[ReturnType], DOMNode):
             self.call_next(await_mount)
             return (_screen, await_mount)
 
+    def _load_screen_css(self, screen: Screen):
+        """Loads the CSS associated with a screen."""
+
+        self._css_screens_loaded.add(screen)
+        if self.css_monitor is not None:
+            self.css_monitor.paths.extend(screen.css_path)
+
+        update = False
+        if screen.css_path:
+            self.stylesheet.read_all(screen.css_path)
+            update = True
+        if screen.CSS:
+            try:
+                screen_css_path = (
+                    f"{inspect.getfile(screen.__class__)}:{screen.__class__.__name__}"
+                )
+            except (TypeError, OSError):
+                screen_css_path = f"{screen.__class__.__name__}"
+            self.stylesheet.add_source(
+                screen.CSS, path=screen_css_path, is_default_css=False
+            )
+            update = True
+        if update:
+            self.stylesheet.reparse()
+            self.stylesheet.update(self)
+
     def _replace_screen(self, screen: Screen) -> Screen:
         """Handle the replaced screen.
 
@@ -1604,6 +1613,8 @@ class App(Generic[ReturnType], DOMNode):
         next_screen._push_result_callback(
             self.screen if self._screen_stack else None, callback
         )
+        if next_screen not in self._css_screens_loaded:
+            self._load_screen_css(next_screen)
         self._screen_stack.append(next_screen)
         next_screen.post_message(events.ScreenResume())
         self.log.system(f"{self.screen} is current (PUSHED)")
@@ -1627,6 +1638,8 @@ class App(Generic[ReturnType], DOMNode):
 
         previous_screen = self._replace_screen(self._screen_stack.pop())
         previous_screen._pop_result_callback()
+        if next_screen not in self._css_screens_loaded:
+            self._load_screen_css(next_screen)
         self._screen_stack.append(next_screen)
         self.screen.post_message(events.ScreenResume())
         self.screen._push_result_callback(self.screen, None)

--- a/src/textual/file_monitor.py
+++ b/src/textual/file_monitor.py
@@ -13,8 +13,10 @@ from ._callback import invoke
 class FileMonitor:
     """Monitors files for changes and invokes a callback when it does."""
 
+    paths: list[PurePath]
+
     def __init__(self, paths: Sequence[PurePath], callback: Callable) -> None:
-        self.paths = paths
+        self.paths = list(paths)
         self.callback = callback
         self._modified = self._get_last_modified_time()
 

--- a/src/textual/types.py
+++ b/src/textual/types.py
@@ -4,6 +4,7 @@ Export some objects that are used by Textual and that help document other featur
 
 from ._animator import Animatable, EasingFunction
 from ._context import NoActiveAppError
+from ._path import CSSPathError, CSSPathType
 from ._types import CallbackType, MessageTarget, WatchCallbackType
 from .actions import ActionParseResult
 from .css.styles import RenderStyles
@@ -13,6 +14,8 @@ __all__ = [
     "ActionParseResult",
     "Animatable",
     "CallbackType",
+    "CSSPathError",
+    "CSSPathType",
     "CursorType",
     "EasingFunction",
     "MessageTarget",

--- a/tests/css/test_screen_css.css
+++ b/tests/css/test_screen_css.css
@@ -1,0 +1,7 @@
+#screen-css-path {
+    background: #0000ff;
+}
+
+#screen-css {
+    background: #0000ff;
+}

--- a/tests/css/test_screen_css.py
+++ b/tests/css/test_screen_css.py
@@ -1,0 +1,273 @@
+from textual.app import App
+from textual.color import Color
+from textual.screen import Screen
+from textual.widgets import Label
+
+RED = Color(255, 0, 0)
+GREEN = Color(0, 255, 0)
+BLUE = Color(0, 0, 255)
+
+
+class BaseScreen(Screen):
+    def compose(self):
+        yield Label("Hello, world!", id="app-css")
+        yield Label("Hello, world!", id="screen-css-path")
+        yield Label("Hello, world!", id="screen-css")
+
+
+class ScreenWithCSS(Screen):
+    CSS = """
+    #screen-css {
+        background: #ff0000;
+    }
+    """
+
+    CSS_PATH = "test_screen_css.css"
+
+    def compose(self):
+        yield Label("Hello, world!", id="app-css")
+        yield Label("Hello, world!", id="screen-css-path")
+        yield Label("Hello, world!", id="screen-css")
+
+
+class BaseApp(App):
+    """Base app for testing screen CSS when pushing screens."""
+
+    CSS = """
+    #app-css {
+        background: #00ff00;
+    }
+    #screen-css-path {
+        background: #00ff00;
+    }
+    #screen-css {
+        background: #00ff00;
+    }
+    """
+
+    def on_mount(self):
+        self.push_screen(BaseScreen())
+
+
+class SwitchBaseApp(BaseApp):
+    """Base app for testing screen CSS when switching a screen."""
+
+    def on_mount(self):
+        self.push_screen(BaseScreen())
+
+
+def check_colors_before_screen_css(app: BaseApp):
+    assert app.query_one("#app-css").styles.background == GREEN
+    assert app.query_one("#screen-css-path").styles.background == GREEN
+    assert app.query_one("#screen-css").styles.background == GREEN
+
+
+def check_colors_after_screen_css(app: BaseApp):
+    assert app.query_one("#app-css").styles.background == GREEN
+    assert app.query_one("#screen-css-path").styles.background == BLUE
+    assert app.query_one("#screen-css").styles.background == RED
+
+
+async def test_screen_css_push_screen_instance():
+    """Check that screen CSS is loaded and applied when pushing a screen instance."""
+
+    class MyApp(BaseApp):
+        def key_p(self):
+            self.push_screen(ScreenWithCSS())
+
+        def key_o(self):
+            self.pop_screen()
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_push_screen_instance_by_name():
+    """Check that screen CSS is loaded and applied when pushing a screen name that points to a screen instance."""
+
+    class MyApp(BaseApp):
+        SCREENS = {"screenwithcss": ScreenWithCSS()}
+
+        def key_p(self):
+            self.push_screen("screenwithcss")
+
+        def key_o(self):
+            self.pop_screen()
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_push_screen_type_by_name():
+    """Check that screen CSS is loaded and applied when pushing a screen name that points to a screen class."""
+
+    class MyApp(BaseApp):
+        SCREENS = {"screenwithcss": ScreenWithCSS}
+
+        def key_p(self):
+            self.push_screen("screenwithcss")
+
+        def key_o(self):
+            self.pop_screen()
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_switch_screen_instance():
+    """Check that screen CSS is loaded and applied when switching to a screen instance."""
+
+    class MyApp(SwitchBaseApp):
+        def key_p(self):
+            self.switch_screen(ScreenWithCSS())
+
+        def key_o(self):
+            self.pop_screen()
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_switch_screen_instance_by_name():
+    """Check that screen CSS is loaded and applied when switching a screen name that points to a screen instance."""
+
+    class MyApp(SwitchBaseApp):
+        SCREENS = {"screenwithcss": ScreenWithCSS()}
+
+        def key_p(self):
+            self.switch_screen("screenwithcss")
+
+        def key_o(self):
+            self.pop_screen()
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_switch_screen_type_by_name():
+    """Check that screen CSS is loaded and applied when switching a screen name that points to a screen class."""
+
+    class MyApp(SwitchBaseApp):
+        SCREENS = {"screenwithcss": ScreenWithCSS}
+
+        def key_p(self):
+            self.switch_screen("screenwithcss")
+
+        def key_o(self):
+            self.pop_screen()
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_switch_mode_screen_instance():
+    """Check that screen CSS is loaded and applied when switching to a mode with a screen instance."""
+
+    class MyApp(BaseApp):
+        MODES = {
+            "base": BaseScreen(),
+            "mode": ScreenWithCSS(),
+        }
+
+        def key_p(self):
+            self.switch_mode("mode")
+
+        def key_o(self):
+            self.switch_mode("base")
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        await pilot.press("o")
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_switch_mode_screen_instance_by_name():
+    """Check that screen CSS is loaded and applied when switching to a mode with a screen instance name."""
+
+    class MyApp(BaseApp):
+        SCREENS = {
+            "screenwithcss": ScreenWithCSS(),
+        }
+
+        MODES = {
+            "base": BaseScreen(),
+            "mode": "screenwithcss",
+        }
+
+        def key_p(self):
+            self.switch_mode("mode")
+
+        def key_o(self):
+            self.switch_mode("base")
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        await pilot.press("o")
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)
+
+
+async def test_screen_css_switch_mode_screen_type_by_name():
+    """Check that screen CSS is loaded and applied when switching to a mode with a screen type name."""
+
+    class MyApp(BaseApp):
+        SCREENS = {
+            "screenwithcss": ScreenWithCSS,
+        }
+
+        MODES = {
+            "base": BaseScreen(),
+            "mode": "screenwithcss",
+        }
+
+        def key_p(self):
+            self.switch_mode("mode")
+
+        def key_o(self):
+            self.switch_mode("base")
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        await pilot.press("o")
+        check_colors_before_screen_css(app)
+        await pilot.press("p")
+        check_colors_after_screen_css(app)
+        await pilot.press("o")
+        check_colors_after_screen_css(app)


### PR DESCRIPTION
Closes #2137.
Adds `CSS` and `CSS_PATH` class variables to screens.

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

@willmcgugan inside `App._load_screen_css`, why don't I traverse all the rules that were read and dynamically add a CSS selector to match the screen so that screen CSS only matches the screen it was imported from?