### PR TITLE
Fixes missing fileno function (#3111)

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -238,6 +238,10 @@ class _PrintCapture:
         # TODO: should this be configurable?
         return True
 
+    def fileno(self) -> int:
+        """Return invalid fileno."""
+        return -1
+
 
 @rich.repr.auto
 class App(Generic[ReturnType], DOMNode):


### PR DESCRIPTION
Adds missing fileno function to _PrintCapture class. This is needed because _PrintCapture behaves like a normal stdin/stdout/stderr class which provides this method.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
