### PR TITLE
parse cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Buttons will now display multiple lines, and have auto height https://github.com/Textualize/textual/pull/3539
 - DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
 - Breaking change: empty rules now result in an error https://github.com/Textualize/textual/pull/3566
-- Improved startup time by caching CSS parsing
+- Improved startup time by caching CSS parsing https://github.com/Textualize/textual/pull/3575
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Buttons will now display multiple lines, and have auto height https://github.com/Textualize/textual/pull/3539
 - DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
 - Breaking change: empty rules now result in an error https://github.com/Textualize/textual/pull/3566
+- Improved startup time by caching CSS parsing
 
 ### Added
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -135,7 +135,7 @@ class Stylesheet:
         self.source: dict[str, CssSource] = {}
         self._require_parse = False
         self._invalid_css: set[str] = set()
-        self._parse_cache = LRUCache(64)
+        self._parse_cache: LRUCache[tuple, list[RuleSet]] = LRUCache(64)
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield list(self.source.keys())


### PR DESCRIPTION
I added an `@lru_cache` to parse_rules in a previous PR, for a decent speedup. On reflection, this was naive as there was additional state. This update adds a manual "parse cache", which is cleared if variables are update.

The startup time for demo.py went from 177ms to 126ms. Not too shabby.

The main reason this happens is that inherited CSS was parsed multiple times. I.e. the default CSS in widget.py.