### PR TITLE
fix(tabbed content): handle pane containing tabs

### DIFF
--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -377,7 +377,11 @@ class TabbedContent(Widget):
 
     def _on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
         """User clicked a tab."""
-        assert isinstance(event.tab, ContentTab)
+        if not isinstance(event.tab, ContentTab):
+            # A tab pane could contain its own Tabs widget, so just return
+            # early if the tab activated is not a ContentTab.
+            # https://github.com/Textualize/textual/issues/3412
+            return
         assert isinstance(event.tab.id, str)
         event.stop()
         switcher = self.get_child_by_type(ContentSwitcher)
@@ -392,6 +396,11 @@ class TabbedContent(Widget):
 
     def _on_tabs_cleared(self, event: Tabs.Cleared) -> None:
         """All tabs were removed."""
+        if self.get_child_by_type(Tabs).tab_count != 0:
+            # A tab pane could contain its own Tabs widget, so just return
+            # early if the TabbedContent still contains tabs.
+            # https://github.com/Textualize/textual/issues/3412
+            return
         event.stop()
         self.get_child_by_type(ContentSwitcher).current = None
         self.active = ""


### PR DESCRIPTION
Fixes #3412. There might be a better way of discerning Tabs messages, so creating only as a draft for now.

I would still need to add regression tests, but this seems to work from some quick manual testing with the app below:

```python
from textual.app import App, ComposeResult
from textual.widgets import TabbedContent, TabPane, Tabs


class TabsApp(App):
    BINDINGS = [("space", "clear_inner_tabs")]
    CSS = """
    TabPane > Tabs {
        height: auto;
    }
    """

    def compose(self) -> ComposeResult:
        with TabbedContent():
            with TabPane("outer tab #1"):
                yield Tabs(
                    "inner tab#1",
                    "inner tab#2",
                    "inner tab#3",
                    id="inner-tabs-one",
                )
            with TabPane("outer tab #2"):
                yield Tabs(
                    "inner tab#4",
                    "inner tab#5",
                    "inner tab#6",
                    id="inner-tabs-two",
                )

    def action_clear_inner_tabs(self) -> None:
        self.query_one("#inner-tabs-one", Tabs).clear()
        self.query_one("#inner-tabs-two", Tabs).clear()


if __name__ == "__main__":
    app = TabsApp()
    app.run()
```

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
