### PR TITLE
Workers inside workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
 - Breaking change: empty rules now result in an error https://github.com/Textualize/textual/pull/3566
 - Improved startup time by caching CSS parsing https://github.com/Textualize/textual/pull/3575
-- The work decorated now creates workers in a thread-safe way https://github.com/Textualize/textual/pull/3586
+- Workers are now created/ran in a thread-safe way https://github.com/Textualize/textual/pull/3586
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
 - Breaking change: empty rules now result in an error https://github.com/Textualize/textual/pull/3566
 - Improved startup time by caching CSS parsing https://github.com/Textualize/textual/pull/3575
+- The work decorated now creates workers in a thread-safe way https://github.com/Textualize/textual/pull/3586
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DataTable now has a max-height of 100vh rather than 100%, which doesn't work with auto
 - Breaking change: empty rules now result in an error https://github.com/Textualize/textual/pull/3566
 - Improved startup time by caching CSS parsing https://github.com/Textualize/textual/pull/3575
-- Workers are now created/ran in a thread-safe way https://github.com/Textualize/textual/pull/3586
+- Workers are now created/run in a thread-safe way https://github.com/Textualize/textual/pull/3586
 
 ### Added
 

--- a/src/textual/_work_decorator.py
+++ b/src/textual/_work_decorator.py
@@ -6,7 +6,6 @@ A decorator used to create [workers](/guide/workers).
 
 from __future__ import annotations
 
-import threading
 from functools import partial, wraps
 from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Callable, Coroutine, TypeVar, Union, cast, overload
