### PR TITLE
Background refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed background refresh https://github.com/Textualize/textual/issues/3055
+
+
 ## [0.32.0] - 2023-08-03
 
 ### Added

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2342,9 +2342,6 @@ class App(Generic[ReturnType], DOMNode):
                 and not self.is_headless
                 and self._driver is not None
             ):
-                if screen is not self.screen:
-                    self.screen.refresh()
-                    return
                 console = self.console
                 self._begin_update()
                 try:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2333,7 +2333,7 @@ class App(Generic[ReturnType], DOMNode):
         """
 
         try:
-            if screen is not self.screen or renderable is None:
+            if renderable is None:
                 return
 
             if (
@@ -2342,6 +2342,9 @@ class App(Generic[ReturnType], DOMNode):
                 and not self.is_headless
                 and self._driver is not None
             ):
+                if screen is not self.screen:
+                    self.screen.refresh()
+                    return
                 console = self.console
                 self._begin_update()
                 try:

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -561,6 +561,21 @@ class Screen(Generic[ScreenResultType], Widget):
 
         await self._invoke_and_clear_callbacks()
 
+    def _compositor_refresh(self) -> None:
+        """Perform a compositor refresh."""
+        if self is self.app.screen:
+            # Top screen
+            update = self._compositor.render_update(
+                screen_stack=self.app._background_screens
+            )
+            self.app._display(self, update)
+            self._dirty_widgets.clear()
+        elif self in self.app._background_screens and self._compositor._dirty_regions:
+            # Background screen
+            self.app.screen.refresh(*self._compositor._dirty_regions)
+            self._compositor._dirty_regions.clear()
+            self._dirty_widgets.clear()
+
     def _on_timer_update(self) -> None:
         """Called by the _update_timer."""
         self._update_timer.pause()
@@ -581,11 +596,7 @@ class Screen(Generic[ScreenResultType], Widget):
 
             if self._dirty_widgets:
                 self._compositor.update_widgets(self._dirty_widgets)
-                update = self._compositor.render_update(
-                    screen_stack=self.app._background_screens
-                )
-                self.app._display(self, update)
-                self._dirty_widgets.clear()
+                self._compositor_refresh()
 
         if self._callbacks:
             self.call_next(self._invoke_and_clear_callbacks)
@@ -702,10 +713,7 @@ class Screen(Generic[ScreenResultType], Widget):
             self.app._handle_exception(error)
             return
         if self.is_current:
-            display_update = self._compositor.render_update(
-                full=full, screen_stack=self.app._background_screens
-            )
-            self.app._display(self, display_update)
+            self._compositor_refresh()
 
         if not self.app._dom_ready:
             self.app.post_message(events.Ready())

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -183,7 +183,7 @@ class Screen(Generic[ScreenResultType], Widget):
         from .app import ScreenStackError
 
         try:
-            return self.app.screen is self
+            return self.app.screen is self or self in self.app._background_screens
         except ScreenStackError:
             return False
 


### PR DESCRIPTION
The previous attempt at refreshing background screens would prompt a refresh of the entire screen, even if a single widget updated. This update ensures that only the changed portions of the screen is updated.