### PR TITLE
Fix missing Tree.NodeHighlighted message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Clicking on the last node of an new Tree would not emit NodeHighlighted message https://github.com/Textualize/textual/pull/3528
+### Added
+### Changed
+
 ## [0.40.0] - 2023-10-11
 
 - Added `loading` reactive property to widgets https://github.com/Textualize/textual/pull/3509

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -825,6 +825,8 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         return NodeID(id)
 
     def _get_node(self, line: int) -> TreeNode[TreeDataType] | None:
+        if line < 0:
+            return None
         try:
             tree_line = self._tree_lines[line]
         except IndexError:


### PR DESCRIPTION
When the tree has no selection the cursor_line is -1, then clicking on the last node in the tree will check if the selection is different from the last selection, and do a check nodes[previous_cursor_line] != nodes[new_cursor_line] but if previous_cursor_line=-1 and new_cursor_line=len(nodes)-1 then this will fail and the message will not be emitted.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
