### PR TITLE
Update gitignore to refer to new default snapshot report location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,8 @@ venv.bak/
 # mypy
 .mypy_cache/
 
-# Snapshot testing report output directory
-tests/snapshot_tests/output
+# Snapshot testing report output (default location)
+snapshot_report.html
 
 # Sandbox folder - convenient place for us to develop small test apps without leaving the repo
 sandbox/


### PR DESCRIPTION
While extracting the snapshot testing framework into a separate pip installable package, I made the location of the output configurable and updated the default location to be something more generic. This updates the gitignore to refer to that new default.