### PR TITLE
Fix CancelledError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed CancelledError issue with timer https://github.com/Textualize/textual/issues/2854
+
+
 ## [0.29.0] - 2023-07-03
 
 ### Changed
@@ -23,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed crash when columns were added to populated `DataTable` https://github.com/Textualize/textual/pull/2836
 - Fixed issues with opacity on Screens https://github.com/Textualize/textual/issues/2616
 - Fixed style problem with selected selections in a non-focused selection list https://github.com/Textualize/textual/issues/2768
+- Fixed sys.stdout and sys.stderr being None https://github.com/Textualize/textual/issues/2879
 
 ## [0.28.1] - 2023-06-20
 

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -149,6 +149,8 @@ class Timer:
             try:
                 await invoke(self._callback)
             except CancelledError:
+                # https://github.com/Textualize/textual/pull/2895
+                # Re-raise CancelledErrors that would be caught by the following exception block in Python 3.7
                 raise
             except Exception as error:
                 app = active_app.get()

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -148,6 +148,8 @@ class Timer:
         if self._callback is not None:
             try:
                 await invoke(self._callback)
+            except CancelledError:
+                raise
             except Exception as error:
                 app = active_app.get()
                 app._handle_exception(error)

--- a/tests/test_await_remove.py
+++ b/tests/test_await_remove.py
@@ -1,0 +1,22 @@
+from textual.app import App
+from textual.widgets import Label
+
+
+class SelfRemovingLabel(Label):
+    def on_mount(self) -> None:
+        self.set_timer(0.2, self.remove)
+
+
+class RemoveOnTimerApp(App[None]):
+    def on_mount(self):
+        for _ in range(5):
+            self.mount(SelfRemovingLabel("I will remove myself!"))
+
+
+async def test_multiple_simultaneous_removals():
+    """Regression test for https://github.com/Textualize/textual/issues/2854."""
+    # The app should run and finish without raising any errors.
+    async with RemoveOnTimerApp().run_test() as pilot:
+        await pilot.pause(0.3)
+        # Sanity check to ensure labels were removed.
+        assert len(pilot.app.query(Label)) == 0


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/2854

In Python3.7 `CancelledError` extends `Exception`, in 3.8 and above it does not.