### PR TITLE
CSS initial special value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with `LRUCache.discard` https://github.com/Textualize/textual/issues/3537
 - Fixed `DataTable` not scrolling to rows that were just added https://github.com/Textualize/textual/pull/3552
 - Fixed cache bug with `DataTable.update_cell` https://github.com/Textualize/textual/pull/3551
-- Fixed CSS errors being repeated
+- Fixed CSS errors being repeated https://github.com/Textualize/textual/pull/3566
 
 ### Changed
 
 - Buttons will now display multiple lines, and have auto height https://github.com/Textualize/textual/pull/3539
 - DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
-- Breaking change: empty rules now result in an error
+- Breaking change: empty rules now result in an error https://github.com/Textualize/textual/pull/3566
 
 ### Added
 
-- Added `initial` to all css rules, which restores default (i.e. value from DEFAULT_CSS)
+- Added `initial` to all css rules, which restores default (i.e. value from DEFAULT_CSS) https://github.com/Textualize/textual/pull/3566
 
 ## [0.40.0] - 2023-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added `unset` to all css rules, which restores defaults
+- Added `initial` to all css rules, which restores defaults
 
 ## [0.40.0] - 2023-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with `LRUCache.discard` https://github.com/Textualize/textual/issues/3537
 - Fixed `DataTable` not scrolling to rows that were just added https://github.com/Textualize/textual/pull/3552
 - Fixed cache bug with `DataTable.update_cell` https://github.com/Textualize/textual/pull/3551
+- Fixed CSS errors being repeated
 
 ### Changed
 
 - Buttons will now display multiple lines, and have auto height https://github.com/Textualize/textual/pull/3539
+- DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
+- Breaking change: empty rules now result in an error
 
+### Added
+
+- Added `unset` to all css rules, which restores defaults
 
 ## [0.40.0] - 2023-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added `initial` to all css rules, which restores defaults
+- Added `initial` to all css rules, which restores default (i.e. value from DEFAULT_CSS)
 
 ## [0.40.0] - 2023-10-11
 

--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -456,7 +456,7 @@ Button {
 }
 ```
 
-If we want a specific button to use the default color, we can set the value to `initial`.
+If we want a specific button (or buttons) to use the default color, we can set the value to `initial`.
 For instance, if we have a widget with a (CSS) class called `dialog`, we could reset the background color of all buttons inside the dialog with the following CSS:
 
 ```sass

--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -442,3 +442,28 @@ Variables can refer to other variables.
 Let's say we define a variable `$success: lime;`.
 Our `$border` variable could then be updated to `$border: wide $success;`, which will
 be translated to `$border: wide lime;`.
