### PR TITLE
refresh children on layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Callbacks scheduled with `call_next` will now have the same prevented messages as when the callback was scheduled https://github.com/Textualize/textual/pull/3065
 - Added `cursor_type` to the `DataTable` constructor.
 
+### Fixes
+
+- Fixed setting styles.layout not updating https://github.com/Textualize/textual/issues/3047
+
 ## [0.35.1]
 
 ### Fixed

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -614,10 +614,10 @@ class LayoutProperty:
         _rich_traceback_omit = True
         if layout is None:
             if obj.clear_rule("layout"):
-                obj.refresh(layout=True)
+                obj.refresh(layout=True, children=True)
         elif isinstance(layout, Layout):
             if obj.set_rule("layout", layout):
-                obj.refresh(layout=True)
+                obj.refresh(layout=True, children=True)
         else:
             try:
                 layout_object = get_layout(layout)
@@ -627,7 +627,7 @@ class LayoutProperty:
                     help_text=layout_property_help_text(self.name, context="inline"),
                 )
             if obj.set_rule("layout", layout_object):
-                obj.refresh(layout=True)
+                obj.refresh(layout=True, children=True)
 
 
 class OffsetProperty:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -638,3 +638,7 @@ class Print(Event, bubble=False):
         super().__init__()
         self.text = text
         self.stderr = stderr
+
+    def __rich_repr__(self) -> rich.repr.Result:
+        yield self.text
+        yield self.stderr


### PR DESCRIPTION
When you change layout programatically, it should refresh children as well.

Fixes https://github.com/Textualize/textual/issues/3047