### PR TITLE
Document CellKey being a RowKey, ColumnKey tuple

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -138,7 +138,9 @@ class CellKey(NamedTuple):
     can still be used to retrieve it, regardless of where it currently is."""
 
     row_key: RowKey
+    """The key of this cell's row."""
     column_key: ColumnKey
+    """The key of this cell's column."""
 
     def __rich_repr__(self):
         yield "row_key", self.row_key

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -131,6 +131,8 @@ class ColumnKey(StringKey):
 class CellKey(NamedTuple):
     """A unique identifier for a cell in the DataTable.
 
+    A cell key is a `(row_key, column_key)` tuple.
+
     Even if the cell changes
     visual location (i.e. moves to a different coordinate in the table), this key
     can still be used to retrieve it, regardless of where it currently is."""


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

---

Following https://github.com/Textualize/textual/discussions/3623.

An alternative is to add docstrings to the `row_key` and `column_key` attributes of the `CellKey` class. (UPDATE: also added)