### PR TITLE
Tweak docs.

### DIFF
--- a/docs/widgets/_template.md
+++ b/docs/widgets/_template.md
@@ -30,7 +30,7 @@ Example app showing the widget:
     ```
 
 
-## Reactive attributes
+## Reactive Attributes
 
 
 ## Bindings

--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -41,6 +41,14 @@ Clicking any of the non-disabled buttons in the example app below will result in
 
 - [Button.Pressed][textual.widgets.Button.Pressed]
 
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
 ## Additional Notes
 
 - The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` has the `height` set to 3 lines and a `min-width` of 16 columns. To create a button with zero visible padding, you will need to change these values and also remove the border with `border: none;`.

--- a/docs/widgets/checkbox.md
+++ b/docs/widgets/checkbox.md
@@ -34,6 +34,10 @@ The example below shows check boxes in various states.
 | ------- | ------ | ------- | -------------------------- |
 | `value` | `bool` | `False` | The value of the checkbox. |
 
+## Messages
+
+- [Checkbox.Changed][textual.widgets.Checkbox.Changed]
+
 ## Bindings
 
 The checkbox widget defines the following bindings:
@@ -45,16 +49,12 @@ The checkbox widget defines the following bindings:
 
 ## Component Classes
 
-The checkbox widget provides the following component classes:
+The checkbox widget inherits the following component classes:
 
 ::: textual.widgets._toggle_button.ToggleButton.COMPONENT_CLASSES
     options:
       show_root_heading: false
       show_root_toc_entry: false
-
-## Messages
-
-- [Checkbox.Changed][textual.widgets.Checkbox.Changed]
 
 
 ---

--- a/docs/widgets/collapsible.md
+++ b/docs/widgets/collapsible.md
@@ -120,11 +120,28 @@ The following example shows `Collapsible` widgets with custom expand/collapse sy
     --8<-- "docs/examples/widgets/collapsible_custom_symbol.py"
     ```
 
-## Reactive attributes
+## Reactive Attributes
 
 | Name        | Type   | Default | Description                                          |
 | ----------- | ------ | ------- | ---------------------------------------------------- |
 | `collapsed` | `bool` | `True`  | Controls the collapsed/expanded state of the widget. |
+
+## Messages
+
+This widget posts no messages.
+
+## Bindings
+
+The collapsible widget defines the following binding on its title:
+
+::: textual.widgets._collapsible.CollapsibleTitle.BINDINGS
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+
+## Component Classes
+
+This widget has no component classes.
 
 
 ::: textual.widgets.Collapsible

--- a/docs/widgets/content_switcher.md
+++ b/docs/widgets/content_switcher.md
@@ -50,6 +50,18 @@ When the user presses the "Markdown" button the view is switched:
 | --------- | --------------- | ------- | ----------------------------------------------------------------------- |
 | `current` | `str` \| `None` | `None`  | The ID of the currently-visible child. `None` means nothing is visible. |
 
+## Messages
+
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
 
 ---
 

--- a/docs/widgets/digits.md
+++ b/docs/widgets/digits.md
@@ -44,15 +44,19 @@ Here's another example which uses `Digits` to display the current time:
     --8<-- "docs/examples/widgets/clock.py"
     ```
 
-## Reactive attributes
+## Reactive Attributes
 
 This widget has no reactive attributes.
+
+## Messages
+
+This widget posts no messages.
 
 ## Bindings
 
 This widget has no bindings.
 
-## Component classes
+## Component Classes
 
 This widget has no component classes.
 

--- a/docs/widgets/directory_tree.md
+++ b/docs/widgets/directory_tree.md
@@ -34,10 +34,6 @@ and directories:
     --8<-- "docs/examples/widgets/directory_tree_filtered.py"
     ~~~
 
-## Messages
-
-- [DirectoryTree.FileSelected][textual.widgets.DirectoryTree.FileSelected]
-
 ## Reactive Attributes
 
 | Name          | Type   | Default | Description                                     |
@@ -45,6 +41,14 @@ and directories:
 | `show_root`   | `bool` | `True`  | Show the root node.                             |
 | `show_guides` | `bool` | `True`  | Show guide lines between levels.                |
 | `guide_depth` | `int`  | `4`     | Amount of indentation between parent and child. |
+
+## Messages
+
+- [DirectoryTree.FileSelected][textual.widgets.DirectoryTree.FileSelected]
+
+## Bindings
+
+The directory tree widget inherits [the bindings from the tree widget][textual.widgets.Tree.BINDINGS].
 
 ## Component Classes
 

--- a/docs/widgets/footer.md
+++ b/docs/widgets/footer.md
@@ -30,7 +30,11 @@ widget. Notice how the `Footer` automatically displays the keybinding.
 
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
 
 ## Component Classes
 

