### PR TITLE
TextArea test fixes for 3.7

### DIFF
--- a/tests/snapshot_tests/language_snippets.py
+++ b/tests/snapshot_tests/language_snippets.py
@@ -426,8 +426,7 @@ JSON = """\
 
 """
 
-REGEX = """\
-^abc            # Matches any string that starts with "abc"
+REGEX = r"""^abc            # Matches any string that starts with "abc"
 abc$            # Matches any string that ends with "abc"
 ^abc$           # Matches the string "abc" and nothing else
 a.b             # Matches any string containing "a", any character, then "b"

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -759,7 +759,7 @@ I am the final line."""
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="tree-sitter requires python3.8 or higher")
 @pytest.mark.parametrize("theme_name",
                          [theme.name for theme in TextAreaTheme.builtin_themes()])
 def test_text_area_themes(snap_compare, theme_name):

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -707,7 +707,7 @@ def test_nested_fr(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "nested_fr.py")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="tree-sitter requires python3.8 or higher")
 @pytest.mark.parametrize("language", BUILTIN_LANGUAGES)
 def test_text_area_language_rendering(language, snap_compare):
     # This test will fail if we're missing a snapshot test for a valid

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -706,6 +707,7 @@ def test_nested_fr(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "nested_fr.py")
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @pytest.mark.parametrize("language", BUILTIN_LANGUAGES)
 def test_text_area_language_rendering(language, snap_compare):
     # This test will fail if we're missing a snapshot test for a valid
@@ -757,6 +759,7 @@ I am the final line."""
     )
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @pytest.mark.parametrize("theme_name",
                          [theme.name for theme in TextAreaTheme.builtin_themes()])
 def test_text_area_themes(snap_compare, theme_name):

--- a/tests/text_area/test_languages.py
+++ b/tests/text_area/test_languages.py
@@ -61,7 +61,7 @@ async def test_setting_unknown_language():
             text_area.language = "this-language-doesnt-exist"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="tree-sitter requires python3.8 or higher")
 async def test_register_language():
     app = TextAreaApp()
 

--- a/tests/text_area/test_languages.py
+++ b/tests/text_area/test_languages.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from textual.app import App, ComposeResult
@@ -59,13 +61,13 @@ async def test_setting_unknown_language():
             text_area.language = "this-language-doesnt-exist"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 async def test_register_language():
     app = TextAreaApp()
 
     async with app.run_test():
         text_area = app.query_one(TextArea)
 
-        # Get the language from py-tree-sitter-languages...
         from tree_sitter_languages import get_language
 
         language = get_language("elm")
@@ -82,6 +84,7 @@ async def test_register_language():
         assert text_area.language == "elm"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 async def test_register_language_existing_language():
     app = TextAreaApp()
     async with app.run_test():

--- a/tests/text_area/test_languages.py
+++ b/tests/text_area/test_languages.py
@@ -84,7 +84,7 @@ async def test_register_language():
         assert text_area.language == "elm"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="tree-sitter requires python3.8 or higher")
 async def test_register_language_existing_language():
     app = TextAreaApp()
     async with app.run_test():


### PR DESCRIPTION
Some tests were failing on 3.7 so we've skipped them.

Unfortunately this makes updating snapshot tests awkward if you're running 3.7.

> you can’t just run pytest --snapshot-update, you’d have to do pytest -k test_name_of_snapshot_test --snapshot-update