### PR TITLE
Expose the AwaitMount from Markdown.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added can-focus pseudo-class to target widgets that may receive focus
+- Make `Markdown.update` optionally awaitable https://github.com/Textualize/textual/pull/2838
 
 ### Fixed
 


### PR DESCRIPTION
`Markdown.update` ultimately mounts some widgets. This PR returns that `AwaitMount` for the corresponding mount calls, allowing users to (optionally) await to ensure that the mounting of child markdown elements has complete.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
