### PR TITLE
Fix notifications CSS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed CSS errors being repeated https://github.com/Textualize/textual/pull/3566
 - Fix issue with chunky highlights on buttons https://github.com/Textualize/textual/pull/3571
 - Fixed `OptionList` event leakage from `CommandPalette` to `App`.
+- Fixed `Toast` CSS that should use `initial` instead of empty value.
 
 ### Added
 

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -45,7 +45,7 @@ class Toast(Static, inherit_css=False):
         padding: 1 1;
         background: $panel;
         tint: white 5%;
-        link-background:;
+        link-background: initial;
         link-color: $text;
         link-style: underline;
         link-hover-background: $accent;


### PR DESCRIPTION
This was merged more or less at the same time as 'initial' was added to CSS but the tests weren't ran with that change. Related PRs: #3566, #3531.

This fix was [prompted by CI failures](https://github.com/Textualize/textual/actions/runs/6630104679/job/18017476351?pr=3582) in #3582.