### PR TITLE
Fix a crash caused by a prompt being wider than a `SelectionList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.31.0] - Unreleased
+
+### Fixed
+
+- Fixed a crash when a `SelectionList` had a prompt wider than itself https://github.com/Textualize/textual/issues/2900
+
 ## [0.30.0] - 2023-07-17
 
 ### Added

--- a/src/textual/widgets/_selection_list.py
+++ b/src/textual/widgets/_selection_list.py
@@ -256,6 +256,7 @@ class SelectionList(Generic[SelectionType], OptionList):
             id=id,
             classes=classes,
             disabled=disabled,
+            wrap=False,
         )
 
     @property
@@ -483,6 +484,19 @@ class SelectionList(Generic[SelectionType], OptionList):
         """
         if self.highlighted is not None:
             self.toggle(self.get_option_at_index(self.highlighted))
+
+    def _left_gutter_width(self) -> int:
+        """Returns the size of any left gutter that should be taken into account.
+
+        Returns:
+            The width of the left gutter.
+        """
+        return len(
+            ToggleButton.BUTTON_LEFT
+            + ToggleButton.BUTTON_INNER
+            + ToggleButton.BUTTON_RIGHT
+            + " "
+        )
 
     def render_line(self, y: int) -> Strip:
         """Render a line in the display.

--- a/tests/selection_list/test_over_wide_selections.py
+++ b/tests/selection_list/test_over_wide_selections.py
@@ -14,7 +14,7 @@ class SelectionListApp(App[None]):
     """
 
     def compose(self) -> ComposeResult:
-        yield SelectionList[int](*[(f"{n} " * 10, n) for n in range(10)])
+        yield SelectionList[int](*[(f"{n} " * 100, n) for n in range(10)])
 
 
 async def test_over_wide_options() -> None:

--- a/tests/selection_list/test_over_wide_selections.py
+++ b/tests/selection_list/test_over_wide_selections.py
@@ -1,0 +1,29 @@
+"""See https://github.com/Textualize/textual/issues/2900 for the reason behind these tests."""
+
+from textual.app import App, ComposeResult
+from textual.widgets import SelectionList
+
+
+class SelectionListApp(App[None]):
+    """Test selection list application."""
+
+    CSS = """
+    OptionList {
+        width: 20;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield SelectionList[int](*[(f"{n} " * 10, n) for n in range(10)])
+
+
+async def test_over_wide_options() -> None:
+    """Options wider than the widget should not be an issue."""
+    async with SelectionListApp().run_test() as pilot:
+        assert pilot.app.query_one(SelectionList).highlighted == 0
+        await pilot.pause()
+        assert pilot.app.query_one(SelectionList).highlighted == 0
+
+
+if __name__ == "__main__":
+    SelectionListApp().run()


### PR DESCRIPTION
This fixes the issue raised in #2900 (and also #2969).