### PR TITLE
Fix the Focusable flag in the Markdown docs

### DIFF
--- a/docs/widgets/markdown.md
+++ b/docs/widgets/markdown.md
@@ -4,7 +4,7 @@
 
 A widget to display a Markdown document.
 
-- [x] Focusable
+- [ ] Focusable
 - [ ] Container
 
 


### PR DESCRIPTION
It said it was focusable; it isn't.
