### PR TITLE
feat(datatable): add cursor_type to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Added `cursor_type` to the `DataTable` constructor.
+
 ## [0.35.0]
 
 ### Added

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -35,14 +35,8 @@ from ..widget import PseudoClasses
 CellCacheKey: TypeAlias = (
     "tuple[RowKey, ColumnKey, Style, bool, bool, int, PseudoClasses]"
 )
-LineCacheKey: TypeAlias = (
-    "tuple[int, int, int, int, Coordinate, Coordinate, Style, CursorType, bool, int,"
-    " PseudoClasses]"
-)
-RowCacheKey: TypeAlias = (
-    "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, int,"
-    " PseudoClasses]"
-)
+LineCacheKey: TypeAlias = "tuple[int, int, int, int, Coordinate, Coordinate, Style, CursorType, bool, int, PseudoClasses]"
+RowCacheKey: TypeAlias = "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, int, PseudoClasses]"
 CursorType = Literal["cell", "row", "column", "none"]
 """The legal types of cursors for [`DataTable.cursor_type`][textual.widgets.DataTable.cursor_type]."""
 CellType = TypeVar("CellType")

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -35,8 +35,14 @@ from ..widget import PseudoClasses
 CellCacheKey: TypeAlias = (
     "tuple[RowKey, ColumnKey, Style, bool, bool, int, PseudoClasses]"
 )
-LineCacheKey: TypeAlias = "tuple[int, int, int, int, Coordinate, Coordinate, Style, CursorType, bool, int, PseudoClasses]"
-RowCacheKey: TypeAlias = "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, int, PseudoClasses]"
+LineCacheKey: TypeAlias = (
+    "tuple[int, int, int, int, Coordinate, Coordinate, Style, CursorType, bool, int,"
+    " PseudoClasses]"
+)
+RowCacheKey: TypeAlias = (
+    "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, int,"
+    " PseudoClasses]"
+)
 CursorType = Literal["cell", "row", "column", "none"]
 """The legal types of cursors for [`DataTable.cursor_type`][textual.widgets.DataTable.cursor_type]."""
 CellType = TypeVar("CellType")
@@ -582,6 +588,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         show_cursor: bool = True,
         cursor_foreground_priority: Literal["renderable", "css"] = "css",
         cursor_background_priority: Literal["renderable", "css"] = "renderable",
+        cursor_type: CursorType = "cell",
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
@@ -669,6 +676,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self.cursor_background_priority = cursor_background_priority
         """Should we prioritize the cursor component class CSS background or the renderable background
          in the event where a cell contains a renderable with a background color."""
+        self.cursor_type = cursor_type
+        """The type of cursor of the `DataTable`."""
 
     @property
     def hover_row(self) -> int:


### PR DESCRIPTION
I have a use-case where I need a table with `cursor_type="row"`. I'd like to be able to set this in the constructor like `yield DataTable(cursor_type="row")`.