### PR TITLE
Fix component classes section for sparkline widget.

### DIFF
--- a/docs/widgets/sparkline.md
+++ b/docs/widgets/sparkline.md
@@ -110,7 +110,12 @@ This widget has no bindings.
 
 ## Component Classes
 
-This widget has no component classes.
+The sparkline widget provides the following component classes:
+
+::: textual.widgets.Sparkline.COMPONENT_CLASSES
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
 
 ---
 


### PR DESCRIPTION
Fixes component classes header in reference page for the sparkline widget.