### PR TITLE
Fix `DataTable.update_cell` not updating cell immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed issue with LRUCache.discard https://github.com/Textualize/textual/issues/3537
+- Fixed issue with `LRUCache.discard` https://github.com/Textualize/textual/issues/3537
+- Fixed cache bug with `DataTable.update_cell` https://github.com/Textualize/textual/pull/3551
 
 ### Changed
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1230,6 +1230,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             column = self.columns.get(column_key)
             if column is None:
                 continue
+
             console = self.app.console
             label_width = measure(console, column.label, 1)
             content_width = column.content_width
@@ -1286,6 +1287,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
             if row.auto_height:
                 auto_height_rows.append((row_index, row, cells_in_row))
+
+        self._clear_caches()
 
         # If there are rows that need to have their height computed, render them correctly
         # so that we can cache this rendering for later.
@@ -1690,9 +1693,9 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         if self._updated_cells:
             # Cell contents have already been updated at this point.
             # Now we only need to worry about measuring column widths.
-            updated_columns = self._updated_cells.copy()
+            updated_cells = self._updated_cells.copy()
             self._updated_cells.clear()
-            self._update_column_widths(updated_columns)
+            self._update_column_widths(updated_cells)
 
         if self._require_update_dimensions:
             # Add the new rows *before* updating the column widths, since


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/3533

This `clear_cache` call was removed in the recent "auto height" PR, which resulted in the regression mentioned in #3533.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
