### PR TITLE
Awaitable tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Breaking change: The `@on` decorator will now match a message class and any child classes https://github.com/Textualize/textual/pull/2746
+- `Tabs.add_tab` is now optionally awaitable https://github.com/Textualize/textual/pull/2778
+- `Tabs.add_tab` now takes `before` and `after` arguments to position a new tab https://github.com/Textualize/textual/pull/2778
+- `Tabs.remove_tab` is now optionally awaitable https://github.com/Textualize/textual/pull/2778
+- Breaking change: `Tabs.clear` has been changed from returning `self` to being optionally awaitable https://github.com/Textualize/textual/pull/2778
 
 ## [0.27.0] - 2023-06-01
 

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -363,6 +363,9 @@ class Tabs(Widget, can_focus=True):
 
         Args:
             tab_or_id: The Tab's id.
+
+        Returns:
+            An awaitable object that waits for the tab to be removed.
         """
         if tab_or_id is None:
             return self.app._remove_nodes([], None)

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -345,18 +345,17 @@ class Tabs(Widget, can_focus=True):
 
         return mount_await
 
-    def clear(self) -> Self:
+    def clear(self) -> AwaitRemove:
         """Clear all the tabs.
 
         Returns:
-            The `Tabs` instance.
+            An awaitable object that waits for the tabs to be removed.
         """
         underline = self.query_one(Underline)
         underline.highlight_start = 0
         underline.highlight_end = 0
-        self.query("#tabs-list > Tab").remove()
-        self.post_message(self.Cleared(self))
-        return self
+        self.call_after_refresh(self.post_message, self.Cleared(self))
+        return self.query("#tabs-list > Tab").remove()
 
     def remove_tab(self, tab_or_id: Tab | str | None) -> AwaitRemove:
         """Remove a tab.

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -419,7 +419,10 @@ class Tabs(Widget, can_focus=True):
     def watch_active(self, previously_active: str, active: str) -> None:
         """Handle a change to the active tab."""
         if active:
-            active_tab = self.query_one(f"#tabs-list > #{active}", Tab)
+            try:
+                active_tab = self.query_one(f"#tabs-list > #{active}", Tab)
+            except NoMatches:
+                return
             self.query("#tabs-list > Tab.-active").remove_class("-active")
             active_tab.add_class("-active")
             self.call_later(self._highlight_active, animate=previously_active != "")

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -334,8 +334,8 @@ class Tabs(Widget, can_focus=True):
             Tabs.TabError: If there is a problem with the addition request.
 
         Note:
-            Only one of ``before`` or ``after`` can be provided. If both are
-            provided a ``MountError`` will be raised.
+            Only one of `before` or `after` can be provided. If both are
+            provided a `Tabs.TabError` will be raised.
         """
 
         if before and after:

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -20,9 +20,6 @@ from ..renderables.bar import Bar
 from ..widget import AwaitMount, Widget
 from ..widgets import Static
 
-if TYPE_CHECKING:
-    from typing_extensions import Self
-
 
 class Underline(Widget):
     """The animated underline beneath tabs."""

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from textual import on
 from textual.app import App, ComposeResult
 from textual.widgets import Tab, Tabs
@@ -56,7 +58,7 @@ async def test_compose_tabs_from_tabs():
         assert tabs.active_tab.id == "tab-1"
 
 
-async def test_add_tabs_after():
+async def test_add_tabs_later():
     """It should be possible to add tabs later on in the app's cycle."""
 
     class TabsApp(App[None]):
