### PR TITLE
Inherited tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue where internal data of `OptionList` could be invalid for short window after `clear_options` https://github.com/Textualize/textual/pull/2754
 - Fixed `Tooltip` causing a `query_one` on a lone `Static` to fail https://github.com/Textualize/textual/issues/2723
 - Nested widgets wouldn't lose focus when parent is disabled https://github.com/Textualize/textual/issues/2772
+- Tooltips now work with compound widgets https://github.com/Textualize/textual/issues/2789
 
 ### Changed
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -447,6 +447,8 @@ class Widget(DOMNode):
     @property
     def tooltip(self) -> RenderableType | None:
         """Tooltip for the widget, or `None` for no tooltip."""
+        if self._tooltip is None and isinstance(self.parent, Widget):
+            return self.parent.tooltip
         return self._tooltip
 
     @tooltip.setter

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -355,3 +355,15 @@ def test_get_set_tooltip():
     assert widget.tooltip == "This is a tooltip."
 
 
+def test_get_set_inherited_tooltip():
+    tooltip = "This is a tooltip."
+    child = Widget()
+    parent = Widget(child)
+    parent.tooltip = tooltip
+    assert parent.tooltip == tooltip
+    assert child.tooltip == tooltip
+    child = Widget()
+    parent = Widget(child)
+    child.tooltip = tooltip
+    assert parent.tooltip is None
+    assert child.tooltip == tooltip


### PR DESCRIPTION
If a widget's tooltip is checked for, and it doesn't have one, one will be looked for within its ancestors. This allows for the setting of tooltips on compound widgets and solves #2789.