### PR TITLE
Update the blog author metadata

### DIFF
--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -1,16 +1,17 @@
-willmcgugan:
-  name: Will McGugan
-  description: CEO / code-monkey
-  avatar: https://github.com/willmcgugan.png
-darrenburns:
-  name: Darren Burns
-  description: Code-monkey
-  avatar: https://github.com/darrenburns.png
-davep:
-  name: Dave Pearson
-  description: Code-monkey
-  avatar: https://github.com/davep.png
-rodrigo:
-  name: Rodrigo Girão Serrão
-  description: Code-monkey
-  avatar: https://github.com/rodrigogiraoserrao.png
+authors:
+  willmcgugan:
+    name: Will McGugan
+    description: CEO / code-monkey
+    avatar: https://github.com/willmcgugan.png
+  darrenburns:
+    name: Darren Burns
+    description: Code-monkey
+    avatar: https://github.com/darrenburns.png
+  davep:
+    name: Dave Pearson
+    description: Code-monkey
+    avatar: https://github.com/davep.png
+  rodrigo:
+    name: Rodrigo Girão Serrão
+    description: Code-monkey
+    avatar: https://github.com/rodrigogiraoserrao.png


### PR DESCRIPTION
As per the warning if you use the latest release of mkdocs-material:

```
WARNING -  Action required: the format of the authors file changed.
           All authors must now be located under the 'authors' key.
           Please adjust 'docs/blog/.authors.yml' to match:

           authors:
             squidfunk:
               avatar: https://avatars.githubusercontent.com/u/932156
               description: Creator
               name: Martin Donath
```
Note that this is for after:

```
Updating mkdocs-material (8.5.9+insiders.4.26.2 /Users/davep/develop/python/mkdocs-material-insiders -> 9.2.7)
```

It's also worth noting that our docs should now build regardless of insiders' edition or not now; given that the blog module is part of the mainstream release.
