### PR TITLE
Add more pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-      - id: check-ast
-      - id: check-builtin-literals
-      - id: check-case-conflict
-      - id: check-merge-conflict
-      - id: check-json
-      - id: check-toml
-      - id: check-yaml
-        args: [ '--unsafe' ]
-      - id: check-shebang-scripts-are-executable
-      - id: check-vcs-permalinks
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
+      - id: check-ast  # simply checks whether the files parse as valid python
+      - id: check-builtin-literals  # requires literal syntax when initializing empty or zero python builtin types
+      - id: check-case-conflict  # checks for files that would conflict in case-insensitive filesystems
+      - id: check-merge-conflict  # checks for files that contain merge conflict strings
+      - id: check-json  # checks json files for parseable syntax
+      - id: check-toml  # checks toml files for parseable syntax
+      - id: check-yaml  # checks yaml files for parseable syntax
+        args: [ '--unsafe' ]  # Instead of loading the files, simply parse them for syntax.
+      - id: check-shebang-scripts-are-executable  # ensures that (non-binary) files with a shebang are executable
+      - id: check-vcs-permalinks  # ensures that links to vcs websites are permalinks
+      - id: end-of-file-fixer  # ensures that a file is either empty, or ends with one newline
+      - id: mixed-line-ending  # replaces or checks mixed line ending
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -27,7 +27,7 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://github.com/hadialqattan/pycln
+  - repo: https://github.com/hadialqattan/pycln  # removes unused imports
     rev: v2.3.0
     hooks:
       - id: pycln

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,19 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-toml
       - id: check-yaml
         args: [ '--unsafe' ]
+      - id: check-shebang-scripts-are-executable
+      - id: check-vcs-permalinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -19,4 +28,9 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.3.0
+    hooks:
+      - id: pycln
+        args: [--all]
 exclude: ^tests/snapshot_tests

--- a/docs/blog/snippets/2022-12-07-responsive-app-background-task/nonblocking01.py
+++ b/docs/blog/snippets/2022-12-07-responsive-app-background-task/nonblocking01.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from random import randint
 
 from textual.app import App, ComposeResult

--- a/docs/examples/events/on_decorator01.py
+++ b/docs/examples/events/on_decorator01.py
@@ -1,4 +1,3 @@
-from textual import on
 from textual.app import App, ComposeResult
 from textual.widgets import Button
 

--- a/docs/examples/events/prevent.py
+++ b/docs/examples/events/prevent.py
@@ -1,5 +1,4 @@
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
 from textual.widgets import Button, Input
 
 

--- a/docs/examples/guide/reactivity/validate01.py
+++ b/docs/examples/guide/reactivity/validate01.py
@@ -30,7 +30,7 @@ class ValidateApp(App):
             self.count += 1
         else:
             self.count -= 1
-        self.query_one(RichLog).write(f"{self.count=}")
+        self.query_one(RichLog).write(f"count = {self.count}")
 
 
 if __name__ == "__main__":

--- a/docs/examples/styles/padding_all.py
+++ b/docs/examples/styles/padding_all.py
@@ -1,5 +1,5 @@
 from textual.app import App
-from textual.containers import Container, Grid
+from textual.containers import Grid
 from textual.widgets import Placeholder
 
 

--- a/docs/examples/widgets/content_switcher.py
+++ b/docs/examples/widgets/content_switcher.py
@@ -1,5 +1,3 @@
-from rich.align import VerticalCenter
-
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Button, ContentSwitcher, DataTable, Markdown

--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -165,8 +165,6 @@ if __name__ == "__main__":
 
     test_parser = TestParser()
 
-    import time
-
     for n in range(0, len(data), 5):
         for token in test_parser.feed(data[n : n + 5]):
             print(token)

--- a/src/textual/_types.py
+++ b/src/textual/_types.py
@@ -1,12 +1,6 @@
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Union
 
-from typing_extensions import (
-    Literal,
-    Protocol,
-    SupportsIndex,
-    get_args,
-    runtime_checkable,
-)
+from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from rich.segment import Segment

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -47,7 +47,7 @@ from .transition import Transition
 
 if TYPE_CHECKING:
     from .._layout import Layout
