### PR TITLE
Make notification titles work as documented again (notifications fix option 1)

### DIFF
--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -98,10 +98,15 @@ class Toast(Static, inherit_css=False):
 
     def render(self) -> RenderableType:
         notification = self._notification
-        if notification.title:
+        title = (
+            notification.severity.capitalize()
+            if notification.title is None
+            else notification.title
+        )
+        if title:
             header_style = self.get_component_rich_style("toast--title")
             notification_text = Text.assemble(
-                (notification.title, header_style),
+                (title, header_style),
                 "\n",
                 Text.from_markup(notification.message),
             )

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -76,10 +76,6 @@ class Toast(Static, inherit_css=False):
     Toast.-error .toast--title {
        color: $error-darken-1;
     }
-
-    Toast.-empty-title {
-
-    }
     """
 
     COMPONENT_CLASSES = {"toast--title"}

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -86,9 +86,7 @@ class Toast(Static, inherit_css=False):
         Args:
             notification: The notification to show in the toast.
         """
-        super().__init__(
-            classes=f"-{notification.severity} {'-empty-title' if not notification.title else ''}"
-        )
+        super().__init__(classes=f"-{notification.severity}")
         self._notification = notification
         self._timeout = notification.time_left
 


### PR DESCRIPTION
*Note: This PR is one of a pair of either/or PRs. See also #2963 as the alternative.*

It seems that the [last moment style tweaks](https://github.com/Textualize/textual/pull/2866/commits/7fc7ef20ef52ba515033940e9f84420700cc1fe8) also changed the way that notifications work in regard to how titles are handled. As released, notifications no longer work as documented.

This PR reinstates the documented behaviour. The assumption here, based on the fact that it wasn't called out in the PR's subject or description, is that it was an unintended consequence of adding the `render` method.