### PR TITLE
Center DataTable within available space

### DIFF
--- a/docs/examples/widgets/data_table_renderables_centered.py
+++ b/docs/examples/widgets/data_table_renderables_centered.py
@@ -1,0 +1,37 @@
+from rich.text import Text
+
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+ROWS = [
+    ("lane", "swimmer", "country", "time"),
+    (4, "Joseph Schooling", "Singapore", 50.39),
+    (2, "Michael Phelps", "United States", 51.14),
+    (5, "Chad le Clos", "South Africa", 51.14),
+    (6, "László Cseh", "Hungary", 51.14),
+    (3, "Li Zhuhao", "China", 51.26),
+    (8, "Mehdy Metella", "France", 51.58),
+    (7, "Tom Shields", "United States", 51.73),
+    (1, "Aleksandr Sadovnikov", "Russia", 51.84),
+    (10, "Darren Burns", "Scotland", 51.84),
+]
+
+
+class TableApp(App):
+    def compose(self) -> ComposeResult:
+        yield DataTable(center_table=True)
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.add_columns(*ROWS[0])
+        for row in ROWS[1:]:
+            # Adding styled and justified `Text` objects instead of plain strings.
+            styled_row = [
+                Text(str(cell), style="italic #03AC13", justify="right") for cell in row
+            ]
+            table.add_row(*styled_row)
+
+
+app = TableApp()
+if __name__ == "__main__":
+    app.run()

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -171,7 +171,7 @@ The example below shows how to attach simple numbered labels to rows.
 
 The `DataTable` can be centered within the available space using the `center_table` parameter.
 
-=== "Original"
+=== "Default"
 
     ```{.textual path="docs/examples/widgets/data_table_renderables.py"}
     ```

--- a/docs/widgets/data_table.md
+++ b/docs/widgets/data_table.md
@@ -167,10 +167,24 @@ The example below shows how to attach simple numbered labels to rows.
     --8<-- "docs/examples/widgets/data_table_labels.py"
     ```
 
+### Centered Data
+
+The `DataTable` can be centered within the available space using the `center_table` parameter.
+
+=== "Original"
+
+    ```{.textual path="docs/examples/widgets/data_table_renderables.py"}
+    ```
+
+=== "Centered"
+
+    ```{.textual path="docs/examples/widgets/data_table_renderables_centered.py"}
+    ```
+
 ## Reactive Attributes
 
 | Name                | Type                                        | Default            | Description                                           |
-|---------------------|---------------------------------------------|--------------------|-------------------------------------------------------|
+| ------------------- | ------------------------------------------- | ------------------ | ----------------------------------------------------- |
 | `show_header`       | `bool`                                      | `True`             | Show the table header                                 |
 | `show_row_labels`   | `bool`                                      | `True`             | Show the row labels (if applicable)                   |
 | `fixed_rows`        | `int`                                       | `0`                | Number of fixed rows (rows which do not scroll)       |


### PR DESCRIPTION
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

Added parameter to center DataTable content within available width. 

Without `center_table`:

`yield DataTable()`

<img width="500" alt="Screenshot 2023-07-15 at 3 23 14 PM" src="https://github.com/Textualize/textual/assets/22514713/009f461c-84d2-422d-bcb3-1974d3a65d8c">

With `center_table`:

`yield DataTable(center_table=True)`

<img width="471" alt="Screenshot 2023-07-15 at 6 26 00 PM" src="https://github.com/Textualize/textual/assets/22514713/be229681-2a00-4f79-92a5-8c89ddac8295">
