### PR TITLE
docs: fix typos in release 0.37.0 blog

### DIFF
--- a/docs/blog/posts/release0.37.0.md
+++ b/docs/blog/posts/release0.37.0.md
@@ -46,7 +46,7 @@ class ColorCommands(Provider):
                 )
 ```
 
-And here is how you add a provider to you app:
+And here is how you add a provider to your app:
 
 ```python
 class ColorApp(App):
@@ -55,7 +55,7 @@ class ColorApp(App):
     COMMANDS = App.COMMANDS | {ColorCommands}
 ```
 
-We're excited about this feature because it is a step towards brining a common user interface to Textual apps.
+We're excited about this feature because it is a step towards bringing a common user interface to Textual apps.
 
 !!! quote
 


### PR DESCRIPTION
Sorry just a couple of typos spotted in the latest release blog!
