### PR TITLE
Ignore CancelledErrors because of Python 3.7

### DIFF
--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -3,7 +3,7 @@
 An *optionally* awaitable object returned by methods that remove widgets.
 """
 
-from asyncio import Event, Task
+from asyncio import CancelledError, Event, Task
 from typing import Generator
 
 
@@ -30,6 +30,11 @@ class AwaitRemove:
     def __await__(self) -> Generator[None, None, None]:
         async def await_prune() -> None:
             """Wait for the prune operation to finish."""
-            await self.finished_flag.wait()
+            # Ignore CancelledErrors while 3.7 is supported.
+            # C.f. https://github.com/Textualize/textual/issues/2854
+            try:
+                await self.finished_flag.wait()
+            except CancelledError:
+                pass
 
         return await_prune().__await__()

--- a/tests/test_await_remove.py
+++ b/tests/test_await_remove.py
@@ -18,3 +18,5 @@ async def test_multiple_simultaneous_removals():
     # The app should run and finish without raising any errors.
     async with RemoveOnTimerApp().run_test() as pilot:
         await pilot.pause(0.3)
+        # Sanity check to ensure labels were removed.
+        assert len(pilot.app.query(Label)) == 0

--- a/tests/test_await_remove.py
+++ b/tests/test_await_remove.py
@@ -1,0 +1,20 @@
+from textual.app import App
+from textual.widgets import Label
+
+
+class SelfRemovingLabel(Label):
+    def on_mount(self) -> None:
+        self.set_timer(0.2, self.remove)
+
+
+class RemoveOnTimerApp(App[None]):
+    def on_mount(self):
+        for _ in range(5):
+            self.mount(SelfRemovingLabel("I will remove myself!"))
+
+
+async def test_multiple_simultaneous_removals():
+    """Regression test for https://github.com/Textualize/textual/issues/2854."""
+    # The app should run and finish without raising any errors.
+    async with RemoveOnTimerApp().run_test() as pilot:
+        await pilot.pause(0.3)


### PR DESCRIPTION
This fixes #2854 by ignoring the `CancelledError`.