### PR TITLE
Add title and sub-title to screens.

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -426,7 +426,7 @@ class App(Generic[ReturnType], DOMNode):
         an empty string if it doesn't.
 
         Sub-titles are typically used to show the high-level state of the app, such as the current mode, or path to
-        the file being worker on.
+        the file being worked on.
 
         Assign a new value to this attribute to change the sub-title.
         The new value is always converted to string.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -9,6 +9,7 @@ from functools import partial
 from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
+    Any,
     Awaitable,
     Callable,
     ClassVar,
@@ -128,10 +129,31 @@ class Screen(Generic[ScreenResultType], Widget):
         background: $surface;
     }
     """
+
+    TITLE: str | None = None
+    """A class variable to set the *default* title for the screen.
+
+    This overrides the app title.
+    To update the title while the screen is running,
+    you can set the [title][textual.screen.Screen.title] attribute.
+    """
+
+    SUB_TITLE: str | None = None
+    """A class variable to set the *default* sub-title for the screen.
+
+    This overrides the app sub-title.
+    To update the sub-title while the screen is running,
+    you can set the [sub_title][textual.screen.Screen.sub_title] attribute.
+    """
+
     focused: Reactive[Widget | None] = Reactive(None)
     """The focused [widget][textual.widget.Widget] or `None` for no focus."""
     stack_updates: Reactive[int] = Reactive(0, repaint=False)
     """An integer that updates when the screen is resumed."""
+    sub_title: Reactive[str | None] = Reactive(None, compute=False)
+    """Screen sub-title to override [the app sub-title][textual.app.App.sub_title]."""
+    title: Reactive[str | None] = Reactive(None, compute=False)
+    """Screen title to override [the app title][textual.app.App.title]."""
 
     BINDINGS = [
         Binding("tab", "focus_next", "Focus Next", show=False),
@@ -172,6 +194,9 @@ class Screen(Generic[ScreenResultType], Widget):
             )
         ]
         self.css_path = css_paths
+
+        self.title = self.TITLE
+        self.sub_title = self.SUB_TITLE
 
     @property
     def is_modal(self) -> bool:
@@ -1001,6 +1026,14 @@ class Screen(Generic[ScreenResultType], Widget):
             return widget.region in self.region
         # Failing that fall back to normal checking.
         return super().can_view(widget)
+
+    def validate_title(self, title: Any) -> str | None:
+        """Ensure the title is a string or `None`."""
+        return None if title is None else str(title)
+
+    def validate_sub_title(self, sub_title: Any) -> str | None:
+        """Ensure the sub-title is a string or `None`."""
+        return None if sub_title is None else str(sub_title)
 
 
 @rich.repr.auto

--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -161,11 +161,19 @@ class Header(Widget):
         self.toggle_class("-tall")
 
     def _on_mount(self, _: Mount) -> None:
-        def set_title(title: str) -> None:
+        def set_title() -> None:
+            screen_title = self.screen.title
+            title = screen_title if screen_title is not None else self.app.title
             self.query_one(HeaderTitle).text = title
 
         def set_sub_title(sub_title: str) -> None:
+            screen_sub_title = self.screen.sub_title
+            sub_title = (
+                screen_sub_title if screen_sub_title is not None else self.app.sub_title
+            )
             self.query_one(HeaderTitle).sub_text = sub_title
 
         self.watch(self.app, "title", set_title)
         self.watch(self.app, "sub_title", set_sub_title)
+        self.watch(self.screen, "title", set_title)
+        self.watch(self.screen, "sub_title", set_sub_title)


### PR DESCRIPTION
Mimicking 'App', we provide class variables TITLE and SUB_TITLE for the screen defaults and those can then be changed via the title and sub_title reactive attributes.

Related issue: #3195
