### PR TITLE
Catch exception when the markdown file cannot be found

### DIFF
--- a/examples/markdown.py
+++ b/examples/markdown.py
@@ -25,8 +25,10 @@ class MarkdownApp(App):
 
     async def on_mount(self) -> None:
         self.markdown_viewer.focus()
-        if not await self.markdown_viewer.go(self.path):
-            self.exit(message=f"Unable to load {self.path!r}")
+        try:
+            await self.markdown_viewer.go(self.path)
+        except FileNotFoundError as e:
+            self.exit(message=f"File not found {self.path!r}")
 
     def action_toggle_table_of_contents(self) -> None:
         self.markdown_viewer.show_table_of_contents = (


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

Since [#2972](https://github.com/Textualize/textual/pull/2972), the example for the markdown viewer is not working anymore:
```
Unable to load PosixPath('.../demo.md')
```

In this pull request, I propose to catch the FileNotFoundException and exit the application in the same way. 
Should I update CHANGELOG.md with the fix? 