### PR TITLE
feat(datatable): add remove column method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added `DataTable.remove_column` method https://github.com/Textualize/textual/pull/2899
+
 ### Fixed
 
 - Fixed CancelledError issue with timer https://github.com/Textualize/textual/issues/2854

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -107,6 +107,20 @@ row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
 table.remove_row(row_key)
 ```
 
+### Removing columns
+
+To remove individual columns, use [remove_column][textual.widgets.DataTable.remove_column].
+The `remove_column` method accepts a `key` argument, which identifies the column to be removed.
+
+You can remove the column below the cursor using the same `coordinate_to_cell_key` method described above:
+
+```python
+# Get the keys for the row and column under the cursor.
+_, column_key = table.coordinate_to_cell_key(table.cursor_coordinate)
+# Supply the column key to `column_row` to delete the column.
+table.remove_column(column_key)
+```
+
 ### Fixed data
 
 You can fix a number of rows and columns in place, keeping them pinned to the top and left of the table respectively.

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1432,6 +1432,42 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._update_count += 1
         self.refresh(layout=True)
 
+    def remove_column(self, column_key: ColumnKey | str) -> None:
+        """Remove a column (identified by a key) from the DataTable.
+
+        Args:
+            column_key: The key identifying the column to remove.
+
+        Raises:
+            ColumnDoesNotExist: If the column key does not exist.
+        """
+        if column_key not in self._column_locations:
+            raise ColumnDoesNotExist(f"Column key {column_key!r} is not valid.")
+
+        self._require_update_dimensions = True
+        self.check_idle()
+
+        index_to_delete = self._column_locations.get(column_key)
+        new_column_locations = TwoWayDict({})
+        for column_location_key in self._column_locations:
+            column_index = self._column_locations.get(column_location_key)
+            if column_index > index_to_delete:
+                new_column_locations[column_location_key] = column_index - 1
+            elif column_index < index_to_delete:
+                new_column_locations[column_location_key] = column_index
+
+        self._column_locations = new_column_locations
+
+        del self.columns[column_key]
+        for row in self._data:
+            del self._data[row][column_key]
+
+        self.cursor_coordinate = self.cursor_coordinate
+        self.hover_coordinate = self.hover_coordinate
+
+        self._update_count += 1
+        self.refresh(layout=True)
+
     async def _on_idle(self, _: events.Idle) -> None:
         """Runs when the message pump is empty.
 

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -306,10 +306,14 @@ async def test_remove_column():
     app = DataTableApp()
     async with app.run_test():
         table = app.query_one(DataTable)
-        column_keys = table.add_columns("1", "2", "3")
-        assert len(table.columns) == 3
-        table.remove_column(column_keys[0])
+        column_keys = table.add_columns("A", "B")
+        table.add_rows(ROWS)
         assert len(table.columns) == 2
+        table.remove_column(column_keys[0])
+        assert len(table.columns) == 1
+        assert table.get_row_at(0) == ["0/1"]
+        assert table.get_row_at(1) == ["1/1"]
+        assert table.get_row_at(2) == ["2/1"]
 
 
 async def test_clear():

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -302,6 +302,16 @@ async def test_remove_row():
         assert len(table.rows) == 2
 
 
+async def test_remove_column():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        column_keys = table.add_columns("1", "2", "3")
+        assert len(table.columns) == 3
+        table.remove_column(column_keys[0])
+        assert len(table.columns) == 2
+
+
 async def test_clear():
     app = DataTableApp()
     async with app.run_test():


### PR DESCRIPTION
### Description

Add a `remove_column` method to remove individual columns from a DataTable. The code is essentially just a copy of the existing `remove_row` method, apart from deleting from `DataTable._data`.

### Related Issue

- #2897

### How Has This Been Tested?

The new test simply checks the column length and the row data after a column is removed. This has also been tested manually with a simple app that removes the column under the cursor (as described in the updated docs).

There are currently no snapshot tests. If this is required I'm afraid I may need some guidance!

### Checklist:

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)