### PR TITLE
Tab hide disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Methods `TabbedContent.disable_tab` and `TabbedContent.enable_tab` https://github.com/Textualize/textual/pull/3112
 - Methods `Tabs.disable` and `Tabs.enable` https://github.com/Textualize/textual/pull/3112
 - Messages `Tab.Disabled`, `Tab.Enabled`, `Tabs.TabDisabled` and `Tabs.Enabled` https://github.com/Textualize/textual/pull/3112
+- Methods `TabbedContent.hide_tab` and `TabbedContent.show_tab` https://github.com/Textualize/textual/pull/3112
+- Methods `Tabs.hide` and `Tabs.show` https://github.com/Textualize/textual/pull/3112
+- Messages `Tabs.TabHidden` and `Tabs.TabShown` https://github.com/Textualize/textual/pull/3112
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Methods `TabbedContent.disable_tab` and `TabbedContent.enable_tab` https://github.com/Textualize/textual/pull/3112
+- Methods `Tabs.disable` and `Tabs.enable` https://github.com/Textualize/textual/pull/3112
+- Messages `Tab.Disabled`, `Tab.Enabled`, `Tabs.TabDisabled` and `Tabs.Enabled` https://github.com/Textualize/textual/pull/3112
+
 ### Changed
 
 - grid-columns and grid-rows now accept an `auto` token to detect the optimal size https://github.com/Textualize/textual/pull/3107

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -375,3 +375,45 @@ class TabbedContent(Widget):
     def tab_count(self) -> int:
         """Total number of tabs."""
         return self.get_child_by_type(Tabs).tab_count
+
+    def _on_tabs_tab_disabled(self, event: Tabs.TabDisabled) -> None:
+        """Disable the corresponding tab pane."""
+        event.stop()
+        tab_id = event.tab.id
+        try:
+            self.query_one(f"TabPane#{tab_id}").disabled = True
+        except NoMatches:
+            return
+
+    def _on_tabs_tab_enabled(self, event: Tabs.TabEnabled) -> None:
+        """Enable the corresponding tab pane."""
+        event.stop()
+        tab_id = event.tab.id
+        try:
+            self.query_one(f"TabPane#{tab_id}").disabled = False
+        except NoMatches:
+            return
+
+    def disable_tab(self, tab_id: str) -> None:
+        """Disables the tab with the given ID.
+
+        Args:
+            tab_id: The ID of the [`TabPane`][textual.widgets.TabPane] to disable.
+
+        Raises:
+            Tabs.TabError: If there are any issues with the request.
+        """
+
+        self.query_one(Tabs).disable(tab_id)
+
+    def enable_tab(self, tab_id: str) -> None:
+        """Enables the tab with the given ID.
+
+        Args:
+            tab_id: The ID of the [`TabPane`][textual.widgets.TabPane] to enable.
+
+        Raises:
+            Tabs.TabError: If there are any issues with the request.
+        """
+
+        self.query_one(Tabs).enable(tab_id)

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -417,3 +417,27 @@ class TabbedContent(Widget):
         """
 
         self.query_one(Tabs).enable(tab_id)
+
+    def hide_tab(self, tab_id: str) -> None:
+        """Hides the tab with the given ID.
+
+        Args:
+            tab_id: The ID of the [`TabPane`][textual.widgets.TabPane] to hide.
+
+        Raises:
+            Tabs.TabError: If there are any issues with the request.
+        """
+
+        self.query_one(Tabs).hide(tab_id)
+
+    def show_tab(self, tab_id: str) -> None:
+        """Shows the tab with the given ID.
+
+        Args:
+            tab_id: The ID of the [`TabPane`][textual.widgets.TabPane] to show.
+
+        Raises:
+            Tabs.TabError: If there are any issues with the request.
+        """
+
+        self.query_one(Tabs).show(tab_id)

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -412,7 +412,7 @@ class Tabs(Widget, can_focus=True):
         """Remove a tab.
 
         Args:
-            tab_or_id: The Tab's id.
+            tab_or_id: The Tab to remove or its id.
 
         Returns:
             An awaitable object that waits for the tab to be removed.

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -115,25 +115,32 @@ class Tab(Static):
     """
 
     @dataclass
-    class Clicked(Message):
+    class TabMessage(Message):
+        """Tab-related messages.
+
+        These are mostly intended for internal use when interacting with `Tabs`.
+        """
+
+        tab: Tab
+        """The tab that is the object of this message."""
+
+        @property
+        def control(self) -> Tab:
+            """The tab that is the object of this message.
+
+            This is an alias for the attribute `tab` and is used by the
+            [`on`][textual.on] decorator.
+            """
+            return self.tab
+
+    class Clicked(TabMessage):
         """A tab was clicked."""
 
-        tab: Tab
-        """The tab that was clicked."""
-
-    @dataclass
-    class Disabled(Message):
+    class Disabled(TabMessage):
         """A tab was disabled."""
 
-        tab: Tab
-        """The tab that was disabled."""
-
-    @dataclass
-    class Enabled(Message):
+    class Enabled(TabMessage):
         """A tab was enabled."""
-
-        tab: Tab
-        """The tab that was enabled."""
 
     def __init__(
         self,

--- a/tests/snapshot_tests/snapshot_apps/modified_tabs.py
+++ b/tests/snapshot_tests/snapshot_apps/modified_tabs.py
@@ -1,0 +1,27 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Button, TabbedContent
+
+
+class FiddleWithTabsApp(App[None]):
+    CSS = """
+    TabPane:disabled {
+        background: red;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            yield Button()
+            yield Button()
+            yield Button()
+            yield Button()
+            yield Button()
+
+    def on_mount(self) -> None:
+        self.query_one(TabbedContent).disable_tab(f"tab-1")
+        self.query_one(TabbedContent).disable_tab(f"tab-2")
+        self.query_one(TabbedContent).hide_tab(f"tab-3")
+
+
+if __name__ == "__main__":
+    FiddleWithTabsApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -222,6 +222,11 @@ def test_tabbed_content(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "tabbed_content.py")
 
 
+def test_tabbed_content_with_modified_tabs(snap_compare):
+    # Tabs enabled and hidden.
+    assert snap_compare(SNAPSHOT_APPS_DIR / "modified_tabs.py")
+
+
 def test_option_list_strings(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "option_list_strings.py")
 


### PR DESCRIPTION
This fixes #3088.

Adds API to enable/disable/show/hide tabs.
 - A `Tab` widget can be disabled directly via the reactive `.disabled`, which then fires a `Tab.Disabled` message, which is turned into a `Tabs.Disabled` message.
 - Preferably, and in line with the show/hide API, one can use the methods on `Tabs` or `TabbedContent`.