### PR TITLE
Change vh to vw in min/max-width styles reference docs

### DIFF
--- a/docs/styles/max_width.md
+++ b/docs/styles/max_width.md
@@ -42,7 +42,7 @@ Then, we set `max-width` individually on each placeholder.
 max-width: 10;
 
 /* Set the maximum width to 25% of the viewport width */
-max-width: 25vh;
+max-width: 25vw;
 ```
 
 ## Python
@@ -52,7 +52,7 @@ max-width: 25vh;
 widget.styles.max_width = 10
 
 # Set the maximum width to 25% of the viewport width
-widget.styles.max_width = "25vh"
+widget.styles.max_width = "25vw"
 ```
 
 ## See also

--- a/docs/styles/min_width.md
+++ b/docs/styles/min_width.md
@@ -42,7 +42,7 @@ Then, we set `min-width` individually on each placeholder.
 min-width: 10;
 
 /* Set the minimum width to 25% of the viewport width */
-min-width: 25vh;
+min-width: 25vw;
 ```
 
 ## Python
@@ -52,7 +52,7 @@ min-width: 25vh;
 widget.styles.min_width = 10
 
 # Set the minimum width to 25% of the viewport width
-widget.styles.min_width = "25vh"
+widget.styles.min_width = "25vw"
 ```
 
 ## See also


### PR DESCRIPTION
Fix typo in styles reference docs. Change viewport height to viewport width in min/max-width reference.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
