### PR TITLE
Lazy command provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Optimized startup time https://github.com/Textualize/textual/pull/3753
-
+- App.COMMANDS or Screen.COMMANDS can now accept a callable which returns a command palette privoder
 
 ## [0.42.0] - 2023-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Optimized startup time https://github.com/Textualize/textual/pull/3753
-- App.COMMANDS or Screen.COMMANDS can now accept a callable which returns a command palette privoder
+- App.COMMANDS or Screen.COMMANDS can now accept a callable which returns a command palette provider https://github.com/Textualize/textual/pull/3756
 
 ## [0.42.0] - 2023-11-22
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -67,7 +67,6 @@ from ._context import active_app, active_message_pump
 from ._context import message_hook as message_hook_context_var
 from ._event_broker import NoHandler, extract_handler_actions
 from ._path import CSSPathType, _css_path_type_as_list, _make_path_object_relative
-from ._system_commands import SystemCommands
 from ._wait import wait_for_idle
 from ._worker_manager import WorkerManager
 from .actions import ActionParseResult, SkipAction
@@ -107,6 +106,7 @@ if TYPE_CHECKING:
     from textual_dev.client import DevtoolsClient
     from typing_extensions import Coroutine, Literal, TypeAlias
 
+    from ._system_commands import SystemCommands
     from ._types import MessageTarget
 
     # Unused & ignored imports are needed for the docs to link to these objects:
@@ -156,6 +156,17 @@ AutopilotCallbackType: TypeAlias = (
     "Callable[[Pilot[object]], Coroutine[Any, Any, None]]"
 )
 """Signature for valid callbacks that can be used to control apps."""
+
+
+def get_system_commands() -> type[SystemCommands]:
+    """Callable to lazy load the system commands.
+
+    Returns:
+        System commands class.
+    """
+    from ._system_commands import SystemCommands
+
+    return SystemCommands
 
 
 class AppError(Exception):
@@ -330,7 +341,9 @@ class App(Generic[ReturnType], DOMNode):
     ENABLE_COMMAND_PALETTE: ClassVar[bool] = True
     """Should the [command palette][textual.command.CommandPalette] be enabled for the application?"""
 
-    COMMANDS: ClassVar[set[type[Provider]]] = {SystemCommands}
+    COMMANDS: ClassVar[set[type[Provider] | Callable[[], type[Provider]]]] = {
+        get_system_commands
+    }
     """Command providers used by the [command palette](/guide/command_palette).
 
     Should be a set of [command.Provider][textual.command.Provider] classes.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -164,7 +164,7 @@ class Screen(Generic[ScreenResultType], Widget):
     title: Reactive[str | None] = Reactive(None, compute=False)
     """Screen title to override [the app title][textual.app.App.title]."""
 
-    COMMANDS: ClassVar[set[type[Provider]]] = set()
+    COMMANDS: ClassVar[set[type[Provider] | Callable[[], type[Provider]]]] = set()
     """Command providers used by the [command palette](/guide/command_palette), associated with the screen.
 
     Should be a set of [`command.Provider`][textual.command.Provider] classes.

--- a/tests/command_palette/test_declare_sources.py
+++ b/tests/command_palette/test_declare_sources.py
@@ -73,10 +73,10 @@ async def test_screen_command_sources() -> None:
     """Command sources declared on a screen should be in the command palette."""
     async with AppWithInitialScreen(ScreenWithSources()).run_test() as pilot:
         assert isinstance(pilot.app.screen, CommandPalette)
-        assert (
-            pilot.app.screen._provider_classes
-            == App.COMMANDS | ScreenWithSources.COMMANDS
-        )
+        assert pilot.app.screen._provider_classes == {
+            SystemCommands,
+            ExampleCommandSource,
+        }
 
 
 class AnotherCommandSource(ExampleCommandSource):

--- a/tests/command_palette/test_declare_sources.py
+++ b/tests/command_palette/test_declare_sources.py
@@ -1,3 +1,4 @@
+from textual._system_commands import SystemCommands
 from textual.app import App
 from textual.command import CommandPalette, Hit, Hits, Provider
 from textual.screen import Screen
@@ -29,7 +30,7 @@ async def test_no_app_command_sources() -> None:
     """An app with no sources declared should work fine."""
     async with AppWithNoSources().run_test() as pilot:
         assert isinstance(pilot.app.screen, CommandPalette)
-        assert pilot.app.screen._provider_classes == App.COMMANDS
+        assert pilot.app.screen._provider_classes == {SystemCommands}
 
 
 class AppWithSources(AppWithActiveCommandPalette):
@@ -40,7 +41,7 @@ async def test_app_command_sources() -> None:
     """Command sources declared on an app should be in the command palette."""
     async with AppWithSources().run_test() as pilot:
         assert isinstance(pilot.app.screen, CommandPalette)
-        assert pilot.app.screen._provider_classes == AppWithSources.COMMANDS
+        assert pilot.app.screen._provider_classes == {ExampleCommandSource}
 
 
 class AppWithInitialScreen(App[None]):
@@ -61,7 +62,7 @@ async def test_no_screen_command_sources() -> None:
     """An app with a screen with no sources declared should work fine."""
     async with AppWithInitialScreen(ScreenWithNoSources()).run_test() as pilot:
         assert isinstance(pilot.app.screen, CommandPalette)
-        assert pilot.app.screen._provider_classes == App.COMMANDS
+        assert pilot.app.screen._provider_classes == {SystemCommands}
 
 
 class ScreenWithSources(ScreenWithNoSources):


### PR DESCRIPTION
Avoids importing the system commands until the user opens the command palette.

This is a significant improvement to startup time, for simpler apps at least.

Fixes https://github.com/Textualize/textual/issues/3754