### PR TITLE
Link the centring FAQ to the HOWTO

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -65,6 +65,11 @@ For more information on ANSI colors in Textual, see [Why no Ansi Themes?](#why-d
 <a name="how-do-i-center-a-widget-in-a-screen"></a>
 ## How do I center a widget in a screen?
 
+!!! tip
+
+    See [*How To Center Things*](https://textual.textualize.io/how-to/center-things/) in the
+    Textual documentation for a more comprensive answer to this question.
+
 To center a widget within a container use
 [`align`](https://textual.textualize.io/styles/align/). But remember that
 `align` works on the *children* of a container, it isn't something you use

--- a/questions/align-center-middle.question.md
+++ b/questions/align-center-middle.question.md
@@ -9,6 +9,11 @@ alt_titles:
   - "centre controls"
 ---
 
+!!! tip
+
+    See [*How To Center Things*](https://textual.textualize.io/how-to/center-things/) in the
+    Textual documentation for a more comprensive answer to this question.
+
 To center a widget within a container use
 [`align`](https://textual.textualize.io/styles/align/). But remember that
 `align` works on the *children* of a container, it isn't something you use


### PR DESCRIPTION
Keeping it as a FAQ makes sense, as it means that FAQtory will be able to point to it, but now that we have the HOWTO, and it's more comprehensive, it makes sense to direct the reader in that direction if they want something more involved.
