### PR TITLE
Add wait_for_dismiss to push_screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Reactive `cell_padding` (and respective parameter) to define horizontal cell padding in data table columns https://github.com/Textualize/textual/issues/3435
 - Added `Input.clear` method https://github.com/Textualize/textual/pull/3430
 - Added `TextArea.SelectionChanged` and `TextArea.Changed` messages https://github.com/Textualize/textual/pull/3442
+- Added `wait_for_dismiss` parameter to `App.push_screen` https://github.com/Textualize/textual/pull/3477
 
 ### Changed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1780,8 +1780,8 @@ class App(Generic[ReturnType], DOMNode):
     def push_screen(
         self,
         screen: Screen[ScreenResultType] | str,
-        callback: ScreenResultCallbackType[ScreenResultType] | None,
-        wait_for_dismiss: Literal[False],
+        callback: ScreenResultCallbackType[ScreenResultType] | None = None,
+        wait_for_dismiss: Literal[False] = False,
     ) -> AwaitMount:
         ...
 
@@ -1789,8 +1789,8 @@ class App(Generic[ReturnType], DOMNode):
     def push_screen(
         self,
         screen: Screen[ScreenResultType] | str,
-        callback: ScreenResultCallbackType[ScreenResultType] | None,
-        wait_for_dismiss: Literal[True],
+        callback: ScreenResultCallbackType[ScreenResultType] | None = None,
+        wait_for_dismiss: Literal[True] = True,
     ) -> asyncio.Future[ScreenResultType]:
         ...
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -274,17 +274,14 @@ class App(Generic[ReturnType], DOMNode):
     and therefore takes priority in the event of a specificity clash."""
 
     # Default (the lowest priority) CSS
-    DEFAULT_CSS: ClassVar[
-        str
-    ] = """
+    DEFAULT_CSS: ClassVar[str]
+    DEFAULT_CSS = """
     App {
         background: $background;
         color: $text;
     }
-
     *:disabled:can-focus {
         opacity: 0.7;
-
     }
     """
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -258,6 +258,7 @@ class ScreenAwaitable(Generic[ScreenResultType]):
 
     def __await__(self) -> Generator[None, None, ScreenResultType]:
         async def await_screen() -> ScreenResultType:
+            """Await the mount and the future."""
             await self._await_mount
             await self._future
             return self._future.result()

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1840,8 +1840,13 @@ class App(Generic[ReturnType], DOMNode):
                 f"push_screen requires a Screen instance or str; not {screen!r}"
             )
 
-        loop = asyncio.get_running_loop()
-        future = loop.create_future()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Mainly for testing, when push_screen isn't called in an async context
+            future: asyncio.Future[ScreenResultType] = asyncio.Future()
+        else:
+            future = loop.create_future()
 
         if self._screen_stack:
             self.screen.post_message(events.ScreenSuspend())

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1780,8 +1780,8 @@ class App(Generic[ReturnType], DOMNode):
     def push_screen(
         self,
         screen: Screen[ScreenResultType] | str,
-        callback: ScreenResultCallbackType[ScreenResultType] | None = None,
-        wait_for_dismiss: Literal[False] = False,
+        callback: ScreenResultCallbackType[ScreenResultType] | None,
+        wait_for_dismiss: Literal[False],
     ) -> AwaitMount:
         ...
 
@@ -1789,8 +1789,8 @@ class App(Generic[ReturnType], DOMNode):
     def push_screen(
         self,
         screen: Screen[ScreenResultType] | str,
-        callback: ScreenResultCallbackType[ScreenResultType] | None = None,
-        wait_for_dismiss: Literal[True] = True,
+        callback: ScreenResultCallbackType[ScreenResultType] | None,
+        wait_for_dismiss: Literal[True],
     ) -> asyncio.Future[ScreenResultType]:
         ...
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1829,6 +1829,9 @@ class App(Generic[ReturnType], DOMNode):
             wait_for_dismiss: If `True`, awaiting this method will return the dismiss value from the screen. When set to `False`, awaiting
                 this method will wait for the screen to be mounted. Note that `wait_for_dismiss` should only be set to `True` when running in a worker.
 
+        Raises:
+            NoActiveWorker: If using `wait_for_dismiss` outside of a worker.
+
         Returns:
             An optional awaitable that awaits the mounting of the screen and its children.
         """

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -82,7 +82,7 @@ class ResultCallback(Generic[ScreenResultType]):
         Args:
             requester: The object making a request for the callback.
             callback: The callback function.
-            future: A Future to hold the result
+            future: A Future to hold the result.
         """
         self.requester = requester
         """The object in the DOM that requested the callback."""

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -5,6 +5,7 @@ The `Screen` class is a special widget which represents the content in the termi
 
 from __future__ import annotations
 
