### PR TITLE
Tidy up the notes in the `stop_animation` docstrings

### DIFF
--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -476,9 +476,7 @@ class Animator:
             complete: Should the animation be set to its final value?
 
         Note:
-            If there is no animation running, this is a no-op. If there is
-            an animation running the attribute will be left in the last
-            state it was in before the call to stop.
+            If there is no animation scheduled or running, this is a no-op.
         """
         key = (id(obj), attribute)
         if key in self._scheduled:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -609,7 +609,7 @@ class App(Generic[ReturnType], DOMNode):
             complete: Should the animation be set to its final value?
 
         Note:
-            If there is no animation running, this is a no-op.
+            If there is no animation scheduled or running, this is a no-op.
         """
         await self._animator.stop_animation(self, attribute, complete)
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1575,7 +1575,7 @@ class Widget(DOMNode):
             complete: Should the animation be set to its final value?
 
         Note:
-            If there is no animation running, this is a no-op.
+            If there is no animation scheduled or running, this is a no-op.
         """
         await self.app.animator.stop_animation(self, attribute, complete)
 


### PR DESCRIPTION
In one case there was a hangover from before we added the `complete` option; in the other two cases it also needed to be made clear that it's only a no-op if there's no animation running or also scheduled.
