### PR TITLE
Hide some members from the public docs.

### DIFF
--- a/docs/api/widget.md
+++ b/docs/api/widget.md
@@ -1,1 +1,5 @@
 ::: textual.widget
+    options:
+        filters:
+          - "!^_"
+          - "^__init__$"

--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -87,7 +87,6 @@ plugins:
             - "!^render_lines$"
             - "!^get_content_width$"
             - "!^get_content_height$"
-            - "!^on_mount$"
     watch:
       - mkdocs-common.yml
       - mkdocs-nav.yml

--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -78,6 +78,16 @@ plugins:
             - "!^_"
             - "^__init__$"
             - "!^can_replace$"
+            # Hide some methods that Widget subclasses implement but that we don't want
+            # to be shown in the docs.
+            # This is then overridden in widget.md so that it shows in the base class.
+            - "!^compose$"
+            - "!^render$"
+            - "!^render_line$"
+            - "!^render_lines$"
+            - "!^get_content_width$"
+            - "!^get_content_height$"
+            - "!^on_mount$"
     watch:
       - mkdocs-common.yml
       - mkdocs-nav.yml

--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -120,7 +120,7 @@ class Placeholder(Widget):
         while next(self._variants_cycle) != self.variant:
             pass
 
-    def on_mount(self) -> None:
+    def _on_mount(self) -> None:
         """Set the color for this placeholder."""
         colors = Placeholder._COLORS.setdefault(
             self.app, cycle(_PLACEHOLDER_BACKGROUND_COLORS)


### PR DESCRIPTION
See relevant issue: #3076.
Some methods need to be implemented to make the widget work but the user doesn't really care about them. For that matter, we can hide them from the public documentation.

I decided to hide these methods that some widgets inherit and document:

  - "compose"
  - "render"
  - "render_line"
  - "render_lines"
  - "get_content_width"
  - "get_content_height"
  - ~~"on_mount"~~

On a case-by-case basis, we may also want to hide specific methods from specific widgets, but that _probably_ entails manually curating such a list of excluded methods.