### PR TITLE
fix: replace textlog references

### DIFF
--- a/docs/examples/guide/input/mouse01.tcss
+++ b/docs/examples/guide/input/mouse01.tcss
@@ -2,7 +2,7 @@ Screen {
     layers: log ball;
 }
 
-TextLog {
+RichLog {
     layer: log;
 }
 

--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -75,7 +75,7 @@ class Log(ScrollView, can_focus=True):
 
     @property
     def lines(self) -> Sequence[str]:
-        """The raw lines in the TextLog.
+        """The raw lines in the Log.
 
         Note that this attribute is read only.
         Changing the lines will not update the Log's contents.


### PR DESCRIPTION
Update a couple of references to the old TextLog widget. 

This update does not fix other issues with the mouse movement example in the docs however, see #3652.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
