### PR TITLE
add devtools_host env

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -475,7 +475,7 @@ class App(Generic[ReturnType], DOMNode):
                 # Dev dependencies not installed
                 pass
             else:
-                self.devtools = DevtoolsClient()
+                self.devtools = DevtoolsClient(constants.DEVTOOLS_HOST)
                 self._devtools_redirector = StdoutRedirector(self.devtools)
 
         self._loop: asyncio.AbstractEventLoop | None = None

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -56,6 +56,9 @@ FILTERS: Final[str] = get_environ("TEXTUAL_FILTERS", "")
 LOG_FILE: Final[str | None] = get_environ("TEXTUAL_LOG", None)
 """A last resort log file that appends all logs, when devtools isn't working."""
 
+DEVTOOLS_HOST: Final[str] = get_environ("TEXTUAL_DEVTOOLS_HOST", "127.0.0.1")
+"""The host where textual console is running."""
+
 DEVTOOLS_PORT: Final[int] = get_environ_int("TEXTUAL_DEVTOOLS_PORT", 8081)
 """Constant with the port that the devtools will connect to."""
 


### PR DESCRIPTION
Adds a `DEVTOOLS_HOST` env var, to allow connecting to a textual console somewhere else on the network.