### PR TITLE
fix doc: change `rule:` to `text-align:` in css_types

### DIFF
--- a/docs/css_types/text_align.md
+++ b/docs/css_types/text_align.md
@@ -29,7 +29,7 @@ A [`<text-align>`](./text_align.md) can be any of the following values:
 
 ```sass
 Label {
-    rule: justify;
+    text-align: justify;
 }
 ```
 


### PR DESCRIPTION
I think that's an mistake in the doc, because the `rule` actually will throw an Exception. `Invalid CSS property 'rule'`.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
