### PR TITLE
More `Makefile` tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ clean: clean-screenshot-cache clean-offline-docs
 .PHONY: setup
 setup:
 	poetry install
+	poetry install --extras syntax
 
 .PHONY: update
 update:

--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,7 @@ install-pre-commit:
 .PHONY: demo
 demo:
 	$(run) python -m textual
+
+.PHONY: repl
+repl:
+	$(run) python


### PR DESCRIPTION
Ensure that the `syntax` extras gets installed as part of `make setup`, and also add `make repl`[^1].

[^1]: Sure, I'm probably the only one who'll ever use it, but it's a handy thing I have within every Python project and my muscle memory fails me every time I'm in the Textual development directory and every time I keep thinking "I should add that" so here I am adding that.