### PR TITLE
Re-raise encountered exceptions in pilot tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed setting `TreeNode.label` on an existing `Tree` node not immediately https://github.com/Textualize/textual/pull/2713
 - Correctly implement `__eq__` protocol in DataTable https://github.com/Textualize/textual/pull/2705
 - Fixed exceptions in Pilot tests being silently ignored https://github.com/Textualize/textual/pull/2754
+- Fixed issue where internal data of `OptionList` could be invalid for short window after `clear_options` https://github.com/Textualize/textual/pull/2754
 - Fixed `Tooltip` causing a `query_one` on a lone `Static` to fail https://github.com/Textualize/textual/issues/2723
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed setting `TreeNode.label` on an existing `Tree` node not immediately https://github.com/Textualize/textual/pull/2713
 - Correctly implement `__eq__` protocol in DataTable https://github.com/Textualize/textual/pull/2705
+- Fixed exceptions in Pilot tests being silently ignored https://github.com/Textualize/textual/pull/2754
 
 ### Changed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -370,7 +370,7 @@ class App(Generic[ReturnType], DOMNode):
         """The unhandled exception which is leading to the app shutting down,
         or None if the app is still running with no unhandled exceptions."""
 
-        self._exception_event: asyncio.Event | None = None
+        self._exception_event: asyncio.Event = asyncio.Event()
         """An event that will be set when the first exception is encountered."""
 
         self.title = (
@@ -1089,7 +1089,6 @@ class App(Generic[ReturnType], DOMNode):
                 message_hook_context_var.set(message_hook)
             app._loop = asyncio.get_running_loop()
             app._thread_id = threading.get_ident()
-            app._exception_event = asyncio.Event()
             await app._process_messages(
                 ready_callback=on_app_ready,
                 headless=headless,

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -491,14 +491,25 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Process messages until the queue is closed."""
         _rich_traceback_guard = True
         self._thread_id = threading.get_ident()
+        from .app import App
+
         while not self._closed:
             try:
                 message = await self._get_message()
+                if isinstance(self, App):
+                    print(f"APP received message = {message!r}")
+                    print(f"App queue = {self._message_queue._queue}")
             except MessagePumpClosed:
+                if isinstance(self, App):
+                    print(f"APP MESSAGE PUMP CLOSED - NO LONGER PROCESSING MESSAGES")
+                    print(f"App queue = {self._message_queue._queue}")
                 break
             except CancelledError:
                 raise
             except Exception as error:
+                if isinstance(self, App):
+                    print(f"Exception occurred in process messages loop")
+                    print(f"App queue = {self._message_queue._queue}")
                 raise error from None
 
             # Combine any pending messages that may supersede this one

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -491,25 +491,15 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Process messages until the queue is closed."""
         _rich_traceback_guard = True
         self._thread_id = threading.get_ident()
-        from .app import App
 
         while not self._closed:
             try:
                 message = await self._get_message()
-                if isinstance(self, App):
-                    print(f"APP received message = {message!r}")
-                    print(f"App queue = {self._message_queue._queue}")
             except MessagePumpClosed:
-                if isinstance(self, App):
-                    print(f"APP MESSAGE PUMP CLOSED - NO LONGER PROCESSING MESSAGES")
-                    print(f"App queue = {self._message_queue._queue}")
                 break
             except CancelledError:
                 raise
             except Exception as error:
-                if isinstance(self, App):
-                    print(f"Exception occurred in process messages loop")
-                    print(f"App queue = {self._message_queue._queue}")
                 raise error from None
 
             # Combine any pending messages that may supersede this one

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -133,7 +133,7 @@ class Pilot(Generic[ReturnType]):
         app.post_message(MouseMove(**message_arguments))
         await self.pause()
 
-    async def _wait_for_screen(self, timeout: float = 4.0) -> bool:
+    async def _wait_for_screen(self, timeout: float = 10.0) -> bool:
         """Wait for the current screen to have processed all pending events.
 
         Args:
@@ -164,8 +164,8 @@ class Pilot(Generic[ReturnType]):
             # Wait for the count to return to zero, or a timeout, or an exception
             _, pending = await asyncio.wait(
                 [
-                    count_zero_event.wait(),
-                    self.app._exception_event.wait(),
+                    asyncio.create_task(count_zero_event.wait()),
+                    asyncio.create_task(self.app._exception_event.wait()),
                 ],
                 timeout=timeout,
                 return_when=asyncio.FIRST_COMPLETED,

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -162,7 +162,7 @@ class Pilot(Generic[ReturnType]):
 
         if count:
             # Wait for the count to return to zero, or a timeout, or an exception
-            await asyncio.wait(
+            _, pending = await asyncio.wait(
                 [
                     count_zero_event.wait(),
                     self.app._exception_event.wait(),
@@ -170,6 +170,8 @@ class Pilot(Generic[ReturnType]):
                 timeout=timeout,
                 return_when=asyncio.FIRST_COMPLETED,
             )
+            for task in pending:
+                task.cancel()
 
             # We've either timed out, encountered an exception, or we've finished
             # decrementing all the counters (all events processed in children).

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -133,7 +133,7 @@ class Pilot(Generic[ReturnType]):
         app.post_message(MouseMove(**message_arguments))
         await self.pause()
 
-    async def _wait_for_screen(self, timeout: float = 30.0) -> bool:
+    async def _wait_for_screen(self, timeout: float = 10.0) -> bool:
         """Wait for the current screen to have processed all pending events.
 
         Args:
@@ -162,8 +162,10 @@ class Pilot(Generic[ReturnType]):
         if count:
             # Wait for the count to return to zero, or a timeout
             try:
+                print("NOW WE WAIT")
                 await asyncio.wait_for(count_zero_event.wait(), timeout=timeout)
             except asyncio.TimeoutError:
+                print("WE'VE TIMED OUT")
                 return False
 
         return True

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -138,14 +138,17 @@ class Pilot(Generic[ReturnType]):
         await self.pause()
 
     async def _wait_for_screen(self, timeout: float = 30.0) -> bool:
-        """Wait for the current screen to have processed all pending events.
+        """Wait for the current screen and its children to have processed all pending events.
 
         Args:
             timeout: A timeout in seconds to wait.
 
         Returns:
-            `True` if all events were processed. `False` if the wait timed
-            out or an exception occurred while in the application.
+            `True` if all events were processed. `False` if an exception occurred,
+            meaning that not all events could be processed.
+
+        Raises:
+            WaitForScreenTimeout: If the screen and its children didn't finish processing within the timeout.
         """
         children = [self.app, *self.app.screen.walk_children(with_self=True)]
         count = 0

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -630,14 +630,7 @@ class OptionList(ScrollView, can_focus=True):
         self.highlighted = None
         self._mouse_hovering_over = None
         self.virtual_size = Size(self.scrollable_content_region.width, 0)
-        # TODO: See https://github.com/Textualize/textual/issues/2582 -- it
-        # should not be necessary to do this like this here; ideally here in
-        # clear_options it would be a forced refresh, and also in a
-        # `on_show` it would be the same (which, I think, would actually
-        # solve the problem we're seeing). But, until such a time as we get
-        # to the bottom of 2582... this seems to delay the refresh enough
-        # that things fall into place.
-        self._request_content_tracking_refresh()
+        self._refresh_content_tracking()
         return self
 
     def _set_option_disabled(self, index: int, disabled: bool) -> Self:

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -630,7 +630,7 @@ class OptionList(ScrollView, can_focus=True):
         self.highlighted = None
         self._mouse_hovering_over = None
         self.virtual_size = Size(self.scrollable_content_region.width, 0)
-        self._refresh_content_tracking()
+        self._refresh_content_tracking(force=True)
         return self
 
     def _set_option_disabled(self, index: int, disabled: bool) -> Self:

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -422,9 +422,7 @@ class Tabs(Widget, can_focus=True):
             active_tab = self.query_one(f"#tabs-list > #{active}", Tab)
             self.query("#tabs-list > Tab.-active").remove_class("-active")
             active_tab.add_class("-active")
-            self.call_after_refresh(
-                self._highlight_active, animate=previously_active != ""
-            )
+            self.call_later(self._highlight_active, animate=previously_active != "")
             self.post_message(self.TabActivated(self, active_tab))
         else:
             underline = self.query_one(Underline)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -1,7 +1,11 @@
 from string import punctuation
 
+import pytest
+
 from textual import events
-from textual.app import App
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widgets import Label
 
 KEY_CHARACTERS_TO_TEST = "akTW03" + punctuation
 """Test some "simple" characters (letters + digits) and all punctuation."""
@@ -19,3 +23,32 @@ async def test_pilot_press_ascii_chars():
         for char in KEY_CHARACTERS_TO_TEST:
             await pilot.press(char)
             assert keys_pressed[-1] == char
+
+
+async def test_pilot_exception_catching_compose():
+    """Ensuring that test frameworks are aware of exceptions
+    inside compose methods when running via Pilot run_test()."""
+
+    class FailingApp(App):
+        def compose(self) -> ComposeResult:
+            1 / 0
+            yield Label("Beep")
+
+    with pytest.raises(ZeroDivisionError):
+        async with FailingApp().run_test():
+            pass
+
+
+async def test_pilot_exception_catching_action():
+    """Ensure that exceptions inside action handlers are presented
+    to the test framework when running via Pilot run_test()."""
+
+    class FailingApp(App):
+        BINDINGS = [Binding("b", "beep", "beep")]
+
+        def action_beep(self) -> None:
+            1 / 0
+
+    with pytest.raises(ZeroDivisionError):
+        async with FailingApp().run_test() as pilot:
+            await pilot.press("b")

--- a/tests/test_screen_modes.py
+++ b/tests/test_screen_modes.py
@@ -182,7 +182,7 @@ async def test_inactive_stack_is_alive():
             yield Label("fast")
 
         def on_mount(self) -> None:
-            self.set_interval(0.01, self.ping)
+            self.call_later(self.set_interval, 0.01, self.ping)
 
         def ping(self) -> None:
             pings.append(str(self.app.query_one(Label).renderable))


### PR DESCRIPTION
When an exception was raised in a pilot test, it prevented logic in `_wait_for_screen` from working correctly (counters would never decrement to zero). The result was that when exceptions occurred, it always timed out.

We now record the first exception that occurs in an app, and we re-raise that exception in the `__aexit__` of the context manager returned by `run_test`, so that tests fail and test frameworks will print the stack trace.

We now detect if an exception occurs and set an event. If the event is set, then `_wait_for_screen` won't wait for the timeout to be reached allowing it to exit early.

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
