### PR TITLE
fix(datatable): unset hover cursor when no cell under mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a bug where `Click` events were bubbling up from `Switch` widgets https://github.com/Textualize/textual/issues/2366
 - Fixed a crash when using empty CSS variables https://github.com/Textualize/textual/issues/1849
 - Fixed issue with tabs in TextLog https://github.com/Textualize/textual/issues/3007
-
+- Fixed a bug with `DataTable` hover highlighting https://github.com/Textualize/textual/issues/2909
 
 ### Changed
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1757,6 +1757,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             base_style,
             cursor,
             hover,
+            self._show_hover_cursor,
             self._update_count,
             self._pseudo_class_state,
         )
@@ -2076,8 +2077,11 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         and column metadata from the segments present in the cells."""
         self._set_hover_cursor(True)
         meta = event.style.meta
+        if not meta:
+            self._set_hover_cursor(False)
+            return
 
-        if meta and self.show_cursor and self.cursor_type != "none":
+        if self.show_cursor and self.cursor_type != "none":
             try:
                 self.hover_coordinate = Coordinate(meta["row"], meta["column"])
             except KeyError:

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -1137,3 +1137,25 @@ async def test_move_cursor():
         assert table.cursor_coordinate == Coordinate(3, 6)
         table.move_cursor(column=3)
         assert table.cursor_coordinate == Coordinate(3, 3)
+
+
+async def test_unset_hover_highlight_when_no_table_cell_under_mouse():
+    """When there isn't a table cell under the mouse cursor, there should be no
+    hover highlighting.
+
+    Regression test for #2909 https://github.com/Textualize/textual/issues/2909
+    """
+    app = DataTableApp()
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        table.add_column("ABC")
+        table.add_row("123")
+        await pilot.pause()
+        assert table.hover_coordinate == Coordinate(0, 0)
+        # Hover over a cell, and the hover cursor is visible
+        await pilot.hover(DataTable, offset=Offset(1, 1))
+        assert table._show_hover_cursor
+        # Move our cursor so it is outside any table cells but still within
+        # the widget, and the hover cursor is hidden
+        await pilot.hover(DataTable, offset=Offset(42, 1))
+        assert not table._show_hover_cursor


### PR DESCRIPTION
### Description

Fixes #2909 by unsetting the hover cursor when there isn't a table cell under the mouse.

Many thanks to @darrenburns for identifying the caching bug that was giving me such grief trying to solve this! (Sorry Darren, in hindsight I should have added you as a co-author, but I don't know how to add this to the PR!)

I wasn't quite sure how best to conditionally set/unset the hover highlight, so let me know if this could be improved.

### Related Issue

- #2909 

### Checklist:

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)