### PR TITLE
Add see-also entries to the various blur/focus messages

### DIFF
--- a/docs/events/blur.md
+++ b/docs/events/blur.md
@@ -12,3 +12,9 @@ _No other attributes_
 ## Code
 
 ::: textual.events.Blur
+
+## See also
+
+- [DescendantBlur](descendant_blur.md)
+- [DescendantFocus](descendant_focus.md)
+- [Focus](focus.md)

--- a/docs/events/descendant_blur.md
+++ b/docs/events/descendant_blur.md
@@ -12,3 +12,9 @@ _No other attributes_
 ## Code
 
 ::: textual.events.DescendantBlur
+
+## See also
+
+- [Blur](blur.md)
+- [DescendantFocus](descendant_focus.md)
+- [Focus](focus.md)

--- a/docs/events/descendant_focus.md
+++ b/docs/events/descendant_focus.md
@@ -12,3 +12,9 @@ _No other attributes_
 ## Code
 
 ::: textual.events.DescendantFocus
+
+## See also
+
+- [Blur](blur.md)
+- [DescendantBlur](descendant_blur.md)
+- [Focus](focus.md)

--- a/docs/events/focus.md
+++ b/docs/events/focus.md
@@ -16,5 +16,5 @@ _No other attributes_
 ## See also
 
 - [Blur](blur.md)
-- [DescendantFocus](descendant_focus.md)
 - [DescendantBlur](descendant_blur.md)
+- [DescendantFocus](descendant_focus.md)

--- a/docs/events/focus.md
+++ b/docs/events/focus.md
@@ -12,3 +12,9 @@ _No other attributes_
 ## Code
 
 ::: textual.events.Focus
+
+## See also
+
+- [Blur](blur.md)
+- [DescendantFocus](descendant_focus.md)
+- [DescendantBlur](descendant_blur.md)


### PR DESCRIPTION
This question crops up from time to time, often with people looking for "focus" or "blur" and wondering why they don't bubble and so then wondering how they can catch such events in ancestors in the DOM.

The Descendant prefix isn't obvious (I always forget what it is and need to go hunting), so having the focus and blur events link to the descendant events should help make them easier to discover.
