### PR TITLE
Add countdown to showing command palette `no matches` message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Pilot.click`/`Pilot.hover` now raises `OutOfBounds` when clicking outside visible screen https://github.com/Textualize/textual/pull/3360
 - `Pilot.click`/`Pilot.hover` now return a Boolean indicating whether the click/hover landed on the widget that matches the selector https://github.com/Textualize/textual/pull/3360
+- Added a delay to when the `No Matches` message appears in the command palette, thus removing a flicker https://github.com/Textualize/textual/pull/3399
 
 ## [0.38.1] - 2023-09-21
 

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -458,6 +458,8 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         """The command that was selected by the user."""
         self._busy_timer: Timer | None = None
         """Keeps track of if there's a busy indication timer in effect."""
+        self._no_matches_timer: Timer | None = None
+        """Keeps track of if there are 'No matches found' message waiting to be displayed."""
         self._providers: list[Provider] = []
         """List of Provider instances involved in searches."""
 
@@ -558,6 +560,37 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
                 self._show_busy = True
 
         self._busy_timer = self.set_timer(self._BUSY_COUNTDOWN, _become_busy)
+
+    def _stop_no_matches_countdown(self) -> None:
+        """Stop any 'No matches' countdown that's in effect."""
+        if self._no_matches_timer is not None:
+            self._no_matches_timer.stop()
+            self._no_matches_timer = None
+
+    _NO_MATCHES_COUNTDOWN: Final[float] = 0.5
+    """How many seconds to wait before showing 'No matches found'."""
+
+    def _start_no_matches_countdown(self) -> None:
+        """Start a countdown to showing that there are no matches for the query.
+
+        Adds a 'No matches found' option to the command list after `_NO_MATCHES_COUNTDOWN` seconds.
+        """
+        self._stop_no_matches_countdown()
+
+        def _show_no_matches() -> None:
+            command_list = self.query_one(CommandList)
+            command_list.add_option(
+                Option(
+                    Align.center(Text("No matches found")),
+                    disabled=True,
+                    id=self._NO_MATCHES,
+                )
+            )
+
+        self._no_matches_timer = self.set_timer(
+            self._NO_MATCHES_COUNTDOWN,
+            _show_no_matches,
+        )
 
     def _watch__list_visible(self) -> None:
         """React to the list visible flag being toggled."""
@@ -861,13 +894,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         # mean nothing was found. Give the user positive feedback to that
         # effect.
         if command_list.option_count == 0 and not worker.is_cancelled:
-            command_list.add_option(
-                Option(
-                    Align.center(Text("No matches found")),
-                    disabled=True,
-                    id=self._NO_MATCHES,
-                )
-            )
+            self._start_no_matches_countdown()
 
     @on(Input.Changed)
     def _input(self, event: Input.Changed) -> None:
@@ -878,6 +905,8 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         """
         event.stop()
         self.workers.cancel_all()
+        self._stop_no_matches_countdown()
+
         search_value = event.value.strip()
         if search_value:
             self._gather_commands(search_value)

--- a/tests/command_palette/test_no_results.py
+++ b/tests/command_palette/test_no_results.py
@@ -18,7 +18,7 @@ async def test_no_results() -> None:
         assert results.visible is False
         assert results.option_count == 0
         await pilot.press("a")
-        await pilot.pause()
+        await pilot.pause(delay=CommandPalette._NO_MATCHES_COUNTDOWN)
         assert results.visible is True
         assert results.option_count == 1
         assert "No matches found" in str(results.get_option_at_index(0).prompt)


### PR DESCRIPTION
The countdown protects from spamming the message and helping the palette feel smoother when there are no matches.

- [x] Docstrings on all new or modified functions / classes
- [x] Change `test_no_results` to wait for the countdown

Resolves #3278 
