### PR TITLE
Typo fix in the module docstring for events.py

### DIFF
--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -4,7 +4,7 @@ Builtin events sent by Textual.
 
 Events may be marked as "Bubbles" and "Verbose".
 See the [events guide](/guide/events/#bubbling) for an explanation of bubbling.
-Verbose events are excluded from the textual console, unless you explicit request them with the `-v` switch as follows:
+Verbose events are excluded from the textual console, unless you explicitly request them with the `-v` switch as follows:
 
 ```
 textual console -v


### PR DESCRIPTION
Noticed this in passing.