### PR TITLE
Move `Markdown.goto_anchor` change to correct version in `CHANGELOG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Breaking change: CSS in DEFAULT_CSS is now automatically scoped to the widget (set SCOPED_CSS=False) to disable
+- Breaking change: Changed `Markdown.goto_anchor` to return a boolean (if the anchor was found) instead of `None` https://github.com/Textualize/textual/pull/3334
 
 ## [0.37.1] - 2023-09-16
 
@@ -32,10 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed the command palette crashing with a `TimeoutError` in any Python before 3.11 https://github.com/Textualize/textual/issues/3320
 - Fixed `Input` event leakage from `CommandPalette` to `App`.
-
-### Changed
-
-- Breaking change: Changed `Markdown.goto_anchor` to return a boolean (if the anchor was found) instead of `None` https://github.com/Textualize/textual/pull/3334
 
 ## [0.37.0] - 2023-09-15
 


### PR DESCRIPTION
Looks like this ended up dropped into the wrong version.
