### PR TITLE
Detect non widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Widgets now complain on attempts to mount a non-widget.
+- Attribute errors are suppressed when mounting widgets to improve reporting 
 - `Pilot.click`/`Pilot.hover` now raises `OutOfBounds` when clicking outside visible screen https://github.com/Textualize/textual/pull/3360
 - `Pilot.click`/`Pilot.hover` now return a Boolean indicating whether the click/hover landed on the widget that matches the selector https://github.com/Textualize/textual/pull/3360
 - Added a delay to when the `No Matches` message appears in the command palette, thus removing a flicker https://github.com/Textualize/textual/pull/3399

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Widgets now complain on attempts to mount a non-widget.
 - `Pilot.click`/`Pilot.hover` now raises `OutOfBounds` when clicking outside visible screen https://github.com/Textualize/textual/pull/3360
 - `Pilot.click`/`Pilot.hover` now return a Boolean indicating whether the click/hover landed on the widget that matches the selector https://github.com/Textualize/textual/pull/3360
 - Added a delay to when the `No Matches` message appears in the command palette, thus removing a flicker https://github.com/Textualize/textual/pull/3399

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -755,10 +755,8 @@ class Widget(DOMNode):
         # Check for duplicate IDs in the incoming widgets
         try:
             ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
-        except AttributeError as e:
-            for widget in widgets:
-                if not isinstance(widget, Widget):
-                    raise TypeError(f"Objects of type {type(widget).__name__!r} are not widgets and cannot be mounted")
+        except AttributeError:  # Lack of an id is checked in App._register()
+            ids_to_mount = []
         unique_ids = set(ids_to_mount)
         num_unique_ids = len(unique_ids)
         num_widgets_with_ids = len(ids_to_mount)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -758,7 +758,7 @@ class Widget(DOMNode):
         except AttributeError as e:
             for widget in widgets:
                 if not isinstance(widget, Widget):
-                    raise TypeError(f"Objects of type {type(widget).__name__!r} are not widgets")
+                    raise TypeError(f"Objects of type {type(widget).__name__!r} are not widgets and cannot be mounted")
         unique_ids = set(ids_to_mount)
         num_unique_ids = len(unique_ids)
         num_widgets_with_ids = len(ids_to_mount)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -753,7 +753,12 @@ class Widget(DOMNode):
         """
 
         # Check for duplicate IDs in the incoming widgets
-        ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
+        try:
+            ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
+        except AttributeError as e:
+            for widget in widgets:
+                if not isinstance(widget, Widget):
+                    raise TypeError(f"Objects of type {type(widget).__name__!r} are not widgets")
         unique_ids = set(ids_to_mount)
         num_unique_ids = len(unique_ids)
         num_widgets_with_ids = len(ids_to_mount)

--- a/tests/test_widget_mounting.py
+++ b/tests/test_widget_mounting.py
@@ -1,6 +1,6 @@
 import pytest
 
-from textual.app import App
+from textual.app import App, AppError
 from textual.css.query import TooManyMatches
 from textual.widget import MountError, Widget, WidgetError
 from textual.widgets import Static
@@ -116,8 +116,10 @@ async def test_mount_via_app() -> None:
             await pilot.app.mount(Static(), before="Static")
 
     async with App().run_test() as pilot:
-        # Make sure we get told off trying to mount something
-        # that isn't actually a widget.
-        await pilot.app.mount_all(widgets)
-        with pytest.raises(TypeError):
-            await pilot.app.mount([])
+        # Make sure we get told off trying to mount a widget
+        # class rather than an instance.
+        with pytest.raises(AppError):
+            class BadWidget(Widget):
+                def __init_(self, *args, **kw):
+                    ...
+            await pilot.app.mount(BadWidget)

--- a/tests/test_widget_mounting.py
+++ b/tests/test_widget_mounting.py
@@ -114,3 +114,10 @@ async def test_mount_via_app() -> None:
         await pilot.app.mount_all(widgets)
         with pytest.raises(TooManyMatches):
             await pilot.app.mount(Static(), before="Static")
+
+    async with App().run_test() as pilot:
+        # Make sure we get told off trying to mount something
+        # that isn't actually a widget.
+        await pilot.app.mount_all(widgets)
+        with pytest.raises(TypeError):
+            await pilot.app.mount([])


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

I've been dogged by an `AttributeError` that occurs when trying to mount non-widgets (either directly, or because I've omitted the call to `Widget__init__()`), that points out a particular item has no `id`, so I added a message that should catch both cases. You may find better wording for the message.

Impact on speed should be zero, as the code only executes of a fatal error.