--- a/docs/widgets/header.md
+++ b/docs/widgets/header.md
@@ -45,7 +45,15 @@ This example shows how to set the text in the `Header` using `App.title` and `Ap
 
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -88,7 +88,7 @@ as seen for `Palindrome` in the example above.
 
 ## Bindings
 
-The Input widget defines the following bindings:
+The input widget defines the following bindings:
 
 ::: textual.widgets.Input.BINDINGS
     options:

--- a/docs/widgets/label.md
+++ b/docs/widgets/label.md
@@ -28,7 +28,15 @@ This widget has no reactive attributes.
 
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/list_item.md
+++ b/docs/widgets/list_item.md
@@ -29,12 +29,17 @@ of multiple `ListItem`s. The arrow keys can be used to navigate the list.
 | ------------- | ------ | ------- | ------------------------------------ |
 | `highlighted` | `bool` | `False` | True if this ListItem is highlighted |
 
+## Messages
 
-#### Attributes
+This widget posts no messages.
 
-| attribute | type       | purpose                     |
-| --------- | ---------- | --------------------------- |
-| `item`    | `ListItem` | The item that was selected. |
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/list_view.md
+++ b/docs/widgets/list_view.md
@@ -31,9 +31,9 @@ The example below shows an app with a simple `ListView`.
 
 ## Reactive Attributes
 
-| Name    | Type  | Default | Description                     |
-| ------- | ----- | ------- | ------------------------------- |
-| `index` | `int` | `0`     | The currently highlighted index |
+| Name    | Type  | Default | Description                      |
+| ------- | ----- | ------- | -------------------------------- |
+| `index` | `int` | `0`     | The currently highlighted index. |
 
 ## Messages
 
@@ -48,6 +48,10 @@ The list view widget defines the following bindings:
     options:
       show_root_heading: false
       show_root_toc_entry: false
+
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/loading_indicator.md
+++ b/docs/widgets/loading_indicator.md
@@ -7,16 +7,9 @@ Displays pulsating dots to indicate when data is being loaded.
 - [ ] Focusable
 - [ ] Container
 
-You can set the color of the loading indicator by setting its `color` style.
+## Example
 
-Here's how you would do that with CSS:
-
-```sass
-LoadingIndicator {
-    color: red;
-}
-```
-
+Simple usage example:
 
 === "Output"
 
@@ -28,6 +21,35 @@ LoadingIndicator {
     ```python
     --8<-- "docs/examples/widgets/loading_indicator.py"
     ```
+
+## Changing Indicator Color
+
+You can set the color of the loading indicator by setting its `color` style.
+
+Here's how you would do that with CSS:
+
+```sass
+LoadingIndicator {
+    color: red;
+}
+```
+
+## Reactive Attributes
+
+This widget has no reactive attributes.
+
+## Messages
+
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
 ---
 
 

--- a/docs/widgets/log.md
+++ b/docs/widgets/log.md
@@ -37,10 +37,17 @@ The example below shows how to write text to a `Log` widget:
 | `max_lines`   | `int`  | `None`  | Maximum number of lines in the log or `None` for no maximum. |
 | `auto_scroll` | `bool` | `False` | Scroll to end of log when new lines are added.               |
 
-
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 
 ---

--- a/docs/widgets/markdown.md
+++ b/docs/widgets/markdown.md
@@ -27,11 +27,28 @@ The following example displays Markdown from a string.
     --8<-- "docs/examples/widgets/markdown.py"
     ~~~
 
+## Reactive Attributes
+
+This widget has no reactive attributes.
+
 ## Messages
 
 - [Markdown.TableOfContentsUpdated][textual.widgets.Markdown.TableOfContentsUpdated]
 - [Markdown.TableOfContentsSelected][textual.widgets.Markdown.TableOfContentsSelected]
 - [Markdown.LinkClicked][textual.widgets.Markdown.LinkClicked]
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+The markdown widget provides the following component classes:
+
+::: textual.widgets.Markdown.COMPONENT_CLASSES
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
 
 
 ## See Also

--- a/docs/widgets/markdown_viewer.md
+++ b/docs/widgets/markdown_viewer.md
@@ -33,6 +33,18 @@ The following example displays Markdown from a string and a Table of Contents.
 | ------------------------ | ---- | ------- | ----------------------------------------------------------------- |
 | `show_table_of_contents` | bool | True    | Wether a Table of Contents should be displayed with the Markdown. |
 
+## Messages
+
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
 ## See Also
 
 * [Markdown][textual.widgets.Markdown] code reference

--- a/docs/widgets/placeholder.md
+++ b/docs/widgets/placeholder.md
@@ -41,7 +41,15 @@ The example below shows each placeholder variant.
 
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/progress_bar.md
+++ b/docs/widgets/progress_bar.md
@@ -104,15 +104,6 @@ Refer to the [section below](#styling-the-progress-bar) for more information.
     --8<-- "docs/examples/widgets/progress_bar_styled.tcss"
     ```
 