+
+## Initial value
+
+All CSS rules support a special value called `initial`, which will reset a value back to its default.
+
+Let's look at an example.
+The following will set the background of a button to green:
+
+```sass
+Button {
+  background: green;
+}
+```
+
+If we want a specific button to use the default color, we can set the value to `initial`.
+For instance, if we have a widget with a (CSS) class called `dialog`, we could reset the background color of all buttons inside the dialog with the following CSS:
+
+```sass
+.dialog Button {
+  background: initial;
+}
+```
+
+Note that `initial` will set the value back to the value defined in any [default css](./widgets.md#default-css).
+If you use `initial` within default css, it will treat the rule as completely unstyled.

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -150,7 +150,7 @@ class Layout(ABC):
             width = 0
         else:
             # Use a size of 0, 0 to ignore relative sizes, since those are flexible anyway
-            arrangement = widget._arrange(Size(container.width, 0))
+            arrangement = widget._arrange(Size(0, 0))
             return arrangement.total_region.right
         return width
 

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -150,7 +150,7 @@ class Layout(ABC):
             width = 0
         else:
             # Use a size of 0, 0 to ignore relative sizes, since those are flexible anyway
-            arrangement = widget._arrange(Size(0, 0))
+            arrangement = widget._arrange(Size(container.width, 0))
             return arrangement.total_region.right
         return width
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2231,6 +2231,7 @@ class App(Generic[ReturnType], DOMNode):
             self._handle_exception(error)
 
     async def _pre_process(self) -> bool:
+        """Special case for the app, which doesn't need the functionality in MessagePump."""
         return True
 
     async def _ready(self) -> None:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -375,7 +375,6 @@ class App(Generic[ReturnType], DOMNode):
         super().__init__()
         self.features: frozenset[FeatureFlag] = parse_features(os.getenv("TEXTUAL", ""))
 
-        self._panicked = False
         self._filters: list[LineFilter] = []
         environ = dict(os.environ)
         no_color = environ.pop("NO_COLOR", None)
@@ -2029,7 +2028,6 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             *renderables: Text or Rich renderable(s) to display on exit.
         """
-        self._panicked = True
         assert all(
             is_renderable(renderable) for renderable in renderables
         ), "Can only call panic with strings or Rich renderables"
@@ -2052,7 +2050,6 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             error: An exception instance.
         """
-        self._panicked = True
         self._return_code = 1
         # If we're running via pilot and this is the first exception encountered,
         # take note of it so that we can re-raise for test frameworks later.
@@ -2158,9 +2155,6 @@ class App(Generic[ReturnType], DOMNode):
 
         async def run_process_messages():
             """The main message loop, invoke below."""
-
-            if self._panicked:
-                return
 
             async def invoke_ready_callback() -> None:
                 if ready_callback is not None:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -372,6 +372,7 @@ class App(Generic[ReturnType], DOMNode):
         Raises:
             CssPathError: When the supplied CSS path(s) are an unexpected type.
         """
+        self._start_time = perf_counter()
         super().__init__()
         self.features: frozenset[FeatureFlag] = parse_features(os.getenv("TEXTUAL", ""))
 
@@ -2239,6 +2240,9 @@ class App(Generic[ReturnType], DOMNode):
 
         May be used as a hook for any operations that should run first.
         """
+
+        ready_time = (perf_counter() - self._start_time) * 1000
+        self.log.info(f"ready in {ready_time:0.0f} milliseconds")
 
         async def take_screenshot() -> None:
             """Take a screenshot and exit."""

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -126,15 +126,17 @@ class StylesBuilder:
 
         tokens = declaration.tokens
 
-        # Check for unset token
-        if tokens[0].name == "token" and tokens[0].value == "unset":
-            self.styles._rules[rule_name] = None
-            return
-
         important = tokens[-1].name == "important"
         if important:
             tokens = tokens[:-1]
             self.styles.important.add(rule_name)
+
+        # Check for special token(s)
+        if tokens[0].name == "token":
+            value = tokens[0].value
+            if value == "initial":
+                self.styles.initial[rule_name] = None
+                return
         try:
             process_method(declaration.name, tokens)
         except DeclarationError:

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -135,7 +135,8 @@ class StylesBuilder:
         if tokens[0].name == "token":
             value = tokens[0].value
             if value == "initial":
-                self.styles.initial[rule_name] = None
+                self.styles._rules[rule_name] = None
+                # self.styles.initial[rule_name] = None
                 return
         try:
             process_method(declaration.name, tokens)

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -136,7 +136,6 @@ class StylesBuilder:
             value = tokens[0].value
             if value == "initial":
                 self.styles._rules[rule_name] = None
-                # self.styles.initial[rule_name] = None
                 return
         try:
             process_method(declaration.name, tokens)

--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -97,9 +97,17 @@ class StylesBuilder:
         raise DeclarationError(name, token, message)
 
     def add_declaration(self, declaration: Declaration) -> None:
-        if not declaration.tokens:
+        if not declaration.name:
             return
         rule_name = declaration.name.replace("-", "_")
+
+        if not declaration.tokens:
+            self.error(
+                rule_name,
+                declaration.token,
+                f"Missing property value for '{declaration.name}:'",
+            )
+
         process_method = getattr(self, f"process_{rule_name}", None)
 
         if process_method is None:
@@ -117,6 +125,11 @@ class StylesBuilder:
             )
 
         tokens = declaration.tokens
+
+        # Check for unset token
+        if tokens[0].name == "token" and tokens[0].value == "unset":
+            self.styles._rules[rule_name] = None
+            return
 
         important = tokens[-1].name == "important"
         if important:
@@ -259,7 +272,7 @@ class StylesBuilder:
 
         Args:
             prefix: The prefix of the style.
-            siffixes: The suffixes to distribute amongst.
+            suffixes: The suffixes to distribute amongst.
 
         A number of styles can be set with the 'prefix' of the style,
         providing the values as a series of parameters; or they can be set

