### PR TITLE
Pause a moment longer when testing the command palette no-matches timeout

### DIFF
--- a/tests/command_palette/test_no_results.py
+++ b/tests/command_palette/test_no_results.py
@@ -18,7 +18,9 @@ async def test_no_results() -> None:
         assert results.visible is False
         assert results.option_count == 0
         await pilot.press("a")
-        await pilot.pause(delay=CommandPalette._NO_MATCHES_COUNTDOWN)
+        # https://github.com/Textualize/textual/issues/3700 -- note the
+        # little bit of wiggle room to allow for Windows.
+        await pilot.pause(delay=CommandPalette._NO_MATCHES_COUNTDOWN + 0.1)
         assert results.visible is True
         assert results.option_count == 1
         assert "No matches found" in str(results.get_option_at_index(0).prompt)


### PR DESCRIPTION
See #3700.

An important component of the test is that it checks once the timeout has expired that the result list is visible and it contains just the one item (which will show that there are no results). Keeping the timeout is important, but because timing can be fun on certain platforms, it makes sense to wait at least the timeout, and then a moment longer, and *then* see that the timeout happened.

Currently thinking 1/10th of a second makes sense here.