### PR TITLE
fix Tree(disabled=True) breaking app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `Pilot.click`/`Pilot.hover` can't use `Screen` as a selector https://github.com/Textualize/textual/issues/3395
+- App exception when a `Tree` is initialized/mounted with `disabled=True` https://github.com/Textualize/textual/issues/3407
 
 ### Added
 

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -597,8 +597,6 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             disabled: Whether the tree is disabled or not.
         """
 
-        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
-
         text_label = self.process_label(label)
 
         self._updates = 0
@@ -609,6 +607,8 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         self._line_cache: LRUCache[LineCacheKey, Strip] = LRUCache(1024)
         self._tree_lines_cached: list[_TreeLine] | None = None
         self._cursor_node: TreeNode[TreeDataType] | None = None
+
+        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
 
     @property
     def cursor_node(self) -> TreeNode[TreeDataType] | None:

--- a/tests/tree/test_tree_availability.py
+++ b/tests/tree/test_tree_availability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from textual import on
@@ -33,19 +35,19 @@ class TreeApp(App[None]):
         )
 
     @on(Tree.NodeSelected)
-    def node_selected(self, event: Tree.NodeSelected) -> None:
+    def node_selected(self, event: Tree.NodeSelected[None]) -> None:
         self.record(event)
 
     @on(Tree.NodeExpanded)
-    def node_expanded(self, event: Tree.NodeExpanded) -> None:
+    def node_expanded(self, event: Tree.NodeExpanded[None]) -> None:
         self.record(event)
 
     @on(Tree.NodeCollapsed)
-    def node_collapsed(self, event: Tree.NodeCollapsed) -> None:
+    def node_collapsed(self, event: Tree.NodeCollapsed[None]) -> None:
         self.record(event)
 
     @on(Tree.NodeHighlighted)
-    def node_highlighted(self, event: Tree.NodeHighlighted) -> None:
+    def node_highlighted(self, event: Tree.NodeHighlighted[None]) -> None:
         self.record(event)
 
 

--- a/tests/tree/test_tree_availability.py
+++ b/tests/tree/test_tree_availability.py
@@ -1,0 +1,116 @@
+from typing import Any
+
+from textual import on
+from textual.app import App, ComposeResult
+from textual.widgets import Tree
+
+
+class TreeApp(App[None]):
+    """Test tree app."""
+
+    def __init__(self, disabled: bool, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.disabled = disabled
+        self.messages: list[tuple[str, str]] = []
+
+    def compose(self) -> ComposeResult:
+        """Compose the child widgets."""
+        yield Tree("Root", disabled=self.disabled, id="test-tree")
+
+    def on_mount(self) -> None:
+        self.query_one(Tree).root.add("Child")
+        self.query_one(Tree).focus()
+
+    def record(
+        self,
+        event: Tree.NodeSelected[None]
+        | Tree.NodeExpanded[None]
+        | Tree.NodeCollapsed[None]
+        | Tree.NodeHighlighted[None],
+    ) -> None:
+        self.messages.append(
+            (event.__class__.__name__, event.node.tree.id or "Unknown")
+        )
+
+    @on(Tree.NodeSelected)
+    def node_selected(self, event: Tree.NodeSelected) -> None:
+        self.record(event)
+
+    @on(Tree.NodeExpanded)
+    def node_expanded(self, event: Tree.NodeExpanded) -> None:
+        self.record(event)
+
+    @on(Tree.NodeCollapsed)
+    def node_collapsed(self, event: Tree.NodeCollapsed) -> None:
+        self.record(event)
+
+    @on(Tree.NodeHighlighted)
+    def node_highlighted(self, event: Tree.NodeHighlighted) -> None:
+        self.record(event)
+
+
+async def test_creating_disabled_tree():
+    """Mounting a disabled `Tree` should result in the base `Widget`
+    having a `disabled` property equal to `True`"""
+    app = TreeApp(disabled=True)
+    async with app.run_test() as pilot:
+        tree = app.query_one(Tree)
+        assert not tree.focusable
+        assert tree.disabled
+        assert tree.cursor_line == 0
+        await pilot.click("#test-tree")
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert tree.cursor_line == 0
+
+
+async def test_creating_enabled_tree():
+    """Mounting an enabled `Tree` should result in the base `Widget`
+    having a `disabled` property equal to `False`"""
+    app = TreeApp(disabled=False)
+    async with app.run_test() as pilot:
+        tree = app.query_one(Tree)
+        assert tree.focusable
+        assert not tree.disabled
+        assert tree.cursor_line == 0
+        await pilot.click("#test-tree")
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert tree.cursor_line == 1
+
+
+async def test_disabled_tree_node_selected_message() -> None:
+    """Clicking the root node disclosure triangle on a disabled tree
+    should result in no messages being emitted."""
+    app = TreeApp(disabled=True)
+    async with app.run_test() as pilot:
+        tree = app.query_one(Tree)
+        # try clicking on a disabled tree
+        await pilot.click("#test-tree")
+        await pilot.pause()
+        assert not pilot.app.messages
+        # make sure messages DO flow after enabling a disabled tree
+        tree.disabled = False
+        await pilot.click("#test-tree")
+        await pilot.pause()
+        assert pilot.app.messages == [("NodeExpanded", "test-tree")]
+
+
+async def test_enabled_tree_node_selected_message() -> None:
+    """Clicking the root node disclosure triangle on an enabled tree
+    should result in an `NodeExpanded` message being emitted."""
+    app = TreeApp(disabled=False)
+    async with app.run_test() as pilot:
+        tree = app.query_one(Tree)
+        # try clicking on an enabled tree
+        await pilot.click("#test-tree")
+        await pilot.pause()
+        assert pilot.app.messages == [("NodeExpanded", "test-tree")]
+        tree.disabled = True
+        # make sure messages DO NOT flow after disabling an enabled tree
+        app.messages = []
+        await pilot.click("#test-tree")
+        await pilot.pause()
+        assert not pilot.app.messages


### PR DESCRIPTION
Fixes #3407 where `Tree` widget initialized/mounted with `disabled=True` would break its parent app

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
