### PR TITLE
Link the `Header` docs to `App.title` and `App.sub_title`

### DIFF
--- a/docs/examples/widgets/header_app_title.py
+++ b/docs/examples/widgets/header_app_title.py
@@ -1,0 +1,16 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Header
+
+
+class HeaderApp(App):
+    def compose(self) -> ComposeResult:
+        yield Header()
+
+    def on_mount(self) -> None:
+        self.title = "Header Application"
+        self.sub_title = "With title and sub-title"
+
+
+if __name__ == "__main__":
+    app = HeaderApp()
+    app.run()

--- a/docs/widgets/header.md
+++ b/docs/widgets/header.md
@@ -2,6 +2,10 @@
 
 A simple header widget which docks itself to the top of the parent container.
 
+!!! note
+
+    The application title which is shown in the header is taken from the [`title`][textual.app.App.title] and [`sub_title`][textual.app.App.sub_title] of the application.
+
 - [ ] Focusable
 - [ ] Container
 
@@ -18,6 +22,19 @@ The example below shows an app with a `Header`.
 
     ```python
     --8<-- "docs/examples/widgets/header.py"
+    ```
+
+This example shows how to set the text in the `Header` using `App.title` and `App.sub_title`:
+
+=== "Output"
+
+    ```{.textual path="docs/examples/widgets/header_app_title.py"}
+    ```
+
+=== "header_app_title.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/header_app_title.py"
     ```
 
 ## Reactive Attributes


### PR DESCRIPTION
Closes #3103.
