### PR TITLE
fix for cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.41.1] - Unreleased
+
+### Fixed
+
+- Fixed issue with LRUCache.discard https://github.com/Textualize/textual/issues/3537
+
 ## [0.40.0] - 2023-10-11
 
 - Added `loading` reactive property to widgets https://github.com/Textualize/textual/pull/3509

--- a/src/textual/_cache.py
+++ b/src/textual/_cache.py
@@ -183,14 +183,22 @@ class LRUCache(Generic[CacheKey, CacheValue]):
         Args:
             key: Cache key.
         """
-        link = self._cache.get(key)
-        if link is None:
+        if key not in self._cache:
             return
+        link = self._cache[key]
+
         # Remove link from list
         link[0][1] = link[1]  # type: ignore[index]
         link[1][0] = link[0]  # type: ignore[index]
         # Remove link from cache
+
+        if self._head[2] == key:
+            self._head = self._head[1]  # type: ignore[assignment]
+            if self._head[2] == key:  # type: ignore[index]
+                self._head = []
+
         del self._cache[key]
+        self._full = False
 
 
 class FIFOCache(Generic[CacheKey, CacheValue]):

--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -294,6 +294,7 @@ class Log(ScrollView, can_focus=True):
             line = Strip(line_text.render(self.app.console), cell_len(_line))
         else:
             line = Strip([Segment(_line, rich_style)], cell_len(_line))
+
         self._render_line_cache[y] = line
         return line
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -259,3 +259,29 @@ def test_discard():
     cache.discard("key4")  # key that does not exist
 
     assert len(cache) == 2  # size should not change
+
+
+def test_discard_regression():
+    """Regression test for https://github.com/Textualize/textual/issues/3537"""
+
+    cache = LRUCache(maxsize=3)
+    cache[1] = "foo"
+    cache[2] = "bar"
+    cache[3] = "baz"
+    cache[4] = "egg"
+
+    assert cache.keys() == {2, 3, 4}
+
+    cache.discard(2)
+    assert cache.keys() == {3, 4}
+
+    cache[5] = "bob"
+    assert cache.keys() == {3, 4, 5}
+
+    cache.discard(5)
+    assert cache.keys() == {3, 4}
+
+    cache.discard(4)
+    cache.discard(3)
+
+    assert cache.keys() == set()


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/3537

When discarding an item from the cache, the `discard` method wasn't updating the `_full` flag. 