### PR TITLE
Fix documentation warnings

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,1 +1,5 @@
 ::: textual.app
+    options:
+        filters:
+            - "!^_"
+            - "^__init__$"

--- a/docs/styles/layout.md
+++ b/docs/styles/layout.md
@@ -23,7 +23,7 @@ See the [layout](../guide/layout.md) guide for more information.
 ## Example
 
 Note how the `layout` style affects the arrangement of widgets in the example below.
-To learn more about the grid layout, you can see the [layout guide](../guide/layout.md) or the [grid reference](./grid.md).
+To learn more about the grid layout, you can see the [layout guide](../guide/layout.md) or the [grid reference](./grid/index.md).
 
 === "Output"
 

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -165,6 +165,7 @@ nav:
           - "widgets/tabbed_content.md"
           - "widgets/tabs.md"
           - "widgets/text_area.md"
+          - "widgets/toast.md"
           - "widgets/tree.md"
   - API:
       - "api/index.md"
@@ -174,6 +175,7 @@ nav:
       - "api/color.md"
       - "api/command.md"
       - "api/containers.md"
+      - "api/content_switcher.md"
       - "api/coordinate.md"
       - "api/dom_node.md"
       - "api/events.md"
@@ -190,6 +192,7 @@ nav:
       - "api/pilot.md"
       - "api/query.md"
       - "api/reactive.md"
+      - "api/validation.md"
       - "api/screen.md"
       - "api/scrollbar.md"
       - "api/scroll_view.md"

--- a/src/textual/_system_commands.py
+++ b/src/textual/_system_commands.py
@@ -17,7 +17,7 @@ class SystemCommands(Provider):
         """Handle a request to search for system commands that match the query.
 
         Args:
-            user_input: The user input to be matched.
+            query: The user input to be matched.
 
         Yields:
             Command hits for use in the command palette.

--- a/src/textual/document/_syntax_aware_document.py
+++ b/src/textual/document/_syntax_aware_document.py
@@ -80,7 +80,7 @@ class SyntaxAwareDocument(Document):
         To execute a query, call `query_syntax_tree`.
 
         Args:
-            The string query to prepare.
+            query: The string query to prepare.
 
         Returns:
             The prepared query.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3202,7 +3202,7 @@ class Widget(DOMNode):
         self.app.begin_capture_print(self, stdout=stdout, stderr=stderr)
 
     def end_capture_print(self) -> None:
-        """End print capture (set with [capture_print][textual.widget.Widget.capture_print])."""
+        """End print capture (set with [capture_print][textual.widget.Widget.begin_capture_print])."""
         self.app.end_capture_print(self)
 
     def check_message_enabled(self, message: Message) -> bool:

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -825,7 +825,7 @@ class OptionList(ScrollView, can_focus=True):
         """
         return self.get_option_at_index(self.get_option_index(option_id))
 
-    def get_option_index(self, option_id):
+    def get_option_index(self, option_id: str):
         """Get the index of the option with the given ID.
 
         Args:


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Updated documentation
- [x] For some reason `textual.app.App.compose()` doesn't seem to appear in the reference section of the docs hence breaking a specific link on the `App basics` page.

Resolves #2699 