### PR TITLE
Add missing return type and return detail for `OptionList.get_option_index`

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -851,11 +851,14 @@ class OptionList(ScrollView, can_focus=True):
         """
         return self.get_option_at_index(self.get_option_index(option_id))
 
-    def get_option_index(self, option_id):
+    def get_option_index(self, option_id) -> int:
         """Get the index of the option with the given ID.
 
         Args:
             option_id: The ID of the option to get the index of.
+
+        Returns:
+            The index of the item with the given ID.
 
         Raises:
             OptionDoesNotExist: If no option has the given ID.


### PR DESCRIPTION
https://github.com/Textualize/textual/commit/a3590ac19253b43bb2f92d1264ea1fd4ab981426 added this but it looks like the type hint for the return value, and the return value explanation were left off in the PR.
