### PR TITLE
DataTable new rows can have auto height.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Reactive callbacks are now scheduled on the message pump of the reactable that is watching instead of the owner of reactive attribute https://github.com/Textualize/textual/pull/3065
 - Callbacks scheduled with `call_next` will now have the same prevented messages as when the callback was scheduled https://github.com/Textualize/textual/pull/3065
 - Added `cursor_type` to the `DataTable` constructor.
+- `DataTable.add_row` accepts `height=None` to automatically compute optimal height for a row https://github.com/Textualize/textual/pull/3213
 
 ### Fixed
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1228,8 +1228,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             if row.auto_height:
                 auto_height_rows.append((row_index, row, cells_in_row))
 
-        self._clear_caches()
-
         # If there are rows that need to have their height computed, render them correctly
         # so that we can cache this rendering for later.
         if auto_height_rows:

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -952,6 +952,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._styles_cache.clear()
         self._offset_cache.clear()
         self._ordered_row_cache.clear()
+        self._get_styles_to_render_cell.cache_clear()
 
     def get_row_height(self, row_key: RowKey) -> int:
         """Given a row key, return the height of that row in terminal cells.

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -33,7 +33,7 @@ from ..strip import Strip
 from ..widget import PseudoClasses
 
 CellCacheKey: TypeAlias = (
-    "tuple[RowKey, ColumnKey, Style, bool, bool, int, PseudoClasses]"
+    "tuple[RowKey, ColumnKey, Style, bool, bool, bool, int, PseudoClasses]"
 )
 LineCacheKey: TypeAlias = "tuple[int, int, int, int, Coordinate, Coordinate, Style, CursorType, bool, int, PseudoClasses]"
 RowCacheKey: TypeAlias = "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, int, PseudoClasses]"
@@ -1813,7 +1813,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             row_key = self._row_locations.get_key(row_index)
 
         column_key = self._column_locations.get_key(column_index)
-        cell_cache_key = (
+        cell_cache_key: CellCacheKey = (
             row_key,
             column_key,
             base_style,

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1459,9 +1459,12 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             for column, cell in zip_longest(self.ordered_columns, cells)
         }
         label = Text.from_markup(label) if isinstance(label, str) else label
+        # Rows with auto-height get a height of 0 because 1) we need an integer height
+        # to do some intermediate computations and 2) because 0 doesn't impact the data
+        # table while we don't figure out how tall this row is.
         self.rows[row_key] = Row(
             row_key,
-            height if height is not None else 1,
+            height or 0,
             label,
             height is None,
         )

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1891,9 +1891,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
         return self._cell_render_cache[cell_cache_key]
 
-    @functools.lru_cache(
-        maxsize=512
-    )  # 9 Boolean arguments = 512 possible combinations.
+    @functools.lru_cache(maxsize=32)
     def _get_styles_to_render_cell(
         self,
         is_header_cell: bool,

--- a/tests/snapshot_tests/snapshot_apps/data_table_add_row_auto_height.py
+++ b/tests/snapshot_tests/snapshot_apps/data_table_add_row_auto_height.py
@@ -1,0 +1,21 @@
+from rich.panel import Panel
+from rich.text import Text
+
+from textual.app import App
+from textual.widgets import DataTable
+
+
+class AutoHeightRowsApp(App[None]):
+    def compose(self):
+        table = DataTable()
+        table.add_column("Column", width=10)
+        table.add_row("hey there", height=None)
+        table.add_row(Text("hey there"), height=None)
+        table.add_row(Text("long string", overflow="fold"), height=None)
+        table.add_row(Panel.fit("Hello\nworld"), height=None)
+        table.add_row("1\n2\n3\n4\n5\n6\n7", height=None)
+        yield table
+
+
+if __name__ == "__main__":
+    AutoHeightRowsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/data_table_add_row_auto_height.py
+++ b/tests/snapshot_tests/snapshot_apps/data_table_add_row_auto_height.py
@@ -8,13 +8,17 @@ from textual.widgets import DataTable
 class AutoHeightRowsApp(App[None]):
     def compose(self):
         table = DataTable()
+        self.column = table.add_column("N")
         table.add_column("Column", width=10)
-        table.add_row("hey there", height=None)
-        table.add_row(Text("hey there"), height=None)
-        table.add_row(Text("long string", overflow="fold"), height=None)
-        table.add_row(Panel.fit("Hello\nworld"), height=None)
-        table.add_row("1\n2\n3\n4\n5\n6\n7", height=None)
+        table.add_row(3, "hey there", height=None)
+        table.add_row(1, Text("hey there"), height=None)
+        table.add_row(5, Text("long string", overflow="fold"), height=None)
+        table.add_row(2, Panel.fit("Hello\nworld"), height=None)
+        table.add_row(4, "1\n2\n3\n4\n5\n6\n7", height=None)
         yield table
+
+    def key_s(self):
+        self.query_one(DataTable).sort(self.column)
 
 
 if __name__ == "__main__":

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -153,6 +153,13 @@ def test_datatable_add_row_auto_height(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_add_row_auto_height.py")
 
 
+def test_datatable_add_row_auto_height_sorted(snap_compare):
+    # Check that rows added with auto height computation look right.
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "data_table_add_row_auto_height.py", press=["s"]
+    )
+
+
 def test_footer_render(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "footer.py")
 

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -148,6 +148,11 @@ def test_datatable_add_column(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_add_column.py")
 
 
+def test_datatable_add_row_auto_height(snap_compare):
+    # Check that rows added with auto height computation look right.
+    assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_add_row_auto_height.py")
+
+
 def test_footer_render(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "footer.py")
 

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -6,7 +6,7 @@ from rich.text import Text
 
 from textual._wait import wait_for_idle
 from textual.actions import SkipAction
-from textual.app import App
+from textual.app import App, RenderableType
 from textual.coordinate import Coordinate
 from textual.geometry import Offset
 from textual.message import Message

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -1183,3 +1183,22 @@ async def test_add_row_auto_height(cell: RenderableType, height: int):
         row = table.rows.get(row_key)
         await pilot.pause()
         assert row.height == height
+
+
+async def test_add_row_expands_column_widths():
+    """Regression test for https://github.com/Textualize/textual/issues/1026."""
+    app = DataTableApp()
+    from textual.widgets._data_table import CELL_X_PADDING
+
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        table.add_column("First")
+        table.add_column("Second", width=10)
+        await pilot.pause()
+        assert table.ordered_columns[0].render_width == 5 + CELL_X_PADDING
+        assert table.ordered_columns[1].render_width == 10 + CELL_X_PADDING
+
+        table.add_row("a" * 20, "a" * 20)
+        await pilot.pause()
+        assert table.ordered_columns[0].render_width == 20 + CELL_X_PADDING
+        assert table.ordered_columns[1].render_width == 10 + CELL_X_PADDING

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from rich.panel import Panel
 from rich.text import Text
 
 from textual._wait import wait_for_idle
