### PR TITLE
fix(markdown): render softbreak split links

### DIFF
--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -725,7 +725,7 @@ class Markdown(Widget):
                         if child.type == "hardbreak":
                             content.append("\n")
                         if child.type == "softbreak":
-                            content.append(" ")
+                            content.append(" ", style_stack[-1])
                         elif child.type == "code_inline":
                             content.append(
                                 child.content,


### PR DESCRIPTION
Fixes #2805.

Currently a link split over several lines is not rendered correctly in `Markdown`, as the softbreak tokens are parsed only as spaces without any Rich styling.

**Example markdown:**

```
My site [has
this
URL](https://example.com)
```

**Screenshot:**

![Screenshot from 2023-06-19 15-07-27](https://user-images.githubusercontent.com/781059/246853583-0b765e80-cc45-400e-b72f-22f75f60c68e.png)

**Rich `Text` object:**

```python
<text 'My site has this URL' [
    Span(0, 8, Style()), 
    Span(8, 11, Style(meta={'@click': "link('https://example.com')"})), 
    Span(12, 16, Style(meta={'@click': "link('https://example.com')"})), 
    Span(17, 20, Style(meta={'@click': "link('https://example.com')"}))
]>
```

Here's the Text object after the fix suggested in this PR, where the spaces at indices 11 and 16 also have the link styling applied:

```python
<text 'My site has this URL' [
    Span(0, 8, Style()), 
    Span(8, 11, Style(meta={'@click': "link('https://example.com')"})), 
    Span(11, 12, Style(meta={'@click': "link('https://example.com')"})), 
    Span(12, 16, Style(meta={'@click': "link('https://example.com')"})), 
    Span(16, 17, Style(meta={'@click': "link('https://example.com')"})), 
    Span(17, 20, Style(meta={'@click': "link('https://example.com')"}))
]>
```