--- a/src/textual/css/parse.py
+++ b/src/textual/css/parse.py
@@ -153,11 +153,10 @@ def parse_rule_set(
         if token_name in ("whitespace", "declaration_end"):
             continue
         if token_name == "declaration_name":
-            if declaration.tokens:
-                try:
-                    styles_builder.add_declaration(declaration)
-                except DeclarationError as error:
-                    errors.append((error.token, error.message))
+            try:
+                styles_builder.add_declaration(declaration)
+            except DeclarationError as error:
+                errors.append((error.token, error.message))
             declaration = Declaration(token, "")
             declaration.name = token.value.rstrip(":")
         elif token_name == "declaration_set_end":
@@ -165,11 +164,10 @@ def parse_rule_set(
         else:
             declaration.tokens.append(token)
 
-    if declaration.tokens:
-        try:
-            styles_builder.add_declaration(declaration)
-        except DeclarationError as error:
-            errors.append((error.token, error.message))
+    try:
+        styles_builder.add_declaration(declaration)
+    except DeclarationError as error:
+        errors.append((error.token, error.message))
 
     rule_set = RuleSet(
         list(SelectorSet.from_selectors(rule_selectors)),
@@ -198,7 +196,6 @@ def parse_declarations(css: str, path: str) -> Styles:
 
     declaration: Declaration | None = None
     errors: list[tuple[Token, str | HelpText]] = []
-
     while True:
         token = next(tokens, None)
         if token is None:
@@ -207,7 +204,7 @@ def parse_declarations(css: str, path: str) -> Styles:
         if token_name in ("whitespace", "declaration_end", "eof"):
             continue
         if token_name == "declaration_name":
-            if declaration and declaration.tokens:
+            if declaration:
                 try:
                     styles_builder.add_declaration(declaration)
                 except DeclarationError as error:
@@ -221,7 +218,7 @@ def parse_declarations(css: str, path: str) -> Styles:
             if declaration:
                 declaration.tokens.append(token)
 
-    if declaration and declaration.tokens:
+    if declaration:
         try:
             styles_builder.add_declaration(declaration)
         except DeclarationError as error:

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import lru_cache
-from itertools import chain
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Iterable, NamedTuple, cast
 

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -648,7 +648,6 @@ class Styles(StylesBase):
     _updates: int = 0
 
     important: set[str] = field(default_factory=set)
-    initial: dict[str, None] = field(default_factory=dict)
 
     def copy(self) -> Styles:
         """Get a copy of this Styles object."""
@@ -656,7 +655,6 @@ class Styles(StylesBase):
             node=self.node,
             _rules=self.get_rules(),
             important=self.important,
-            initial=self.initial,
         )
 
     def has_rule(self, rule: str) -> bool:
@@ -720,7 +718,6 @@ class Styles(StylesBase):
         """Reset the rules to initial state."""
         self._updates += 1
         self._rules.clear()  # type: ignore
-        self.initial.clear()
 
     def merge(self, other: StylesBase) -> None:
         """Merge values from another Styles.
@@ -764,9 +761,7 @@ class Styles(StylesBase):
                 ),
                 rule_value,
             )
-            for rule_name, rule_value in chain(
-                self._rules.items(), self.initial.items()
-            )
+            for rule_name, rule_value in self._rules.items()
         ]
 
         return rules

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -456,12 +456,11 @@ class Stylesheet:
                 ]
                 if default_rules:
                     # There is a default value
-                    node_rules[initial_rule_name] = max(  # type: ignore[literal-required]
+                    new_value = max(
                         default_rules,
                         key=get_first_item,
-                    )[
-                        1
-                    ]
+                    )[1]
+                    node_rules[initial_rule_name] = new_value  # type: ignore[literal-required]
                 else:
                     # No default value
                     node_rules[initial_rule_name] = None  # type: ignore[literal-required]

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -426,7 +426,7 @@ class Stylesheet:
                 for key, rule_specificity, value in rule.styles.extract_rules(
                     base_specificity, is_default_rules, tie_breaker
                 ):
-                    if value is None:
+                    if value is None and not is_default_rules:
                         initial.add(key)
                     rule_attributes[key].append((rule_specificity, value))
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -418,7 +418,7 @@ class Stylesheet:
 
         # Rules that may be set to the special value `initial`
         initial: set[str] = set()
-        # Rules in DEFAULT_CSS with an initial value
+        # Rules in DEFAULT_CSS set to the special value `initial`
         initial_defaults: set[str] = set()
 
         for rule in rules:

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -416,7 +416,7 @@ class Stylesheet:
         node._has_hover_style = False
         node._has_focus_within = False
 
-        # Rules that may have an initial value
+        # Rules that may be set to the special value `initial`
         initial: set[str] = set()
         # Rules in DEFAULT_CSS with an initial value
         initial_defaults: set[str] = set()

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
+from functools import lru_cache
 from itertools import chain
 from operator import itemgetter
 from pathlib import Path, PurePath
@@ -194,6 +195,7 @@ class Stylesheet:
         self.__variable_tokens = None
         self._invalid_css = set()
 
+    @lru_cache(128)
     def _parse_rules(
         self,
         css: str,

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -446,7 +446,7 @@ class Stylesheet:
         # Set initial values
         for initial_rule_name in initial:
             # Rules with a value of None should be set to the default value
-            if node_rules[initial_rule_name] is None:
+            if node_rules[initial_rule_name] is None:  # type: ignore[literal-required]
                 # Exclude non default values
                 # rule[0] is the specificity, rule[0][1] is 0 for default
                 default_rules = [
@@ -456,13 +456,15 @@ class Stylesheet:
                 ]
                 if default_rules:
                     # There is a default value
-                    node_rules[initial_rule_name] = max(
+                    node_rules[initial_rule_name] = max(  # type: ignore[literal-required]
                         default_rules,
                         key=get_first_item,
-                    )[1]
+                    )[
+                        1
+                    ]
                 else:
                     # No default value
-                    node_rules[initial_rule_name] = None
+                    node_rules[initial_rule_name] = None  # type: ignore[literal-required]
 
         self.replace_rules(node, node_rules, animate=animate)
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -479,11 +479,10 @@ class Stylesheet:
                 ]
                 if default_rules:
                     # There is a default value
-                    new_value = max(default_rules, key=get_first_item)[1]
-                    node_rules[initial_rule_name] = new_value  # type: ignore[literal-required]
+                    rule_value = max(default_rules, key=get_first_item)[1]
                 else:
-                    initial_value = getattr(_DEFAULT_STYLES, initial_rule_name)
-                    node_rules[initial_rule_name] = initial_value  # type: ignore[literal-required]
+                    rule_value = getattr(_DEFAULT_STYLES, initial_rule_name)
+                node_rules[initial_rule_name] = rule_value  # type: ignore[literal-required]
 
         self.replace_rules(node, node_rules, animate=animate)
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -426,6 +426,7 @@ class Stylesheet:
 
         if not rule_attributes:
             return
+
         # For each rule declared for this node, keep only the most specific one
         get_first_item = itemgetter(0)
         node_rules: RulesMap = cast(
@@ -476,6 +477,7 @@ class Stylesheet:
         # Styles currently used on new rules
         modified_rule_keys = base_styles.get_rules().keys() | rules.keys()
         # Current render rules (missing rules are filled with default)
+
         current_render_rules = styles.get_render_rules()
 
         # Calculate replacement rules (defaults + new rules)

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -492,7 +492,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Procedure to run before processing messages.
 
         Returns:
-            `True` if successful, or `False` if any exception occurred
+            `True` if successful, or `False` if any exception occurred.
 
         """
         # Dispatch compose and mount messages without going through loop

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -489,7 +489,12 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 timer.stop()
 
     async def _pre_process(self) -> bool:
-        """Procedure to run before processing messages."""
+        """Procedure to run before processing messages.
+
+        Returns:
+            `True` if successful, or `False` if any exception occurred
+
+        """
         # Dispatch compose and mount messages without going through loop
         # These events must occur in this order, and at the start.
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -246,7 +246,7 @@ class Widget(DOMNode):
         scrollbar-corner-color: $panel-darken-1;
         scrollbar-size-vertical: 2;
         scrollbar-size-horizontal: 1;
-        link-background:;
+        link-background: unset;
         link-color: $text;
         link-style: underline;
         link-hover-background: $accent;

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -246,7 +246,7 @@ class Widget(DOMNode):
         scrollbar-corner-color: $panel-darken-1;
         scrollbar-size-vertical: 2;
         scrollbar-size-horizontal: 1;
-        link-background: unset;
+        link-background: initial;
         link-color: $text;
         link-style: underline;
         link-hover-background: $accent;

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -251,13 +251,13 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
     DEFAULT_CSS = """
     DataTable:dark {
-        background:;
+        background: unset;
     }
     DataTable {
         background: $surface ;
         color: $text;
         height: auto;
-        max-height: 100%;
+        max-height: 100vh;
     }
     DataTable > .datatable--header {
         text-style: bold;

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -251,7 +251,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
     DEFAULT_CSS = """
     DataTable:dark {
-        background: unset;
+        background: initial;
     }
     DataTable {
         background: $surface ;

--- a/tests/css/test_inheritance.py
+++ b/tests/css/test_inheritance.py
@@ -1,0 +1,39 @@
+import pytest
+
+from textual.app import App, ComposeResult
+from textual.color import Color
+from textual.widget import Widget
+
+
+class Widget1(Widget):
+    DEFAULT_CSS = """
+    Widget1 {
+        background: red;
+    }
+    """
+
+
+class Widget2(Widget1):
+    DEFAULT_CSS = """
+    Widget1 {
+        background: green;
+    }
+    """
+
+
+# TODO: tie breaker on CSS
+@pytest.mark.xfail(
+    reason="Overlapping styles should prioritize the most recent widget in the inheritance chain"
+)
+async def test_inheritance():
+    class InheritanceApp(App):
+        def compose(self) -> ComposeResult:
+            yield Widget1(id="widget1")
+            yield Widget2(id="widget2")
+
+    app = InheritanceApp()
+    async with app.run_test():
+        widget1 = app.query_one("#widget1", Widget1)
+        widget2 = app.query_one("#widget2", Widget2)
+
+        assert widget2.styles.background == Color.parse("green")

--- a/tests/css/test_initial.py
+++ b/tests/css/test_initial.py
@@ -1,0 +1,95 @@
+from textual.app import App, ComposeResult
+from textual.color import Color
+from textual.widget import Widget
+
+
+class Base(Widget):
+    DEFAULT_CSS = """
+    Base {
+        color: magenta;
+    }
+    """
+
+
+class CustomWidget1(Base):
+    DEFAULT_CSS = """
+    CustomWidget1 {
+        background: red
+    }
+    """
+
+
+class CustomWidget2(CustomWidget1):
+    DEFAULT_CSS = """
+    CustomWidget2 {
+        background: initial;
+    }
+    """
+
+
+class CustomWidget3(CustomWidget2):
+    pass
+
+
+async def test_initial_default():
+    class InitialApp(App):
+        def compose(self) -> ComposeResult:
+            yield Base(id="base")
+            yield CustomWidget1(id="custom1")
+            yield CustomWidget2(id="custom2")
+
+    app = InitialApp()
+    async with app.run_test():
+        base = app.query_one("#base", Base)
+        custom1 = app.query_one("#custom1", CustomWidget1)
+        custom2 = app.query_one("#custom2", CustomWidget2)
+
+        # No background set on base
+        default_background = base.styles.background
+        assert default_background == Color.parse("rgba(0,0,0,0)")
+        # Customized background value, should be red
+        assert custom1.styles.background == Color.parse("red")
+        # Background has default value
+        assert custom2.styles.background == default_background
+
+
+async def test_initial():
+    class InitialApp(App):
+        CSS = """
+        CustomWidget1 {
+            color: red;
+        }
+
+        CustomWidget2 {
+           color: initial;
+        }
+
+        CustomWidget3 {
+            color: blue;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            yield Base(id="base")
+            yield CustomWidget1(id="custom1")
+            yield CustomWidget2(id="custom2")
+            yield CustomWidget3(id="custom3")
+
+    app = InitialApp()
+    async with app.run_test():
+        base = app.query_one("#base")
+        custom1 = app.query_one("#custom1")
+        custom2 = app.query_one("#custom2")
+        custom3 = app.query_one("#custom3")
+
+        # Default color
+        assert base.styles.color == Color.parse("magenta")
+
+        # Explicitly set to red
+        assert custom1.styles.color == Color.parse("red")
+
+        # Set to initial, should be same as base
+        assert custom2.styles.color == Color.parse("magenta")
+
+        # Set to blue
+        assert custom3.styles.color == Color.parse("blue")

--- a/tests/css/test_parse.py
+++ b/tests/css/test_parse.py
@@ -1200,12 +1200,6 @@ class TestParseTextAlign:
         rules = stylesheet._parse_rules(css, "foo")
         assert rules[0].errors
 
-    def test_text_align_empty_uses_default(self):
-        css = "#foo { text-align: ; }"
-        stylesheet = Stylesheet()
-        stylesheet.add_source(css)
-        assert stylesheet.rules[0].styles.text_align == "start"
-
 
 class TestTypeNames:
     def test_type_no_number(self):


### PR DESCRIPTION
- Makes empty CSS rules an error
- Adds `initial` to all rules, which restores default
- Fixed issues with CSS error reporting duplicate errors
- Set the max height of the DataTable to 100vh by default. This is because the previous value of 100% broke with horizontal layouts.
- Added log message for startup time
- Added xfail for CSS inheritance. Need to come back to this one.