### PR TITLE
Make Button inherit directly from Widget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - CSS error reporting will no longer provide links to the files in question https://github.com/Textualize/textual/pull/3582
 - inline CSS error reporting will report widget/class variable where the CSS was read from https://github.com/Textualize/textual/pull/3582
 - Breaking change: Setting `Select.value` to `None` no longer clears the selection (See `Select.BLANK` and `Select.clear`) https://github.com/Textualize/textual/pull/3614
+- Breaking change: `Button` no longer inherits from `Static`, now it inherits directly from `Widget` https://github.com/Textualize/textual/issues/3603
 
 
 ## [0.41.0] - 2023-10-31

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -14,7 +14,7 @@ from ..css._error_tools import friendly_list
 from ..message import Message
 from ..pad import HorizontalPad
 from ..reactive import reactive
-from ..widgets import Static
+from ..widget import Widget
 
 ButtonVariant = Literal["default", "primary", "success", "warning", "error"]
 """The names of the valid button variants.
@@ -29,7 +29,7 @@ class InvalidButtonVariant(Exception):
     """Exception raised if an invalid button variant is used."""
 
 
-class Button(Static, can_focus=True):
+class Button(Widget, can_focus=True):
     """A simple clickable button."""
 
     DEFAULT_CSS = """


### PR DESCRIPTION
Fixes #3603.

At the present time, it's nonsensical for `Button` to inherit from `Static`, so I'm guessing this inheritance is remnant of a previous `Button` implementation.

The point of `Static` is to cache the rendering and use the cache in its method `render`.
The implementation of `Button` overrides `Static.render`, so we're not making use of the only thing we get by inheriting from `Static`...