### PR TITLE
Fix an OptionList crash when removing an option during mouse hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a crash when removing an option from an `OptionList` while the mouse is hovering over the last option https://github.com/Textualize/textual/issues/3270
+
 ## [0.36.0] - 2023-09-05
 
 ### Added

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -613,6 +613,7 @@ class OptionList(ScrollView, can_focus=True):
         self._refresh_content_tracking(force=True)
         # Force a re-validation of the highlight.
         self.highlighted = self.highlighted
+        self._mouse_hovering_over = None
         self.refresh()
 
     def remove_option(self, option_id: str) -> Self:

--- a/tests/option_list/test_option_removal.py
+++ b/tests/option_list/test_option_removal.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from textual.app import App, ComposeResult
+from textual.geometry import Offset
 from textual.widgets import OptionList
 from textual.widgets.option_list import Option, OptionDoesNotExist
 
@@ -99,3 +100,13 @@ async def test_remove_invalid_index() -> None:
     async with OptionListApp().run_test() as pilot:
         with pytest.raises(OptionDoesNotExist):
             pilot.app.query_one(OptionList).remove_option_at_index(23)
+
+
+async def test_remove_with_hover_on_last_option():
+    """https://github.com/Textualize/textual/issues/3270"""
+    async with OptionListApp().run_test() as pilot:
+        await pilot.hover(OptionList, Offset(1, 1) + Offset(2, 1))
+        option_list = pilot.app.query_one(OptionList)
+        assert option_list._mouse_hovering_over == 1
+        option_list.remove_option_at_index(0)
+        assert option_list._mouse_hovering_over == None


### PR DESCRIPTION
If the mouse is hovering over the last option in an `OptionList`, and an option is removed, the application will crash with an `IndexError`. The problem was that the record of the hovered option needed to be cleared when an option is removed (as it is during other changes).

Fixes #3270
