### PR TITLE
feat(listview): add method to append multiple items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added App.begin_capture_print, App.end_capture_print, Widget.begin_capture_print, Widget.end_capture_print https://github.com/Textualize/textual/issues/2952
 - Added the ability to run async methods as thread workers https://github.com/Textualize/textual/pull/2938
+- Added `ListView.extend` method to append multiple items https://github.com/Textualize/textual/pull/3012
 
 ### Changed
 

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import ClassVar, Optional
+from typing import ClassVar, Iterable, Optional
 
 from textual.await_remove import AwaitRemove
 from textual.binding import Binding, BindingType
@@ -172,6 +172,21 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
         self._scroll_highlighted_region()
         self.post_message(self.Highlighted(self, new_child))
 
+    def extend(self, items: Iterable[ListItem]) -> AwaitMount:
+        """Append multiple new ListItems to the end of the ListView.
+
+        Args:
+            items: The ListItems to append.
+
+        Returns:
+            An awaitable that yields control to the event loop
+                until the DOM has been updated with the new child items.
+        """
+        await_mount = self.mount(*items)
+        if len(self) == 1:
+            self.index = 0
+        return await_mount
+
     def append(self, item: ListItem) -> AwaitMount:
         """Append a new ListItem to the end of the ListView.
 
@@ -182,10 +197,7 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
             An awaitable that yields control to the event loop
                 until the DOM has been updated with the new child item.
         """
-        await_mount = self.mount(item)
-        if len(self) == 1:
-            self.index = 0
-        return await_mount
+        return self.extend([item])
 
     def clear(self) -> AwaitRemove:
         """Clear all items from the ListView.


### PR DESCRIPTION
Closes #2997 by adding a `ListView.extend` method to append multiple items. This is essentially a cut-and-paste from the existing `append` method!

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
