### PR TITLE
Fix erroneous ButtonDown mouse event reporting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed CSS watcher crash if file becomes unreadable (even temporarily) https://github.com/Textualize/textual/pull/4079
 - Fixed display of keys when used in conjunction with other keys https://github.com/Textualize/textual/pull/3050
 - Fixed double detection of <kbd>Escape</kbd> on Windows https://github.com/Textualize/textual/issues/4038
+- Fixed erroneous mouse 'ButtonDown' reporting for mouse movement when any-event mode is enabled in xterm. https://github.com/Textualize/textual/pull/3647
+
 
 ## [0.47.1] - 2024-01-05
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -73,12 +73,13 @@ class XTermParser(Parser[events.Event]):
                 )
                 button = 0
             else:
-                if buttons & 32:
+                button = (buttons + 1) & 3
+                # XTerm events for mouse movement can look like mouse button down events. But if there is no key pressed,
+                # it's a mouse move event.
+                if buttons & 32 or button == 0:
                     event_class = events.MouseMove
                 else:
                     event_class = events.MouseDown if state == "M" else events.MouseUp
-
-                button = (buttons + 1) & 3
 
             event = event_class(
                 x,

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -218,6 +218,7 @@ def test_mouse_click(parser, sequence, event_type, shift, meta):
         ("\x1b[<35;15;38M", False, False, 0),  # Basic cursor movement
         ("\x1b[<39;15;38M", True, False, 0),  # Shift held down
         ("\x1b[<43;15;38M", False, True, 0),  # Meta held down
+        ("\x1b[<3;15;38M", False, False, 0),
     ],
 )
 def test_mouse_move(parser, sequence, shift, meta, button):


### PR DESCRIPTION
After v0.38.0, I was seeing Input fields lose focus whenever the mouse left the input field area (but without having clicked anywhere). This behavior started after the release v0.38.0 release when Mouse ButtonDown began to trigger loss of focus (This change seemed intentional). However, I wasn't pressing the mouse button down.

The erronious ButtonDown events were actually MouseMove events with no keys held down. According to the docs for xterm escape sequences, when SGR (1006) mode is enabled, the encoded button value isn't always incremented by 32 for move movements events. [1]

I believe the correct fix to this issue is to detect mouse movement events with no button down by checking if the "pressed button" is 0. Which appears to indicate that no mouse button is pressed (in this specific case). Whereas, the button value will be set to 1 when left click is pressed for example.

I'm not sure if this change is fully correct for terminals which don't support SGR mode.

[1] https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Extended-coordinates


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
