### PR TITLE
fix for opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added can-focus pseudo-class to target widgets that may receive focus
+
+### Fixed
+
+- Fixed issues with opacity on Screens https://github.com/Textualize/textual/issues/2616
+
+
 ## [0.28.1] - 2023-06-20
 
 ### Fixed

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -917,13 +917,12 @@ class Compositor:
             widget_regions = [
                 (widget, region, clip)
                 for widget, (region, clip) in visible_widgets.items()
-                if crop_overlaps(clip) and widget.styles.opacity > 0
+                if crop_overlaps(clip)
             ]
         else:
             widget_regions = [
                 (widget, region, clip)
                 for widget, (region, clip) in visible_widgets.items()
-                if widget.styles.opacity > 0
             ]
 
         intersection = _Region.intersection

--- a/src/textual/_opacity.py
+++ b/src/textual/_opacity.py
@@ -27,19 +27,19 @@ def _apply_opacity(
     blend = base_background.blend
     for segment in segments:
         text, style, _ = segment
-        if not style:
-            yield segment
-            continue
+        # if not style:
+        #     yield segment
+        #     continue
 
         blended_style = style
-        if style.color:
+        if style.color is not None:
             color = from_rich_color(style.color)
-            blended_foreground = blend(color, factor=opacity)
+            blended_foreground = blend(color, opacity)
             blended_style += from_color(color=blended_foreground.rich_color)
 
-        if style.bgcolor:
+        if style.bgcolor is not None:
             bgcolor = from_rich_color(style.bgcolor)
-            blended_background = blend(bgcolor, factor=opacity)
+            blended_background = blend(bgcolor, opacity)
             blended_style += from_color(bgcolor=blended_background.rich_color)
 
         yield _Segment(text, blended_style)

--- a/src/textual/_opacity.py
+++ b/src/textual/_opacity.py
@@ -27,11 +27,8 @@ def _apply_opacity(
     blend = base_background.blend
     for segment in segments:
         text, style, _ = segment
-        # if not style:
-        #     yield segment
-        #     continue
-
         blended_style = style
+
         if style.color is not None:
             color = from_rich_color(style.color)
             blended_foreground = blend(color, opacity)

--- a/src/textual/_styles_cache.py
+++ b/src/textual/_styles_cache.py
@@ -321,7 +321,7 @@ class StylesCache:
             is_top = y == 0
             border_color = base_background + (
                 border_top_color if is_top else border_bottom_color
-            )
+            ).multiply_alpha(opacity)
             border_color_as_style = from_color(color=border_color.rich_color)
             border_edge_type = border_top if is_top else border_bottom
             has_left = border_left != ""
@@ -383,11 +383,15 @@ class StylesCache:
         ):
             background_style = from_color(bgcolor=background.rich_color)
             left_style = from_color(
-                color=(base_background + border_left_color).rich_color
+                color=(
+                    base_background + border_left_color.multiply_alpha(opacity)
+                ).rich_color
             )
             left = get_box(border_left, inner, outer, left_style)[1][0]
             right_style = from_color(
-                color=(base_background + border_right_color).rich_color
+                color=(
+                    base_background + border_right_color.multiply_alpha(opacity)
+                ).rich_color
             )
             right = get_box(border_right, inner, outer, right_style)[1][2]
             if border_left and border_right:
@@ -415,11 +419,15 @@ class StylesCache:
             if border_left or border_right:
                 # Add left / right border
                 left_style = from_color(
-                    (base_background + border_left_color).rich_color
+                    (
+                        base_background + border_left_color.multiply_alpha(opacity)
+                    ).rich_color
                 )
                 left = get_box(border_left, inner, outer, left_style)[1][0]
                 right_style = from_color(
-                    (base_background + border_right_color).rich_color
+                    (
+                        base_background + border_right_color.multiply_alpha(opacity)
+                    ).rich_color
                 )
                 right = get_box(border_right, inner, outer, right_style)[1][2]
 

--- a/src/textual/_styles_cache.py
+++ b/src/textual/_styles_cache.py
@@ -110,7 +110,7 @@ class StylesCache:
         border_title = widget._border_title
         border_subtitle = widget._border_subtitle
 
