### PR TITLE
Scroll DataTable cursor after refresh

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1116,9 +1116,10 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             cursor_row = row
         if column is not None:
             cursor_column = column
+
         destination = Coordinate(cursor_row, cursor_column)
         self.cursor_coordinate = destination
-        self._scroll_cursor_into_view(animate=animate)
+        self.call_after_refresh(self._scroll_cursor_into_view, animate=animate)
 
     def _highlight_coordinate(self, coordinate: Coordinate) -> None:
         """Apply highlighting to the cell at the coordinate, and post event."""
@@ -1612,9 +1613,11 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         Raises:
             RowDoesNotExist: If the row key does not exist.
         """
+
         if row_key not in self._row_locations:
             raise RowDoesNotExist(f"Row key {row_key!r} is not valid.")
 
+        self._new_rows.discard(row_key)
         self._require_update_dimensions = True
         self.check_idle()
 


### PR DESCRIPTION
The virtual_size of the `DataTable` isn't computed until `on_idle`. If you call `move_cursor` before `on_idle` runs, you may try to move to region of the widget that hasn't yet been accounted for in the `virtual_size`.

By updating `move_cursor` to update the cursor location _after_ refresh, we know that the virtual_size will already have been recomputed.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
