### PR TITLE
clear option from select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added `Select.Clear` method
+
 ## [0.40.0] - 2023-10-11
 
 - Added `loading` reactive property to widgets https://github.com/Textualize/textual/pull/3509

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -385,3 +385,8 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         select_current = self.query_one(SelectCurrent)
         select_current.has_value = True
         self.expanded = True
+        
+    def clear(self) -> None:
+        """Clear the selected option."""
+        self.value = None
+        self.query_one(SelectCurrent).update(None)

--- a/tests/select/test_select_clear.py
+++ b/tests/select/test_select_clear.py
@@ -1,0 +1,17 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Select
+
+
+class SelectApp(App[None]):
+    INITIAL_VALUE = 3
+
+    def compose(self) -> ComposeResult:
+        yield Select[int]([(str(n), n) for n in range(10)],
+                          value=self.INITIAL_VALUE)
+
+
+async def test_select_clear_value():
+    async with SelectApp().run_test() as pilot:
+        assert pilot.app.query_one(Select).value == SelectApp.INITIAL_VALUE
+        pilot.app.query_one(Select).clear()
+        assert pilot.app.query_one(Select).value is None


### PR DESCRIPTION
Adding a `clear` method for the `Select` similar to https://github.com/Textualize/textual/pull/3430.

Example:
```
from textual.app import App, ComposeResult
from textual.widgets import Select


class SelectApp(App[None]):

    def compose(self) -> ComposeResult:
        yield Select[int]([(str(n), n) for n in range(10)])

    def on_select_changed(self, event: Select.Changed) -> None:
        self.notify(f"You have selected '{event.value}'")
        event.select.clear()


if __name__ == "__main__":
    SelectApp().run()
```

- [x] Docstrings on all new or modified functions / classes 
- [ ]  Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
