### PR TITLE
Compositor ignores non-mounted widgets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Off-by-one in CSS error reporting https://github.com/Textualize/textual/issues/3625
 - Loading indicators and app notifications overlapped in the wrong order https://github.com/Textualize/textual/issues/3677
 - Widgets being loaded are disabled and have their scrolling explicitly disabled too https://github.com/Textualize/textual/issues/3677
+- Method render on a widget could be called before mounting said widget https://github.com/Textualize/textual/issues/2914
 
 ### Added
 

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -573,6 +573,9 @@ class Compositor:
                 visible: Whether the widget should be visible by default.
                     This may be overridden by the CSS rule `visibility`.
             """
+            if not widget._is_mounted:
+                return
+
             styles = widget.styles
             visibility = styles.get_rule("visibility")
             if visibility is not None:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2202,6 +2202,7 @@ class App(Generic[ReturnType], DOMNode):
                         self.check_idle()
                     finally:
                         self._mounted_event.set()
+                        self._is_mounted = True
 
                     Reactive._initialize_object(self)
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -396,7 +396,7 @@ class Widget(DOMNode):
     @property
     def is_mounted(self) -> bool:
         """Check if this widget is mounted."""
-        return self._mounted_event.is_set()
+        return self._is_mounted
 
     @property
     def siblings(self) -> list[Widget]:

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -1,0 +1,27 @@
+"""Regression test for https://github.com/Textualize/textual/issues/2914
+
+Make sure that calls to render only happen after a widget being mounted.
+"""
+
+import asyncio
+
+from textual.app import App
+from textual.widget import Widget
+
+
+class W(Widget):
+    def render(self):
+        return self.renderable
+
+    async def on_mount(self):
+        await asyncio.sleep(0.1)
+        self.renderable = "1234"
+
+
+async def test_render_only_after_mount():
+    """Regression test for https://github.com/Textualize/textual/issues/2914"""
+    app = App()
+    async with app.run_test() as pilot:
+        app.mount(W())
+        app.mount(W())
+        await pilot.pause()


### PR DESCRIPTION
By making sure that the compositor ignores widgets that haven't been mounted we can be sure that our widgets are only rendered after being mounted.

An exception to this seems to be scrollbars and scrollbar corners which are created on the fly in the `Widget` properties `horizontal_scrollbar`, `vertical_scrollbar`, and `scrollbar_corner`, because they are handled in a slightly different way (they aren't in the DOM).