-        base_background, background = widget.background_colors
+        base_background, background = widget._opacity_background_colors
         styles = widget.styles
         strips = self.render(
             styles,
@@ -139,6 +139,7 @@ class StylesCache:
             padding=styles.padding,
             crop=crop,
             filters=widget.app._filters,
+            opacity=widget.opacity,
         )
         if widget.auto_links:
             hover_style = widget.hover_style
@@ -170,6 +171,7 @@ class StylesCache:
         padding: Spacing | None = None,
         crop: Region | None = None,
         filters: Sequence[LineFilter] | None = None,
+        opacity: float = 1.0,
     ) -> list[Strip]:
         """Render a widget content plus CSS styles.
 
@@ -186,6 +188,7 @@ class StylesCache:
             padding: Override padding from Styles, or None to use styles.padding.
             crop: Region to crop to.
             filters: Additional post-processing for the segments.
+            opacity: Widget opacity.
 
         Returns:
             Rendered lines.
@@ -220,6 +223,7 @@ class StylesCache:
                     console,
                     border_title,
                     border_subtitle,
+                    opacity,
                 )
                 self._cache[y] = strip
             else:
@@ -249,6 +253,7 @@ class StylesCache:
         console: Console,
         border_title: tuple[Text, Color, Color, Style] | None,
         border_subtitle: tuple[Text, Color, Color, Style] | None,
+        opacity: float,
     ) -> Strip:
         """Render a styled line.
 
@@ -264,6 +269,7 @@ class StylesCache:
             console: The console in use by the app.
             border_title: Optional tuple of (title, color, background, style).
             border_subtitle: Optional tuple of (subtitle, color, background, style).
+            opacity: Opacity of line.
 
         Returns:
             A line of segments.
@@ -305,8 +311,8 @@ class StylesCache:
             """
             if styles.tint.a:
                 segments = Tint.process_segments(segments, styles.tint)
-            if styles.opacity != 1.0:
-                segments = _apply_opacity(segments, base_background, styles.opacity)
+            if opacity != 1.0:
+                segments = _apply_opacity(segments, base_background, opacity)
             return segments
 
         line: Iterable[Segment]

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -715,10 +715,6 @@ class App(Generic[ReturnType], DOMNode):
             yield "pseudo_classes", set(pseudo_classes)
 
     @property
-    def is_transparent(self) -> bool:
-        return True
-
-    @property
     def animator(self) -> Animator:
         return self._animator
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -221,9 +221,9 @@ class App(Generic[ReturnType], DOMNode):
         color: $text;
     }
 
-    *:disabled {
-        opacity: 0.6;
-        text-opacity: 0.8;
+    *:disabled:can-focus {
+        opacity: 0.7;
+
     }
     """
 

--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -348,6 +348,7 @@ class Color(NamedTuple):
         r, g, b, a = self
         return Color(r, g, b, a * alpha)
 
+    @lru_cache(maxsize=1024)
     def blend(
         self, destination: Color, factor: float, alpha: float | None = None
     ) -> Color:
@@ -365,9 +366,9 @@ class Color(NamedTuple):
         Returns:
             A new color.
         """
-        if factor == 0:
+        if factor <= 0:
             return self
-        elif factor == 1:
+        elif factor >= 1:
             return destination
         r1, g1, b1, a1 = self
         r2, g2, b2, a2 = destination
@@ -386,8 +387,7 @@ class Color(NamedTuple):
 
     def __add__(self, other: object) -> Color:
         if isinstance(other, Color):
-            new_color = self.blend(other, other.a, alpha=1.0)
-            return new_color
+            return self.blend(other, other.a, 1.0)
         return NotImplemented
 
     @classmethod

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -1023,8 +1023,9 @@ class FractionalProperty:
     string percentage (e.g. '10%'). Values will be clamped to the range (0, 1).
     """
 
-    def __init__(self, default: float = 1.0):
+    def __init__(self, default: float = 1.0, children: bool = False):
         self.default = default
+        self.children = children
 
     def __set_name__(self, owner: StylesBase, name: str) -> None:
         self.name = name
@@ -1053,7 +1054,7 @@ class FractionalProperty:
         name = self.name
         if value is None:
             if obj.clear_rule(name):
-                obj.refresh()
+                obj.refresh(children=self.children)
             return
 
         if isinstance(value, float):
