### PR TITLE
Remove the implementation of notify from `Screen`

### DIFF
--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -36,7 +36,6 @@ from .css.parse import parse_selectors
 from .css.query import NoMatches, QueryType
 from .dom import DOMNode
 from .geometry import Offset, Region, Size
-from .notifications import Notification, SeverityLevel
 from .reactive import Reactive
 from .renderables.background_screen import BackgroundScreen
 from .renderables.blank import Blank

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -940,30 +940,6 @@ class Screen(Generic[ScreenResultType], Widget):
         """
         self.dismiss(result)
 
-    def notify(
-        self,
-        message: str,
-        *,
-        title: str = "",
-        severity: SeverityLevel = "information",
-        timeout: float = Notification.timeout,
-    ) -> Notification:
-        """Create a notification.
-
-        Args:
-            message: The message for the notification.
-            title: The title for the notification.
-            severity: The severity of the notification.
-            timeout: The timeout for the notification.
-
-        Returns:
-            The new notification.
-
-        See [`App.notify`][textual.app.App.notify] for the full
-        documentation for this method.
-        """
-        return self.app.notify(message, title=title, severity=severity, timeout=timeout)
-
 
 @rich.repr.auto
 class ModalScreen(Screen[ScreenResultType]):


### PR DESCRIPTION
It's on `Widget` too and `Screen` will inherit it from `Widget`. I seem to always forget that `Screen` derives from `Widget`.