### PR TITLE
Fix a broken link in the documentation guide

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,1 +1,5 @@
 ::: textual.app
+    options:
+        filters:
+          - "!^_"
+          - "^__init__$"

--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -82,7 +82,8 @@ plugins:
             - "!^can_replace$"
             # Hide some methods that Widget subclasses implement but that we don't want
             # to be shown in the docs.
-            # This is then overridden in widget.md so that it shows in the base class.
+            # This is then overridden in widget.md and app.md so that it shows in the
+            # base class.
             - "!^compose$"
             - "!^render$"
             - "!^render_line$"


### PR DESCRIPTION
The link in the doc[1] is not rendering properly, because the method `textual.app.App.compose` is ignored in the doc in the filter[2]. This commit overrides the filter in the app.md file, generating the doc for the "protocol" method and fixing the
link rendering in the guide.

[1]: https://textual.textualize.io/guide/app/#composing
[2]: textual/mkdocs-common.yml

Fix #3141


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