@@ -419,11 +420,11 @@ async def test_get_cell_coordinate_returns_coordinate():
         table.add_row("ValR2C1", "ValR2C2", "ValR2C3", key="R2")
         table.add_row("ValR3C1", "ValR3C2", "ValR3C3", key="R3")
 
-        assert table.get_cell_coordinate('R1', 'C1') == Coordinate(0, 0)
-        assert table.get_cell_coordinate('R2', 'C2') == Coordinate(1, 1)
-        assert table.get_cell_coordinate('R1', 'C3') == Coordinate(0, 2)
-        assert table.get_cell_coordinate('R3', 'C1') == Coordinate(2, 0)
-        assert table.get_cell_coordinate('R3', 'C2') == Coordinate(2, 1)
+        assert table.get_cell_coordinate("R1", "C1") == Coordinate(0, 0)
+        assert table.get_cell_coordinate("R2", "C2") == Coordinate(1, 1)
+        assert table.get_cell_coordinate("R1", "C3") == Coordinate(0, 2)
+        assert table.get_cell_coordinate("R3", "C1") == Coordinate(2, 0)
+        assert table.get_cell_coordinate("R3", "C2") == Coordinate(2, 1)
 
 
 async def test_get_cell_coordinate_invalid_row_key():
@@ -434,7 +435,7 @@ async def test_get_cell_coordinate_invalid_row_key():
         table.add_row("TargetValue", key="R1")
 
         with pytest.raises(CellDoesNotExist):
-            coordinate = table.get_cell_coordinate('INVALID_ROW', 'C1')
+            coordinate = table.get_cell_coordinate("INVALID_ROW", "C1")
 
 
 async def test_get_cell_coordinate_invalid_column_key():
