### PR TITLE
Stop `OptionList.OptionHighlighted` leaking to the `App`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed cache bug with `DataTable.update_cell` https://github.com/Textualize/textual/pull/3551
 - Fixed CSS errors being repeated https://github.com/Textualize/textual/pull/3566
 - Fix issue with chunky highlights on buttons https://github.com/Textualize/textual/pull/3571
+- Fixed `OptionList` event leakage from `CommandPalette` to `App`.
 
 ### Changed
 

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -961,6 +961,11 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
                 self.workers.cancel_all()
                 self.dismiss(self._selected_command.command)
 
+    @on(OptionList.OptionHighlighted)
+    def _stop_event_leak(self, event: OptionList.OptionHighlighted) -> None:
+        """Stop any unused events so they don't leak to the application."""
+        event.stop()
+
     def _action_escape(self) -> None:
         """Handle a request to escape out of the command palette."""
         if self._list_visible:


### PR DESCRIPTION
If `App` was catching `OptionList.OptionHighlighted` without any other checks, moving through the options in the command palette could cause false positives.