@@ -75,6 +77,127 @@ async def test_add_tabs_after():
         assert tabs.tab_count == 2
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-1"
+
+
+async def test_add_tab_before():
+    """It should be possible to add a tab before another tab."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        await tabs.add_tab("John", before="tab-1")
+        assert tabs.tab_count == 2
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        await tabs.add_tab("John", before=tabs.active_tab)
+        assert tabs.tab_count == 3
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+
+
+async def test_add_tab_before_badly():
+    """Test exceptions from badly adding a tab before another."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        with pytest.raises(Tabs.TabError):
+            tabs.add_tab("John", before="this-is-not-a-tab")
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        with pytest.raises(Tabs.TabError):
+            tabs.add_tab("John", before=Tab("I just made this up"))
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+
+
+async def test_add_tab_after():
+    """It should be possible to add a tab after another tab."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        await tabs.add_tab("John", after="tab-1")
+        assert tabs.tab_count == 2
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        await tabs.add_tab("John", after=tabs.active_tab)
+        assert tabs.tab_count == 3
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+
+
+async def test_add_tab_after_badly():
+    """Test exceptions from badly adding a tab after another."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        with pytest.raises(Tabs.TabError):
+            tabs.add_tab("John", after="this-is-not-a-tab")
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        with pytest.raises(Tabs.TabError):
+            tabs.add_tab("John", after=Tab("I just made this up"))
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+
+
+async def test_add_tab_before_and_after():
+    """Attempting to add a tab before and after another is an error."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == "tab-1"
+        with pytest.raises(Tabs.TabError):
+            tabs.add_tab("John", before="tab-1", after="tab-1")
 
 
 async def test_remove_tabs():

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -213,3 +213,25 @@ async def test_navigate_empty_tabs_with_keyboard():
         await pilot.press("left")
         assert tabs.active_tab is None
         assert tabs.active == ""
+
+
+async def test_navigate_tabs_with_mouse():
+    """It should be possible to navigate tabs with the mouse."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+
+        await pilot.click("#tab-2")
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-2"
+
+        await pilot.click("Underline")
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -66,3 +66,27 @@ async def test_add_tabs_after():
         assert tabs.tab_count == 2
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-1"
+
+
+async def test_remove_tabs():
+    """It should be possible to remove tabs."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        await tabs.remove_tab("tab-1")
+        await pilot.pause()
+        assert tabs.tab_count == 3
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-2"
+        await tabs.remove_tab(tabs.query_one("#tab-2", Tab))
+        await pilot.pause()
+        assert tabs.tab_count == 2
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-3"

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -121,3 +121,33 @@ async def test_clear_tabs():
         await tabs.clear()
         assert tabs.tab_count == 0
         assert tabs.active_tab is None
+
+
+async def test_change_active_from_code():
+    """It should be possible to change the active tab from code.."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == tabs.active_tab.id
+
+        tabs.active = "tab-2"
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-2"
+        assert tabs.active == tabs.active_tab.id
+
+        # TODO: This one is questionable. It seems Tabs has been designed so
+        # that you can set the active tab to an empty string, and it remains
+        # so, and just removes the underline; no other changes. So active
+        # will be an empty string while active_tab will be a tab. This feels
+        # like an oversight. Need to investigate and possibly modify this
+        # behaviour unless there's a good reason for this.
+        tabs.active = ""
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-2"

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -80,12 +80,26 @@ async def test_remove_tabs():
         assert tabs.tab_count == 4
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-1"
+
         await tabs.remove_tab("tab-1")
         await pilot.pause()
         assert tabs.tab_count == 3
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-2"
+
         await tabs.remove_tab(tabs.query_one("#tab-2", Tab))
