### PR TITLE
Grid auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- grid-columns and grid-rows now accept an `auto` token to detect the optimal size.
+- grid-columns and grid-rows now accept an `auto` token to detect the optimal size https://github.com/Textualize/textual/pull/3107
 
 ## [0.33.0] - 2023-08-15
 

--- a/tests/snapshot_tests/snapshot_apps/auto_grid.py
+++ b/tests/snapshot_tests/snapshot_apps/auto_grid.py
@@ -1,0 +1,32 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Label, Input
+from textual.containers import Container
+
+
+class GridApp(App):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+    Container {
+        layout: grid;
+        grid-size: 2;
+        grid-columns: auto 1fr;
+        grid-rows: auto;
+        height:auto;
+        border: solid green;
+    }
+
+    """
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            yield Label("foo")
+            yield Input()
+            yield Label("Longer label")
+            yield Input()
+
+
+if __name__ == "__main__":
+    app = GridApp()
+    app.run()


### PR DESCRIPTION
Allows grid columns / row to specify an "auto" token which will determine an optimal size.

I screwed up and pushed the actual implementation to main. Here's the commit: https://github.com/Textualize/textual/commit/5eb91820979cf80556603b5663173a8d08b6a217

No docs as yet. I'll create an issue to add those later https://github.com/Textualize/textual/issues/3108.