### PR TITLE
docs(contributing): update setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,11 @@ You can follow these steps:
  1. Make sure you have Poetry installed ([see instructions here](https://python-poetry.org))
  2. Clone the Textual repository
  3. Run `poetry shell` to create a virtual environment for the dependencies
- 4. Run `make setup` to install all dependencies ([read this](#makefile-commands) if the command `make` doesn't work for you.)
+ 4. Run `make setup` to install all dependencies
  5. Make sure the latest version of Textual was installed by running the command `textual --version`
  6. Install the pre-commit hooks with the command `pre-commit install`
+
+([Read this](#makefile-commands) if the command `make` doesn't work for you.)
 
 ## Demo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ You can follow these steps:
  1. Make sure you have Poetry installed ([see instructions here](https://python-poetry.org))
  2. Clone the Textual repository
  3. Run `poetry shell` to create a virtual environment for the dependencies
- 4. Run `poetry install` to install all dependencies
+ 4. Run `make setup` to install all dependencies ([read this](#makefile-commands) if the command `make` doesn't work for you.)
  5. Make sure the latest version of Textual was installed by running the command `textual --version`
  6. Install the pre-commit hooks with the command `pre-commit install`
 


### PR DESCRIPTION
Currently the contributing guidelines advise in the setup steps to:

```md
Run `poetry install` to install all dependencies
```

However this doesn't install all dependencies required for development. Running `make test` will have failing tests due to missing dependencies in the `syntax` extras.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
