### PR TITLE
docs(radio set): add bindings

### DIFF
--- a/docs/widgets/radioset.md
+++ b/docs/widgets/radioset.md
@@ -58,7 +58,12 @@ Here is an example of using the message to react to changes in a `RadioSet`:
 
 ## Bindings
 
-This widget has no bindings.
+The `RadioSet` widget defines the following bindings:
+
+::: textual.widgets.RadioSet.BINDINGS
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
 
 ## Component Classes
 


### PR DESCRIPTION
I spotted in passing that the RadioSet docs currently say "This widget has no bindings."

https://textual.textualize.io/widgets/radioset/#bindings

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
