### PR TITLE
Don't document `TextArea` `language` and `theme` twice

### DIFF
--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -305,10 +305,8 @@ TextArea {
         corresponding `TextAreaTheme` object."""
 
         self.language = language
-        """The language of the `TextArea`."""
 
-        self.theme: str | None = theme
-        """The name of the theme of the `TextArea` as set by the user."""
+        self.theme = theme
 
     @staticmethod
     def _get_builtin_highlight_query(language_name: str) -> str:


### PR DESCRIPTION
Small tweak to the `TextArea` to let the main documentation for `TextArea.language` and `TextArea.theme` shine through (the second docstrings were causing the reactive docstrings to not make it into the docs); also removes the second type declaration of `TextArea.theme` so as to remove the following complaints from pyright:

![Screenshot 2023-09-22 at 22 13 23](https://github.com/Textualize/textual/assets/28237/76fcb3ee-b62f-4c5c-b49a-314940d299c9)
![Screenshot 2023-09-22 at 22 13 38](https://github.com/Textualize/textual/assets/28237/1cae900e-82f5-4629-b63d-d928ee35830a)
