### PR TITLE
fix(datatable): raise error for update cell with invalid column key

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -744,12 +744,15 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         if isinstance(column_key, str):
             column_key = ColumnKey(column_key)
 
-        try:
-            self._data[row_key][column_key] = value
-        except KeyError:
+        if (
+            row_key not in self._row_locations
+            or column_key not in self._column_locations
+        ):
             raise CellDoesNotExist(
                 f"No cell exists for row_key={row_key!r}, column_key={column_key!r}."
-            ) from None
+            )
+
+        self._data[row_key][column_key] = value
         self._update_count += 1
 
         # Recalculate widths if necessary

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -640,6 +640,17 @@ async def test_update_cell_cell_doesnt_exist():
             table.update_cell("INVALID", "CELL", "Value")
 
 
+async def test_update_cell_invalid_column_key():
+    """Regression test for https://github.com/Textualize/textual/issues/3335"""
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        table.add_column("Column1", key="C1")
+        table.add_row("TargetValue", key="R1")
+        with pytest.raises(CellDoesNotExist):
+            table.update_cell("R1", "INVALID_COLUMN", "New Value")
+
+
 async def test_update_cell_at_coordinate_exists():
     app = DataTableApp()
     async with app.run_test():


### PR DESCRIPTION
Fixes #3335.

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