-## Reactive Attributes
-
-| Name         | Type    | Default | Description                                                                                             |
-| ------------ | ------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `percentage` | `float  | None`   | The read-only percentage of progress that has been made. This is `None` if the `total` hasn't been set. |
-| `progress`   | `float` | `0`     | The number of steps of progress already made.                                                           |
-| `total`      | `float  | None`   | The total number of steps that we are keeping track of.                                                 |
-
-
 ## Styling the Progress Bar
 
 The progress bar is composed of three sub-widgets that can be styled independently:
@@ -130,8 +121,27 @@ The progress bar is composed of three sub-widgets that can be styled independent
       show_root_heading: false
       show_root_toc_entry: false
 
----
+## Reactive Attributes
 
+| Name         | Type    | Default | Description                                                                                             |
+| ------------ | ------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `percentage` | `float  | None`   | The read-only percentage of progress that has been made. This is `None` if the `total` hasn't been set. |
+| `progress`   | `float` | `0`     | The number of steps of progress already made.                                                           |
+| `total`      | `float  | None`   | The total number of steps that we are keeping track of.                                                 |
+
+## Messages
+
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
+---
 
 ::: textual.widgets.ProgressBar
     options:

--- a/docs/widgets/radiobutton.md
+++ b/docs/widgets/radiobutton.md
@@ -36,6 +36,10 @@ The example below shows radio buttons, used within a [`RadioSet`](./radioset.md)
 | ------- | ------ | ------- | ------------------------------ |
 | `value` | `bool` | `False` | The value of the radio button. |
 
+## Messages
+
+- [RadioButton.Changed][textual.widgets.RadioButton.Changed]
+
 ## Bindings
 
 The radio button widget defines the following bindings:
@@ -47,16 +51,12 @@ The radio button widget defines the following bindings:
 
 ## Component Classes
 
-The radio button widget provides the following component classes:
+The checkbox widget inherits the following component classes:
 
 ::: textual.widgets._toggle_button.ToggleButton.COMPONENT_CLASSES
     options:
       show_root_heading: false
       show_root_toc_entry: false
-
-## Messages
-
-- [RadioButton.Changed][textual.widgets.RadioButton.Changed]
 
 ## See Also
 

--- a/docs/widgets/radioset.md
+++ b/docs/widgets/radioset.md
@@ -9,6 +9,8 @@ A container widget that groups [`RadioButton`](./radiobutton.md)s together.
 
 ## Example
 
+### Simple example
+
 The example below shows two radio sets, one built using a collection of
 [radio buttons](./radiobutton.md), the other a collection of simple strings.
 
@@ -29,11 +31,7 @@ The example below shows two radio sets, one built using a collection of
     --8<-- "docs/examples/widgets/radio_set.tcss"
     ```
 
-## Messages
-
--  [RadioSet.Changed][textual.widgets.RadioSet.Changed]
-
-#### Example
+### Reacting to Changes in a Radio Set
 
 Here is an example of using the message to react to changes in a `RadioSet`:
 
@@ -53,6 +51,18 @@ Here is an example of using the message to react to changes in a `RadioSet`:
     ```sass
     --8<-- "docs/examples/widgets/radio_set_changed.tcss"
     ```
+
+## Messages
+
+-  [RadioSet.Changed][textual.widgets.RadioSet.Changed]
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ## See Also
 

--- a/docs/widgets/rich_log.md
+++ b/docs/widgets/rich_log.md
@@ -42,6 +42,14 @@ The example below shows an application showing a `RichLog` with different kinds 
 
 This widget sends no messages.
 
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
 
 ---
 

--- a/docs/widgets/rule.md
+++ b/docs/widgets/rule.md
@@ -62,6 +62,14 @@ The example below shows vertical rules with all the available line styles.
 
 This widget sends no messages.
 
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
+
 ---
 
 

--- a/docs/widgets/select.md
+++ b/docs/widgets/select.md
@@ -58,12 +58,8 @@ The following example presents a `Select` with a number of options.
     --8<-- "docs/examples/widgets/select.tcss"
     ```
 
-## Messages
 
--  [Select.Changed][textual.widgets.Select.Changed]
-
-
-## Reactive attributes
+## Reactive Attributes
 
 
 | Name       | Type                   | Default | Description                         |
@@ -71,6 +67,9 @@ The following example presents a `Select` with a number of options.
 | `expanded` | `bool`                 | `False` | True to expand the options overlay. |
 | `value`    | `SelectType` \| `None` | `None`  | Current value of the Select.        |
 
