### PR TITLE
Remove an unused import from command.py

### DIFF
--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -7,7 +7,7 @@ See the guide on the [Command Palette](../guide/command_palette.md) for full det
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from asyncio import CancelledError, Queue, Task, TimeoutError, wait, wait_for
+from asyncio import CancelledError, Queue, Task, TimeoutError, wait_for
 from dataclasses import dataclass
 from functools import total_ordering
 from time import monotonic


### PR DESCRIPTION
Presumably a hangover from the recent tweak session.
