### PR TITLE
feat(input): add clear method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `OutOfBounds` exception to be raised by `Pilot` https://github.com/Textualize/textual/pull/3360
-- Added `Input.Clear` method https://github.com/Textualize/textual/pull/3430
+- Added `Input.clear` method https://github.com/Textualize/textual/pull/3430
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `OutOfBounds` exception to be raised by `Pilot` https://github.com/Textualize/textual/pull/3360
+- Added `Input.Clear` method https://github.com/Textualize/textual/pull/3430
 
 ### Changed
 

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -481,6 +481,10 @@ class Input(Widget, can_focus=True):
             self.value = f"{before}{text}{after}"
             self.cursor_position += len(text)
 
+    def clear(self) -> None:
+        """Clear the input."""
+        self.value = ""
+
     def action_cursor_left(self) -> None:
         """Move the cursor one position to the left."""
         self.cursor_position -= 1

--- a/tests/input/test_input_clear.py
+++ b/tests/input/test_input_clear.py
@@ -1,0 +1,16 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+
+
+class InputApp(App):
+    def compose(self) -> ComposeResult:
+        yield Input("Hello, World!")
+
+
+async def test_input_clear():
+    async with InputApp().run_test() as pilot:
+        input_widget = pilot.app.query_one(Input)
+        assert input_widget.value == "Hello, World!"
+        input_widget.clear()
+        await pilot.pause()
+        assert input_widget.value == ""


### PR DESCRIPTION
Closes #3428 by adding a `Input.clear` method.

Example usage:

```python
from textual.app import App, ComposeResult
from textual.widgets import Input


class InputApp(App):
    def compose(self) -> ComposeResult:
        yield Input(placeholder="Enter some text and press enter")

    def on_input_submitted(self, event: Input.Submitted) -> None:
        self.notify(f"You entered '{event.value}'")
        event.input.clear()


if __name__ == "__main__":
    app = InputApp()
    app.run()
```



- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
