### PR TITLE
Be less strict about typing timer callbacks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Pilot.click`/`Pilot.hover` now raises `OutOfBounds` when clicking outside visible screen https://github.com/Textualize/textual/pull/3360
 - `Pilot.click`/`Pilot.hover` now return a Boolean indicating whether the click/hover landed on the widget that matches the selector https://github.com/Textualize/textual/pull/3360
 - Added a delay to when the `No Matches` message appears in the command palette, thus removing a flicker https://github.com/Textualize/textual/pull/3399
+- Timer callbacks are now typed more loosely https://github.com/Textualize/textual/issues/3434
 
 ## [0.38.1] - 2023-09-21
 

--- a/src/textual/_work_decorator.py
+++ b/src/textual/_work_decorator.py
@@ -87,7 +87,7 @@ def work(
     exclusive: bool = False,
     description: str | None = None,
     thread: bool = False,
-) -> Callable[FactoryParamSpec, Worker[ReturnType]] | Decorator:
+) -> Callable[FactoryParamSpec, Worker[ReturnType]] | Decorator[..., ReturnType]:
     """A decorator used to create [workers](/guide/workers).
 
     Args:

--- a/src/textual/_work_decorator.py
+++ b/src/textual/_work_decorator.py
@@ -1,5 +1,4 @@
 """
-
 A decorator used to create [workers](/guide/workers).
 """
 
@@ -87,7 +86,7 @@ def work(
     exclusive: bool = False,
     description: str | None = None,
     thread: bool = False,
-) -> Callable[FactoryParamSpec, Worker[ReturnType]] | Decorator[..., ReturnType]:
+) -> Callable[FactoryParamSpec, Worker[ReturnType]] | Decorator:
     """A decorator used to create [workers](/guide/workers).
 
     Args:

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import weakref
 from asyncio import CancelledError, Event, Task
-from typing import Awaitable, Callable, Union
+from typing import Any, Awaitable, Callable, Union
 
 from rich.repr import Result, rich_repr
 
@@ -19,7 +19,7 @@ from ._context import active_app
 from ._time import sleep
 from ._types import MessageTarget
 
-TimerCallback = Union[Callable[[], Awaitable[None]], Callable[[], None]]
+TimerCallback = Union[Callable[[], Awaitable[Any]], Callable[[], Any]]
 """Type of valid callbacks to be used with timers."""
 
 


### PR DESCRIPTION
Fixes #3434.

Timer callbacks can now return `Any` instead of `None`.

This change did not introduce any new typing errors and it fixed two typing errors in our codebase.