### PR TITLE
Set pycln pre-commit hook language_version to 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: pycln
-        language_version: "3.8"
+        language_version: "3.11"
         args: [--all]
 exclude: ^tests/snapshot_tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: pycln
+        language_version: "3.8"
         args: [--all]
 exclude: ^tests/snapshot_tests


### PR DESCRIPTION
`pycln` doesn't work on 3.7 unless a Rust compiler is available.