### PR TITLE
satisfy pyright

### DIFF
--- a/docs/examples/guide/input/binding01.py
+++ b/docs/examples/guide/input/binding01.py
@@ -8,7 +8,6 @@ class Bar(Static):
 
 
 class BindingApp(App):
-
     CSS_PATH = "binding01.css"
     BINDINGS = [
         ("r", "add_bar('red')", "Add Red"),

--- a/src/textual/_types.py
+++ b/src/textual/_types.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Union
 from typing_extensions import Protocol
 
 if TYPE_CHECKING:
+    from rich.segment import Segment
+
     from .message import Message
 
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -721,7 +721,7 @@ class App(Generic[ReturnType], DOMNode):
         return self._animator
 
     @property
-    def screen(self) -> Screen:
+    def screen(self) -> Screen[object]:
         """The current active screen.
 
         Returns:
@@ -834,8 +834,8 @@ class App(Generic[ReturnType], DOMNode):
     def call_from_thread(
         self,
         callback: Callable[..., CallThreadReturnType | Awaitable[CallThreadReturnType]],
-        *args,
-        **kwargs,
+        *args: object,
+        **kwargs: object,
     ) -> CallThreadReturnType:
         """Run a callable from another thread, and return the result.
 
@@ -1712,7 +1712,7 @@ class App(Generic[ReturnType], DOMNode):
                     return name
         return None
 
-    def pop_screen(self) -> Screen:
+    def pop_screen(self) -> Screen[object]:
         """Pop the current [screen](/guide/screens) from the stack, and switch to the previous screen.
 
         Returns:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -457,7 +457,7 @@ class DOMNode(MessagePump):
         return cast("DOMNode | None", self._parent)
 
     @property
-    def screen(self) -> "Screen":
+    def screen(self) -> "Screen[object]":
         """The screen containing this node.
 
         Returns:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -31,8 +31,13 @@ from .reactive import Reactive, TooManyComputesError
 from .timer import Timer, TimerCallback
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from .app import App
     from .css.model import SelectorSet
+
+
+Callback: TypeAlias = "Callable[..., Any] | Callable[..., Awaitable[Any]]"
 
 
 class CallbackError(Exception):
@@ -174,7 +179,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         return self._parent is not None
 
     @property
-    def app(self) -> "App":
+    def app(self) -> "App[object]":
         """
         Get the current app.
 
@@ -369,7 +374,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         self._timers.add(timer)
         return timer
 
-    def call_after_refresh(self, callback: Callable, *args: Any, **kwargs: Any) -> bool:
+    def call_after_refresh(self, callback: Callback, *args: Any, **kwargs: Any) -> bool:
         """Schedule a callback to run after all messages are processed and the screen
         has been refreshed. Positional and keyword arguments are passed to the callable.
 
@@ -387,7 +392,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         message = messages.InvokeLater(partial(callback, *args, **kwargs))
         return self.post_message(message)
 
-    def call_later(self, callback: Callable, *args: Any, **kwargs: Any) -> bool:
+    def call_later(self, callback: Callback, *args: Any, **kwargs: Any) -> bool:
         """Schedule a callback to run after all messages are processed in this object.
         Positional and keywords arguments are passed to the callable.
 
@@ -404,7 +409,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         message = events.Callback(callback=partial(callback, *args, **kwargs))
         return self.post_message(message)
 
-    def call_next(self, callback: Callable, *args: Any, **kwargs: Any) -> None:
+    def call_next(self, callback: Callback, *args: Any, **kwargs: Any) -> None:
         """Schedule a callback to run immediately after processing the current message.
 
         Args:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -20,7 +20,7 @@ def test_call_from_thread():
     class BackgroundThread(Thread):
         """A background thread which will modify app in some way."""
 
-        def __init__(self, app: App) -> None:
+        def __init__(self, app: App[object]) -> None:
             self.app = app
             super().__init__()
 
@@ -33,7 +33,7 @@ def test_call_from_thread():
             # Exit the app with a code we can assert
             self.app.call_from_thread(self.app.exit, 123)
 
-    class ThreadTestApp(App):
+    class ThreadTestApp(App[object]):
         """Trivial app with a single widget."""
 
         def compose(self) -> ComposeResult:


### PR DESCRIPTION
Proposed changed to satisfy Pyright in strict mode.

By typing the App and Screen with `[object]`, we are basically telling Pyright we don't know what the return type is, but it doesn't matter in this context.

had to adjust some settings in VSCode to get these errors to raise in the first place.