### PR TITLE
Fix for DataTable race-condition crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed flicker when calling pop_screen multiple times https://github.com/Textualize/textual/issues/3126
 - Fixed setting styles.layout not updating https://github.com/Textualize/textual/issues/3047
 - Fixed flicker when scrolling tree up or down a line https://github.com/Textualize/textual/issues/3206
+- DataTable race condition that caused crash https://github.com/Textualize/textual/pull/3211
 
 ## [0.35.1]
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1170,15 +1170,23 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             column = self.columns.get(column_key)
             if column is None:
                 continue
+            row = self._data.get(row_key)
+            if row is None:
+                continue
+            cell_value = row.get(column_key)
+            if cell_value is None:
+                continue
             console = self.app.console
             label_width = measure(console, column.label, 1)
             content_width = column.content_width
-            cell_value = self._data[row_key][column_key]
 
             new_content_width = measure(console, default_cell_formatter(cell_value), 1)
 
             if new_content_width < content_width:
-                cells_in_column = self.get_column(column_key)
+                try:
+                    cells_in_column = self.get_column(column_key)
+                except (KeyError, ColumnDoesNotExist):
+                    continue
                 cell_widths = [
                     measure(console, default_cell_formatter(cell), 1)
                     for cell in cells_in_column
@@ -1201,6 +1209,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                 continue
 
             row = self.rows.get(row_key)
+            if row is None:
+                continue
 
             if row.label is not None:
                 self._labelled_row_exists = True

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -173,6 +173,18 @@ async def test_empty_table_interactions():
         assert app.message_names == []
 
 
+async def test_table_update_remove_on_idle():
+    """Regression test for https://github.com/Textualize/textual/issues/1955"""
+    app = DataTableApp()
+    async with app.run_test() as pilot:
+        table: DataTable = app.query_one(DataTable)
+        table.add_column("A", key="A")
+        table.add_row("1", key="1")
+        table.update_cell("1", "A", "X", update_width=True)
+        table.remove_row("1")
+        await pilot.pause()
+
+
 @pytest.mark.parametrize("show_header", [True, False])
 async def test_cursor_movement_with_home_pagedown_etc(show_header):
     app = DataTableApp()


### PR DESCRIPTION
This patch fix some race condition crashes not fixed in #1962.

When updating a cell in DataTable with `update_width=True`, then remove the row, a crash will happen when on_idle run.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