-    from .styles import Styles, StylesBase
+    from .styles import StylesBase
 
 from .types import AlignHorizontal, AlignVertical, DockEdge, EdgeType
 

--- a/src/textual/document/_document.py
+++ b/src/textual/document/_document.py
@@ -5,12 +5,13 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, NamedTuple, Tuple, overload
 
+from typing_extensions import Literal, get_args
+
 if TYPE_CHECKING:
     from tree_sitter import Node
     from tree_sitter.binding import Query
 
 from textual._cells import cell_len
-from textual._types import Literal, get_args
 from textual.geometry import Size
 
 Newline = Literal["\r\n", "\n", "\r"]

--- a/src/textual/drivers/_input_reader_linux.py
+++ b/src/textual/drivers/_input_reader_linux.py
@@ -4,8 +4,6 @@ import sys
 from threading import Event
 from typing import Iterator
 
-from textual import log
-
 
 class InputReader:
     """Read input from stdin."""

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import rich.repr
 import rich.traceback
 
-from .. import events, log
+from .. import events
 from .._xterm_parser import XTermParser
 from ..driver import Driver
 from ..geometry import Size

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -26,7 +26,6 @@ from ._context import message_hook as message_hook_context_var
 from ._context import prevent_message_types_stack
 from ._on import OnNoWidget
 from ._time import time
-from ._types import CallbackType
 from .case import camel_to_snake
 from .css.match import match
 from .errors import DuplicateKeyHandlers

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from asyncio import create_task
 from dataclasses import dataclass
 from typing import ClassVar
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple
 
 from rich.style import Style
 from rich.text import Text
+from typing_extensions import Literal, Protocol, runtime_checkable
 
 from textual._text_area_theme import TextAreaTheme
 from textual._tree_sitter import TREE_SITTER
@@ -30,11 +31,9 @@ from textual.expand_tabs import expand_tabs_inline
 
 if TYPE_CHECKING:
     from tree_sitter import Language
-    from tree_sitter.binding import Query
 
 from textual import events, log
 from textual._cells import cell_len
-from textual._types import Literal, Protocol, runtime_checkable
 from textual.binding import Binding
 from textual.events import Message, MouseEvent
 from textual.geometry import Offset, Region, Size, Spacing, clamp

--- a/tests/css/test_programmatic_style_changes.py
+++ b/tests/css/test_programmatic_style_changes.py
@@ -2,7 +2,6 @@ import pytest
 
 from textual.app import App
 from textual.containers import Grid
-from textual.screen import Screen
 from textual.widgets import Label
 
 

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -1,5 +1,4 @@
 from contextlib import nullcontext as does_not_raise
-from typing import Any
 
 import pytest
 

--- a/tests/input/test_input_validation.py
+++ b/tests/input/test_input_validation.py
@@ -2,7 +2,6 @@ import pytest
 
 from textual import on
 from textual.app import App, ComposeResult
-from textual.events import Blur
 from textual.validation import Number, ValidationResult
 from textual.widgets import Input
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -298,8 +298,6 @@ async def test_reactive_inheritance():
     class Tertiary(Secondary):
         baz = reactive("baz")
 
-    from rich import print
-
     primary = Primary()
     secondary = Secondary()
     tertiary = Tertiary()

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -6,10 +6,10 @@ import pytest
 
 from textual import work
 from textual.app import App, ComposeResult, ScreenStackError
-from textual.events import MouseMove, MouseScrollDown, MouseScrollUp
+from textual.events import MouseMove
 from textual.geometry import Offset
 from textual.screen import Screen
-from textual.widgets import Button, DataTable, Input, Label
+from textual.widgets import Button, Input, Label
 from textual.worker import NoActiveWorker
 
 skip_py310 = pytest.mark.skipif(

--- a/tests/test_style_inheritance.py
+++ b/tests/test_style_inheritance.py
@@ -1,5 +1,3 @@
-from rich.style import Style
-
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Static
 


### PR DESCRIPTION
Went through the list of Rich pre-commit hooks and added the ones that look useful.
Prompted by the fact that I commit unused imports way too many times.

Took the opportunity to fix imports in the code and make sure one of the examples is compatible with Python 3.7 out of the box, which we still support.