### PR TITLE
Ensure that the command palette doesn't kill *all* workers when stoping command gathering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `OptionList` event leakage from `CommandPalette` to `App`.
 - Fixed crash in `LoadingIndicator` https://github.com/Textualize/textual/pull/3498
 - Fixed crash when `Tabs` appeared as a descendant of `TabbedContent` in the DOM https://github.com/Textualize/textual/pull/3602
+- Fixed the command palette cancelling other workers https://github.com/Textualize/textual/issues/3615
 
 ### Added
 

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -515,7 +515,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         method of dismissing the palette.
         """
         if self.get_widget_at(event.screen_x, event.screen_y)[0] is self:
-            self.workers.cancel_all()
+            self._cancel_gather_commands()
             self.dismiss()
 
     def on_mount(self, _: Mount) -> None:
@@ -774,7 +774,10 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
     _NO_MATCHES: Final[str] = "--no-matches"
     """The ID to give the disabled option that shows there were no matches."""
 
-    @work(exclusive=True)
+    _GATHER_COMMANDS_GROUP: Final[str] = "--textual-command-palette-gather-commands"
+    """The group name of the command gathering worker."""
+
+    @work(exclusive=True, group=_GATHER_COMMANDS_GROUP)
     async def _gather_commands(self, search_value: str) -> None:
         """Gather up all of the commands that match the search value.
 
@@ -895,6 +898,10 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         if command_list.option_count == 0 and not worker.is_cancelled:
             self._start_no_matches_countdown()
 
+    def _cancel_gather_commands(self) -> None:
+        """Cancel any operation that is gather commands."""
+        self.workers.cancel_group(self, self._GATHER_COMMANDS_GROUP)
+
     @on(Input.Changed)
     def _input(self, event: Input.Changed) -> None:
         """React to input in the command palette.
@@ -903,7 +910,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
             event: The input event.
         """
         event.stop()
-        self.workers.cancel_all()
+        self._cancel_gather_commands()
         self._stop_no_matches_countdown()
 
         search_value = event.value.strip()
@@ -921,7 +928,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
             event: The option selection event.
         """
         event.stop()
-        self.workers.cancel_all()
+        self._cancel_gather_commands()
         input = self.query_one(CommandInput)
         with self.prevent(Input.Changed):
             assert isinstance(event.option, Command)
@@ -958,7 +965,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
             if self._selected_command is not None:
                 # ...we should return it to the parent screen and let it
                 # decide what to do with it (hopefully it'll run it).
-                self.workers.cancel_all()
+                self._cancel_gather_commands()
                 self.dismiss(self._selected_command.command)
 
     @on(OptionList.OptionHighlighted)
@@ -971,7 +978,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         if self._list_visible:
             self._list_visible = False
         else:
-            self.workers.cancel_all()
+            self._cancel_gather_commands()
             self.dismiss()
 
     def _action_command_list(self, action: str) -> None:

--- a/tests/command_palette/test_worker_interference.py
+++ b/tests/command_palette/test_worker_interference.py
@@ -1,0 +1,37 @@
+"""Tests for https://github.com/Textualize/textual/issues/3615"""
+
+from asyncio import sleep
+
+from textual import work
+from textual.app import App
+from textual.command import Hit, Hits, Provider
+
+
+class SimpleSource(Provider):
+    async def search(self, query: str) -> Hits:
+        def goes_nowhere_does_nothing() -> None:
+            pass
+
+        for _ in range(100):
+            yield Hit(1, query, goes_nowhere_does_nothing, query)
+
+
+class CommandPaletteApp(App[None]):
+    COMMANDS = {SimpleSource}
+
+    def on_mount(self) -> None:
+        self.innocent_worker()
+
+    @work
+    async def innocent_worker(self) -> None:
+        while True:
+            await sleep(1)
+
+
+async def test_innocent_worker_is_untouched() -> None:
+    """Using the command palette should not halt other workers."""
+    async with CommandPaletteApp().run_test() as pilot:
+        assert len(pilot.app.workers) > 0
+        pilot.app.action_command_palette()
+        await pilot.press("a", "enter")
+        assert len(pilot.app.workers) > 0


### PR DESCRIPTION
As per #3615 (initially from #3613), this fixes the issue of the command palette getting a wee bit carried away when it attempted to cancel the worker that is gathering commands.

Also adds a tests to ensure that the command palette doesn't leave any workers behind, and also tests that it doesn't stop any workers that were originally running before it was called.