### PR TITLE
Stop command palette `Input` message leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Fixed `Input` event leakage from `CommandPalette` to `App`.
+
 ## [0.37.0] - 2023-09-15
 
 ### Added

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -876,6 +876,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         Args:
             event: The input event.
         """
+        event.stop()
         self.workers.cancel_all()
         search_value = event.value.strip()
         if search_value:
@@ -906,10 +907,14 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
 
     @on(Input.Submitted)
     @on(Button.Pressed)
-    def _select_or_command(self) -> None:
+    def _select_or_command(
+        self, event: Input.Submitted | Button.Pressed | None = None
+    ) -> None:
         """Depending on context, select or execute a command."""
         # If the list is visible, that means we're in "pick a command"
         # mode...
+        if event is not None:
+            event.stop()
         if self._list_visible:
             # ...so if nothing in the list is highlighted yet...
             if self.query_one(CommandList).highlighted is None:


### PR DESCRIPTION
It was possible for `Input` events to leak from the `CommandPalette` up to the developer's application, which could result in unintended side-effects if the developer had broad event handlers on their application (not an unreasonable situation if writing a simple all-in-the-app tool).

This does raise the question of what to do about all possible messages that could be posted from something like the command palette, which the developer may not be expecting and which could bubble up to their application. I'll raise an issue for considering that (perhaps there should be, or is there, a way to say "no message shall pass!" on a screen).

Edit to add: raised the wider issue as #3323