### PR TITLE
Remove the docstring for `OptionList.DEFAULT_CSS`

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -245,7 +245,6 @@ class OptionList(ScrollView, can_focus=True):
         background: $accent 60%;
     }
     """
-    """The default styling for an `OptionList`."""
 
     highlighted: reactive[int | None] = reactive["int | None"](None)
     """The index of the currently-highlighted option, or `None` if no option is highlighted."""


### PR DESCRIPTION
We really don't need to document anything like this, I'll have done it by habit, and having it there pulls it into the docs which then pollutes the search results if someone is searching for what DEFAULT_CSS is all about.
