### PR TITLE
error if no children allowed

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -48,8 +48,7 @@ jobs:
       #          make typecheck
       - name: Test with pytest
         run: |
-          source $VENV
-          pytest tests -v --cov=./src/textual --cov-report=xml:./coverage.xml --cov-report term-missing
+          poetry run pytest tests -v --cov=./src/textual --cov-report=xml:./coverage.xml --cov-report term-missing
       - name: Upload snapshot report
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -48,7 +48,8 @@ jobs:
       #          make typecheck
       - name: Test with pytest
         run: |
-          poetry run pytest tests -v --cov=./src/textual --cov-report=xml:./coverage.xml --cov-report term-missing
+          source $VENV
+          pytest tests -v --cov=./src/textual --cov-report=xml:./coverage.xml --cov-report term-missing
       - name: Upload snapshot report
         if: always()
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added experimental Canvas class https://github.com/Textualize/textual/pull/3669/
 - Added `keyline` rule https://github.com/Textualize/textual/pull/3669/
+- Widgets can now have an ALLOW_CHILDREN (bool) classvar to disallow adding children to a widget
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added experimental Canvas class https://github.com/Textualize/textual/pull/3669/
 - Added `keyline` rule https://github.com/Textualize/textual/pull/3669/
-- Widgets can now have an ALLOW_CHILDREN (bool) classvar to disallow adding children to a widget
+- Widgets can now have an ALLOW_CHILDREN (bool) classvar to disallow adding children to a widget https://github.com/Textualize/textual/pull/3758
 
 ### Changed
 

--- a/src/textual/_box_drawing.py
+++ b/src/textual/_box_drawing.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 
 from typing_extensions import TypeAlias
 
-Quad: TypeAlias = tuple[int, int, int, int]
+Quad: TypeAlias = "tuple[int, int, int, int]"
 """Four values indicating the composition of the box character."""
 
 # Yes, I typed this out by hand. - WM

--- a/src/textual/_box_drawing.py
+++ b/src/textual/_box_drawing.py
@@ -12,6 +12,8 @@ There are also fewer characters for the "double" line type.
 
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
 
 from typing_extensions import TypeAlias

--- a/src/textual/_compose.py
+++ b/src/textual/_compose.py
@@ -25,7 +25,6 @@ def compose(node: App | Widget) -> list[Widget]:
     app._composed.append(composed)
     iter_compose = iter(node.compose())
     try:
-        # for child in node.compose():
         while True:
             try:
                 child = next(iter_compose)

--- a/src/textual/_compose.py
+++ b/src/textual/_compose.py
@@ -16,19 +16,34 @@ def compose(node: App | Widget) -> list[Widget]:
     Returns:
         A list of widgets.
     """
+    _rich_traceback_omit = True
     app = node.app
     nodes: list[Widget] = []
     compose_stack: list[Widget] = []
     composed: list[Widget] = []
     app._compose_stacks.append(compose_stack)
     app._composed.append(composed)
+    iter_compose = iter(node.compose())
     try:
-        for child in node.compose():
+        # for child in node.compose():
+        while True:
+            try:
+                child = next(iter_compose)
+            except StopIteration:
+                break
             if composed:
                 nodes.extend(composed)
                 composed.clear()
             if compose_stack:
-                compose_stack[-1].compose_add_child(child)
+                try:
+                    compose_stack[-1].compose_add_child(child)
+                except Exception as error:
+                    if hasattr(iter_compose, "throw"):
+                        # So the error is raised inside the generator
+                        # This will generate a more sensible traceback for the dev
+                        iter_compose.throw(error)  # type: ignore
+                    else:
+                        raise
             else:
                 nodes.append(child)
         if composed:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2305,6 +2305,7 @@ class App(Generic[ReturnType], DOMNode):
             )
 
     async def _on_compose(self) -> None:
+        _rich_traceback_omit = True
         try:
             widgets = [*self.screen._nodes, *compose(self)]
         except TypeError as error:

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -18,6 +18,8 @@ class ScrollView(ScrollableContainer):
     on the compositor to render children).
     """
 
