### PR TITLE
`Markdown` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed indented code blocks not showing up in `Markdown` https://github.com/Textualize/textual/issues/2781
 - Fixed inline code blocks in lists showing out of order in `Markdown` https://github.com/Textualize/textual/issues/2676
+- Fixed list items in a `Markdown` being added to the focus chain https://github.com/Textualize/textual/issues/2380
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed indented code blocks not showing up in `Markdown` https://github.com/Textualize/textual/issues/2781
+- Fixed inline code blocks in lists showing out of order in `Markdown` https://github.com/Textualize/textual/issues/2676
+
+### Added
+
+- Added a method of allowing third party code to handle unhandled tokens in `Markdown` https://github.com/Textualize/textual/pull/2803
+- Added `MarkdownBlock` as an exported symbol in `textual.widgets.markdown` https://github.com/Textualize/textual/pull/2803
+
 ## [0.28.0] - 2023-06-19
 
 ### Added

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -654,7 +654,6 @@ class Markdown(Widget):
         Returns:
             Either a widget to be added to the output, or `None`.
         """
-        del token
         return None
 
     def update(self, markdown: str) -> None:

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -790,7 +790,7 @@ class Markdown(Widget):
                             style_stack.pop()
 
                 stack[-1].set_content(content)
-            elif token.type == "fence":
+            elif token.type in ("fence", "code_block"):
                 output.append(
                     MarkdownFence(
                         self,

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -801,7 +801,7 @@ class Markdown(Widget):
             else:
                 external = self.unhandled_token(token)
                 if external is not None:
-                    output.append(external)
+                    (stack[-1]._blocks if stack else output).append(external)
 
         self.post_message(Markdown.TableOfContentsUpdated(self, table_of_contents))
         with self.app.batch_update():

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -13,7 +13,7 @@ from rich.text import Text
 from typing_extensions import TypeAlias
 
 from ..app import ComposeResult
-from ..containers import Horizontal, VerticalScroll
+from ..containers import Horizontal, Vertical, VerticalScroll
 from ..events import Mount
 from ..message import Message
 from ..reactive import reactive, var
@@ -270,7 +270,7 @@ class MarkdownBulletList(MarkdownList):
         width: 1fr;
     }
 
-    MarkdownBulletList VerticalScroll {
+    MarkdownBulletList Vertical {
         height: auto;
         width: 1fr;
     }
@@ -281,7 +281,7 @@ class MarkdownBulletList(MarkdownList):
             if isinstance(block, MarkdownListItem):
                 bullet = MarkdownBullet()
                 bullet.symbol = block.bullet
-                yield Horizontal(bullet, VerticalScroll(*block._blocks))
+                yield Horizontal(bullet, Vertical(*block._blocks))
         self._blocks.clear()
 
 
@@ -299,7 +299,7 @@ class MarkdownOrderedList(MarkdownList):
         width: 1fr;
     }
 
-    MarkdownOrderedList VerticalScroll {
+    MarkdownOrderedList Vertical {
         height: auto;
         width: 1fr;
     }
@@ -322,7 +322,7 @@ class MarkdownOrderedList(MarkdownList):
             if isinstance(block, MarkdownListItem):
                 bullet = MarkdownBullet()
                 bullet.symbol = f"{number}{suffix}".rjust(symbol_size + 1)
-                yield Horizontal(bullet, VerticalScroll(*block._blocks))
+                yield Horizontal(bullet, Vertical(*block._blocks))
 
         self._blocks.clear()
 
@@ -450,7 +450,7 @@ class MarkdownListItem(MarkdownBlock):
         height: auto;
     }
 
-    MarkdownListItem > VerticalScroll {
+    MarkdownListItem > Vertical {
         width: 1fr;
         height: auto;
     }

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -4,6 +4,7 @@ from pathlib import Path, PurePath
 from typing import Callable, Iterable
 
 from markdown_it import MarkdownIt
+from markdown_it.token import Token
 from rich import box
 from rich.style import Style
 from rich.syntax import Syntax
@@ -644,6 +645,18 @@ class Markdown(Widget):
         self.update(markdown)
         return True
 
+    def unhandled_token(self, token: Token) -> MarkdownBlock | None:
+        """Process an unhandled token.
+
+        Args:
+            token: The token to handle.
+
+        Returns:
+            Either a widget to be added to the output, or `None`.
+        """
+        del token
+        return None
+
     def update(self, markdown: str) -> None:
         """Update the document with new Markdown.
 
@@ -785,6 +798,10 @@ class Markdown(Widget):
                         token.info,
                     )
                 )
+            else:
+                external = self.unhandled_token(token)
+                if external is not None:
+                    output.append(external)
 
         self.post_message(Markdown.TableOfContentsUpdated(self, table_of_contents))
         with self.app.batch_update():

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -791,7 +791,7 @@ class Markdown(Widget):
 
                 stack[-1].set_content(content)
             elif token.type in ("fence", "code_block"):
