### PR TITLE
Don't return anything from `AwaitMount.__call__`

### DIFF
--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -25,7 +25,7 @@ class AwaitRemove:
         self._task = task
 
     async def __call__(self) -> None:
-        return await self
+        await self
 
     def __await__(self) -> Generator[None, None, None]:
         async def await_prune() -> None:


### PR DESCRIPTION
Possibly the least-useful PR I've made yet; but once seen it could not be unseen.
