### PR TITLE
chore: remove superfluous bubble=true from messages

### DIFF
--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -158,7 +158,7 @@ class Button(Static, can_focus=True):
     variant = reactive("default")
     """The variant name for the button."""
 
-    class Pressed(Message, bubble=True):
+    class Pressed(Message):
         """Event sent when a `Button` is pressed.
 
         Can be handled using `on_button_pressed` in a subclass of

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -322,7 +322,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
     )
     """The coordinate of the `DataTable` that is being hovered."""
 
-    class CellHighlighted(Message, bubble=True):
+    class CellHighlighted(Message):
         """Posted when the cursor moves to highlight a new cell.
 
         This is only relevant when the `cursor_type` is `"cell"`.
@@ -359,7 +359,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class CellSelected(Message, bubble=True):
+    class CellSelected(Message):
         """Posted by the `DataTable` widget when a cell is selected.
 
         This is only relevant when the `cursor_type` is `"cell"`. Can be handled using
@@ -394,7 +394,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class RowHighlighted(Message, bubble=True):
+    class RowHighlighted(Message):
         """Posted when a row is highlighted.
 
         This message is only posted when the
@@ -423,7 +423,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class RowSelected(Message, bubble=True):
+    class RowSelected(Message):
         """Posted when a row is selected.
 
         This message is only posted when the
@@ -452,7 +452,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class ColumnHighlighted(Message, bubble=True):
+    class ColumnHighlighted(Message):
         """Posted when a column is highlighted.
 
         This message is only posted when the
@@ -481,7 +481,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class ColumnSelected(Message, bubble=True):
+    class ColumnSelected(Message):
         """Posted when a column is selected.
 
         This message is only posted when the
@@ -510,7 +510,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class HeaderSelected(Message, bubble=True):
+    class HeaderSelected(Message):
         """Posted when a column header/label is clicked."""
 
         def __init__(
@@ -540,7 +540,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             """Alias for the data table."""
             return self.data_table
 
-    class RowLabelSelected(Message, bubble=True):
+    class RowLabelSelected(Message):
         """Posted when a row label is clicked."""
 
         def __init__(

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -65,7 +65,7 @@ class DirectoryTree(Tree[DirEntry]):
     PATH: Callable[[str | Path], Path] = Path
     """Callable that returns a fresh path object."""
 
-    class FileSelected(Message, bubble=True):
+    class FileSelected(Message):
         """Posted when a file is selected.
 
         Can be handled using `on_directory_tree_file_selected` in a subclass of

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -38,7 +38,7 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
 
     index = reactive[Optional[int]](0, always_update=True)
 
-    class Highlighted(Message, bubble=True):
+    class Highlighted(Message):
         """Posted when the highlighted item changes.
 
         Highlighted item is controlled using up/down keys.
@@ -65,7 +65,7 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
             """
             return self.list_view
 
-    class Selected(Message, bubble=True):
+    class Selected(Message):
         """Posted when a list item is selected, e.g. when you press the enter key on it.
 
         Can be handled using `on_list_view_selected` in a subclass of `ListView` or in

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -565,7 +565,7 @@ class Markdown(Widget):
         self._markdown = markdown
         self._parser_factory = parser_factory
 
-    class TableOfContentsUpdated(Message, bubble=True):
+    class TableOfContentsUpdated(Message):
         """The table of contents was updated."""
 
         def __init__(
@@ -586,7 +586,7 @@ class Markdown(Widget):
             """
             return self.markdown
 
-    class TableOfContentsSelected(Message, bubble=True):
+    class TableOfContentsSelected(Message):
         """An item in the TOC was selected."""
 
         def __init__(self, markdown: Markdown, block_id: str) -> None:
@@ -605,7 +605,7 @@ class Markdown(Widget):
             """
             return self.markdown
 
-    class LinkClicked(Message, bubble=True):
+    class LinkClicked(Message):
         """A link in the document was clicked."""
 
         def __init__(self, markdown: Markdown, href: str) -> None:

--- a/src/textual/widgets/_radio_set.py
+++ b/src/textual/widgets/_radio_set.py
@@ -76,7 +76,7 @@ class RadioSet(Container, can_focus=True, can_focus_children=False):
     """The index of the currently-selected radio button."""
 
     @rich.repr.auto
-    class Changed(Message, bubble=True):
+    class Changed(Message):
         """Posted when the pressed button in the set changes.
 
         This message can be handled using an `on_radio_set_changed` method.

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -226,7 +226,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
     value: var[SelectType | None] = var[Optional[SelectType]](None)
     """The value of the select."""
 
-    class Changed(Message, bubble=True):
+    class Changed(Message):
         """Posted when the select value was changed.
 
         This message can be handled using a `on_select_changed` method.

--- a/src/textual/widgets/_switch.py
+++ b/src/textual/widgets/_switch.py
@@ -80,7 +80,7 @@ class Switch(Widget, can_focus=True):
     slider_pos = reactive(0.0)
     """The position of the slider."""
 
-    class Changed(Message, bubble=True):
+    class Changed(Message):
         """Posted when the status of the switch changes.
 
         Can be handled using `on_switch_changed` in a subclass of `Switch`

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -232,7 +232,7 @@ class ToggleButton(Static, can_focus=True):
         """Toggle the value of the widget when clicked with the mouse."""
         self.toggle()
 
-    class Changed(Message, bubble=True):
+    class Changed(Message):
         """Posted when the value of the toggle button changes."""
 
         def __init__(self, toggle_button: ToggleButton, value: bool) -> None:

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -508,7 +508,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         ),
     }
 
-    class NodeCollapsed(Generic[EventTreeDataType], Message, bubble=True):
+    class NodeCollapsed(Generic[EventTreeDataType], Message):
         """Event sent when a node is collapsed.
 
         Can be handled using `on_tree_node_collapsed` in a subclass of `Tree` or in a
@@ -525,7 +525,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             """The tree that sent the message."""
             return self.node.tree
 
-    class NodeExpanded(Generic[EventTreeDataType], Message, bubble=True):
+    class NodeExpanded(Generic[EventTreeDataType], Message):
         """Event sent when a node is expanded.
 
         Can be handled using `on_tree_node_expanded` in a subclass of `Tree` or in a
@@ -542,7 +542,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             """The tree that sent the message."""
             return self.node.tree
 
-    class NodeHighlighted(Generic[EventTreeDataType], Message, bubble=True):
+    class NodeHighlighted(Generic[EventTreeDataType], Message):
         """Event sent when a node is highlighted.
 
         Can be handled using `on_tree_node_highlighted` in a subclass of `Tree` or in a
@@ -559,7 +559,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             """The tree that sent the message."""
             return self.node.tree
 
-    class NodeSelected(Generic[EventTreeDataType], Message, bubble=True):
+    class NodeSelected(Generic[EventTreeDataType], Message):
         """Event sent when a node is selected.
 
         Can be handled using `on_tree_node_selected` in a subclass of `Tree` or in a


### PR DESCRIPTION
@davep [recently commented](https://github.com/Textualize/textual/pull/3203#pullrequestreview-1602076289) that:

> It's also made me realise that `bubble` is `True` by default but many messages explicitly set that too. Note to self: perhaps we should tidy that up a bit?

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