-                output.append(
+                (stack[-1]._blocks if stack else output).append(
                     MarkdownFence(
                         self,
                         token.content.rstrip(),

--- a/src/textual/widgets/markdown.py
+++ b/src/textual/widgets/markdown.py
@@ -1,3 +1,3 @@
-from ._markdown import Markdown, MarkdownTableOfContents
+from ._markdown import Markdown, MarkdownBlock, MarkdownTableOfContents
 
-__all__ = ["MarkdownTableOfContents", "Markdown"]
+__all__ = ["MarkdownTableOfContents", "Markdown", "MarkdownBlock"]

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,60 @@
+"""Unit tests for the Markdown widget."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+
+import textual.widgets._markdown as MD
+from textual.app import App, ComposeResult
+from textual.widget import Widget
+from textual.widgets import Markdown
+
+
+class MarkdownApp(App[None]):
+    def __init__(self, markdown: str) -> None:
+        super().__init__()
+        self._markdown = markdown
+
+    def compose(self) -> ComposeResult:
+        yield Markdown(self._markdown)
+
+
+@pytest.mark.parametrize(
+    ["document", "expected_nodes"],
+    [
+        # Basic markup.
+        ("", []),
+        ("# Hello", [MD.MarkdownH1]),
+        ("## Hello", [MD.MarkdownH2]),
+        ("### Hello", [MD.MarkdownH3]),
+        ("#### Hello", [MD.MarkdownH4]),
+        ("##### Hello", [MD.MarkdownH5]),
+        ("###### Hello", [MD.MarkdownH6]),
+        ("---", [MD.MarkdownHorizontalRule]),
+        ("Hello", [MD.MarkdownParagraph]),
+        ("Hello\nWorld", [MD.MarkdownParagraph]),
+        ("> Hello", [MD.MarkdownBlockQuote, MD.MarkdownParagraph]),
+        ("- One\n-Two", [MD.MarkdownBulletList]),
+        ("1. One\n2. Two", [MD.MarkdownOrderedList]),
+        ("```\n1\n```", [MD.MarkdownFence]),
+        ("```python\n1\n```", [MD.MarkdownFence]),
+        ("""| One | Two |\n| :- | :- |\n| 1 | 2 |""", [MD.MarkdownTable]),
+    ],
+)
+async def test_markdown_nodes(
+    document: str, expected_nodes: list[Widget | list[Widget]]
+) -> None:
+    """A Markdown document should parse into the expected Textual node list."""
+
+    def markdown_nodes(root: Markdown | MD.MarkdownBlock) -> Iterator[MD.MarkdownBlock]:
+        for node in root.children:
+            if isinstance(node, MD.MarkdownBlock):
+                yield node
+                yield from markdown_nodes(node)
+
+    async with MarkdownApp(document).run_test() as pilot:
+        assert [
+            node.__class__ for node in markdown_nodes(pilot.app.query_one(Markdown))
+        ] == expected_nodes

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -54,6 +54,7 @@ class MarkdownApp(App[None]):
         ("> Hello", [MD.MarkdownBlockQuote, MD.MarkdownParagraph]),
         ("- One\n-Two", [MD.MarkdownBulletList]),
         ("1. One\n2. Two", [MD.MarkdownOrderedList]),
+        ("    1", [MD.MarkdownFence]),
         ("```\n1\n```", [MD.MarkdownFence]),
         ("```python\n1\n```", [MD.MarkdownFence]),
         ("""| One | Two |\n| :- | :- |\n| 1 | 2 |""", [MD.MarkdownTable]),

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -86,7 +86,6 @@ async def test_markdown_nodes(
             yield from markdown_nodes(node)
 
     async with MarkdownApp(document).run_test() as pilot:
-        await pilot.pause()
         assert [
             node.__class__ for node in markdown_nodes(pilot.app.query_one(Markdown))
         ] == expected_nodes


### PR DESCRIPTION
A small selection of `Markdown` QoL changes and fixes, including:

1. Adds an `unhandled_token` method, which in `Markdown` itself is a no-op (giving the effect of what happened before this was added), but also lets anyone inherit from `Markdown` and handle other MarkdownIT tokens -- possibly those added via extensions that aren't included in core Textual. This is also useful for testing purposes too as the method can be overridden to raise an error rather than ignore unknown tokens.
2. Exports `MarkdownBlock` from `textual.widgets.markdown`; pretty necessary for anyone wanting to use the above[^1].
3. Starts some `Markdown`-specific unit testing. Just the basics for now, but this at least provides some baseline tests and also a framework for further testing.
4. Adds a fix for #2781 (code blocks not appearing; not to be confused with fenced blocks).
5. By extension adds a fix for half of #2676.
6. Adds a fix for the main half of #2676 -- ensuring that code blocks in lists are rendered inline.
7. Adds a fix for #2380 

[^1]: I am thinking it might be a good idea to export all the major Markdown widgets in this way.