+## Messages
+
+-  [Select.Changed][textual.widgets.Select.Changed]
 
 ## Bindings
 
@@ -81,6 +80,9 @@ The Select widget defines the following bindings:
       show_root_heading: false
       show_root_toc_entry: false
 
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/sparkline.md
+++ b/docs/widgets/sparkline.md
@@ -102,7 +102,15 @@ The example below shows how to use component classes to change the colors of the
 
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/static.md
+++ b/docs/widgets/static.md
@@ -27,7 +27,15 @@ This widget has no reactive attributes.
 
 ## Messages
 
-This widget sends no messages.
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ## See Also
 

--- a/docs/widgets/switch.md
+++ b/docs/widgets/switch.md
@@ -32,6 +32,10 @@ The example below shows switches in various states.
 | ------- | ------ | ------- | ------------------------ |
 | `value` | `bool` | `False` | The value of the switch. |
 
+## Messages
+
+- [Switch.Changed][textual.widgets.Switch.Changed]
+
 ## Bindings
 
 The switch widget defines the following bindings:
@@ -49,10 +53,6 @@ The switch widget provides the following component classes:
     options:
       show_root_heading: false
       show_root_toc_entry: false
-
-## Messages
-
-- [Switch.Changed][textual.widgets.Switch.Changed]
 
 ## Additional Notes
 

--- a/docs/widgets/tabbed_content.md
+++ b/docs/widgets/tabbed_content.md
@@ -94,7 +94,7 @@ The following example contains a `TabbedContent` with three tabs.
     --8<-- "docs/examples/widgets/tabbed_content.py"
     ```
 
-## Reactive attributes
+## Reactive Attributes
 
 | Name     | Type  | Default | Description                                                    |
 | -------- | ----- | ------- | -------------------------------------------------------------- |
@@ -104,6 +104,14 @@ The following example contains a `TabbedContent` with three tabs.
 ## Messages
 
 - [TabbedContent.TabActivated][textual.widgets.TabbedContent.TabActivated]
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+This widget has no component classes.
 
 ## See also
 

--- a/docs/widgets/tabs.md
+++ b/docs/widgets/tabs.md
@@ -73,6 +73,9 @@ The Tabs widget defines the following bindings:
       show_root_heading: false
       show_root_toc_entry: false
 
+## Component Classes
+
+This widget has no component classes.
 
 ---
 

--- a/docs/widgets/toast.md
+++ b/docs/widgets/toast.md
@@ -71,6 +71,27 @@ Toast.-information .toast--title {
     --8<-- "docs/examples/widgets/toast.py"
     ```
 
+## Reactive Attributes
+
+This widget has no reactive attributes.
+
+## Messages
+
+This widget posts no messages.
+
+## Bindings
+
+This widget has no bindings.
+
+## Component Classes
+
+The toast widget provides the following component classes:
+
+::: textual.widgets._toast.Toast.COMPONENT_CLASSES
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+
 ---
 
 ::: textual.widgets._toast

--- a/src/textual/widgets/_collapsible.py
+++ b/src/textual/widgets/_collapsible.py
@@ -37,6 +37,11 @@ class CollapsibleTitle(Widget, can_focus=True):
     """
 
     BINDINGS = [Binding("enter", "toggle", "Toggle collapsible", show=False)]
+    """
+    | Key(s) | Description |
+    | :- | :- |
+    | enter | Toggle the collapsible. |
+    """
 
     collapsed = reactive(True)
 

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -544,7 +544,19 @@ class Markdown(Widget):
         text-style: bold dim;
     }
     """
+
     COMPONENT_CLASSES = {"em", "strong", "s", "code_inline"}
+    """
+    These component classes target standard inline markdown styles.
+    Changing these will potentially break the standard markdown formatting.
+
+    | Class | Description |
+    | :- | :- |
+    | `code_inline` | Target text that is styled as inline code. |
+    | `em` | Target text that is emphasized inline. |
+    | `s` | Target text that is styled inline with strykethrough. |
+    | `strong` | Target text that is styled inline with strong. |
+    """
 
     BULLETS = ["\u25CF ", "▪ ", "‣ ", "• ", "⭑ "]
 


### PR DESCRIPTION
I added all headers about reactives, messages, bindings, and component classes for all widgets, even if the widget doesn't have them.
Some widgets already had it and I noticed I was quicker to find the header in the ToC and then read “this widget doesn't have bindings” than to go over the ToC three times, only to deduce the widget didn't have any bindings because the header wasn't there.

This is also more foolproof than omitting headers that are not relevant because omitting an irrelevant header or forgetting a header look the same.