### PR TITLE
Override can_view in Screen to check if a widget is overlay screen

### DIFF
--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -939,6 +939,25 @@ class Screen(Generic[ScreenResultType], Widget):
         """
         self.dismiss(result)
 
+    def can_view(self, widget: Widget) -> bool:
+        """Check if a given widget is in the current view (scrollable area).
+
+        Note: This doesn't necessarily equate to a widget being visible.
+        There are other reasons why a widget may not be visible.
+
+        Args:
+            widget: A widget that is a descendant of self.
+
+        Returns:
+            True if the entire widget is in view, False if it is partially visible or not in view.
+        """
+        # If the widget is one that overlays the screen...
+        if widget.styles.overlay == "screen":
+            # ...simply check if it's within the screen's region.
+            return widget.region in self.region
+        # Failing that fall back to normal checking.
+        return super().can_view(widget)
+
 
 @rich.repr.auto
 class ModalScreen(Screen[ScreenResultType]):


### PR DESCRIPTION
This PR is based on the idea that if a widget is `overlay: screen` it's totally outside the normal flow of things and so trying to see if it's visually within its ancestors doesn't make a whole lot of sense as it might deliberately not be (see the makeup of `Select`, for example). At which point the only sensible question we can ask is "can the screen see it?".

Fixes #2958.