+import asyncio
 from functools import partial
 from operator import attrgetter
 from typing import (
@@ -74,17 +75,21 @@ class ResultCallback(Generic[ScreenResultType]):
         self,
         requester: MessagePump,
         callback: ScreenResultCallbackType[ScreenResultType] | None,
+        future: asyncio.Future[ScreenResultType] | None = None,
     ) -> None:
         """Initialise the result callback object.
 
         Args:
             requester: The object making a request for the callback.
             callback: The callback function.
+            future: A Future to hold the result
         """
         self.requester = requester
         """The object in the DOM that requested the callback."""
         self.callback: ScreenResultCallbackType | None = callback
         """The callback function."""
+        self.future = future
+        """A future for the result"""
 
     def __call__(self, result: ScreenResultType) -> None:
         """Call the callback, passing the given result.
@@ -95,6 +100,8 @@ class ResultCallback(Generic[ScreenResultType]):
         Note:
             If the requested or the callback are `None` this will be a no-op.
         """
+        if self.future is not None:
+            self.future.set_result(result)
         if self.requester is not None and self.callback is not None:
             self.requester.call_next(self.callback, result)
 
@@ -687,15 +694,17 @@ class Screen(Generic[ScreenResultType], Widget):
         self,
         requester: MessagePump,
         callback: ScreenResultCallbackType[ScreenResultType] | None,
+        future: asyncio.Future[ScreenResultType] | None = None,
     ) -> None:
         """Add a result callback to the screen.
 
         Args:
             requester: The object requesting the callback.
             callback: The callback.
+            future: A Future to hold the result.
         """
         self._result_callbacks.append(
-            ResultCallback[ScreenResultType](requester, callback)
+            ResultCallback[ScreenResultType](requester, callback, future)
         )
 
     def _pop_result_callback(self) -> None:

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -418,7 +418,7 @@ async def test_mouse_move_event_bubbles_to_screen_from_widget():
 async def test_push_screen_wait_for_dismiss() -> None:
     """Test push_screen returns result."""
 
-    class QuitScreen(Screen):
+    class QuitScreen(Screen[bool]):
         BINDINGS = [
             ("y", "quit(True)"),
             ("n", "quit(False)"),
@@ -445,7 +445,7 @@ async def test_push_screen_wait_for_dismiss() -> None:
 
     results.clear()
     app = ScreensApp()
-    # Press X to exit, then Y to dismiss, expect True result
+    # Press X to exit, then Y to dismiss, expect False result
     async with app.run_test() as pilot:
         await pilot.press("x", "n")
     assert results == [False]
@@ -454,7 +454,7 @@ async def test_push_screen_wait_for_dismiss() -> None:
 async def test_push_screen_wait_for_dismiss_no_worker() -> None:
     """Test wait_for_dismiss raises NoActiveWorker when not using workers."""
 
-    class QuitScreen(Screen):
+    class QuitScreen(Screen[bool]):
         BINDINGS = [
             ("y", "quit(True)"),
             ("n", "quit(False)"),
@@ -473,6 +473,7 @@ async def test_push_screen_wait_for_dismiss_no_worker() -> None:
             results.append(result)
 
     app = ScreensApp()
+    # using `wait_for_dismiss` outside of a worker should raise NoActiveWorker
     with pytest.raises(NoActiveWorker):
         async with app.run_test() as pilot:
             await pilot.press("x", "y")

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -445,7 +445,7 @@ async def test_push_screen_wait_for_dismiss() -> None:
 
     results.clear()
     app = ScreensApp()
-    # Press X to exit, then Y to dismiss, expect False result
+    # Press X to exit, then N to dismiss, expect False result
     async with app.run_test() as pilot:
         await pilot.press("x", "n")
     assert results == [False]


### PR DESCRIPTION
An addition to the screens API to avoid callbacks. Adds a `wait_for_dismiss` parameter which waits for the new screen to be dismissed.

It works like this:

```python
result = await self.push_screen(MyScreen(), wait_for_dismiss=True)
```

This only works from within a worker. If not run within a worker it will raise a `NoActiveWorker` error.

Without a worker, waiting on the result would cause a deadlock. But at least we can identify that and raise a helpful error.

This allows for more natural code than callbacks. For example, here's how you might use a screen to ask the user if they want to quit:

```python
@work
async def action_close(self) -> None:
    if await self.push_screen(QuitScreen(), wait_for_dismiss=True):
        self.app.quit()
```

The `push_screen` has overloaded signatures, so the type checker knows that there will only be a return value when `wait_for_dismiss` is True, and it knows the type of the return -- which is nice!