### PR TITLE
Adds an interface for replacing prompt of an individual option in an `OptionList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed relative units not always expanding auto containers https://github.com/Textualize/textual/pull/3059
 - Fixed background refresh https://github.com/Textualize/textual/issues/3055
 
+### Added
+- Added an interface for replacing prompt of an individual option in an `OptionList` https://github.com/Textualize/textual/issues/2603 
 
 ## [0.32.0] - 2023-08-03
 

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -663,7 +663,7 @@ class OptionList(ScrollView, can_focus=True):
             prompt: The new prompt for the option.
 
         Raises:
-            IndexError: If there is no option of the given index.
+            OptionDoesNotExist: If there is no option with the given index.
         """
         self.get_option_at_index(index).set_prompt(prompt)
         self._refresh_content_tracking(force=True)
@@ -678,6 +678,9 @@ class OptionList(ScrollView, can_focus=True):
 
         Returns:
             The `OptionList` instance.
+
+        Raises:
+            OptionDoesNotExist: If no option has the given ID.
         """
         self._replace_option_prompt(self.get_option_index(option_id), prompt)
         return self
@@ -814,7 +817,7 @@ class OptionList(ScrollView, can_focus=True):
             The option at that index.
 
         Raises:
-            OptionDoesNotExist: If there is no option with the index.
+            OptionDoesNotExist: If there is no option with the given index.
         """
         try:
             return self._options[index]
@@ -853,7 +856,7 @@ class OptionList(ScrollView, can_focus=True):
         """
         try:
             return self._option_ids[option_id]
-        except:
+        except KeyError:
             raise OptionDoesNotExist(
                 f"There is no option with an ID of '{option_id}'"
             ) from None

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -665,8 +665,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             IndexError: If there is no option of the given index.
         """
-        option = self._options[index]
-        option.set_prompt(prompt)
+        self.get_option_at_index(index).set_prompt(prompt)
         self._refresh_content_tracking(force=True)
         self.refresh()
 

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -627,12 +627,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             OptionDoesNotExist: If no option has the given ID.
         """
-        try:
-            self._remove_option(self._option_ids[option_id])
-        except KeyError:
-            raise OptionDoesNotExist(
-                f"There is no option with an ID of '{option_id}'"
-            ) from None
+        self._remove_option(self.get_option_index(option_id))
         return self
 
     def remove_option_at_index(self, index: int) -> Self:
@@ -776,12 +771,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             OptionDoesNotExist: If no option has the given ID.
         """
-        try:
-            return self.enable_option_at_index(self._option_ids[option_id])
-        except KeyError:
-            raise OptionDoesNotExist(
-                f"There is no option with an ID of '{option_id}'"
-            ) from None
+        return self.enable_option_at_index(self.get_option_index(option_id))
 
     def disable_option(self, option_id: str) -> Self:
         """Disable the option with the given ID.
@@ -795,12 +785,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             OptionDoesNotExist: If no option has the given ID.
         """
-        try:
-            return self.disable_option_at_index(self._option_ids[option_id])
-        except KeyError:
-            raise OptionDoesNotExist(
-                f"There is no option with an ID of '{option_id}'"
-            ) from None
+        return self.disable_option_at_index(self.get_option_index(option_id))
 
     @property
     def option_count(self) -> int:
@@ -838,12 +823,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             OptionDoesNotExist: If no option has the given ID.
         """
-        try:
-            return self.get_option_at_index(self._option_ids[option_id])
-        except KeyError:
-            raise OptionDoesNotExist(
-                f"There is no option with an ID of '{option_id}'"
-            ) from None
+        return self.get_option_at_index(self.get_option_index(option_id))
 
     def get_option_index(self, option_id):
         """Get the index of the option with the given ID.

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -678,16 +678,8 @@ class OptionList(ScrollView, can_focus=True):
 
         Returns:
             The `OptionList` instance.
-
-        Raises:
-            OptionDoesNotExist: If no option has the given ID.
         """
-        try:
-            self._replace_option_prompt(self._option_ids[option_id], prompt)
-        except KeyError:
-            raise OptionDoesNotExist(
-                f"There is no option with an ID of '{option_id}'"
-            ) from None
+        self._replace_option_prompt(self.get_option_index(option_id), prompt)
         return self
 
     def replace_option_prompt_at_index(
@@ -705,12 +697,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             OptionDoesNotExist: If there is no option with the given index.
         """
-        try:
-            self._replace_option_prompt(index, prompt)
-        except IndexError:
-            raise OptionDoesNotExist(
-                f"There is no option with an index of {index}"
-            ) from None
+        self._replace_option_prompt(index, prompt)
         return self
 
     def clear_options(self) -> Self:
@@ -851,6 +838,22 @@ class OptionList(ScrollView, can_focus=True):
         try:
             return self.get_option_at_index(self._option_ids[option_id])
         except KeyError:
+            raise OptionDoesNotExist(
+                f"There is no option with an ID of '{option_id}'"
+            ) from None
+
+    def get_option_index(self, option_id):
+        """Get the index of the option with the given ID.
+
+        Args:
+            option_id: The ID of the option to get the index of.
+
+        Raises:
+            OptionDoesNotExist: If no option has the given ID.
+        """
+        try:
+            return self._option_ids[option_id]
+        except:
             raise OptionDoesNotExist(
                 f"There is no option with an ID of '{option_id}'"
             ) from None

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -55,6 +55,14 @@ class Option:
         """The prompt for the option."""
         return self.__prompt
 
+    def set_prompt(self, prompt: RenderableType) -> None:
+        """Set the prompt for the option.
+
+        Args:
+            prompt: The new prompt for the option.
+        """
+        self.__prompt = prompt
+
     @property
     def id(self) -> str | None:
         """The optional ID for the option."""
@@ -641,6 +649,65 @@ class OptionList(ScrollView, can_focus=True):
         """
         try:
             self._remove_option(index)
+        except IndexError:
+            raise OptionDoesNotExist(
+                f"There is no option with an index of {index}"
+            ) from None
+        return self
+
+    def _replace_option_prompt(self, index: int, prompt: RenderableType) -> None:
+        """Replace the prompt of an option in the list.
+
+        Args:
+            index: The index of the option to replace the prompt of.
+            prompt: The new prompt for the option.
+
+        Raises:
+            IndexError: If there is no option of the given index.
+        """
+        option = self._options[index]
+        option.set_prompt(prompt)
+        self._refresh_content_tracking(force=True)
+        self.refresh()
+
+    def replace_option_prompt(self, option_id: str, prompt: RenderableType) -> Self:
+        """Replace the prompt of the option with the given ID.
+
+        Args:
+            option_id: The ID of the option to replace the prompt of.
+            prompt: The new prompt for the option.
+
+        Returns:
+            The `OptionList` instance.
+
+        Raises:
+            OptionDoesNotExist: If no option has the given ID.
+        """
+        try:
+            self._replace_option_prompt(self._option_ids[option_id], prompt)
+        except KeyError:
+            raise OptionDoesNotExist(
+                f"There is no option with an ID of '{option_id}'"
+            ) from None
+        return self
+
+    def replace_option_prompt_at_index(
+        self, index: int, prompt: RenderableType
+    ) -> Self:
+        """Replace the prompt of the option at the given index.
+
+        Args:
+            index: The index of the option to replace the prompt of.
+            prompt: The new prompt for the option.
+
+        Returns:
+            The `OptionList` instance.
+
+        Raises:
+            OptionDoesNotExist: If there is no option with the given index.
+        """
+        try:
+            self._replace_option_prompt(index, prompt)
         except IndexError:
             raise OptionDoesNotExist(
                 f"There is no option with an index of {index}"

--- a/tests/option_list/test_option_prompt_replacement.py
+++ b/tests/option_list/test_option_prompt_replacement.py
@@ -1,0 +1,41 @@
+"""Test replacing options prompt from an option list."""
+import pytest
+
+from textual.app import App, ComposeResult
+from textual.widgets import OptionList
+from textual.widgets.option_list import Option, OptionDoesNotExist
+
+
+class OptionListApp(App[None]):
+    """Test option list application."""
+
+    def compose(self) -> ComposeResult:
+        yield OptionList(
+            Option("0", id="0"),
+            Option("1"),
+        )
+
+async def test_replace_option_prompt_with_invalid_id() -> None:
+    """Attempting to replace the prompt of an option ID that doesn't exist should raise an exception."""
+    async with OptionListApp().run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).replace_option_prompt("does-not-exist", "new-prompt")
+
+async def test_replace_option_prompt_with_invalid_index() -> None:
+    """Attempting to replace the prompt of an option index that doesn't exist should raise an exception."""
+    async with OptionListApp().run_test() as pilot:
+        with pytest.raises(OptionDoesNotExist):
+            pilot.app.query_one(OptionList).replace_option_prompt_at_index(23, "new-prompt")
+
+async def test_replace_option_prompt_with_valid_id() -> None:
+    """It should be possible to replace the prompt of an option ID that does exist."""
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        option_list.replace_option_prompt("0", "new-prompt")
+        assert option_list.get_option("0").prompt == "new-prompt"
+
+async def test_replace_option_prompt_with_valid_index() -> None:
+    """It should be possible to replace the prompt of an option index that does exist."""
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList).replace_option_prompt_at_index(1, "new-prompt")
+        assert option_list.get_option_at_index(1).prompt == "new-prompt"

--- a/tests/option_list/test_option_prompt_replacement.py
+++ b/tests/option_list/test_option_prompt_replacement.py
@@ -12,8 +12,9 @@ class OptionListApp(App[None]):
     def compose(self) -> ComposeResult:
         yield OptionList(
             Option("0", id="0"),
-            Option("1"),
+            Option("line1\nline2"),
         )
+
 
 async def test_replace_option_prompt_with_invalid_id() -> None:
     """Attempting to replace the prompt of an option ID that doesn't exist should raise an exception."""
@@ -21,11 +22,13 @@ async def test_replace_option_prompt_with_invalid_id() -> None:
         with pytest.raises(OptionDoesNotExist):
             pilot.app.query_one(OptionList).replace_option_prompt("does-not-exist", "new-prompt")
 
+
 async def test_replace_option_prompt_with_invalid_index() -> None:
     """Attempting to replace the prompt of an option index that doesn't exist should raise an exception."""
     async with OptionListApp().run_test() as pilot:
         with pytest.raises(OptionDoesNotExist):
             pilot.app.query_one(OptionList).replace_option_prompt_at_index(23, "new-prompt")
+
 
 async def test_replace_option_prompt_with_valid_id() -> None:
     """It should be possible to replace the prompt of an option ID that does exist."""
@@ -34,8 +37,36 @@ async def test_replace_option_prompt_with_valid_id() -> None:
         option_list.replace_option_prompt("0", "new-prompt")
         assert option_list.get_option("0").prompt == "new-prompt"
 
+
 async def test_replace_option_prompt_with_valid_index() -> None:
     """It should be possible to replace the prompt of an option index that does exist."""
     async with OptionListApp().run_test() as pilot:
         option_list = pilot.app.query_one(OptionList).replace_option_prompt_at_index(1, "new-prompt")
         assert option_list.get_option_at_index(1).prompt == "new-prompt"
+
+
+async def test_replace_single_line_option_prompt_with_multiple() -> None:
+    """It should be possible to replace single line prompt with multiple lines """
+    new_prompt = "new-prompt\nsecond line"
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        option_list.replace_option_prompt("0", new_prompt)
+        assert option_list.get_option("0").prompt == new_prompt
+
+
+async def test_replace_multiple_line_option_prompt_with_single() -> None:
+    """It should be possible to replace multiple line prompt with a single line"""
+    new_prompt = "new-prompt"
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        option_list.replace_option_prompt("0", new_prompt)
+        assert option_list.get_option("0").prompt == new_prompt
+
+
+async def test_replace_multiple_line_option_prompt_with_multiple() -> None:
+    """It should be possible to replace multiple line prompt with multiple lines"""
+    new_prompt = "new-prompt\nsecond line"
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        option_list.replace_option_prompt_at_index(1, new_prompt)
+        assert option_list.get_option_at_index(1).prompt == new_prompt

--- a/tests/snapshot_tests/snapshot_apps/option_list_multiline_options.py
+++ b/tests/snapshot_tests/snapshot_apps/option_list_multiline_options.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+from textual.app import App, ComposeResult
+from textual.widgets import OptionList, Header, Footer
+from textual.widgets.option_list import Option
+
+
+class OptionListApp(App[None]):
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield OptionList(
+            Option("1. Single line", id="one"),
+            Option("2. Two\nlines", id="two"),
+            Option("3. Three\nlines\nof text", id="three"),
+        )
+
+        yield Footer()
+
+    def key_1(self):
+        self.query_one(OptionList).replace_option_prompt_at_index(0, "1. Another single line")
+
+    def key_2(self):
+        self.query_one(OptionList).replace_option_prompt_at_index(0, "1. Two\nlines")
+
+    def key_3(self):
+        self.query_one(OptionList).replace_option_prompt_at_index(1, "1. Three\nlines\nof text")
+
+
+if __name__ == "__main__":
+    OptionListApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -238,6 +238,18 @@ def test_option_list_build(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "option_list.py")
 
 
+def test_option_list_replace_prompt_from_single_line_to_single_line(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "option_list_multiline_options.py", press=["1"])
+
+
+def test_option_list_replace_prompt_from_single_line_to_two_lines(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "option_list_multiline_options.py", press=["2"])
+
+
+def test_option_list_replace_prompt_from_two_lines_to_three_lines(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "option_list_multiline_options.py", press=["3"])
+
+
 def test_progress_bar_indeterminate(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "progress_bar_isolated_.py", press=["f"])
 


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

This PR extends `OptionList` class with an interface for replacing prompts in individual options. 

Closes #2603 