### PR TITLE
fix(notifications): add link styles

### DIFF
--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -45,6 +45,12 @@ class Toast(Static, inherit_css=False):
         padding: 1 1;
         background: $panel;
         tint: white 5%;
+        link-background:;
+        link-color: $text;
+        link-style: underline;
+        link-hover-background: $accent;
+        link-hover-color: $text;
+        link-hover-style: bold not underline;
     }
 
     .toast--title {

--- a/tests/snapshot_tests/snapshot_apps/notification_with_inline_link.py
+++ b/tests/snapshot_tests/snapshot_apps/notification_with_inline_link.py
@@ -1,0 +1,11 @@
+from textual.app import App
+
+
+class NotifyWithInlineLinkApp(App):
+    def on_mount(self) -> None:
+        self.notify("Click [@click=bell]here[/] for the bell sound.")
+
+
+if __name__ == "__main__":
+    app = NotifyWithInlineLinkApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -707,6 +707,23 @@ def test_notifications_through_modes(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "notification_through_modes.py")
 
 
+def test_notification_with_inline_link(snap_compare) -> None:
+    # https://github.com/Textualize/textual/issues/3530
+    assert snap_compare(SNAPSHOT_APPS_DIR / "notification_with_inline_link.py")
+
+
+def test_notification_with_inline_link_hover(snap_compare) -> None:
+    # https://github.com/Textualize/textual/issues/3530
+    async def run_before(pilot) -> None:
+        await pilot.pause()
+        await pilot.hover("Toast", offset=(8, 1))
+
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "notification_with_inline_link.py",
+        run_before=run_before,
+    )
+
+
 def test_print_capture(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "capture_print.py")
 


### PR DESCRIPTION
Fixes #3530 by adding link styles (copied from `Widget`) to the `Toast` widget.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
