### PR TITLE
Update `TabbedContent` with methods to add, remove and clear tabs/panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Class variable `CSS` to screens https://github.com/Textualize/textual/issues/2137
 - Class variable `CSS_PATH` to screens https://github.com/Textualize/textual/issues/2137
 - Added `cursor_foreground_priority` and `cursor_background_priority` to `DataTable` https://github.com/Textualize/textual/pull/2736
+- Added `TabbedContent.tab_count` https://github.com/Textualize/textual/pull/2751
+- Added `TabbedContnet.add_pane` https://github.com/Textualize/textual/pull/2751
+- Added `TabbedContent.remove_pane` https://github.com/Textualize/textual/pull/2751
+- Added `TabbedContent.clear_panes` https://github.com/Textualize/textual/pull/2751
+- Added `TabbedContent.Cleared` https://github.com/Textualize/textual/pull/2751
 
 ### Fixed
 
@@ -22,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue where internal data of `OptionList` could be invalid for short window after `clear_options` https://github.com/Textualize/textual/pull/2754
 - Fixed `Tooltip` causing a `query_one` on a lone `Static` to fail https://github.com/Textualize/textual/issues/2723
 - Nested widgets wouldn't lose focus when parent is disabled https://github.com/Textualize/textual/issues/2772
+- Fixed the `Tabs` `Underline` highlight getting "lost" in some extreme situations https://github.com/Textualize/textual/pull/2751
 
 ### Changed
 

--- a/src/textual/widgets/_content_switcher.py
+++ b/src/textual/widgets/_content_switcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from ..containers import Container
+from ..css.query import NoMatches
 from ..events import Mount
 from ..reactive import reactive
 from ..widget import Widget
