### PR TITLE
Docs table rendering change/cleanup

### DIFF
--- a/docs/_templates/python/material/_base/docstring/parameters.html
+++ b/docs/_templates/python/material/_base/docstring/parameters.html
@@ -5,33 +5,33 @@
   <table>
     <thead>
       <tr>
-        <th>Name</th>
-        <th>Type</th>
-        <th>Description</th>
+        <th>Parameter</th>
         <th>Default</th>
+        <th>Description</th>
       </tr>
     </thead>
     <tbody>
       {% for parameter in section.value %}
         <tr>
-          <td><code>{{ parameter.name }}</code></td>
           <td>
+            <strong><code>{{ parameter.name }}</code></strong>
+            <br>
             {% if parameter.annotation %}
               {% with expression = parameter.annotation %}
                 <code>{% include "expression.html" with context %}</code>
               {% endwith %}
             {% endif %}
           </td>
-          <td>{{ parameter.description|convert_markdown(heading_level, html_id) }}</td>
           <td>
             {% if parameter.default %}
-              {% with expression = parameter.default %}
-                <code>{% include "expression.html" with context %}</code>
-              {% endwith %}
+            {% with expression = parameter.default %}
+            <code>{% include "expression.html" with context %}</code>
+            {% endwith %}
             {% else %}
-              <em>required</em>
+            <em>required</em>
             {% endif %}
           </td>
+          <td>{{ parameter.description|convert_markdown(heading_level, html_id) }}</td>
         </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Columns inside the parameter tables could be quite squished if there were params or types with long names.

Fixes #3534 

![Image](https://github.com/Textualize/textual/assets/5740731/990afb7e-e7c4-411b-b7ad-81381a9092a2)
