### PR TITLE
Change some log groups

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2242,7 +2242,7 @@ class App(Generic[ReturnType], DOMNode):
         """
 
         ready_time = (perf_counter() - self._start_time) * 1000
-        self.log.info(f"ready in {ready_time:0.0f} milliseconds")
+        self.log.system(f"ready in {ready_time:0.0f} milliseconds")
 
         async def take_screenshot() -> None:
             """Take a screenshot and exit."""
@@ -2677,7 +2677,7 @@ class App(Generic[ReturnType], DOMNode):
         """
         _rich_traceback_guard = True
 
-        log(
+        log.system(
             "<action>",
             namespace=namespace,
             action_name=action_name,
@@ -2693,13 +2693,13 @@ class App(Generic[ReturnType], DOMNode):
             if callable(public_method):
                 await invoke(public_method, *params)
                 return True
-            log(
+            log.system(
                 f"<action> {action_name!r} has no target."
                 f" Could not find methods '_action_{action_name}' or 'action_{action_name}'"
             )
         except SkipAction:
             # The action method raised this to explicitly not handle the action
-            log(f"<action> {action_name!r} skipped.")
+            log.system(f"<action> {action_name!r} skipped.")
         return False
 
     async def _broker_event(
@@ -2744,7 +2744,7 @@ class App(Generic[ReturnType], DOMNode):
             await self.dispatch_key(event)
 
     async def _on_shutdown_request(self, event: events.ShutdownRequest) -> None:
-        log("shutdown request")
+        log.system("shutdown request")
         await self._close_messages()
 
     async def _on_resize(self, event: events.Resize) -> None:


### PR DESCRIPTION
We usually use the SYSTEM log group when logging from the App, but there were a few cases of using INFO - I'm not sure I understand the difference and how to choose which group to use.

I'm not sure if this PR is correct, but I opened it partly just to try to understand how logging works and how end users are expected to use it.

Have we defined what these groups mean and when we should use each of them? I can't see anything in the docs.

With our current system, it seems like there's no easy way to distinguish between Textual's logs and application logs. e.g. if there's a warning, how do I know if it's a Textual warning or an application warning?
