### PR TITLE
Fix race condition during shutdoen under Windows

### DIFF
--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -76,10 +76,10 @@ class WindowsDriver(Driver):
         """Start application mode."""
         loop = asyncio.get_running_loop()
 
+        self._restore_console = win32.enable_application_mode()
+
         self._writer_thread = WriterThread(self._file)
         self._writer_thread.start()
-
-        self._restore_console = win32.enable_application_mode()
 
         self.write("\x1b[?1049h")  # Enable alt screen
         self._enable_mouse_support()
@@ -110,8 +110,6 @@ class WindowsDriver(Driver):
         """Stop application mode, restore state."""
         self._disable_bracketed_paste()
         self.disable_input()
-        if self._restore_console:
-            self._restore_console()
 
         # Disable alt screen, show cursor
         self.write("\x1b[?1049l" + "\x1b[?25h")
@@ -121,3 +119,5 @@ class WindowsDriver(Driver):
         """Perform cleanup."""
         if self._writer_thread is not None:
             self._writer_thread.stop()
+        if self._restore_console:
+            self._restore_console()


### PR DESCRIPTION
The terminal writer thread could send escape sequences when the terminal was unable to process then; i.e. when not in virtual mode.

The following fixes have been made.

- Switch the terminal to virtual mode before the writer thread is started and any control sequences are queued to the writer thread.

- Wait for the writer thread to finish before switching the terminal out of virtual mode.

I have seen this cause problems at application start up and shut down. The changed code appears to provide stable behaviour. I have not attempted to add any new tests due to the difficulty of reliably reproducing the problem.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
