### PR TITLE
Add support for various modified navigation/edit keys under rxvt

### DIFF
--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -247,7 +247,7 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     "\x1b[5B": (Keys.ControlDown,),
     "\x1b[5C": (Keys.ControlRight,),
     "\x1b[5D": (Keys.ControlLeft,),
-    # Control allow keys in rxvt
+    # Control arrow keys in rxvt
     "\x1bOa": (Keys.ControlUp,),
     "\x1bOb": (Keys.ControlUp,),
     "\x1bOc": (Keys.ControlRight,),

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -152,6 +152,7 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     # --
     # Meta/control/escape + pageup/pagedown/insert/delete.
     "\x1b[3;2~": (Keys.ShiftDelete,),  # xterm, gnome-terminal.
+    "\x1b[3$": (Keys.ShiftDelete,),  # rxvt
     "\x1b[5;2~": (Keys.ShiftPageUp,),
     "\x1b[6;2~": (Keys.ShiftPageDown,),
     "\x1b[2;3~": (Keys.Escape, Keys.Insert),
@@ -163,6 +164,7 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     "\x1b[5;4~": (Keys.Escape, Keys.ShiftPageUp),
     "\x1b[6;4~": (Keys.Escape, Keys.ShiftPageDown),
     "\x1b[3;5~": (Keys.ControlDelete,),  # xterm, gnome-terminal.
+    "\x1b[3^": (Keys.ControlDelete,),  # rxvt
     "\x1b[5;5~": (Keys.ControlPageUp,),
     "\x1b[6;5~": (Keys.ControlPageDown,),
     "\x1b[3;6~": (Keys.ControlShiftDelete,),

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -238,8 +238,11 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     "\x1b[5B": (Keys.ControlDown,),
     "\x1b[5C": (Keys.ControlRight,),
     "\x1b[5D": (Keys.ControlLeft,),
-    "\x1bOc": (Keys.ControlRight,),  # rxvt
-    "\x1bOd": (Keys.ControlLeft,),  # rxvt
+    # Control allow keys in rxvt
+    "\x1bOa": (Keys.ControlUp,),
+    "\x1bOb": (Keys.ControlUp,),
+    "\x1bOc": (Keys.ControlRight,),
+    "\x1bOd": (Keys.ControlLeft,),
     # Control + shift + arrows.
     "\x1b[1;6A": (Keys.ControlShiftUp,),
     "\x1b[1;6B": (Keys.ControlShiftDown,),

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -240,6 +240,9 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     "\x1bb": (Keys.ControlLeft,),  # iTerm natural editing keys
     "\x1b[1;5F": (Keys.ControlEnd,),
     "\x1b[1;5H": (Keys.ControlHome,),
+    # rxvt
+    "\x1b[7^": (Keys.ControlEnd,),
+    "\x1b[8^": (Keys.ControlHome,),
     # Tmux sends following keystrokes when control+arrow is pressed, but for
     # Emacs ansi-term sends the same sequences for normal arrow keys. Consider
     # it a normal arrow press, because that's more important.

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -200,6 +200,13 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     "\x1b[1;2D": (Keys.ShiftLeft,),
     "\x1b[1;2F": (Keys.ShiftEnd,),
     "\x1b[1;2H": (Keys.ShiftHome,),
+    # Shift+navigation in rxvt
+    "\x1b[a": (Keys.ShiftUp,),
+    "\x1b[b": (Keys.ShiftDown,),
+    "\x1b[c": (Keys.ShiftRight,),
+    "\x1b[d": (Keys.ShiftLeft,),
+    "\x1b[7$": (Keys.ShiftHome,),
+    "\x1b[8$": (Keys.ShiftEnd,),
     # Meta + arrow keys. Several terminals handle this differently.
     # The following sequences are for xterm and gnome-terminal.
     #     (Iterm sends ESC followed by the normal arrow_up/down/left/right

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -167,6 +167,8 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...]] = {
     "\x1b[3^": (Keys.ControlDelete,),  # rxvt
     "\x1b[5;5~": (Keys.ControlPageUp,),
     "\x1b[6;5~": (Keys.ControlPageDown,),
+    "\x1b[5^": (Keys.ControlPageUp,),  # rxvt
+    "\x1b[6^": (Keys.ControlPageDown,),  # rxvt
     "\x1b[3;6~": (Keys.ControlShiftDelete,),
     "\x1b[5;6~": (Keys.ControlShiftPageUp,),
     "\x1b[6;6~": (Keys.ControlShiftPageDown,),


### PR DESCRIPTION
Found during #3440, this adds support for various modified navigation and edit keys within rxvt. Mainly discovered and tested on macOS/XQuartz, but also confirmed under GNU/Linux too.

See #3738 (and by extension #3440).
