### PR TITLE
Add missing notification docstrings and type hints

### DIFF
--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -97,6 +97,11 @@ class Toast(Static, inherit_css=False):
         self._timeout = notification.time_left
 
     def render(self) -> RenderableType:
+        """Render the toast's content.
+
+        Returns:
+            A Rich renderable for the title and content of the Toast.
+        """
         notification = self._notification
         if notification.title:
             header_style = self.get_component_rich_style("toast--title")

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from rich.console import RenderableType
 from rich.text import Text
 
@@ -82,7 +84,7 @@ class Toast(Static, inherit_css=False):
     }
     """
 
-    COMPONENT_CLASSES = {"toast--title"}
+    COMPONENT_CLASSES: ClassVar[set[str]] = {"toast--title"}
 
     def __init__(self, notification: Notification) -> None:
         """Initialise the toast.

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -85,6 +85,11 @@ class Toast(Static, inherit_css=False):
     """
 
     COMPONENT_CLASSES: ClassVar[set[str]] = {"toast--title"}
+    """
+    | Class | Description |
+    | :- | :- |
+    | `toast--title` | Targets the title of the toast. |
+    """
 
     def __init__(self, notification: Notification) -> None:
         """Initialise the toast.


### PR DESCRIPTION
The last-moment changes to notifications this morning missed out some of the docstrings and type hinting we normally include in our code. This PR adds them in.