### PR TITLE
Pass App ReturnType to Pilot in run_test

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1220,7 +1220,7 @@ class App(Generic[ReturnType], DOMNode):
         tooltips: bool = False,
         notifications: bool = False,
         message_hook: Callable[[Message], None] | None = None,
-    ) -> AsyncGenerator[Pilot, None]:
+    ) -> AsyncGenerator[Pilot[ReturnType], None]:
         """An asynchronous context manager for testing apps.
 
         !!! tip


### PR DESCRIPTION
Fixes:

```
Type of "pilot" is partially unknown
  Type of "pilot" is "Pilot"PylancereportUnknownVariableType
```

When using:

    async with app.run_test() as pilot:

https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportUnknownVariableType


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
