### PR TITLE
Fix intermittent exception in _progress_bar.py

### DIFF
--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -202,6 +202,7 @@ class ETAStatus(Label):
         self._percentage = None
         self._label_text = "--:--:--"
         self._start_time = None
+        self._refresh_timer = None
 
     def on_mount(self) -> None:
         """Periodically refresh the countdown so that the ETA is always up to date."""
@@ -211,7 +212,8 @@ class ETAStatus(Label):
         if percentage is None:
             self._label_text = "--:--:--"
         else:
-            self._refresh_timer.reset()
+            if self._refresh_timer:
+                self._refresh_timer.reset()
             self.update_eta()
 
     def update_eta(self) -> None:

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -186,7 +186,7 @@ class ETAStatus(Label):
     """This is used as an auxiliary reactive to only refresh the label when needed."""
     _percentage: reactive[float | None] = reactive[Optional[float]](None)
     """The percentage of progress that has been completed."""
-    _refresh_timer: Timer
+    _refresh_timer: Timer | None
     """Timer to update ETA status even when progress stalls."""
     _start_time: float | None
     """The time when the widget started tracking progress."""
@@ -212,7 +212,7 @@ class ETAStatus(Label):
         if percentage is None:
             self._label_text = "--:--:--"
         else:
-            if self._refresh_timer:
+            if self._refresh_timer is not None:
                 self._refresh_timer.reset()
             self.update_eta()
 


### PR DESCRIPTION
Fix for an exception that is raised if percentage changes before the _refresh_timer is instantiated.

```╭─────────────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────────────────────────────────────────╮
│ /data/tom/git/abacura/venv/lib/python3.11/site-packages/textual/widgets/_progress_bar.py:347 in updater                                                                                                          │
│                                                                                                                                                                                                                  │
│   344 │   │   │                                                                                ╭───────────── locals ─────────────╮                                                                              │
│   345 │   │   │   def updater(percentage: float | None) -> None:                               │ percentage = 1                   │                                                                              │
│   346 │   │   │   │   """Update the percentage reactive of the enclosed widget."""             │     widget = ETAStatus(id='eta') │                                                                              │
│ ❱ 347 │   │   │   │   widget._percentage = percentage                                          ╰──────────────────────────────────╯                                                                              │
│   348 │   │   │                                                                                                                                                                                                  │
│   349 │   │   │   return updater                                                                                                                                                                                 │
│   350                                                                                                                                                                                                            │
│                                                                                                                                                                                                                  │
│ /data/tom/git/abacura/venv/lib/python3.11/site-packages/textual/widgets/_progress_bar.py:214 in watch__percentage                                                                                                │
│                                                                                                                                                                                                                  │
│   211 │   │   if percentage is None:                                                           ╭───────────── locals ─────────────╮                                                                              │
│   212 │   │   │   self._label_text = "--:--:--"                                                │ percentage = 1                   │                                                                              │
│   213 │   │   else:                                                                            │       self = ETAStatus(id='eta') │                                                                              │
│ ❱ 214 │   │   │   self._refresh_timer.reset()                                                  ╰──────────────────────────────────╯                                                                              │
│   215 │   │   │   self.update_eta()                                                                                                                                                                              │
│   216 │                                                                                                                                                                                                          │
│   217 │   def update_eta(self) -> None:                                                                                                                                                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'ETAStatus' object has no attribute '_refresh_timer'
```

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
