### PR TITLE
Mark the command palette as existing

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,9 +19,9 @@ High-level features we plan on implementing.
     * [x] Monochrome mode
     * [ ] High contrast theme
     * [ ] Color-blind themes
-- [ ] Command interface
+- [X] Command interface
     * [ ] Command menu
-    * [ ] Fuzzy search
+    * [X] Fuzzy search
 - [ ] Configuration (.toml based extensible configuration format)
 - [x] Console
 - [ ] Devtools

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,8 +19,7 @@ High-level features we plan on implementing.
     * [x] Monochrome mode
     * [ ] High contrast theme
     * [ ] Color-blind themes
-- [X] Command interface
-    * [ ] Command menu
+- [X] Command palette
     * [X] Fuzzy search
 - [ ] Configuration (.toml based extensible configuration format)
 - [x] Console


### PR DESCRIPTION
I've not checked off "Command menu" as that sounds like something slightly different from the command palette.
