### PR TITLE
Typing fix.

### DIFF
--- a/src/textual/_box_drawing.py
+++ b/src/textual/_box_drawing.py
@@ -12,11 +12,13 @@ There are also fewer characters for the "double" line type.
 
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
 
 from typing_extensions import TypeAlias
 
-Quad: TypeAlias = tuple[int, int, int, int]
+Quad: TypeAlias = "tuple[int, int, int, int]"
 """Four values indicating the composition of the box character."""
 
 # Yes, I typed this out by hand. - WM


### PR DESCRIPTION
Fixes the syntax that doesn't work on Python 3.7.
HOW THE HELL DID ci NOT CATCH THIS?! 😢 