### PR TITLE
Added: get_row_key and get_column_key from a row/column index

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -887,6 +887,22 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             raise RowDoesNotExist(f"No row exists for row_key={row_key!r}")
         return self._row_locations.get(row_key)
 
+    def get_row_key(self, row_index: int) -> RowKey:
+        """Return the row key for the row identified by row_index.
+
+        Args:
+            row_index: The index of the row.
+
+        Returns:
+            The current row key of the specified row index
+
+        Raises:
+            RowDoesNotExist: If there is no row with the given index.
+        """
+        if not self.is_valid_row_index(row_index):
+            raise RowDoesNotExist(f"Row index {row_index!r} is not valid.")
+        return self._row_locations.get_key(row_index)
+
     def get_column(self, column_key: ColumnKey | str) -> Iterable[CellType]:
         """Get the values from the column identified by the given column key.
 
@@ -940,6 +956,23 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         if column_key not in self._column_locations:
             raise ColumnDoesNotExist(f"No column exists for column_key={column_key!r}")
         return self._column_locations.get(column_key)
+
+    def get_column_key(self, column_index: int) -> ColumnKey:
+        """Return the current key for the column identified by column_index.
+
+        Args:
+            column_index: The index of the column.
+
+        Returns:
+            The current column key of the specified column index
+
+        Raises:
+            ColumnDoesNotExist: If there is no column with the given index.
+        """
+        if not self.is_valid_column_index(column_index):
+            raise ColumnDoesNotExist(
+                f"Column index {column_index!r} is not valid.")
+        return self._column_locations.get_key(column_index)
 
     def _clear_caches(self) -> None:
         self._row_render_cache.clear()

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -507,6 +507,21 @@ async def test_get_row_at():
         assert table.get_row_at(1) == [2, 4, 1]
 
 
+async def test_get_row_key():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        table.add_columns("A", "B", "C")
+        table.add_row((0, 1, 2), key="R0")
+        table.add_row((3, 4, 5), key="R1")
+        row_key0 = table.get_row_key(0)
+        row_key1 = table.get_row_key(1)
+        assert isinstance(row_key0, RowKey)
+        assert isinstance(row_key1, RowKey)
+        assert row_key0.value == "R0"
+        assert row_key1.value == "R1"
+
+
 @pytest.mark.parametrize("index", (-1, 2))
 async def test_get_row_at_invalid_index(index):
     app = DataTableApp()
@@ -616,6 +631,20 @@ async def test_get_column_index_invalid_column_key():
         with pytest.raises(ColumnDoesNotExist):
             index = table.get_column_index('InvalidCol')
 
+
+async def test_get_column_key():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        table.add_column("Column1", key="C1")
+        table.add_column("Column2", key="C2")
+        table.add_column("Column3", key="C3")
+        column_key_1 = table.get_column_key(0)
+        column_key_2 = table.get_column_key(1)
+        assert isinstance(column_key_1, ColumnKey)
+        assert isinstance(column_key_2, ColumnKey)
+        assert column_key_1.value == "C1"
+        assert column_key_2.value == "C2"
 
 
 async def test_update_cell_cell_exists():


### PR DESCRIPTION
My use case is to add row to a data table with a key dynamically generated, so I need a convenient way to retrieve that key which is in my case not available in values (so not easily retrievable)

This PR add two methods in data_table widget:
* get_row_key
* get_column_key

Those methods respectively return the RowKey / ColumnKey from  the row/column identified by the index given in parameter.