### PR TITLE
Fix heading in changelog for 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the command palette crashing with a `TimeoutError` in any Python before 3.11 https://github.com/Textualize/textual/issues/3320
 - Fixed `Input` event leakage from `CommandPalette` to `App`.
 
-## [0.36.0] - 2023-09-15
+## [0.37.0] - 2023-09-15
 
 ### Added
 


### PR DESCRIPTION
I was confused when I saw two 0.36.0 sections :smile: 