### PR TITLE
Fixes a bug that causes Click events to bubble up from Switch widgets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed a crash when a `SelectionList` had a prompt wider than itself https://github.com/Textualize/textual/issues/2900
+- Fixed a bug where `Click` events were bubbling up from `Switch` widgets https://github.com/Textualize/textual/issues/2366
 
 ## [0.30.0] - 2023-07-17
 

--- a/src/textual/widgets/_switch.py
+++ b/src/textual/widgets/_switch.py
@@ -154,8 +154,9 @@ class Switch(Widget, can_focus=True):
     def get_content_height(self, container: Size, viewport: Size, width: int) -> int:
         return 1
 
-    async def _on_click(self, _: Click) -> None:
+    async def _on_click(self, event: Click) -> None:
         """Toggle the state of the switch."""
+        event.stop()
         self.toggle()
 
     def action_toggle(self) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,18 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Switch
+
+
+async def test_switch_click_doesnt_bubble_up():
+    """Regression test for https://github.com/Textualize/textual/issues/2366"""
+
+    class SwitchApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Switch()
+
+        async def on_click(self) -> None:
+            raise AssertionError(
+                "The app should never receive a click event when Switch is clicked."
+            )
+
+    async with SwitchApp().run_test() as pilot:
+        await pilot.click(Switch)


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

This PR stops _Click_ events from bubbling up from _Switch_ widgets.

The PR adds a corresponding test that fails, if the App containing a Switch receives a Click event when the Switch is clicked and adjusts the changelog.  

Closes #2366 