### PR TITLE
fix doc error in Bubble parameters for events.Focus and events.Blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Updated documentation for `events.Focus` and `events.Blur` to reflect the the default class parameters.
+
 ### Fixed
 
 - Fixed unintuitive sizing behaviour of TabbedContent https://github.com/Textualize/textual/issues/2411

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -534,7 +534,7 @@ class Leave(Event, bubble=False, verbose=True):
 class Focus(Event, bubble=False):
     """Sent when a widget is focussed.
 
-    - [X] Bubbles
+    - [ ] Bubbles
     - [ ] Verbose
     """
 
@@ -542,7 +542,7 @@ class Focus(Event, bubble=False):
 class Blur(Event, bubble=False):
     """Sent when a widget is blurred (un-focussed).
 
-    - [X] Bubbles
+    - [ ] Bubbles
     - [ ] Verbose
     """
 


### PR DESCRIPTION
Quick fix to reflect the bubble parameters for `Blur and Focus` in the docs. I don't remember if these events bubbled before. 