### PR TITLE
Add error property to worker.py

### DIFF
--- a/src/textual/worker.py
+++ b/src/textual/worker.py
@@ -244,6 +244,11 @@ class Worker(Generic[ResultType]):
         """The result of the worker, or `None` if there is no result."""
         return self._result
 
+    @property
+    def error(self) -> BaseException | None:
+        """The exception raised by the worker, or `None` if there was no error."""
+        return self._error
+
     def update(
         self, completed_steps: int | None = None, total_steps: int | None = -1
     ) -> None:


### PR DESCRIPTION
worker.error is described in the worker guide documentation but the property is not present in the code.


**Please review the following checklist.**

- [x ] Docstrings on all new or modified functions / classes 
- [x ] Updated documentation ( this is described in the documentation but not implemented)
- [x ] Updated CHANGELOG.md (where appropriate)
