### PR TITLE
Tick off `TextArea`-related items on the roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,8 +74,8 @@ Widgets are key to making user-friendly interfaces. The builtin widgets should c
 - [X] Spark-lines
 - [X] Switch
 - [X] Tabs
-- [ ] TextArea (multi-line input)
-    * [ ] Basic controls
+- [X] TextArea (multi-line input)
+    * [X] Basic controls
     * [ ] Indentation guides
-    * [ ] Smart features for various languages
-    * [ ] Syntax highlighting
+    * [X] Smart features for various languages
+    * [X] Syntax highlighting

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,5 +77,5 @@ Widgets are key to making user-friendly interfaces. The builtin widgets should c
 - [X] TextArea (multi-line input)
     * [X] Basic controls
     * [ ] Indentation guides
-    * [X] Smart features for various languages
+    * [ ] Smart features for various languages
     * [X] Syntax highlighting


### PR DESCRIPTION
Not actually quite sure what indentation guides means here, so I'm leaving that alone.
