### PR TITLE
Fix the page up/down bindings for OptionList

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -130,8 +130,8 @@ class OptionList(ScrollView, can_focus=True):
         Binding("end", "last", "Last", show=False),
         Binding("enter", "select", "Select", show=False),
         Binding("home", "first", "First", show=False),
-        Binding("page_down", "page_down", "Page Down", show=False),
-        Binding("page_up", "page_up", "Page Up", show=False),
+        Binding("pagedown", "page_down", "Page Down", show=False),
+        Binding("pageup", "page_up", "Page Up", show=False),
         Binding("up", "cursor_up", "Up", show=False),
     ]
     """
@@ -141,8 +141,8 @@ class OptionList(ScrollView, can_focus=True):
     | end | Move the highlight to the last option. |
     | enter | Select the current option. |
     | home | Move the highlight to the first option. |
-    | page_down | Move the highlight down a page of options. |
-    | page_up | Move the highlight up a page of options. |
+    | pagedown | Move the highlight down a page of options. |
+    | pageup | Move the highlight up a page of options. |
     | up | Move the highlight up. |
     """
 

--- a/tests/option_list/test_option_list_movement.py
+++ b/tests/option_list/test_option_list_movement.py
@@ -33,7 +33,7 @@ async def test_cleared_movement_does_nothing() -> None:
         option_list = pilot.app.query_one(OptionList)
         option_list.clear_options()
         assert option_list.highlighted is None
-        await pilot.press("tab", "down", "up", "page_down", "page_up", "home", "end")
+        await pilot.press("tab", "down", "up", "pagedown", "pageup", "home", "end")
         assert option_list.highlighted is None
 
 
@@ -90,7 +90,7 @@ async def test_move_home() -> None:
 async def test_page_down_from_start_short_list() -> None:
     """Doing a page down from the start of a short list should move to the end."""
     async with OptionListApp().run_test() as pilot:
-        await pilot.press("tab", "page_down")
+        await pilot.press("tab", "pagedown")
         assert pilot.app.query_one(OptionList).highlighted == 5
 
 
@@ -101,7 +101,7 @@ async def test_page_up_from_end_short_list() -> None:
         assert option_list.highlighted == 0
         option_list.highlighted = 5
         assert option_list.highlighted == 5
-        await pilot.press("tab", "page_up")
+        await pilot.press("tab", "pageup")
         assert option_list.highlighted == 0
 
 
@@ -112,14 +112,14 @@ async def test_page_down_from_end_short_list() -> None:
         assert option_list.highlighted == 0
         option_list.highlighted = 5
         assert option_list.highlighted == 5
-        await pilot.press("tab", "page_down")
+        await pilot.press("tab", "pagedown")
         assert option_list.highlighted == 5
 
 
 async def test_page_up_from_start_short_list() -> None:
     """Doing a page up from the start of a short list go nowhere."""
     async with OptionListApp().run_test() as pilot:
-        await pilot.press("tab", "page_up")
+        await pilot.press("tab", "pageup")
         assert pilot.app.query_one(OptionList).highlighted == 0
 
 
@@ -135,7 +135,7 @@ async def test_empty_list_movement() -> None:
     async with EmptyOptionListApp().run_test() as pilot:
         option_list = pilot.app.query_one(OptionList)
         await pilot.press("tab")
-        for movement in ("up", "down", "home", "end", "page_up", "page_down"):
+        for movement in ("up", "down", "home", "end", "pageup", "pagedown"):
             await pilot.press(movement)
             assert option_list.highlighted is None
 
@@ -147,8 +147,8 @@ async def test_no_highlight_movement() -> None:
         ("down", 0),
         ("home", 0),
         ("end", 99),
-        ("page_up", 0),
-        ("page_down", 99),
+        ("pageup", 0),
+        ("pagedown", 99),
     ):
         async with EmptyOptionListApp().run_test() as pilot:
             option_list = pilot.app.query_one(OptionList)


### PR DESCRIPTION
I'd had `page_up` and `page_down` bound when the actual names of the bindings are `pageup` and `pagedown`. This has always worked by sheer fluke because of where OptionList inherits from and by the coincidence of the action names.

In other words: this commit has no substantive impact; but it does fix code that wasn't helpful and also makes the documentation more correct.
