### PR TITLE
feat(loadingindicator): default min height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Add `min-height: 1;` to `LoadingIndicator`'s `DEFAULT_CSS`.
+
 ### Added
 
 - Methods `TabbedContent.disable_tab` and `TabbedContent.enable_tab` https://github.com/Textualize/textual/pull/3112

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -18,6 +18,7 @@ class LoadingIndicator(Widget):
     LoadingIndicator {
         width: 100%;
         height: 100%;
+        min-height: 1;
         content-align: center middle;
         color: $accent;
     }
@@ -30,7 +31,7 @@ class LoadingIndicator(Widget):
     def render(self) -> RenderableType:
         elapsed = time() - self._start_time
         speed = 0.8
-        dot = "\u25CF"
+        dot = "\u25cf"
         _, _, background, color = self.colors
 
         gradient = Gradient(


### PR DESCRIPTION
From https://github.com/Textualize/textual/discussions/3131, add `min-height: 1;` to `LoadingIndicator`'s `DEFAULT_CSS`.