@@ -445,7 +446,7 @@ async def test_get_cell_coordinate_invalid_column_key():
         table.add_row("TargetValue", key="R1")
 
         with pytest.raises(CellDoesNotExist):
-            coordinate = table.get_cell_coordinate('R1', 'INVALID_COLUMN')
+            coordinate = table.get_cell_coordinate("R1", "INVALID_COLUMN")
 
 
 async def test_get_cell_at_returns_value_at_cell():
@@ -531,9 +532,9 @@ async def test_get_row_index_returns_index():
         table.add_row("ValR2C1", "ValR2C2", key="R2")
         table.add_row("ValR3C1", "ValR3C2", key="R3")
 
-        assert table.get_row_index('R1') == 0
-        assert table.get_row_index('R2') == 1
-        assert table.get_row_index('R3') == 2
+        assert table.get_row_index("R1") == 0
+        assert table.get_row_index("R2") == 1
+        assert table.get_row_index("R3") == 2
 
 
 async def test_get_row_index_invalid_row_key():
@@ -544,7 +545,7 @@ async def test_get_row_index_invalid_row_key():
         table.add_row("TargetValue", key="R1")
 
         with pytest.raises(RowDoesNotExist):
-            index = table.get_row_index('InvalidRow')
+            index = table.get_row_index("InvalidRow")
 
 
 async def test_get_column():
@@ -591,6 +592,7 @@ async def test_get_column_at_invalid_index(index):
         with pytest.raises(ColumnDoesNotExist):
             list(table.get_column_at(index))
 
+
 async def test_get_column_index_returns_index():
     app = DataTableApp()
     async with app.run_test():
@@ -598,12 +600,12 @@ async def test_get_column_index_returns_index():
         table.add_column("Column1", key="C1")
         table.add_column("Column2", key="C2")
         table.add_column("Column3", key="C3")
-        table.add_row("ValR1C1", "ValR1C2", "ValR1C3",  key="R1")
-        table.add_row("ValR2C1", "ValR2C2", "ValR2C3",  key="R2")
+        table.add_row("ValR1C1", "ValR1C2", "ValR1C3", key="R1")
+        table.add_row("ValR2C1", "ValR2C2", "ValR2C3", key="R2")
 
-        assert table.get_column_index('C1') == 0
-        assert table.get_column_index('C2') == 1
-        assert table.get_column_index('C3') == 2
+        assert table.get_column_index("C1") == 0
+        assert table.get_column_index("C2") == 1
+        assert table.get_column_index("C3") == 2
 
 
 async def test_get_column_index_invalid_column_key():
@@ -613,11 +615,10 @@ async def test_get_column_index_invalid_column_key():
         table.add_column("Column1", key="C1")
         table.add_column("Column2", key="C2")
         table.add_column("Column3", key="C3")
-        table.add_row("TargetValue1", "TargetValue2", "TargetValue3",  key="R1")
+        table.add_row("TargetValue1", "TargetValue2", "TargetValue3", key="R1")
 
         with pytest.raises(ColumnDoesNotExist):
-            index = table.get_column_index('InvalidCol')
-
+            index = table.get_column_index("InvalidCol")
 
 
 async def test_update_cell_cell_exists():
@@ -1161,3 +1162,24 @@ async def test_unset_hover_highlight_when_no_table_cell_under_mouse():
         # the widget, and the hover cursor is hidden
         await pilot.hover(DataTable, offset=Offset(42, 1))
         assert not table._show_hover_cursor
+
+
+@pytest.mark.parametrize(
+    ["cell", "height"],
+    [
+        ("hey there", 1),
+        (Text("hey there"), 1),
+        (Text("long string", overflow="fold"), 2),
+        (Panel.fit("Hello\nworld"), 4),
+        ("1\n2\n3\n4\n5\n6\n7", 7),
+    ],
+)
+async def test_add_row_auto_height(cell: RenderableType, height: int):
+    app = DataTableApp()
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        table.add_column("C", width=10)
+        row_key = table.add_row(cell, height=None)
+        row = table.rows.get(row_key)
+        await pilot.pause()
+        assert row.height == height


### PR DESCRIPTION
Fixes #3122.

Adds `auto_height` to `Row` to try and keep `Row` and `Column` as similar as possible, as per a conversation with @darrenburns.
Temporarily sets the row height to 0 to signal the row height hasn't been computed yet (we can't set to `None` because we really need an `int` there for computations that run in the interim).