### PR TITLE
Add a debug hook for getting sent unknown sequences from the XTerm parser

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -84,6 +84,13 @@ class XTermParser(Parser[events.Event]):
             return event
         return None
 
+    _reissued_sequence_debug_book: Callable[[str], None] | None = None
+    """INTERNAL USE ONLY!
+
+    If this property is set to a callable, it will be called *instead* of
+    the reissued sequence being emitted as key events.
+    """
+
     def parse(self, on_token: TokenCallback) -> Generator[Awaitable, str, None]:
         ESC = "\x1b"
         read1 = self.read1
@@ -94,6 +101,9 @@ class XTermParser(Parser[events.Event]):
         use_prior_escape = False
 
         def reissue_sequence_as_keys(reissue_sequence: str) -> None:
+            if self._reissued_sequence_debug_book is not None:
+                self._reissued_sequence_debug_book(reissue_sequence)
+                return
             for character in reissue_sequence:
                 key_events = sequence_to_key_events(character)
                 for event in key_events:


### PR DESCRIPTION
This is here only for serving the keyboard checker/recorder tool.  It adds an internal hook that, when set to a callable, issues the unknown sequence to that rather than reissues the sequence as individual keys. Not intended for public consumption, only here to help serve the key recorder/explorer application.