### PR TITLE
Change loading indicator layer and effects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed live-reloading of screen CSS https://github.com/Textualize/textual/issues/3454
 - `Select.value` could be in an invalid state https://github.com/Textualize/textual/issues/3612
 - Off-by-one in CSS error reporting https://github.com/Textualize/textual/issues/3625
+- Loading indicators and app notifications overlapped in the wrong order https://github.com/Textualize/textual/issues/3677
+- Widgets being loaded are disabled and have their scrolling explicitly disabled too https://github.com/Textualize/textual/issues/3677
 
 ### Added
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -244,7 +244,7 @@ class Screen(Generic[ScreenResultType], Widget):
         Returns:
             Tuple of layer names.
         """
-        extras = []
+        extras = ["_loading"]
         if not self.app._disable_notifications:
             extras.append("_toastrack")
         if not self.app._disable_tooltips:

--- a/tests/snapshot_tests/snapshot_apps/notifications_above_loading.py
+++ b/tests/snapshot_tests/snapshot_apps/notifications_above_loading.py
@@ -1,0 +1,31 @@
+from textual.app import App, ComposeResult
+from textual.containers import VerticalScroll
+from textual.widgets import Label
+
+
+class LoadingOverlayApp(App[None]):
+    CSS = """
+    VerticalScroll {
+        height: 20;
+    }
+    
+    Toast {
+        max-width: 100%;
+        width: 70%;  /* We need this to cover the dots of the loading indicator
+        so that we don't have flakiness in the tests because the screenshot
+        might be taken a couple ms earlier or later. */
+    }"""
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            yield Label("another big label\n"*30)  # Ensure there's a scrollbar.
+
+    def on_mount(self):
+        self.notify(
+            "This is a big notification.\n" * 10,
+            timeout=9_999_999
+        )
+        self.query_one(VerticalScroll).loading = True
+
+if __name__ == "__main__":
+    LoadingOverlayApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -902,3 +902,12 @@ def test_button_outline(snap_compare):
     Regression test for https://github.com/Textualize/textual/issues/3628
     """
     assert snap_compare(SNAPSHOT_APPS_DIR / "button_outline.py")
+
+
+def test_notifications_loading_overlap_order(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/3677.
+
+    This tests that notifications stay on top of loading indicators and it also
+    tests that loading a widget will remove its scrollbars.
+    """
+    assert snap_compare(SNAPSHOT_APPS_DIR / "notifications_above_loading.py", terminal_size=(80, 20))

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,0 +1,36 @@
+from textual.app import App, ComposeResult
+from textual.containers import VerticalScroll
+from textual.widgets import Label
+
+
+class LoadingApp(App[None]):
+    CSS = """
+    VerticalScroll {
+        height: 20;
+    }
+    """
+
+    BINDINGS = [("l", "loading")]
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            yield Label("another big label\n" * 30)  # Ensure there's a scrollbar.
+
+    def action_loading(self):
+        self.query_one(VerticalScroll).loading = True
+
+
+async def test_loading_disables_and_remove_scrollbars():
+    app = LoadingApp()
+    async with app.run_test() as pilot:
+        vs = app.query_one(VerticalScroll)
+        # Sanity checks:
+        assert not vs.disabled
+        assert vs.styles.overflow_y != "hidden"
+
+        await pilot.press("l")
+        await pilot.pause()
+
+        assert vs.disabled
+        assert vs.styles.overflow_x == "hidden"
+        assert vs.styles.overflow_y == "hidden"


### PR DESCRIPTION
The loading indicator will now disable the underlying widget.
It is also no longer on top of notifications.

Fixes #3677.
