### PR TITLE
feat(widget): add is_mounted property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `restrict`, `type`, `max_length`, and `valid_empty` to Input https://github.com/Textualize/textual/pull/3657
 - Added `Pilot.mouse_down` to simulate `MouseDown` events https://github.com/Textualize/textual/pull/3495
 - Added `Pilot.mouse_up` to simulate `MouseUp` events https://github.com/Textualize/textual/pull/3495
+- Added `Widget.is_mounted` property https://github.com/Textualize/textual/pull/3709
 
 ### Changed
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -394,6 +394,15 @@ class Widget(DOMNode):
     """A title to show in the bottom border (if there is one)."""
 
     @property
+    def is_mounted(self) -> bool:
+        """Check if this widget is mounted.
+
+        Returns:
+            True if this widget is mounted.
+        """
+        return self._mounted_event.is_set()
+
+    @property
     def siblings(self) -> list[Widget]:
         """Get the widget's siblings (self is removed from the return list).
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -395,11 +395,7 @@ class Widget(DOMNode):
 
     @property
     def is_mounted(self) -> bool:
-        """Check if this widget is mounted.
-
-        Returns:
-            True if this widget is mounted.
-        """
+        """Check if this widget is mounted."""
         return self._mounted_event.is_set()
 
     @property

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -383,3 +383,14 @@ async def test_loading():
         label.loading = False  # Setting to same value is a null-op
         await pilot.pause()
         assert len(label.query(LoadingIndicator)) == 0
+
+
+async def test_is_mounted_property():
+    class TestWidgetIsMountedApp(App):
+        pass
+
+    async with TestWidgetIsMountedApp().run_test() as pilot:
+        widget = Widget()
+        assert widget.is_mounted is False
+        await pilot.app.mount(widget)
+        assert widget.is_mounted is True


### PR DESCRIPTION
Credit to @darrenburns for this suggestion.

This helps avoid DOM-related errors by checking if the widget is mounted before trying to do work relating to the DOM (querying, updating, etc.) For example:

```python
    def watch_some_reactive(self) -> None:
        if not self.is_mounted:
            return
        table = self.query_one(DataTable)  # Avoids NoMatches error
        ...
```

### Related Issue

- #3011 

### Checklist:

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
