### PR TITLE
Clean up the f-stringing of a string in `ScalarAnimation.__call__`

### DIFF
--- a/src/textual/css/scalar_animation.py
+++ b/src/textual/css/scalar_animation.py
@@ -62,7 +62,7 @@ class ScalarAnimation(Animation):
             value = self.start + (self.destination - self.start) * eased_factor
         current = self.styles.get_rule(self.attribute)
         if current != value:
-            setattr(self.styles, f"{self.attribute}", value)
+            setattr(self.styles, self.attribute, value)
 
         return False
 


### PR DESCRIPTION
Noticed this unnecessary use of an f-string in passing.
