### PR TITLE
Add will-change to excalidraw diagrams.

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -14,6 +14,7 @@ h3 .doc-heading code {
 }
 
 body[data-md-color-primary="black"] .excalidraw  svg  {
+  will-change: filter;
   filter: invert(100%) hue-rotate(180deg);
 }
 


### PR DESCRIPTION
Adding will-change: filter seems to fix the issue with the Excalidraw diagrams on dark mode and recent Safari versions. This change was also tested on Firefox and Chrome and it didn't break the diagrams in those browsers.

This fixes #3497.

Docs on macbook:

![Screenshot 2023-10-10 at 16 57 58](https://github.com/Textualize/textual/assets/5621605/52500e8a-6db2-4fd2-8c7b-e26b06532aad)

Docs on mobile:

![IMG_1883](https://github.com/Textualize/textual/assets/5621605/d29c6376-924c-4a63-9057-c580571ad764)

