### PR TITLE
Remove assertion that the calling screen is not None

### DIFF
--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -580,7 +580,6 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
 
         # Fire up an instance of each command source, inside a task, and
         # have them go start looking for matches.
-        assert self._calling_screen is not None
         searches = [
             create_task(
                 self._consume(


### PR DESCRIPTION
The assert was for the benefit of type checkers; the code that needed that hint was moved elsewhere by the recent tweak; but this wasn't tidied up.

This tidies that up.