@@ -140,7 +139,6 @@ def work(
                     debug_description = f"{method.__name__}({', '.join(token for token in tokens if token)})"
                 except Exception:
                     debug_description = "<worker>"
-
             worker = cast(
                 "Worker[ReturnType]",
                 self.run_worker(

--- a/src/textual/_work_decorator.py
+++ b/src/textual/_work_decorator.py
@@ -141,15 +141,9 @@ def work(
                 except Exception:
                     debug_description = "<worker>"
 
-            # If we're creating/running a worker from inside a secondary thread,
-            # do so in a thread-safe way.
-            if self.app._thread_id != threading.get_ident():
-                runner = partial(self.app.call_from_thread, self.run_worker)
-            else:
-                runner = self.run_worker
             worker = cast(
                 "Worker[ReturnType]",
-                runner(
+                self.run_worker(
                     partial(method, *args, **kwargs),
                     name=name or method.__name__,
                     group=group,

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -271,10 +271,10 @@ class DOMNode(MessagePump):
         # If we're running a worker from inside a secondary thread,
         # do so in a thread-safe way.
         if self.app._thread_id != threading.get_ident():
-            runner = partial(self.app.call_from_thread, self.workers._new_worker)
+            creator = partial(self.app.call_from_thread, self.workers._new_worker)
         else:
-            runner = self.workers._new_worker
-        worker: Worker[ResultType] = runner(
+            creator = self.workers._new_worker
+        worker: Worker[ResultType] = creator(
             work,
             self,
             name=name,

--- a/tests/workers/test_work_decorator.py
+++ b/tests/workers/test_work_decorator.py
@@ -5,7 +5,6 @@ from typing import Callable, List, Tuple
 import pytest
 
 from textual import work
-from textual._callback import _invoke
 from textual._work_decorator import WorkerDeclarationError
 from textual.app import App
 from textual.worker import Worker, WorkerState, WorkType

--- a/tests/workers/test_work_decorator.py
+++ b/tests/workers/test_work_decorator.py
@@ -1,10 +1,11 @@
 import asyncio
 from time import sleep
-from typing import Callable
+from typing import Callable, List, Tuple
 
 import pytest
 
 from textual import work
+from textual._callback import _invoke
 from textual._work_decorator import WorkerDeclarationError
 from textual.app import App
 from textual.worker import Worker, WorkerState, WorkType
@@ -88,3 +89,115 @@ def test_decorate_non_async_no_thread_is_false() -> None:
             @work(thread=False)
             def foo(self) -> None:
                 pass
+
+
+class NestedWorkersApp(App[None]):
+    def __init__(self, call_stack: List[str]):
+        self.call_stack = call_stack
+        super().__init__()
+
+    def call_from_stack(self):
+        if self.call_stack:
+            call_now = self.call_stack.pop()
+            getattr(self, call_now)()
+
+    @work(thread=False)
+    async def async_no_thread(self):
+        self.call_from_stack()
+
+    @work(thread=True)
+    async def async_thread(self):
+        self.call_from_stack()
+
+    @work(thread=True)
+    def thread(self):
+        self.call_from_stack()
+
+
+@pytest.mark.parametrize(
+    "call_stack",
+    [  # from itertools import product; list(product("async_no_thread async_thread thread".split(), repeat=3))
+        ("async_no_thread", "async_no_thread", "async_no_thread"),
+        ("async_no_thread", "async_no_thread", "async_thread"),
+        ("async_no_thread", "async_no_thread", "thread"),
+        ("async_no_thread", "async_thread", "async_no_thread"),
+        ("async_no_thread", "async_thread", "async_thread"),
+        ("async_no_thread", "async_thread", "thread"),
+        ("async_no_thread", "thread", "async_no_thread"),
+        ("async_no_thread", "thread", "async_thread"),
+        ("async_no_thread", "thread", "thread"),
+        ("async_thread", "async_no_thread", "async_no_thread"),
+        ("async_thread", "async_no_thread", "async_thread"),
+        ("async_thread", "async_no_thread", "thread"),
+        ("async_thread", "async_thread", "async_no_thread"),
+        ("async_thread", "async_thread", "async_thread"),
+        ("async_thread", "async_thread", "thread"),
+        ("async_thread", "thread", "async_no_thread"),
+        ("async_thread", "thread", "async_thread"),
+        ("async_thread", "thread", "thread"),
+        ("thread", "async_no_thread", "async_no_thread"),
+        ("thread", "async_no_thread", "async_thread"),
+        ("thread", "async_no_thread", "thread"),
+        ("thread", "async_thread", "async_no_thread"),
+        ("thread", "async_thread", "async_thread"),
+        ("thread", "async_thread", "thread"),
+        ("thread", "thread", "async_no_thread"),
+        ("thread", "thread", "async_thread"),
+        ("thread", "thread", "thread"),
+    ],
+)
+async def test_calling_workers_from_within_workers(call_stack: Tuple[str]):
+    """Regression test for https://github.com/Textualize/textual/issues/3472.
+
+    This makes sure we can nest worker calls without a problem.
+    """
+    app = NestedWorkersApp(list(call_stack))
+    async with app.run_test():
+        app.call_from_stack()
+        # We need multiple awaits because we're creating a chain of workers that may
+        # have multiple async workers, each of which may need the await to have enough
+        # time to call the next one in the chain.
+        for _ in range(len(call_stack)):
+            await app.workers.wait_for_complete()
+        assert app.call_stack == []
+
+
+async def test_calling_workers_from_within_workers_deep():
+    """Regression test for https://github.com/Textualize/textual/issues/3472.
+
+    This test creates a deep call stack to stress test this.
+    """
+    call_stack = [
+        "async_no_thread",
+        "async_no_thread",
+        "thread",
+        "thread",
+        "async_thread",
+        "async_thread",
+        "async_no_thread",
+        "async_thread",
+        "async_no_thread",
+        "async_thread",
+        "thread",
+        "async_thread",
+        "async_thread",
+        "async_no_thread",
+        "async_no_thread",
+        "thread",
+        "thread",
+        "async_no_thread",
+        "async_no_thread",
+        "thread",
+        "async_no_thread",
+        "thread",
+        "thread",
+    ]
+    app = NestedWorkersApp(call_stack)
+    async with app.run_test():
+        app.call_from_stack()
+        # We need multiple awaits because we're creating a chain of workers that may
+        # have multiple async workers, each of which may need the await to have enough
+        # time to call the next one in the chain.
+        for _ in range(len(call_stack)):
+            await app.workers.wait_for_complete()
+        assert app.call_stack == []

--- a/tests/workers/test_work_decorator.py
+++ b/tests/workers/test_work_decorator.py
@@ -143,6 +143,31 @@ class NestedWorkersApp(App[None]):
         ("thread", "thread", "async_no_thread"),
         ("thread", "thread", "async_thread"),
         ("thread", "thread", "thread"),
+        (  # Plus a longer chain to stress test this mechanism.
+            "async_no_thread",
+            "async_no_thread",
+            "thread",
+            "thread",
+            "async_thread",
+            "async_thread",
+            "async_no_thread",
+            "async_thread",
+            "async_no_thread",
+            "async_thread",
+            "thread",
+            "async_thread",
+            "async_thread",
+            "async_no_thread",
+            "async_no_thread",
+            "thread",
+            "thread",
+            "async_no_thread",
+            "async_no_thread",
+            "thread",
+            "async_no_thread",
+            "thread",
+            "thread",
+        ),
     ],
 )
 async def test_calling_workers_from_within_workers(call_stack: Tuple[str]):
@@ -151,47 +176,6 @@ async def test_calling_workers_from_within_workers(call_stack: Tuple[str]):
     This makes sure we can nest worker calls without a problem.
     """
     app = NestedWorkersApp(list(call_stack))
-    async with app.run_test():
-        app.call_from_stack()
-        # We need multiple awaits because we're creating a chain of workers that may
-        # have multiple async workers, each of which may need the await to have enough
-        # time to call the next one in the chain.
-        for _ in range(len(call_stack)):
-            await app.workers.wait_for_complete()
-        assert app.call_stack == []
-
-
-async def test_calling_workers_from_within_workers_deep():
-    """Regression test for https://github.com/Textualize/textual/issues/3472.
-
-    This test creates a deep call stack to stress test this.
-    """
-    call_stack = [
-        "async_no_thread",
-        "async_no_thread",
-        "thread",
-        "thread",
-        "async_thread",
-        "async_thread",
-        "async_no_thread",
-        "async_thread",
-        "async_no_thread",
-        "async_thread",
-        "thread",
-        "async_thread",
-        "async_thread",
-        "async_no_thread",
-        "async_no_thread",
-        "thread",
-        "thread",
-        "async_no_thread",
-        "async_no_thread",
-        "thread",
-        "async_no_thread",
-        "thread",
-        "thread",
-    ]
-    app = NestedWorkersApp(call_stack)
     async with app.run_test():
         app.call_from_stack()
         # We need multiple awaits because we're creating a chain of workers that may


### PR DESCRIPTION
This makes it so that calling workers inside workers works out of the box in all cases, which fixes #3472.
Depending on whether you were calling a threaded worker or not, you could have trouble calling new workers.