### PR TITLE
Correct Row Highlighting When Labeled

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1193,7 +1193,10 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         rows = self.rows
         row_key = self._row_locations.get_key(row_index)
         row = rows[row_key]
-        row_width = sum(column.render_width for column in self.columns.values())
+        row_width = (
+            sum(column.render_width for column in self.columns.values())
+            + self._row_label_column_width
+        )
         y = sum(ordered_row.height for ordered_row in self.ordered_rows[:row_index])
         if self.show_header:
             y += self.header_height


### PR DESCRIPTION
When a DataTable row has a label, the `_get_row_region()` method doesn't factor in the width of the label `_row_label_column_width` causing incorrect highlighting.

**Screenshot:**

![DataTable Row Label Highlight Error](https://github.com/Textualize/textual/assets/44387852/f99001d4-a9f8-4d55-81d7-f3c98883cc2e)

**Screen Recording:**

![DataTable Row Label Highlight Error](https://github.com/Textualize/textual/assets/44387852/3b28b74d-b3ce-420a-8249-af9636bfee2e)

**Example Code (slightly modified from DataTable docs):**

```python
from textual.app import App, ComposeResult
from textual.widgets import DataTable

ROWS = [
    ("lane", "swimmer", "country", "time"),
    (4, "Joseph Schooling", "Singapore", 50.39),
    (2, "Michael Phelps", "United States", 51.14),
    (5, "Chad le Clos", "South Africa", 51.14),
    (6, "László Cseh", "Hungary", 51.14),
    (3, "Li Zhuhao", "China", 51.26),
    (8, "Mehdy Metella", "France", 51.58),
    (7, "Tom Shields", "United States", 51.73),
    (1, "Aleksandr Sadovnikov", "Russia", 51.84),
    (10, "Darren Burns", "Scotland", 51.84),
]


class TableApp(App):
    def compose(self) -> ComposeResult:
        yield DataTable()

    def on_mount(self) -> None:
        table = self.query_one(DataTable)
        table.cursor_type = "row"
        table.zebra_stripes = True
        table.add_columns(*ROWS[0])
        for row in ROWS[1:]:
            table.add_row(*row, label="Label")


app = TableApp()
if __name__ == "__main__":
    app.run()
```

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
