### PR TITLE
docs(changelog): correct release for pr 3012

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Methods `TabbedContent.hide_tab` and `TabbedContent.show_tab` https://github.com/Textualize/textual/pull/3112
 - Methods `Tabs.hide` and `Tabs.show` https://github.com/Textualize/textual/pull/3112
 - Messages `Tabs.TabHidden` and `Tabs.TabShown` https://github.com/Textualize/textual/pull/3112
+- Added `ListView.extend` method to append multiple items https://github.com/Textualize/textual/pull/3012
 
 ### Changed
 
@@ -64,7 +65,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added App.begin_capture_print, App.end_capture_print, Widget.begin_capture_print, Widget.end_capture_print https://github.com/Textualize/textual/issues/2952
 - Added the ability to run async methods as thread workers https://github.com/Textualize/textual/pull/2938
-- Added `ListView.extend` method to append multiple items https://github.com/Textualize/textual/pull/3012
 - Added `App.stop_animation` https://github.com/Textualize/textual/issues/2786
 - Added `Widget.stop_animation` https://github.com/Textualize/textual/issues/2786
 


### PR DESCRIPTION
I spotted the Changelog became out of sync for #3012 merged today - moved to Unreleased.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
