### PR TITLE
Make notification documentation and interface match changed rendering (notifications fix option 2)

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2795,7 +2795,7 @@ class App(Generic[ReturnType], DOMNode):
         self,
         message: str,
         *,
-        title: str | None = None,
+        title: str = "",
         severity: SeverityLevel = "information",
         timeout: float = Notification.timeout,
     ) -> Notification:
@@ -2821,10 +2821,6 @@ class App(Generic[ReturnType], DOMNode):
         - `error`
 
         The default is `information`.
-
-        If no `title` is provided, the title of the notification will
-        reflect the severity. If you wish to create a notification that has
-        no title whatsoever, pass an empty title (`""`).
 
         Example:
             ```python

--- a/src/textual/notifications.py
+++ b/src/textual/notifications.py
@@ -21,7 +21,7 @@ class Notification:
     message: str
     """The message for the notification."""
 
-    title: str | None = None
+    title: str = ""
     """The title for the notification."""
 
     severity: SeverityLevel = "information"
@@ -48,7 +48,7 @@ class Notification:
 
     def __rich_repr__(self) -> Result:
         yield "message", self.message
-        yield "title", self.title, None
+        yield "title", self.title, ""
         yield "severity", self.severity
         yield "raised_it", self.raised_at
         yield "identity", self.identity

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -944,7 +944,7 @@ class Screen(Generic[ScreenResultType], Widget):
         self,
         message: str,
         *,
-        title: str | None = None,
+        title: str = "",
         severity: SeverityLevel = "information",
         timeout: float = Notification.timeout,
     ) -> Notification:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3314,7 +3314,7 @@ class Widget(DOMNode):
         self,
         message: str,
         *,
-        title: str | None = None,
+        title: str = "",
         severity: SeverityLevel = "information",
         timeout: float = Notification.timeout,
     ) -> Notification:

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -76,10 +76,6 @@ class Toast(Static, inherit_css=False):
     Toast.-error .toast--title {
        color: $error-darken-1;
     }
-
-    Toast.-empty-title {
-
-    }
     """
 
     COMPONENT_CLASSES = {"toast--title"}
@@ -90,9 +86,7 @@ class Toast(Static, inherit_css=False):
         Args:
             notification: The notification to show in the toast.
         """
-        super().__init__(
-            classes=f"-{notification.severity} {'-empty-title' if not notification.title else ''}"
-        )
+        super().__init__(classes=f"-{notification.severity}")
         self._notification = notification
         self._timeout = notification.time_left
 

--- a/tests/notifications/test_notification.py
+++ b/tests/notifications/test_notification.py
@@ -11,8 +11,8 @@ def test_message() -> None:
 
 
 def test_default_title() -> None:
-    """A notification with no title should have a None title."""
-    assert Notification("test").title is None
+    """A notification with no title should have a empty title."""
+    assert Notification("test").title == ""
 
 
 def test_default_severity_level() -> None:


### PR DESCRIPTION
*Note: This PR is one of a pair of either/or PRs. See also #2962 as the alternative.*

It seems that the [last moment style tweaks](https://github.com/Textualize/textual/pull/2866/commits/7fc7ef20ef52ba515033940e9f84420700cc1fe8) also changed the way that notifications work in regard to how titles are handled. As released, notifications no longer work as documented.

This PR changes the interface for notifications to match the new behaviour, and also updates the documentation so that it no longer misrepresents how titles work. The assumption here, based on the fact that it wasn't called out in the PR's subject or description, is that it was an intended consequence of adding the `render` method but the changes weren't carried to completion.