### PR TITLE
`OptionList` safe duplicate check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Pilot.click`/`Pilot.hover` can't use `Screen` as a selector https://github.com/Textualize/textual/issues/3395
 - App exception when a `Tree` is initialized/mounted with `disabled=True` https://github.com/Textualize/textual/issues/3407
 - Fixed application freeze when pasting an emoji into an application on Windows https://github.com/Textualize/textual/issues/3178
+- Fixed duplicate option ID handling in the `OptionList` https://github.com/Textualize/textual/issues/3455
 
 ### Added
 

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -7,7 +7,6 @@ forms of bounce-bar menu.
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import ClassVar, Iterable, NamedTuple
 
 from rich.console import RenderableType
@@ -564,28 +563,19 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             DuplicateID: If there is an attempt to use a duplicate ID.
         """
-        # Get all of the incoming IDs.
-        new_option_ids = [
-            item.id
+        # We're only interested in options, and only those that IDs.
+        new_options = {
+            item
             for item in candidate_items
             if isinstance(item, Option) and item.id is not None
-        ]
-        # Check for duplicates of already-known IDs and also duplicates
-        # within the list of incoming IDs.
-        current_ids = self._option_ids
-        duplicates = {
-            item_id for item_id in new_option_ids if item_id in current_ids
-        }.union(
-            item_id
-            for item_id, id_count in Counter(new_option_ids).items()
-            if id_count > 1
-        )
-        # If there are any duplicates...
-        if duplicates:
-            # ...complain.
-            raise DuplicateID(
-                f"Operation would result in duplicate ids {', '.join(duplicates)}"
-            )
+        }
+        # Get the set of new IDs that we're being given.
+        new_option_ids = set(option.id for option in new_options)
+        # Now check for duplicates, both internally amongst the
+        if len(new_options) != len(new_option_ids) or not new_option_ids.isdisjoint(
+            self._option_ids
+        ):
+            raise DuplicateID("Attempt made to add options with duplicate IDs.")
 
     def add_options(self, items: Iterable[NewOptionListContent]) -> Self:
         """Add new options to the end of the option list.

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -570,11 +570,12 @@ class OptionList(ScrollView, can_focus=True):
             for item in candidate_items
             if isinstance(item, Option) and item.id is not None
         ]
-        # Check for duplicates of already-known IDs.
+        # Check for duplicates of already-known IDs and also duplicates
+        # within the list of incoming IDs.
         current_ids = self._option_ids
-        duplicates = [item_id for item_id in new_option_ids if item_id in current_ids]
-        # Check for duplicates amongst the incoming IDs.
-        duplicates.extend(
+        duplicates = {
+            item_id for item_id in new_option_ids if item_id in current_ids
+        }.union(
             item_id
             for item_id, id_count in Counter(new_option_ids).items()
             if id_count > 1

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -570,7 +570,7 @@ class OptionList(ScrollView, can_focus=True):
             if isinstance(item, Option) and item.id is not None
         ]
         # Get the set of new IDs that we're being given.
-        new_option_ids = set(option.id for option in new_options)
+        new_option_ids = {option.id for option in new_options}
         # Now check for duplicates, both internally amongst the new items
         # incoming, and also against all the current known IDs.
         if len(new_options) != len(new_option_ids) or not new_option_ids.isdisjoint(

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -564,20 +564,16 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             DuplicateID: If there is an attempt to use a duplicate ID.
         """
-        # Where we'll gather up the duplicates.
-        duplicates = []
         # Get all of the incoming IDs.
         new_option_ids = [
             item.id
             for item in candidate_items
             if isinstance(item, Option) and item.id is not None
         ]
-        # First off, check all of the items against the known existing IDs.
-        for item_id in new_option_ids:
-            if item_id in self._option_ids:
-                duplicates.append(item_id)
-        # Next, check that there's no duplicate to be found amongst the
-        # items we're about to add.
+        # Check for duplicates of already-known IDs.
+        current_ids = self._option_ids
+        duplicates = [item_id for item_id in new_option_ids if item_id in current_ids]
+        # Check for duplicates amongst the incoming IDs.
         duplicates.extend(
             item_id
             for item_id, id_count in Counter(new_option_ids).items()

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -564,11 +564,11 @@ class OptionList(ScrollView, can_focus=True):
             DuplicateID: If there is an attempt to use a duplicate ID.
         """
         # We're only interested in options, and only those that have IDs.
-        new_options = {
+        new_options = [
             item
             for item in candidate_items
             if isinstance(item, Option) and item.id is not None
-        }
+        ]
         # Get the set of new IDs that we're being given.
         new_option_ids = set(option.id for option in new_options)
         # Now check for duplicates, both internally amongst the new items

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -571,7 +571,8 @@ class OptionList(ScrollView, can_focus=True):
         }
         # Get the set of new IDs that we're being given.
         new_option_ids = set(option.id for option in new_options)
-        # Now check for duplicates, both internally amongst the
+        # Now check for duplicates, both internally amongst the new items
+        # incoming, and also against all the current known IDs.
         if len(new_options) != len(new_option_ids) or not new_option_ids.isdisjoint(
             self._option_ids
         ):

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -563,7 +563,7 @@ class OptionList(ScrollView, can_focus=True):
         Raises:
             DuplicateID: If there is an attempt to use a duplicate ID.
         """
-        # We're only interested in options, and only those that IDs.
+        # We're only interested in options, and only those that have IDs.
         new_options = {
             item
             for item in candidate_items

--- a/tests/option_list/test_option_list_create.py
+++ b/tests/option_list/test_option_list_create.py
@@ -124,3 +124,17 @@ async def test_create_with_duplicate_id() -> None:
         with pytest.raises(DuplicateID):
             option_list.add_option(Option("dupe", id="3"))
         assert option_list.option_count == 5
+
+
+async def test_create_with_duplicate_id_and_subsequent_non_dupes() -> None:
+    """Adding an option with a duplicate ID should be an error."""
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        assert option_list.option_count == 5
+        with pytest.raises(DuplicateID):
+            option_list.add_option(Option("dupe", id="3"))
+        assert option_list.option_count == 5
+        option_list.add_option(Option("Not a dupe", id="6"))
+        assert option_list.option_count == 6
+        option_list.add_option(Option("Not a dupe", id="7"))
+        assert option_list.option_count == 7

--- a/tests/option_list/test_option_list_create.py
+++ b/tests/option_list/test_option_list_create.py
@@ -138,3 +138,18 @@ async def test_create_with_duplicate_id_and_subsequent_non_dupes() -> None:
         assert option_list.option_count == 6
         option_list.add_option(Option("Not a dupe", id="7"))
         assert option_list.option_count == 7
+
+
+async def test_adding_multiple_duplicates_at_once() -> None:
+    """Adding duplicates together than aren't existing duplicates should be an error."""
+    async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        assert option_list.option_count == 5
+        with pytest.raises(DuplicateID):
+            option_list.add_options(
+                [
+                    Option("dupe", id="42"),
+                    Option("dupe", id="42"),
+                ]
+            )
+        assert option_list.option_count == 5

--- a/tests/option_list/test_option_list_create.py
+++ b/tests/option_list/test_option_list_create.py
@@ -119,5 +119,8 @@ async def test_add_later() -> None:
 async def test_create_with_duplicate_id() -> None:
     """Adding an option with a duplicate ID should be an error."""
     async with OptionListApp().run_test() as pilot:
+        option_list = pilot.app.query_one(OptionList)
+        assert option_list.option_count == 5
         with pytest.raises(DuplicateID):
-            pilot.app.query_one(OptionList).add_option(Option("dupe", id="3"))
+            option_list.add_option(Option("dupe", id="3"))
+        assert option_list.option_count == 5


### PR DESCRIPTION
Simply put: the duplicate check inside `OptionList` was happening *after* a new option was added to the internal structures. This was almost fine back when there was only a method for adding a single option, and even then it was only fine if a `DuplicateID` exception was treated as a "just give up using this `OptionList` signal". Or put another way: attempting to add a duplicate ID had unintended side-effects, making every subsequent attempt to add an option appear to be the creation of a duplicate.

This PR moves to a preflight check for duplicate IDs.

Fixes #3455.