@@ -84,6 +85,9 @@ class ContentSwitcher(Container):
         """
         with self.app.batch_update():
             if old:
-                self.get_child_by_id(old).display = False
+                try:
+                    self.get_child_by_id(old).display = False
+                except NoMatches:
+                    pass
             if new:
                 self.get_child_by_id(new).display = True

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -74,7 +74,7 @@ class TabPane(Widget):
 
 
 class AwaitTabbedContent:
-    """An awaitable return by [`TabbedContent`][textual.widgets.TabbedContent] methods that modify the tabs."""
+    """An awaitable returned by [`TabbedContent`][textual.widgets.TabbedContent] methods that modify the tabs."""
 
     def __init__(self, *awaitables: AwaitMount | AwaitRemove) -> None:
         """Initialise the awaitable.

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -177,12 +177,11 @@ class TabbedContent(Widget):
 
         # Wrap content in a `TabPane` if required.
         pane_content = [
-            (
-                self._set_id(content, index)
+            self._set_id(
+                content
                 if isinstance(content, TabPane)
-                else TabPane(
-                    title or self.render_str(f"Tab {index}"), content, id=f"tab-{index}"
-                )
+                else TabPane(title or self.render_str(f"Tab {index}"), content),
+                index,
             )
             for index, (title, content) in enumerate(
                 zip_longest(self.titles, self._tab_content), 1

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -266,7 +266,7 @@ class TabbedContent(Widget):
             self.post_message(cleared_message)
 
         # Note that I create the message out here, rather than in
-        # _remove_content, to ensure that the message's internal
+        # _clear_content, to ensure that the message's internal
         # understanding of who the sender is is correct.
         #
         # https://github.com/Textualize/textual/issues/2750

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -203,6 +203,9 @@ class TabbedContent(Widget):
 
         Args:
             pane: The pane to add.
+
+        Returns:
+            An awaitable object that waits for the pane to be mounted.
         """
         tabs = self.get_child_by_type(Tabs)
         pane = self._set_id(pane, tabs.tab_count + 1)

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -211,6 +211,17 @@ class TabbedContent(Widget):
         pane.display = False
         return self.get_child_by_type(ContentSwitcher).mount(pane)
 
+    def remove_pane(self, pane_id: str) -> None:
+        """Remove a given pane from the tabbed content.
+
+        Args:
+            pane_id: The ID of the pane to remove.
+        """
+        self.get_child_by_type(Tabs).remove_tab(pane_id)
+        self.call_after_refresh(
+            self.get_child_by_type(ContentSwitcher).get_child_by_id(pane_id).remove
+        )
+
     def compose_add_child(self, widget: Widget) -> None:
         """When using the context manager compose syntax, we want to attach nodes to the switcher.
 
@@ -237,6 +248,7 @@ class TabbedContent(Widget):
     def _on_tabs_cleared(self, event: Tabs.Cleared) -> None:
         """All tabs were removed."""
         event.stop()
+        self.get_child_by_type(ContentSwitcher).current = None
 
     def _watch_active(self, active: str) -> None:
         """Switch tabs when the active attributes changes."""

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -207,9 +207,10 @@ class TabbedContent(Widget):
 
     def _on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
         """User clicked a tab."""
+        assert isinstance(event.tab, ContentTab)
+        assert isinstance(event.tab.id, str)
         event.stop()
         switcher = self.get_child_by_type(ContentSwitcher)
-        assert isinstance(event.tab, ContentTab)
         switcher.current = event.tab.id
         self.active = event.tab.id
         self.post_message(

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -151,10 +151,10 @@ class TabbedContent(Widget):
             Value of `active`.
 
         Raises:
-            ValueError: If the active attribute is set to empty string.
+            ValueError: If the active attribute is set to empty string when there are tabs available.
         """
-        if not active:
-            raise ValueError("'active' tab must not be empty string.")
+        if not active and self.get_child_by_type(ContentSwitcher).current:
+            raise ValueError(f"'active' tab must not be empty string.")
         return active
 
     @staticmethod

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -253,10 +253,10 @@ class TabbedContent(Widget):
         tabs = self.get_child_by_type(Tabs)
         pane = self._set_id(pane, tabs.tab_count + 1)
         assert pane.id is not None
-        await_tab = tabs.add_tab(ContentTab(pane._title, pane.id))
         pane.display = False
         return AwaitTabbedContent(
-            await_tab, self.get_child_by_type(ContentSwitcher).mount(pane)
+            tabs.add_tab(ContentTab(pane._title, pane.id)),
+            self.get_child_by_type(ContentSwitcher).mount(pane),
         )
 
     def remove_pane(self, pane_id: str) -> AwaitTabbedContent:

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -199,7 +199,7 @@ class TabbedContent(Widget):
             ValueError: If the active attribute is set to empty string when there are tabs available.
         """
         if not active and self.get_child_by_type(ContentSwitcher).current:
-            raise ValueError(f"'active' tab must not be empty string.")
+            raise ValueError("'active' tab must not be empty string.")
         return active
 
     @staticmethod

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -224,6 +224,11 @@ class TabbedContent(Widget):
             self.get_child_by_type(ContentSwitcher).get_child_by_id(pane_id).remove
         )
 
+    def clear_panes(self) -> None:
+        """Remove all the panes in the tabbed content."""
+        self.get_child_by_type(Tabs).clear()
+        self.call_after_refresh(self.get_child_by_type(ContentSwitcher).remove_children)
+
     def compose_add_child(self, widget: Widget) -> None:
         """When using the context manager compose syntax, we want to attach nodes to the switcher.
 

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -249,6 +249,7 @@ class TabbedContent(Widget):
         """All tabs were removed."""
         event.stop()
         self.get_child_by_type(ContentSwitcher).current = None
+        self.active = ""
 
     def _watch_active(self, active: str) -> None:
         """Switch tabs when the active attributes changes."""

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from asyncio import gather
 from itertools import zip_longest
 from typing import Generator
 
@@ -87,8 +88,7 @@ class AwaitTabbedContent:
 
     def __await__(self) -> Generator[None, None, None]:
         async def await_tabbed_content() -> None:
-            for awaitable in self._awaitables:
-                await awaitable
+            await gather(*self._awaitables)
 
         return await_tabbed_content().__await__()
 

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -224,7 +224,7 @@ class TabbedContent(Widget):
         """All tabs were removed."""
         event.stop()
 
-    def watch_active(self, active: str) -> None:
+    def _watch_active(self, active: str) -> None:
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated):
             self.get_child_by_type(Tabs).active = active

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -242,21 +242,40 @@ class TabbedContent(Widget):
         with ContentSwitcher(initial=self._initial or None):
             yield from pane_content
 
-    def add_pane(self, pane: TabPane) -> AwaitTabbedContent:
+    def add_pane(
+        self,
+        pane: TabPane,
+        *,
+        before: TabPane | str | None = None,
+        after: TabPane | str | None = None,
+    ) -> AwaitTabbedContent:
         """Add a new pane to the tabbed content.
 
         Args:
             pane: The pane to add.
+            before: Optional pane or pane ID to add the pane before.
+            after: Optional pane or pane ID to add the pane after.
 
         Returns:
             An awaitable object that waits for the pane to be added.
+
+        Raises:
+            Tabs.TabError: If there is a problem with the addition request.
+
+        Note:
+            Only one of `before` or `after` can be provided. If both are
+            provided a `Tabs.TabError` will be raised.
         """
+        if isinstance(before, TabPane):
+            before = before.id
+        if isinstance(after, TabPane):
+            after = after.id
         tabs = self.get_child_by_type(Tabs)
         pane = self._set_id(pane, tabs.tab_count + 1)
         assert pane.id is not None
         pane.display = False
         return AwaitTabbedContent(
-            tabs.add_tab(ContentTab(pane._title, pane.id)),
+            tabs.add_tab(ContentTab(pane._title, pane.id), before=before, after=after),
             self.get_child_by_type(ContentSwitcher).mount(pane),
         )
 

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -256,3 +256,8 @@ class TabbedContent(Widget):
         with self.prevent(Tabs.TabActivated):
             self.get_child_by_type(Tabs).active = active
             self.get_child_by_type(ContentSwitcher).current = active
+
+    @property
+    def tab_count(self) -> int:
+        """Total number of tabs."""
+        return self.get_child_by_type(Tabs).tab_count

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -510,9 +510,11 @@ class Tabs(Widget, can_focus=True):
         try:
             active_tab = self.query_one(f"#tabs-list > Tab.-active")
         except NoMatches:
+            underline.show_highlight = False
             underline.highlight_start = 0
             underline.highlight_end = 0
         else:
+            underline.show_highlight = True
             tab_region = active_tab.virtual_region.shrink(active_tab.styles.gutter)
             start, end = tab_region.column_span
             if animate:

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 import rich.repr
 from rich.style import Style

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -46,6 +46,8 @@ class Underline(Widget):
     """First cell in highlight."""
     highlight_end = reactive(0)
     """Last cell (inclusive) in highlight."""
+    show_highlight: reactive[bool] = reactive(True)
+    """Flag to indicate if a highlight should be shown at all."""
 
     class Clicked(Message):
         """Inform ancestors the underline was clicked."""
@@ -60,7 +62,11 @@ class Underline(Widget):
     @property
     def _highlight_range(self) -> tuple[int, int]:
         """Highlighted range for underline bar."""
-        return (self.highlight_start, self.highlight_end)
+        return (
+            (self.highlight_start, self.highlight_end)
+            if self.show_highlight
+            else (0, 0)
+        )
 
     def render(self) -> RenderResult:
         """Render the bar."""

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -2,7 +2,7 @@ import pytest
 
 from textual.app import App, ComposeResult
 from textual.reactive import var
-from textual.widgets import Label, TabbedContent, TabPane
+from textual.widgets import Label, Tab, TabbedContent, TabPane, Tabs
 
 
 async def test_tabbed_content_switch_via_ui():
@@ -198,6 +198,140 @@ async def test_tabbed_content_add_later_from_composed():
         await pilot.pause()
         assert tabbed_content.tab_count == 5
         assert tabbed_content.active == "initial-1"
+
+
+async def test_tabbed_content_add_before_id():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        await tabbed_content.add_pane(TabPane("Added", id="new-1"), before="initial-1")
+        await pilot.pause()
+        assert tabbed_content.tab_count == 2
+        assert tabbed_content.active == "initial-1"
+        assert [tab.id for tab in tabbed_content.query(Tab).results(Tab)] == [
+            "new-1",
+            "initial-1",
+        ]
+
+
+async def test_tabbed_content_add_before_pane():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        await tabbed_content.add_pane(
+            TabPane("Added", id="new-1"),
+            before=pilot.app.query_one("TabPane#initial-1", TabPane),
+        )
+        await pilot.pause()
+        assert tabbed_content.tab_count == 2
+        assert tabbed_content.active == "initial-1"
+        assert [tab.id for tab in tabbed_content.query(Tab).results(Tab)] == [
+            "new-1",
+            "initial-1",
+        ]
+
+
+async def test_tabbed_content_add_before_badly():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        with pytest.raises(Tabs.TabError):
+            await tabbed_content.add_pane(
+                TabPane("Added", id="new-1"), before="unknown-1"
+            )
+
+
+async def test_tabbed_content_add_after():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        await tabbed_content.add_pane(TabPane("Added", id="new-1"), after="initial-1")
+        await pilot.pause()
+        assert tabbed_content.tab_count == 2
+        assert tabbed_content.active == "initial-1"
+        assert [tab.id for tab in tabbed_content.query(Tab).results(Tab)] == [
+            "initial-1",
+            "new-1",
+        ]
+
+
+async def test_tabbed_content_add_after_pane():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        await tabbed_content.add_pane(
+            TabPane("Added", id="new-1"),
+            after=pilot.app.query_one("TabPane#initial-1", TabPane),
+        )
+        await pilot.pause()
+        assert tabbed_content.tab_count == 2
+        assert tabbed_content.active == "initial-1"
+        assert [tab.id for tab in tabbed_content.query(Tab).results(Tab)] == [
+            "initial-1",
+            "new-1",
+        ]
+
+
+async def test_tabbed_content_add_after_badly():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        with pytest.raises(Tabs.TabError):
+            await tabbed_content.add_pane(
+                TabPane("Added", id="new-1"), after="unknown-1"
+            )
+
+
+async def test_tabbed_content_add_before_and_after():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 1
+        assert tabbed_content.active == "initial-1"
+        with pytest.raises(Tabs.TabError):
+            await tabbed_content.add_pane(
+                TabPane("Added", id="new-1"), before="initial-1", after="initial-1"
+            )
 
 
 async def test_tabbed_content_removal():

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -219,3 +219,21 @@ async def test_tabbed_content_removal():
         await pilot.pause()
         assert tabbed_content.tab_count == 0
         assert tabbed_content.active == ""
+
+
+async def test_tabbed_content_clear():
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield TabPane("Test 1", id="initial-1")
+                yield TabPane("Test 2", id="initial-2")
+                yield TabPane("Test 3", id="initial-3")
+
+    async with TabbedApp().run_test() as pilot:
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 3
+        assert tabbed_content.active == "initial-1"
+        tabbed_content.clear_panes()
+        await pilot.pause()
+        assert tabbed_content.tab_count == 0
+        assert tabbed_content.active == ""

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -215,17 +215,17 @@ async def test_tabbed_content_removal():
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-1"
         tabbed_content.remove_pane("initial-1")
-        await pilot.pause()
+        await pilot.pause(0.01)
         assert tabbed_content.tab_count == 2
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-2"
         tabbed_content.remove_pane("initial-2")
-        await pilot.pause()
+        await pilot.pause(0.01)
         assert tabbed_content.tab_count == 1
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-3"
         tabbed_content.remove_pane("initial-3")
-        await pilot.pause()
+        await pilot.pause(0.01)
         assert tabbed_content.tab_count == 0
         assert pilot.app.cleared == 1
         assert tabbed_content.active == ""
@@ -250,7 +250,7 @@ async def test_tabbed_content_clear():
         assert tabbed_content.active == "initial-1"
         assert pilot.app.cleared == 0
         tabbed_content.clear_panes()
-        await pilot.pause()
+        await pilot.pause(0.01)
         assert tabbed_content.tab_count == 0
         assert tabbed_content.active == ""
         assert pilot.app.cleared == 1

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -191,9 +191,11 @@ async def test_tabbed_content_add_after_from_composed():
         assert tabbed_content.tab_count == 3
         assert tabbed_content.active == "initial-1"
         await tabbed_content.add_pane(TabPane("Test 4", id="test-1"))
+        await pilot.pause()
         assert tabbed_content.tab_count == 4
         assert tabbed_content.active == "initial-1"
         await tabbed_content.add_pane(TabPane("Test 5", id="test-2"))
+        await pilot.pause()
         assert tabbed_content.tab_count == 5
         assert tabbed_content.active == "initial-1"
 

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -215,17 +215,17 @@ async def test_tabbed_content_removal():
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-1"
         tabbed_content.remove_pane("initial-1")
-        await pilot.pause(0.01)
+        await pilot.pause(0.05)
         assert tabbed_content.tab_count == 2
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-2"
         tabbed_content.remove_pane("initial-2")
-        await pilot.pause(0.01)
+        await pilot.pause(0.05)
         assert tabbed_content.tab_count == 1
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-3"
         tabbed_content.remove_pane("initial-3")
-        await pilot.pause(0.01)
+        await pilot.pause(0.05)
         assert tabbed_content.tab_count == 0
         assert pilot.app.cleared == 1
         assert tabbed_content.active == ""
@@ -250,7 +250,7 @@ async def test_tabbed_content_clear():
         assert tabbed_content.active == "initial-1"
         assert pilot.app.cleared == 0
         tabbed_content.clear_panes()
-        await pilot.pause(0.01)
+        await pilot.pause(0.05)
         assert tabbed_content.tab_count == 0
         assert tabbed_content.active == ""
         assert pilot.app.cleared == 1

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -216,18 +216,18 @@ async def test_tabbed_content_removal():
         assert tabbed_content.tab_count == 3
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-1"
-        tabbed_content.remove_pane("initial-1")
-        await pilot.pause(0.05)
+        await tabbed_content.remove_pane("initial-1")
+        await pilot.pause()
         assert tabbed_content.tab_count == 2
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-2"
-        tabbed_content.remove_pane("initial-2")
-        await pilot.pause(0.05)
+        await tabbed_content.remove_pane("initial-2")
+        await pilot.pause()
         assert tabbed_content.tab_count == 1
         assert pilot.app.cleared == 0
         assert tabbed_content.active == "initial-3"
-        tabbed_content.remove_pane("initial-3")
-        await pilot.pause(0.05)
+        await tabbed_content.remove_pane("initial-3")
+        await pilot.pause()
         assert tabbed_content.tab_count == 0
         assert pilot.app.cleared == 1
         assert tabbed_content.active == ""
@@ -251,8 +251,8 @@ async def test_tabbed_content_clear():
         assert tabbed_content.tab_count == 3
         assert tabbed_content.active == "initial-1"
         assert pilot.app.cleared == 0
-        tabbed_content.clear_panes()
-        await pilot.pause(0.05)
+        await tabbed_content.clear_panes()
+        await pilot.pause()
         assert tabbed_content.tab_count == 0
         assert tabbed_content.active == ""
         assert pilot.app.cleared == 1

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -169,9 +169,11 @@ async def test_tabbed_content_add_after_from_empty():
         assert tabbed_content.active == ""
         assert tabbed_content.tab_count == 0
         await tabbed_content.add_pane(TabPane("Test 1", id="test-1"))
+        await pilot.pause()
         assert tabbed_content.tab_count == 1
         assert tabbed_content.active == "test-1"
         await tabbed_content.add_pane(TabPane("Test 2", id="test-2"))
+        await pilot.pause()
         assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "test-1"
 

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -159,7 +159,7 @@ async def test_tabbed_content_messages():
         assert app.message.tab.label.plain == "bar"
 
 
-async def test_tabbed_content_add_after_from_empty():
+async def test_tabbed_content_add_later_from_empty():
     class TabbedApp(App[None]):
         def compose(self) -> ComposeResult:
             yield TabbedContent()
@@ -178,7 +178,7 @@ async def test_tabbed_content_add_after_from_empty():
         assert tabbed_content.active == "test-1"
 
 
-async def test_tabbed_content_add_after_from_composed():
+async def test_tabbed_content_add_later_from_composed():
     class TabbedApp(App[None]):
         def compose(self) -> ComposeResult:
             with TabbedContent():

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -166,9 +166,12 @@ async def test_tabbed_content_add_after_from_empty():
     async with TabbedApp().run_test() as pilot:
         tabbed_content = pilot.app.query_one(TabbedContent)
         assert tabbed_content.active == ""
+        assert tabbed_content.tab_count == 0
         await tabbed_content.add_pane(TabPane("Test 1", id="test-1"))
+        assert tabbed_content.tab_count == 1
         assert tabbed_content.active == "test-1"
         await tabbed_content.add_pane(TabPane("Test 2", id="test-2"))
+        assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "test-1"
 
 
@@ -182,10 +185,13 @@ async def test_tabbed_content_add_after_from_composed():
 
     async with TabbedApp().run_test() as pilot:
         tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 3
         assert tabbed_content.active == "initial-1"
         await tabbed_content.add_pane(TabPane("Test 4", id="test-1"))
+        assert tabbed_content.tab_count == 4
         assert tabbed_content.active == "initial-1"
         await tabbed_content.add_pane(TabPane("Test 5", id="test-2"))
+        assert tabbed_content.tab_count == 5
         assert tabbed_content.active == "initial-1"
 
 
@@ -199,13 +205,17 @@ async def test_tabbed_content_removal():
 
     async with TabbedApp().run_test() as pilot:
         tabbed_content = pilot.app.query_one(TabbedContent)
+        assert tabbed_content.tab_count == 3
         assert tabbed_content.active == "initial-1"
         tabbed_content.remove_pane("initial-1")
         await pilot.pause()
+        assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "initial-2"
         tabbed_content.remove_pane("initial-2")
         await pilot.pause()
+        assert tabbed_content.tab_count == 1
         assert tabbed_content.active == "initial-3"
         tabbed_content.remove_pane("initial-3")
         await pilot.pause()
+        assert tabbed_content.tab_count == 0
         assert tabbed_content.active == ""


### PR DESCRIPTION
This PR extends `TabbedContent` with some new methods, and also adds a new message. The new methods are:

- `add_pane` to add a new `TabPane` to the widget
- `remove_pane` to remove an existing `TabPane` from the widget
- `clear_panes` to remove all existing panes from the widget
- `tab_count` (okay, actually a property) to give easy access to the underlying `Tabs.tab_count`

The new message is `TabbedContent.Cleared`, which, like with `Tabs`, is posted when the number of tabs in the widget falls to zero.

In the process of working on this, a small change has also been made to `Underline` and `Tabs` to counter the case where an animation of the underline is still taking place when the target tab has been removed.

---
Work on this was the cause for #2750 being noted.