### PR TITLE
Fix docstring example.

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -935,9 +935,8 @@ class Widget(DOMNode):
             ```python
             def compose(self) -> ComposeResult:
                 yield Header()
-                yield Container(
-                    Tree(), Viewer()
-                )
+                yield Label("Press the button below:")
+                yield Button()
                 yield Footer()
             ```
         """


### PR DESCRIPTION
Small docstring fix that I noticed en-passant.
The example used a widget that no longer exists so I swapped it out for something simpler & that runs.