### PR TITLE
Added a max fps environment variable

### DIFF
--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -67,3 +67,6 @@ PRESS: Final[str] = get_environ("TEXTUAL_PRESS", "")
 
 SHOW_RETURN: Final[bool] = get_environ_bool("TEXTUAL_SHOW_RETURN")
 """Write the return value on exit."""
+
+MAX_FPS: Final[int] = get_environ_int("TEXTUAL_FPS", 60)
+"""Maximum frames per second for updates."""

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -24,7 +24,7 @@ import rich.repr
 from rich.console import RenderableType
 from rich.style import Style
 
-from . import errors, events, messages
+from . import constants, errors, events, messages
 from ._callback import invoke
 from ._compositor import Compositor, MapGeometry
 from ._context import active_message_pump, visible_screen_stack
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from .message_pump import MessagePump
 
 # Screen updates will be batched so that they don't happen more often than 60 times per second:
-UPDATE_PERIOD: Final[float] = 1 / 60
+UPDATE_PERIOD: Final[float] = 1 / constants.MAX_FPS
 
 ScreenResultType = TypeVar("ScreenResultType")
 """The result type of a screen."""


### PR DESCRIPTION
Adds an environment var for maximum frames per second. This is mainly for the benefit of textual-serve, as 60fps over the wire is excessive.

In the future this may be adaptive, we can use the max FPS as a form of flow control. i.e. reduce it to limit the amount of data being sent.