### PR TITLE
button render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with `LRUCache.discard` https://github.com/Textualize/textual/issues/3537
 - Fixed `DataTable` not scrolling to rows that were just added https://github.com/Textualize/textual/pull/3552
 - Fixed cache bug with `DataTable.update_cell` https://github.com/Textualize/textual/pull/3551
+- Fix issue with chunky highlights on buttons https://github.com/Textualize/textual/pull/3571
 
 ### Changed
 
 - Buttons will now display multiple lines, and have auto height https://github.com/Textualize/textual/pull/3539
 
+### Added
+
+- Added HorizontalPad to pad.py https://github.com/Textualize/textual/pull/3571
 
 ## [0.40.0] - 2023-10-11
 

--- a/src/textual/pad.py
+++ b/src/textual/pad.py
@@ -1,4 +1,3 @@
-from rich._loop import loop_last
 from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
 from rich.measure import Measurement
 from rich.segment import Segment
@@ -25,13 +24,12 @@ class HorizontalPad:
         new_line = Segment.line()
         left_pad = Segment(" " * self.left)
         right_pad = Segment(" " * self.right)
-        for last, line in loop_last(lines):
+        for line in lines:
             if self.left:
                 yield left_pad
             yield from line
             if self.right:
                 yield right_pad
-
             yield new_line
 
     def __rich_measure__(

--- a/src/textual/pad.py
+++ b/src/textual/pad.py
@@ -8,6 +8,8 @@ class HorizontalPad:
 
     def __init__(self, renderable: RenderableType, left: int, right: int) -> None:
         """
+        Initialize HorizontalPad.
+
         Args:
             renderable: A Rich renderable.
             left: Left padding.

--- a/src/textual/pad.py
+++ b/src/textual/pad.py
@@ -1,0 +1,45 @@
+from rich._loop import loop_last
+from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+from rich.measure import Measurement
+from rich.segment import Segment
+
+
+class HorizontalPad:
+    """Rich renderable to add padding on the left and right of a renderable."""
+
+    def __init__(self, renderable: RenderableType, left: int, right: int) -> None:
+        """
+        Args:
+            renderable: A Rich renderable.
+            left: Left padding.
+            right: Right padding.
+        """
+        self.renderable = renderable
+        self.left = left
+        self.right = right
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        lines = console.render_lines(self.renderable, pad=False)
+        new_line = Segment.line()
+        left_pad = Segment(" " * self.left)
+        right_pad = Segment(" " * self.right)
+        for last, line in loop_last(lines):
+            if self.left:
+                yield left_pad
+            yield from line
+            if self.right:
+                yield right_pad
+
+            yield new_line
+
+    def __rich_measure__(
+        self, console: "Console", options: "ConsoleOptions"
+    ) -> Measurement:
+        measurement = Measurement.get(console, options, self.renderable)
+        total_padding = self.left + self.right
+        return Measurement(
+            measurement.minimum + total_padding,
+            measurement.maximum + total_padding,
+        )

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2817,16 +2817,21 @@ class Widget(DOMNode):
         )
         return pseudo_classes
 
+    def _get_rich_justify(self) -> JustifyMethod | None:
+        text_justify: JustifyMethod | None = None
+        if self.styles.has_rule("text_align"):
+            text_align: JustifyMethod = cast(JustifyMethod, self.styles.text_align)
+            text_justify = _JUSTIFY_MAP.get(text_align, text_align)
+        return text_justify
+
     def post_render(self, renderable: RenderableType) -> ConsoleRenderable:
         """Applies style attributes to the default renderable.
 
         Returns:
             A new renderable.
         """
-        text_justify: JustifyMethod | None = None
-        if self.styles.has_rule("text_align"):
-            text_align: JustifyMethod = cast(JustifyMethod, self.styles.text_align)
-            text_justify = _JUSTIFY_MAP.get(text_align, text_align)
+
+        text_justify = self._get_rich_justify()
 
         if isinstance(renderable, str):
             renderable = Text.from_markup(renderable, justify=text_justify)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2934,8 +2934,8 @@ class Widget(DOMNode):
         width, height = self.size
         renderable = self.render()
         renderable = self.post_render(renderable)
-        options = self._console.options.update_dimensions(width, height).update(
-            highlight=False
+        options = self._console.options.update(
+            highlight=False, width=width, height=height
         )
 
         segments = self._console.render(renderable, options)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2818,6 +2818,7 @@ class Widget(DOMNode):
         return pseudo_classes
 
     def _get_rich_justify(self) -> JustifyMethod | None:
+        """Get the justify method that may be passed to a Rich renderable."""
         text_justify: JustifyMethod | None = None
         if self.styles.has_rule("text_align"):
             text_align: JustifyMethod = cast(JustifyMethod, self.styles.text_align)

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from functools import partial
 
 import rich.repr
-from rich.align import Align
 from rich.console import RenderableType
-from rich.padding import Padding
 from rich.text import Text, TextType
 from typing_extensions import Literal, Self
 

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import cast
 
 import rich.repr
-from rich.console import RenderableType
+from rich.console import ConsoleRenderable, RenderableType
 from rich.text import Text, TextType
 from typing_extensions import Literal, Self
 
@@ -41,6 +42,7 @@ class Button(Static, can_focus=True):
         border: none;
         border-top: tall $panel-lighten-2;
         border-bottom: tall $panel-darken-3;
+        text-align: center;
         content-align: center middle;
         text-style: bold;
     }
@@ -231,7 +233,19 @@ class Button(Static, can_focus=True):
         return label
 
     def render(self) -> RenderableType:
-        return HorizontalPad(self.label, 1, 1)
+        assert isinstance(self.label, Text)
+        label = self.label.copy()
+        label.stylize(self.rich_style)
+        return HorizontalPad(
+            label,
+            1,
+            1,
+            self.rich_style,
+            self._get_rich_justify() or "center",
+        )
+
+    def post_render(self, renderable: RenderableType) -> ConsoleRenderable:
+        return cast(ConsoleRenderable, renderable)
 
     async def _on_click(self, event: events.Click) -> None:
         event.stop()

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import partial
 
 import rich.repr
+from rich.align import Align
 from rich.console import RenderableType
 from rich.padding import Padding
 from rich.text import Text, TextType
@@ -12,6 +13,7 @@ from .. import events
 from ..binding import Binding
 from ..css._error_tools import friendly_list
 from ..message import Message
+from ..pad import HorizontalPad
 from ..reactive import reactive
 from ..widgets import Static
 
@@ -224,14 +226,14 @@ class Button(Static, can_focus=True):
         self.remove_class(f"-{old_variant}")
         self.add_class(f"-{variant}")
 
-    def validate_label(self, label: TextType) -> TextType:
+    def validate_label(self, label: TextType) -> Text:
         """Parse markup for self.label"""
         if isinstance(label, str):
             return Text.from_markup(label)
         return label
 
     def render(self) -> RenderableType:
-        return Padding(self.label, (0, 1), expand=False)
+        return HorizontalPad(self.label, 1, 1)
 
     async def _on_click(self, event: events.Click) -> None:
         event.stop()

--- a/tests/snapshot_tests/snapshot_apps/big_button.py
+++ b/tests/snapshot_tests/snapshot_apps/big_button.py
@@ -1,0 +1,19 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+
+class ButtonApp(App):
+    CSS = """
+    Button {
+        height: 9;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Button("Hello")
+        yield Button("Hello\nWorld !!")
+
+
+if __name__ == "__main__":
+    app = ButtonApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -824,3 +824,7 @@ def test_scoped_css(snap_compare) -> None:
 
 def test_unscoped_css(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "unscoped_css.py")
+
+
+def test_big_buttons(snap_compare) -> None:
+    assert snap_compare(SNAPSHOT_APPS_DIR / "big_button.py")


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/3570 and an issue with highlights on buttons larger than one line. Note the chunky highlights that aren't center aligned.

<img width="771" alt="Screenshot 2023-10-22 at 18 22 16" src="https://github.com/Textualize/textual/assets/554369/8062585f-03a9-47b0-b619-43279ae81ab8">

Adds pad.py which contains HorizontalPad. This is similar to Rich's Padding, but simpler and won't stretch the height. This new renderable is public, but I'm going to hold off adding it to the docs for now. Just until I'm certain this is stable.