### PR TITLE
docs(changelog): fix out of sync changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed mouse targeting issue in `TextArea` when tabs were not fully expanded https://github.com/Textualize/textual/pull/3725
+- Fixed `Select` not updating after changing the `prompt` reactive https://github.com/Textualize/textual/issues/2983
 
 ### Changed
 
+- Method `MarkdownTableOfContents.set_table_of_contents` renamed to `MarkdownTableOfContents.rebuild_table_of_contents` https://github.com/Textualize/textual/pull/3730
+- Exception `Tree.UnknownNodeID` moved out of `Tree`, import from `textual.widgets.tree` https://github.com/Textualize/textual/pull/3730
+- Exception `TreeNode.RemoveRootError` moved out of `TreeNode`, import from `textual.widgets.tree` https://github.com/Textualize/textual/pull/3730
 - Optimized startup time https://github.com/Textualize/textual/pull/3753
 
 ## [0.42.0] - 2023-11-22
@@ -32,7 +36,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Loading indicators and app notifications overlapped in the wrong order https://github.com/Textualize/textual/issues/3677
 - Widgets being loaded are disabled and have their scrolling explicitly disabled too https://github.com/Textualize/textual/issues/3677
 - Method render on a widget could be called before mounting said widget https://github.com/Textualize/textual/issues/2914
-- Fixed `Select` not updating after changing the `prompt` reactive https://github.com/Textualize/textual/issues/2983
 
 ### Added
 
@@ -57,9 +60,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Rich markup in markdown headings is now escaped when building the TOC https://github.com/Textualize/textual/issues/3689
 - Mechanics behind mouse clicks. See [this](https://github.com/Textualize/textual/pull/3495#issue-1934915047) for more details. https://github.com/Textualize/textual/pull/3495
 - Breaking change: max/min-width/height now includes padding and border. https://github.com/Textualize/textual/pull/3712
-- Method `MarkdownTableOfContents.set_table_of_contents` renamed to `MarkdownTableOfContents.rebuild_table_of_contents` https://github.com/Textualize/textual/pull/3730
-- Exception `Tree.UnknownNodeID` moved out of `Tree`, import from `textual.widgets.tree` https://github.com/Textualize/textual/pull/3730
-- Exception `TreeNode.RemoveRootError` moved out of `TreeNode`, import from `textual.widgets.tree` https://github.com/Textualize/textual/pull/3730
 
 
 ## [0.41.0] - 2023-10-31


### PR DESCRIPTION
I spotted the changelog is out of sync where #3730 and #2983 were merged after v0.42.0 was released.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