+        await pilot.pause()
+        assert tabs.tab_count == 2
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-3"
+
+        await tabs.remove_tab("tab-does-not-exist")
+        await pilot.pause()
+        assert tabs.tab_count == 2
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-3"
+
+        await tabs.remove_tab(None)
         await pilot.pause()
         assert tabs.tab_count == 2
         assert tabs.active_tab is not None

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -156,3 +156,33 @@ async def test_change_active_from_code():
         tabs.active = ""
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-2"
+
+
+async def test_navigate_tabs_with_keyboard():
+    """It should be possible to navigate tabs with the keyboard."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == tabs.active_tab.id
+
+        await pilot.press("right")
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-2"
+        assert tabs.active == tabs.active_tab.id
+
+        await pilot.press("left")
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == tabs.active_tab.id
+
+        await pilot.press(*(["left"] * tabs.tab_count))
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        assert tabs.active == tabs.active_tab.id

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -2,6 +2,11 @@ from textual.app import App, ComposeResult
 from textual.widgets import Tab, Tabs
 
 
+async def test_tab_label():
+    """It should be possible to access a tab's label."""
+    assert Tab("Pilot").label_text == "Pilot"
+
+
 async def test_compose_empty_tabs():
     """It should be possible to create an empty Tabs."""
 

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -186,3 +186,25 @@ async def test_navigate_tabs_with_keyboard():
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-1"
         assert tabs.active == tabs.active_tab.id
+
+
+async def test_navigate_empty_tabs_with_keyboard():
+    """It should be possible to navigate an empty tabs with the keyboard."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs()
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 0
+        assert tabs.active_tab is None
+        assert tabs.active == ""
+
+        await pilot.press("right")
+        assert tabs.active_tab is None
+        assert tabs.active == ""
+
+        await pilot.press("left")
+        assert tabs.active_tab is None
+        assert tabs.active == ""

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,5 +1,5 @@
 from textual.app import App, ComposeResult
-from textual.widgets import Tabs
+from textual.widgets import Tab, Tabs
 
 
 async def test_compose_empty_tabs():
@@ -20,6 +20,25 @@ async def test_compose_tabs_from_strings():
     class TabsApp(App[None]):
         def compose(self) -> ComposeResult:
             yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+
+
+async def test_compose_tabs_from_tabs():
+    """It should be possible to create a Tabs from some Tabs."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs(
+                Tab("John"),
+                Tab("Aeryn"),
+                Tab("Moya"),
+                Tab("Pilot"),
+            )
 
     async with TabsApp().run_test() as pilot:
         tabs = pilot.app.query_one(Tabs)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -105,6 +105,11 @@ async def test_remove_tabs():
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-3"
 
+        await tabs.remove_tab("tab-3")
+        await tabs.remove_tab("tab-4")
+        assert tabs.tab_count == 0
+        assert tabs.active_tab is None
+
 
 async def test_clear_tabs():
     """It should be possible to clear all tabs."""

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,0 +1,49 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Tabs
+
+
+async def test_compose_empty_tabs():
+    """It should be possible to create an empty Tabs."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs()
+
+    async with TabsApp().run_test() as pilot:
+        assert pilot.app.query_one(Tabs).tab_count == 0
+        assert pilot.app.query_one(Tabs).active_tab is None
+
+
+async def test_compose_tabs_from_strings():
+    """It should be possible to create a Tabs from some strings."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+
+
+async def test_add_tabs_after():
+    """It should be possible to add tabs later on in the app's cycle."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs()
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 0
+        assert tabs.active_tab is None
+        await tabs.add_tab("John")
+        assert tabs.tab_count == 1
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        await tabs.add_tab("Aeryn")
+        assert tabs.tab_count == 2
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -90,3 +90,20 @@ async def test_remove_tabs():
         assert tabs.tab_count == 2
         assert tabs.active_tab is not None
         assert tabs.active_tab.id == "tab-3"
+
+
+async def test_clear_tabs():
+    """It should be possible to clear all tabs."""
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("John", "Aeryn", "Moya", "Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.tab_count == 4
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "tab-1"
+        await tabs.clear()
+        assert tabs.tab_count == 0
+        assert tabs.active_tab is None


### PR DESCRIPTION
A PR that updates the `Tabs` widget with some QoL updates. These include:

- Unit tests; there were none originally so this adds as much as possible
- Changes the way that `add_tab`, `remove_tab` and `clear` work so that they can be optionally awaited (this is in service of changes I started making to `TabbedContent`, which really needed this to happen)
- Adds `before` and `after` arguments to `add_tab`, pulling in the core idea of #2762 by @blob42

