### PR TITLE
Fix command palette `TimeoutError` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the command palette crashing with a `TimeoutError` in any Python before 3.11 https://github.com/Textualize/textual/issues/3320
+
 ## [0.37.0] - 2023-09-15
 
 ### Added

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -7,7 +7,7 @@ See the guide on the [Command Palette](../guide/command_palette.md) for full det
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from asyncio import CancelledError, Queue, Task, wait, wait_for
+from asyncio import CancelledError, Queue, Task, TimeoutError, wait, wait_for
 from dataclasses import dataclass
 from functools import total_ordering
 from time import monotonic


### PR DESCRIPTION
Fixes #3320 

It looks like eaa749665f9b8271eff45be8e5e1e72ac8729b9e unintentionally removed the import of `TimeoutError` from `asyncio`, causing the command palette to only work correctly on Python 3.11 or later.

Tested on Python 3.7 and 3.11 with this change and all working again in both Pythonic extremes.