### PR TITLE
Fix live-reloading of screen CSS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Duplicate CSS errors when parsing CSS from a screen https://github.com/Textualize/textual/issues/3581
 - Added missing `blur` pseudo class https://github.com/Textualize/textual/issues/3439
 - Fixed visual glitched characters on Windows due to Python limitation https://github.com/Textualize/textual/issues/2548
+- Fixed live-reloading of screen CSS https://github.com/Textualize/textual/issues/3454
 
 ### Changed
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -521,7 +521,7 @@ class App(Generic[ReturnType], DOMNode):
 
         self.css_monitor = (
             FileMonitor(self.css_path, self._on_css_change)
-            if ((watch_css or self.debug) and self.css_path)
+            if watch_css or self.debug
             else None
         )
         self._screenshot: str | None = None
@@ -1407,8 +1407,10 @@ class App(Generic[ReturnType], DOMNode):
         return self.return_value
 
     async def _on_css_change(self) -> None:
-        """Called when the CSS changes (if watch_css is True)."""
-        css_paths = self.css_path
+        """Callback for the file monitor, called when CSS files change."""
+        css_paths = (
+            self.css_monitor._paths if self.css_monitor is not None else self.css_path
+        )
         if css_paths:
             try:
                 time = perf_counter()

--- a/src/textual/file_monitor.py
+++ b/src/textual/file_monitor.py
@@ -31,7 +31,7 @@ class FileMonitor:
 
     def _get_last_modified_time(self) -> float:
         """Get the most recent modified time out of all files being watched."""
-        return max(os.stat(path).st_mtime for path in self._paths)
+        return max((os.stat(path).st_mtime for path in self._paths), default=0)
 
     def check(self) -> bool:
         """Check the monitored files. Return True if any were changed since the last modification time."""

--- a/tests/snapshot_tests/snapshot_apps/hot_reloading_app_with_screen_css.py
+++ b/tests/snapshot_tests/snapshot_apps/hot_reloading_app_with_screen_css.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.screen import Screen
+from textual.widgets import Label
+
+
+SCREEN_CSS_PATH = (Path(__file__) / "../hot_reloading_app_with_screen_css.tcss").resolve()
+
+# Write some CSS to the file before the app loads.
+# Then, the test will clear all the CSS to see if the
+# hot reloading applies the changes correctly.
+SCREEN_CSS_PATH.write_text(
+    """
+Container {
+    align: center middle;
+}
+
+Label {
+    border: round $primary;
+    padding: 3;
+}
+"""
+)
+
+
+class MyScreen(Screen[None]):
+    CSS_PATH = SCREEN_CSS_PATH
+
+    def compose(self) -> ComposeResult:
+        yield Container(Label("Hello, world!"))
+
+
+class HotReloadingApp(App[None]):
+    def on_mount(self) -> None:
+        self.push_screen(MyScreen())
+
+
+if __name__ == "__main__":
+    HotReloadingApp(watch_css=True).run()

--- a/tests/snapshot_tests/snapshot_apps/hot_reloading_app_with_screen_css.tcss
+++ b/tests/snapshot_tests/snapshot_apps/hot_reloading_app_with_screen_css.tcss
@@ -1,0 +1,1 @@
+/* This file is purposefully empty. */

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -531,8 +531,10 @@ def test_scrollbar_thumb_height(snap_compare):
     )
 
 
-def test_css_hot_reloading(snap_compare):
+def test_css_hot_reloading(snap_compare, monkeypatch):
     """Regression test for https://github.com/Textualize/textual/issues/2063."""
+
+    monkeypatch.setenv("TEXTUAL", "debug")  # This will make sure we create a file monitor.
 
     async def run_before(pilot):
         css_file = pilot.app.CSS_PATH
@@ -545,8 +547,26 @@ def test_css_hot_reloading(snap_compare):
     )
 
 
-def test_datatable_hot_reloading(snap_compare):
+def test_css_hot_reloading_on_screen(snap_compare, monkeypatch):
+    """Regression test for https://github.com/Textualize/textual/issues/3454."""
+
+    monkeypatch.setenv("TEXTUAL", "debug")  # This will make sure we create a file monitor.
+
+    async def run_before(pilot):
+        css_file = pilot.app.screen.CSS_PATH
+        with open(css_file, "w") as f:
+            f.write("/* This file is purposefully empty. */\n")  # Clear all the CSS.
+        await pilot.app._on_css_change()
+
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "hot_reloading_app_with_screen_css.py", run_before=run_before
+    )
+
+
+def test_datatable_hot_reloading(snap_compare, monkeypatch):
     """Regression test for https://github.com/Textualize/textual/issues/3312."""
+
+    monkeypatch.setenv("TEXTUAL", "debug")  # This will make sure we create a file monitor.
 
     async def run_before(pilot):
         css_file = pilot.app.CSS_PATH


### PR DESCRIPTION
Fix #3454 so that live-reloading also works on screen CSS.
The screen CSS was already being added to the file monitor but the file monitor callback sourced the files from the app and not from the monitor, so it was reloading only a subset of the files that it should.