@@ -1066,7 +1067,7 @@ class FractionalProperty:
                 help_text=fractional_property_help_text(name, context="inline"),
             )
         if obj.set_rule(name, clamp(float_value, 0, 1)):
-            obj.refresh()
+            obj.refresh(children=self.children)
 
 
 class AlignProperty:

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -1024,6 +1024,13 @@ class FractionalProperty:
     """
 
     def __init__(self, default: float = 1.0, children: bool = False):
+        """A property for a fraction / ration.
+
+        Args:
+            default: Default value if the rule wasn't explicitly set.
+            children: If `True`, then updating this value will also refresh children.
+                Otherwise only this widget will be refreshed.
+        """
         self.default = default
         self.children = children
 

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -1024,8 +1024,7 @@ class FractionalProperty:
     """
 
     def __init__(self, default: float = 1.0, children: bool = False):
-        """A property for a fraction / ration.
-
+        """
         Args:
             default: Default value if the rule wasn't explicitly set.
             children: If `True`, then updating this value will also refresh children.

--- a/src/textual/css/constants.py
+++ b/src/textual/css/constants.py
@@ -63,6 +63,7 @@ VALID_STYLE_FLAGS: Final = {
 }
 VALID_PSEUDO_CLASSES: Final = {
     "blur",
+    "can-focus",
     "disabled",
     "enabled",
     "focus-within",

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -242,7 +242,7 @@ class StylesBase(ABC):
     background = ColorProperty(Color(0, 0, 0, 0))
     text_style = StyleFlagsProperty()
 
-    opacity = FractionalProperty()
+    opacity = FractionalProperty(children=True)
     text_opacity = FractionalProperty()
 
     padding = SpacingProperty()

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -744,18 +744,24 @@ class DOMNode(MessagePump):
         """
         background = Color(0, 0, 0, 0)
         color = Color(255, 255, 255, 0)
+
         style = Style()
         opacity = 1.0
+
         for node in reversed(self.ancestors_with_self):
             styles = node.styles
             opacity *= styles.opacity
             if styles.has_rule("background"):
+                text_background = background + styles.background
                 background += styles.background.multiply_alpha(opacity)
+            else:
+                text_background = background
             if styles.has_rule("color"):
                 color = styles.color
             style += styles.text_style
             if styles.has_rule("auto_color") and styles.auto_color:
-                color = background.get_contrast_text(color.a)
+                color = text_background.get_contrast_text(color.a)
+
         style += Style.from_color(
             (background + color).rich_color if (background.a or color.a) else None,
             background.rich_color if background.a else None,
@@ -829,12 +835,12 @@ class DOMNode(MessagePump):
         """
         base_background = background = BLACK
         opacity = 1.0
-        for node in reversed(self.ancestors_with_self[:-1]):
+        for node in reversed(self.ancestors_with_self):
             styles = node.styles
             base_background = background
             opacity *= styles.opacity
             background += styles.background.multiply_alpha(opacity)
-        return (base_background.with_alpha(1), background.with_alpha(1))
+        return (base_background, background)
 
     @property
     def colors(self) -> tuple[Color, Color, Color, Color]:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -745,10 +745,12 @@ class DOMNode(MessagePump):
         background = Color(0, 0, 0, 0)
         color = Color(255, 255, 255, 0)
         style = Style()
+        opacity = 1.0
         for node in reversed(self.ancestors_with_self):
             styles = node.styles
+            opacity *= styles.opacity
             if styles.has_rule("background"):
-                background += styles.background
+                background += styles.background.multiply_alpha(opacity)
             if styles.has_rule("color"):
                 color = styles.color
             style += styles.text_style

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -819,6 +819,22 @@ class DOMNode(MessagePump):
         return (base_background, background)
 
     @property
+    def _opacity_background_colors(self) -> tuple[Color, Color]:
+        """The background color and the color of the parent's background.
+
+        Returns:
+            `(<background color>, <color>)`
+        """
+        base_background = background = BLACK
+        opacity = 1.0
+        for node in reversed(self.ancestors_with_self[:-1]):
+            styles = node.styles
+            base_background = background
+            opacity *= styles.opacity
+            background += styles.background.multiply_alpha(opacity)
+        return (base_background.with_alpha(1), background.with_alpha(1))
+
+    @property
     def colors(self) -> tuple[Color, Color, Color, Color]:
         """The widget's background and foreground colors, and the parent's background and foreground colors.
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -828,7 +828,7 @@ class DOMNode(MessagePump):
 
     @property
     def _opacity_background_colors(self) -> tuple[Color, Color]:
-        """The background color and the color of the parent's background.
+        """Background colors adjusted for opacity.
 
         Returns:
             `(<background color>, <color>)`

--- a/src/textual/renderables/text_opacity.py
+++ b/src/textual/renderables/text_opacity.py
@@ -61,7 +61,7 @@ class TextOpacity:
         _Segment = Segment
         _from_color = Style.from_color
         if opacity == 0:
-            for text, style, control in cast(
+            for text, style, _control in cast(
                 # use Tuple rather than tuple so Python 3.7 doesn't complain
                 Iterable[Tuple[str, Style, object]],
                 segments,

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -177,10 +177,6 @@ class Screen(Generic[ScreenResultType], Widget):
         return self._modal
 
     @property
-    def is_transparent(self) -> bool:
-        return False
-
-    @property
     def is_current(self) -> bool:
         """Is the screen current (i.e. visible to user)?"""
         from .app import ScreenStackError

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -214,7 +214,7 @@ class Screen(Generic[ScreenResultType], Widget):
         except IndexError:
             base_screen = None
 
-        if base_screen is not None and 1 > background.a > 0:
+        if base_screen is not None and background.a < 1:
             return BackgroundScreen(base_screen, background)
 
         if background.is_transparent:

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -29,11 +29,6 @@ class ScrollView(ScrollableContainer):
         """Always scrollable."""
         return True
 
-    @property
-    def is_transparent(self) -> bool:
-        """Not transparent, i.e. renders something."""
-        return False
-
     def watch_scroll_x(self, old_value: float, new_value: float) -> None:
         if self.show_horizontal_scrollbar and round(old_value) != round(new_value):
             self.horizontal_scrollbar.position = round(new_value)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2627,6 +2627,8 @@ class Widget(DOMNode):
             yield "hover"
         if self.has_focus:
             yield "focus"
+        if self.can_focus:
+            yield "can-focus"
         try:
             focused = self.screen.focused
         except NoScreen:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -445,6 +445,16 @@ class Widget(DOMNode):
         self.styles.offset = ScalarOffset.from_offset(offset)
 
     @property
+    def opacity(self) -> float:
+        """Total opacity of widget."""
+        opacity = 1.0
+        for node in reversed(self.ancestors_with_self):
+            opacity *= node.styles.opacity
+            if not opacity:
+                break
+        return opacity
+
+    @property
     def tooltip(self) -> RenderableType | None:
         """Tooltip for the widget, or `None` for no tooltip."""
         return self._tooltip
@@ -1493,11 +1503,6 @@ class Widget(DOMNode):
             Offset a container has been scrolled by.
         """
         return Offset(round(self.scroll_x), round(self.scroll_y))
-
-    @property
-    def is_transparent(self) -> bool:
-        """Does this widget have a transparent background?"""
-        return self.is_scrollable and self.styles.background.is_transparent
 
     @property
     def _console(self) -> Console:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,14 +28,14 @@ async def test_hover_update_styles():
     app = MyApp()
     async with app.run_test() as pilot:
         button = app.query_one(Button)
-        assert button.pseudo_classes == {"enabled"}
+        assert button.pseudo_classes == {"enabled", "can-focus"}
 
         # Take note of the initial background colour
         initial_background = button.styles.background
         await pilot.hover(Button)
 
         # We've hovered, so ensure the pseudoclass is present and background changed
-        assert button.pseudo_classes == {"enabled", "hover"}
+        assert button.pseudo_classes == {"enabled", "hover", "can-focus"}
         assert button.styles.background != initial_background
 
 


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/2616 and more.

Opacity can now be layered. Which means you can have a translucent thing on top of another translucent thing. This created an issue with disabling widgets. If you have a disabled container of widgets, the default styling made them doubly transparent because the default rule target the containers. To solve this, I added a `can-focus` pseudo class so that you can target only widgets that can possibly be focused.