### PR TITLE
Hide command palette mount and unmount handlers from the docs

### DIFF
--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -518,7 +518,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
             self._cancel_gather_commands()
             self.dismiss()
 
-    def on_mount(self, _: Mount) -> None:
+    def _on_mount(self, _: Mount) -> None:
         """Capture the calling screen."""
         self._calling_screen = self.app.screen_stack[-2]
 
@@ -534,7 +534,7 @@ class CommandPalette(ModalScreen[CallbackType], inherit_css=False):
         for provider in self._providers:
             provider._post_init()
 
-    async def on_unmount(self) -> None:
+    async def _on_unmount(self) -> None:
         """Shutdown providers when command palette is closed."""
         if self._providers:
             await wait(


### PR DESCRIPTION
CommandPalette.on_mount and CommandPalette.on_unmount were in the docs and indexed because they're not private and they have docstrings documenting what they do for the command palette. This has the unfortunate side-effect of CommandPalette.on_mount (for example) turning up as the first it if someone searches the docs for `on_mount` (which, if they've not gone through the guide and have read up on events and messages, they're likely to do and then end up confusing themselves due to not reading the docs in a sensible order):

![Screenshot 2023-11-16 at 14 32 17](https://github.com/Textualize/textual/assets/28237/bd9d1e6e-5ecd-4fc7-b7d2-4945bc6c2949)

While it won't help someone understand what `on_mount` does, it will hide an implementation of it that won't help them.
