### PR TITLE
Retired: Add a switch to isolate a widget class from CSS type inheritance

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -284,6 +284,7 @@ class DOMNode(MessagePump):
         inherit_css: bool = True,
         inherit_bindings: bool = True,
         inherit_component_classes: bool = True,
+        isolate_css_type: bool = False,
     ) -> None:
         super().__init_subclass__()
 
@@ -301,7 +302,7 @@ class DOMNode(MessagePump):
         cls._inherit_bindings = inherit_bindings
         cls._inherit_component_classes = inherit_component_classes
         css_type_names: set[str] = set()
-        for base in cls._css_bases(cls):
+        for base in [cls] if isolate_css_type else cls._css_bases(cls):
             css_type_names.add(base.__name__)
         cls._merged_bindings = cls._merge_bindings()
         cls._css_type_names = frozenset(css_type_names)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2545,11 +2545,13 @@ class Widget(DOMNode):
         can_focus_children: bool | None = None,
         inherit_css: bool = True,
         inherit_bindings: bool = True,
+        isolate_css_type: bool = False,
     ) -> None:
         base = cls.__mro__[0]
         super().__init_subclass__(
             inherit_css=inherit_css,
             inherit_bindings=inherit_bindings,
+            isolate_css_type=isolate_css_type,
         )
         if issubclass(base, Widget):
             cls.can_focus = base.can_focus if can_focus is None else can_focus


### PR DESCRIPTION
This PR seeks to satisfy #2749.

It introduces an `isolate_css_type` switch (name still to be finally decided upon, although I think this carries the correct intent), whose default is `False`, which when set to `True` will isolate the new widget type within CSS. While it will inherit all of the mechanics of its ancestors, it will inherit none of their styling and won't be queryable via an ancestor type.

With this PR, this code:

```python
from textual.app        import App, ComposeResult, RenderResult
from textual.containers import Horizontal, Vertical
from textual.widgets    import Static, TextLog

class CustomParent( Static ):

    def __init__( self ) -> None:
        super().__init__()
        self.border_title = self.__class__.__name__

    def render(self) -> RenderResult:
        return str( self._css_type_names )

class CustomChild( CustomParent ):
    pass

class CustomGrandChild( CustomChild, isolate_css_type=True ):
    pass

class CSSTypeExplorerApp( App[ None ] ):

    CSS = """
    Static {
        border: panel green;
    }

    CustomGrandChild {
        border: panel red;
    }
    """

    def compose( self ) -> ComposeResult:
        with Horizontal():
            with Vertical():
                yield CustomParent()
                yield CustomChild()
                yield CustomGrandChild()
            yield TextLog()

    def on_mount( self ) -> None:
        for static in self.query( Static ):
            self.query_one( TextLog ).write( f"{static!r}" )

if __name__ == "__main__":
    CSSTypeExplorerApp().run()
```

produces this:

![Screenshot 2023-06-08 at 11 33 08](https://github.com/Textualize/textual/assets/28237/4b94cf7c-671a-46a4-bba2-8569be82e075)

*(Note Tooltip appearing here, which relates to a motivation behind this quite nicely - #2723)*