### PR TITLE
Replace term 'transparency' with 'opacity'

### DIFF
--- a/docs/css_types/color.md
+++ b/docs/css_types/color.md
@@ -14,8 +14,8 @@ A bullet point summary of the formats available follows:
  - a recognised [named color](#named-colors) (e.g., `red`);
  - a 3 or 6 hexadecimal digit number representing the [RGB values](#hex-rgb-value) of the color (e.g., `#F35573`);
  - a 4 or 8 hexadecimal digit number representing the [RGBA values](#hex-rgba-value) of the color (e.g., `#F35573A0`);
- - a color description in the RGB system, [with](#rgba-description) or [without](#rgb-description) transparency (e.g., `rgb(23, 78, 200)`);
- - a color description in the HSL system, [with](#hsla-description) or [without](#hsl-description) transparency (e.g., `hsl(290, 70%, 80%)`);
+ - a color description in the RGB system, [with](#rgba-description) or [without](#rgb-description) opacity (e.g., `rgb(23, 78, 200)`);
+ - a color description in the HSL system, [with](#hsla-description) or [without](#hsl-description) opacity (e.g., `hsl(290, 70%, 80%)`);
 
 [Textual's default themes](../../guide/design#theme-reference) also provide many CSS variables with colors that can be used out of the box.
 
@@ -66,10 +66,10 @@ For example, the color `#A2F` is the same as `#AA22FF`.
 
 ### Hex RGBA value
 
-This is the same as the [hex RGB value](#hex-rgb-value), but with an extra channel for the alpha component (that sets transparency).
+This is the same as the [hex RGB value](#hex-rgb-value), but with an extra channel for the alpha component (that sets opacity).
 
- - If 8 digits are used, the format is `#RRGGBBAA`, equivalent to the format `#RRGGBB` with two extra digits for transparency.
- - If 4 digits are used, the format is `#RGBA`, equivalent to the format `#RGB` with an extra digit for transparency.
+ - If 8 digits are used, the format is `#RRGGBBAA`, equivalent to the format `#RRGGBB` with two extra digits for opacity.
+ - If 4 digits are used, the format is `#RGBA`, equivalent to the format `#RGB` with an extra digit for opacity.
 
 ### `rgb` description
 
@@ -81,9 +81,9 @@ For example, `rgb(0, 255, 32)` is equivalent to `#00FF20`.
 
 ### `rgba` description
 
-The `rgba` format description is the same as the `rgb` with an extra parameter for transparency, which should be a value between `0` and `1`.
+The `rgba` format description is the same as the `rgb` with an extra parameter for opacity, which should be a value between `0` and `1`.
 
-For example, `rgba(0, 255, 32, 0.5)` is the color `rgb(0, 255, 32)` with 50% transparency.
+For example, `rgba(0, 255, 32, 0.5)` is the color `rgb(0, 255, 32)` with 50% opacity.
 
 ### `hsl` description
 
@@ -98,9 +98,9 @@ For example, the color `#00FF20` would be represented as `hsl(128, 100%, 50%)` i
 
 ### `hsla` description
 
-The `hsla` format description is the same as the `hsl` with an extra parameter for transparency, which should be a value between `0` and `1`.
+The `hsla` format description is the same as the `hsl` with an extra parameter for opacity, which should be a value between `0` and `1`.
 
-For example, `hsla(128, 100%, 50%, 0.5)` is the color `hsl(128, 100%, 50%)` with 50% transparency.
+For example, `hsla(128, 100%, 50%, 0.5)` is the color `hsl(128, 100%, 50%)` with 50% opacity.
 
 ## Examples
 

--- a/docs/styles/background.md
+++ b/docs/styles/background.md
@@ -8,7 +8,7 @@ The `background` style sets the background color of a widget.
 background: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-The `background` style needs a [`<color>`](../../css_types/color) followed by an optional [`<percentage>`](../../css_types/percentage) to specify the color transparency (clamped between `0%` and `100%`).
+The `background` style requires a [`<color>`](../../css_types/color) optionally followed by [`<percentage>`](../../css_types/percentage) to specify the color's opacity (clamped between `0%` and `100%`).
 
 ## Examples
 
@@ -33,9 +33,9 @@ This example creates three widgets and applies a different background to each.
     --8<-- "docs/examples/styles/background.css"
     ```
 
-### Different transparency settings
+### Different opacity settings
 
-The next example creates ten widgets laid out side by side to show the effect of setting different percentages for the transparency of the background color.
+The next example creates ten widgets laid out side by side to show the effect of setting different percentages for the background color's opacity.
 
 === "Output"
 

--- a/docs/styles/border.md
+++ b/docs/styles/border.md
@@ -91,7 +91,7 @@ border: heavy white;
 /* Set a red border on the left */
 border-left: outer red;
 
-/* Set a rounded orange border, 50% transparency. */
+/* Set a rounded orange border, 50% opacity. */
 border: round orange 50%;
 ```
 

--- a/docs/styles/color.md
+++ b/docs/styles/color.md
@@ -8,9 +8,9 @@ The `color` style sets the text color of a widget.
 color: (<a href="../../css_types/color">&lt;color&gt;</a> | auto) [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-The `color` style needs a [`<color>`](../../css_types/color) followed by an optional [`<percentage>`](../../css_types/percentage) to specify the color opacity (opposite of transparency).
+The `color` style requires a [`<color>`](../../css_types/color) followed by an optional [`<percentage>`](../../css_types/percentage) to specify the color's opacity.
 
-Instead of a [`<color>`](../../css_types/color), one can use the special value `"auto"` to choose automatically the color with the best contrast for readability purposes.
+You can also use the special value of `"auto"` in place of a color. This tells Textual to automatically select either white or black text for best contrast against the background.
 
 ## Examples
 

--- a/docs/styles/links/link_background.md
+++ b/docs/styles/links/link_background.md
@@ -12,7 +12,7 @@ The `link-background` style sets the background color of the link.
 link-background: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`link-background` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of text enclosed in Textual action links.
+`link-background` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of text enclosed in Textual action links.
 
 ## Example
 

--- a/docs/styles/links/link_color.md
+++ b/docs/styles/links/link_color.md
@@ -12,7 +12,7 @@ The `link-color` style sets the color of the link text.
 link-color: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`link-color` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of text enclosed in Textual action links.
+`link-color` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of text enclosed in Textual action links.
 
 ## Example
 

--- a/docs/styles/links/link_hover_background.md
+++ b/docs/styles/links/link_hover_background.md
@@ -12,7 +12,7 @@ The `link-hover-background` style sets the background color of the link when the
 link-hover-background: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`link-hover-background` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of text enclosed in Textual action links when the mouse pointer is over it.
+`link-hover-background` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of text enclosed in Textual action links when the mouse pointer is over it.
 
 ### Defaults
 

--- a/docs/styles/links/link_hover_color.md
+++ b/docs/styles/links/link_hover_color.md
@@ -12,7 +12,7 @@ The `link-hover-color` style sets the color of the link text when the mouse curs
 link-hover-color: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`link-hover-color` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of text enclosed in Textual action links when the mouse pointer is over it.
+`link-hover-color` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of text enclosed in Textual action links when the mouse pointer is over it.
 
 ### Defaults
 

--- a/docs/styles/opacity.md
+++ b/docs/styles/opacity.md
@@ -1,6 +1,8 @@
 # Opacity
 
-The `opacity` style sets the opacity/transparency of a widget.
+The `opacity` style sets the opacity of a widget.
+
+While terminals are not capable of true opacity, Textual can create an approximation by blending widgets with their background color.
 
 ## Syntax
 
@@ -9,9 +11,12 @@ opacity: <a href="../../css_types/number">&lt;number&gt;</a> | <a href="../../cs
 --8<-- "docs/snippets/syntax_block_end.md"
 
 The opacity of a widget can be set as a [`<number>`](../css_types/number.md) or a [`<percentage>`](../css_types/percentage.md).
-`0`/`0%` means no opacity, which is equivalent to full transparency.
-Conversely, `1`/`100%` means full opacity, which is equivalent to no transparency.
-Values outside of these ranges will be clamped.
+If given as a number, then `opacity` should be a value between 0 and 1, where 0 is the background color and 1 is fully opaque.
+If given as a percentage, 0% is the background color and 100% is fully opaque.
+
+Typically, if you set this value it would be somewhere between the two extremes.
+For instance, setting the opacity of a widget to `70%` will make it appear dimmer than surrounding widgets, which could be used to display a *disabled* state.
+
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_background.md
+++ b/docs/styles/scrollbar_colors/scrollbar_background.md
@@ -7,7 +7,7 @@ The `scrollbar-background` style sets the background color of the scrollbar.
 <a href="./scrollbar_background">scrollbar-background</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-background` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of a scrollbar.
+`scrollbar-background` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of a scrollbar.
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_background_active.md
+++ b/docs/styles/scrollbar_colors/scrollbar_background_active.md
@@ -8,7 +8,7 @@ The `scrollbar-background-active` style sets the background color of the scrollb
 <a href="./scrollbar_background_active">scrollbar-background-active</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-background-active` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of a scrollbar when its thumb is being dragged.
+`scrollbar-background-active` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of a scrollbar when its thumb is being dragged.
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_background_hover.md
+++ b/docs/styles/scrollbar_colors/scrollbar_background_hover.md
@@ -8,7 +8,7 @@ The `scrollbar-background-hover` style sets the background color of the scrollba
 <a href="./scrollbar_background_hover">scrollbar-background-hover</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-background-hover` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of a scrollbar when the cursor is over it.
+`scrollbar-background-hover` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the background color of a scrollbar when the cursor is over it.
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_color.md
+++ b/docs/styles/scrollbar_colors/scrollbar_color.md
@@ -8,7 +8,7 @@ The `scrollbar-color` style sets the color of the scrollbar.
 <a href="./scrollbar_color">scrollbar-color</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-color` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of a scrollbar.
+`scrollbar-color` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of a scrollbar.
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_color_active.md
+++ b/docs/styles/scrollbar_colors/scrollbar_color_active.md
@@ -8,7 +8,7 @@ The `scrollbar-color-active` style sets the color of the scrollbar when the thum
 <a href="./scrollbar_color_active">scrollbar-color-active</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-color-active` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of a scrollbar when its thumb is being dragged.
+`scrollbar-color-active` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of a scrollbar when its thumb is being dragged.
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_color_hover.md
+++ b/docs/styles/scrollbar_colors/scrollbar_color_hover.md
@@ -8,7 +8,7 @@ The `scrollbar-color-hover` style sets the color of the scrollbar when the curso
 <a href="./scrollbar_color_hover">scrollbar-color-hover</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-color-hover` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of a scrollbar when the cursor is over it.
+`scrollbar-color-hover` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of a scrollbar when the cursor is over it.
 
 ## Example
 

--- a/docs/styles/scrollbar_colors/scrollbar_corner_color.md
+++ b/docs/styles/scrollbar_colors/scrollbar_corner_color.md
@@ -8,7 +8,7 @@ The `scrollbar-corner-color` style sets the color of the gap between the horizon
 <a href="./scrollbar_corner_color">scrollbar-corner-color</a>: <a href="../../css_types/color">&lt;color&gt;</a> [<a href="../../css_types/percentage">&lt;percentage&gt;</a>];
 --8<-- "docs/snippets/syntax_block_end.md"
 
-`scrollbar-corner-color` accepts a [`<color>`](../../../css_types/color) (with an optional transparency level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of the gap between the horizontal and vertical scrollbars of a widget.
+`scrollbar-corner-color` accepts a [`<color>`](../../../css_types/color) (with an optional opacity level defined by a [`<percentage>`](../../../css_types/percentage)) that is used to define the color of the gap between the horizontal and vertical scrollbars of a widget.
 
 ## Example
 

--- a/docs/styles/text_opacity.md
+++ b/docs/styles/text_opacity.md
@@ -18,7 +18,7 @@ For instance, setting `text-opacity` to `70%` would result in slightly faded tex
 
 !!! warning
 
-    Be careful not to set text opacity *too* low.
+    Be careful not to set text opacity so low as to make it hard to read.
 
 
 ## Example

--- a/docs/styles/text_opacity.md
+++ b/docs/styles/text_opacity.md
@@ -1,6 +1,6 @@
 # Text-opacity
 
-The `text-opacity` style blends the color of the content of a widget with the color of the background.
+The `text-opacity` style blends the foreground color (i.e. text) with the background color.
 
 ## Syntax
 
@@ -8,10 +8,18 @@ The `text-opacity` style blends the color of the content of a widget with the co
 text-opacity: <a href="../../css_types/number">&lt;number&gt;</a> | <a href="../../css_types/percentage">&lt;percentage&gt;</a>;
 --8<-- "docs/snippets/syntax_block_end.md"
 
-The text opacity can be set as a [`<number>`](../css_types/number.md) or a [`<percentage>`](../css_types/percentage.md).
-`0`/`0%` means no opacity, which is equivalent to full transparency.
-Conversely, `1`/`100%` means full opacity, which is equivalent to no transparency.
-Values outside of these ranges will be clamped.
+
+The text opacity of a widget can be set as a [`<number>`](../css_types/number.md) or a [`<percentage>`](../css_types/percentage.md).
+If given as a number, then `text-opacity` should be a value between 0 and 1, where 0 makes the foreground color match the background (effectively making text invisible) and 1 will display text as normal.
+If given as a percentage, 0% will result in invisible text, and 100% will display fully opaque text.
+
+Typically, if you set this value it would be somewhere between the two extremes.
+For instance, setting `text-opacity` to `70%` would result in slightly faded text. Setting it to `0.3` would result in very dim text.
+
+!!! warning
+
+    Be careful not to set text opacity *too* low.
+
 
 ## Example
 
@@ -50,4 +58,4 @@ widget.styles.text_opacity = "50%"
 
 ## See also
 
- - [`opacity`](./opacity.md) to specify the transparency of a whole widget.
+ - [`opacity`](./opacity.md) to specify the opacity of a whole widget.

--- a/docs/styles/tint.md
+++ b/docs/styles/tint.md
@@ -25,7 +25,7 @@ This examples shows a green tint with gradually increasing alpha.
     --8<-- "docs/examples/styles/tint.py"
     ```
 
-    1. We set the tint to a `Color` instance with varying levels of transparency, set through the method `.with_alpha`.
+    1. We set the tint to a `Color` instance with varying levels of opacity, set through the method [with_alpha][textual.color.Color.with_alpha].
 
 === "tint.css"
 

--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -165,7 +165,7 @@ class Color(NamedTuple):
     b: int
     """Blue component in range 0 to 255."""
     a: float = 1.0
-    """Alpha component in range 0 to 1."""
+    """Alpha (opacity) component in range 0 to 1."""
 
     @classmethod
     def from_rich_color(cls, rich_color: RichColor) -> Color:


### PR DESCRIPTION
The term "transparency" was used in many places. 

The correct term would be "opacity",  as 100% opacity means the item in question is fully opaque, which reflects the code.