+    ALLOW_CHILDREN = False
+
     DEFAULT_CSS = """
     ScrollView {
         overflow-y: auto;

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -87,6 +87,10 @@ _JUSTIFY_MAP: dict[str, JustifyMethod] = {
 }
 
 
+class NotAContainer(Exception):
+    """Exception raised if you attempt to add a child to a widget which doesn't permit child nodes."""
+
+
 _NULL_STYLE = Style()
 
 
@@ -263,6 +267,9 @@ class Widget(DOMNode):
 
     BORDER_SUBTITLE: ClassVar[str] = ""
     """Initial value for border_subtitle attribute."""
+
+    ALLOW_CHILDREN: ClassVar[bool] = True
+    """Set to `False` to prevent adding children to this widget."""
 
     can_focus: bool = False
     """Widget may receive focus."""
@@ -487,6 +494,21 @@ class Widget(DOMNode):
             self.screen._update_tooltip(self)
         except NoScreen:
             pass
+
+    def compose_add_child(self, widget: Widget) -> None:
+        """Add a node to children.
+
+        This is used by the compose process when it adds children.
+        There is no need to use it directly, but you may want to override it in a subclass
+        if you want children to be attached to a different node.
+
+        Args:
+            widget: A Widget to add.
+        """
+        _rich_traceback_omit = True
+        if not self.ALLOW_CHILDREN:
+            raise NotAContainer(f"Can't add children to {type(widget)} widgets")
+        self._nodes._append(widget)
 
     def __enter__(self) -> Self:
         """Use as context manager when composing."""

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -153,6 +153,8 @@ class Button(Widget, can_focus=True):
 
     BINDINGS = [Binding("enter", "press", "Press Button", show=False)]
 
+    ALLOW_CHILDREN = False
+
     label: reactive[TextType] = reactive[TextType]("")
     """The text label that appears within the button."""
 

--- a/src/textual/widgets/_static.py
+++ b/src/textual/widgets/_static.py
@@ -44,6 +44,8 @@ class Static(Widget, inherit_bindings=False):
     }
     """
 
+    ALLOW_CHILDREN = False
+
     _renderable: RenderableType
 
     def __init__(

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -51,6 +51,8 @@ class ToggleButton(Static, can_focus=True):
     | `toggle--label` | Targets the text label of the toggle button. |
     """
 
+    ALLOW_CHILDREN = False
+
     DEFAULT_CSS = """
     ToggleButton {
         width: auto;

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -397,6 +397,8 @@ async def test_is_mounted_property():
 
 
 async def test_not_allow_children():
+    """Regression test for https://github.com/Textualize/textual/pull/3758"""
+
     class TestAppExpectFail(App):
         def compose(self) -> ComposeResult:
             # Statics don't have children, so this should error

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -9,8 +9,8 @@ from textual.css.errors import StyleValueError
 from textual.css.query import NoMatches
 from textual.geometry import Offset, Size
 from textual.message import Message
-from textual.widget import MountError, PseudoClasses, Widget
-from textual.widgets import Label, LoadingIndicator
+from textual.widget import MountError, NotAContainer, PseudoClasses, Widget
+from textual.widgets import Label, LoadingIndicator, Static
 
 
 @pytest.mark.parametrize(
@@ -394,3 +394,17 @@ async def test_is_mounted_property():
         assert widget.is_mounted is False
         await pilot.app.mount(widget)
         assert widget.is_mounted is True
+
+
+async def test_not_allow_children():
+    class TestAppExpectFail(App):
+        def compose(self) -> ComposeResult:
+            # Statics don't have children, so this should error
+            with Static():
+                yield Label("foo")
+
+    app = TestAppExpectFail()
+
+    with pytest.raises(NotAContainer):
+        async with app.run_test():
+            pass


### PR DESCRIPTION
Adds a `ALLOW_CHILDREN` flag to widgets.

If set to False, and the dev attempts to add a child, it will raise a `NotAContainer` exception. This should prevent a potential gotcha.

<img width="1049" alt="Screenshot 2023-11-27 at 15 57 59" src="https://github.com/Textualize/textual/assets/554369/32d703ed-4c52-4434-ba94-dc4a8cc7c766">

Fixes https://github.com/Textualize/textual/issues/2975