### PR TITLE
Allow setting a toggle button's label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added experimental Canvas class https://github.com/Textualize/textual/pull/3669/
 - Added `keyline` rule https://github.com/Textualize/textual/pull/3669/
 - Widgets can now have an ALLOW_CHILDREN (bool) classvar to disallow adding children to a widget https://github.com/Textualize/textual/pull/3758
+- Added the ability to set the `label` property of a `Checkbox`
+- Added the ability to set the `label` property of a `RadioButton`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added experimental Canvas class https://github.com/Textualize/textual/pull/3669/
 - Added `keyline` rule https://github.com/Textualize/textual/pull/3669/
 - Widgets can now have an ALLOW_CHILDREN (bool) classvar to disallow adding children to a widget https://github.com/Textualize/textual/pull/3758
-- Added the ability to set the `label` property of a `Checkbox`
-- Added the ability to set the `label` property of a `RadioButton`
+- Added the ability to set the `label` property of a `Checkbox` https://github.com/Textualize/textual/pull/3765
+- Added the ability to set the `label` property of a `RadioButton` https://github.com/Textualize/textual/pull/3765
 
 ### Changed
 

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -161,6 +161,11 @@ class ToggleButton(Static, can_focus=True):
         """The label associated with the button."""
         return self._label
 
+    @label.setter
+    def label(self, label: TextType) -> None:
+        self._label = Text.from_markup(label) if isinstance(label, str) else label
+        self.refresh(layout=True)
+
     @property
     def _button(self) -> Text:
         """The button, reflecting the current value."""

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -149,12 +149,24 @@ class ToggleButton(Static, can_focus=True):
         # NOTE: Don't send a Changed message in response to the initial set.
         with self.prevent(self.Changed):
             self.value = value
-        self._label = Text.from_markup(label) if isinstance(label, str) else label
+        self._label = self._make_label(label)
+
+    def _make_label(self, label: TextType) -> Text:
+        """Make a `Text` label from a `TextType` value.
+
+        Args:
+            label: The source value for the label.
+
+        Returns:
+            A `Text` rendering of the label for use in the button.
+        """
+        label = Text.from_markup(label) if isinstance(label, str) else label
         try:
             # Only use the first line if it's a multi-line label.
-            self._label = self._label.split()[0]
+            label = label.split()[0]
         except IndexError:
             pass
+        return label
 
     @property
     def label(self) -> Text:
@@ -163,7 +175,7 @@ class ToggleButton(Static, can_focus=True):
 
     @label.setter
     def label(self, label: TextType) -> None:
-        self._label = Text.from_markup(label) if isinstance(label, str) else label
+        self._label = self._make_label(label)
         self.refresh(layout=True)
 
     @property

--- a/tests/toggles/test_labels.py
+++ b/tests/toggles/test_labels.py
@@ -1,0 +1,36 @@
+"""Test that setting a toggle button's label has the desired effect."""
+
+from rich.text import Text
+
+from textual.app import App, ComposeResult
+from textual.widgets import Checkbox, RadioButton, RadioSet
+
+
+class LabelChangeApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Checkbox("Before")
+        yield RadioButton("Before")
+        yield RadioSet("Before")
+
+
+async def test_change_labels() -> None:
+    """It should be possible to change the labels of toggle buttons."""
+    async with LabelChangeApp().run_test() as pilot:
+        assert pilot.app.query_one(Checkbox).label == Text("Before")
+        assert pilot.app.query_one("Screen > RadioButton", RadioButton).label == Text(
+            "Before"
+        )
+        assert pilot.app.query_one("RadioSet > RadioButton", RadioButton).label == Text(
+            "Before"
+        )
+        pilot.app.query_one(Checkbox).label = "After"
+        pilot.app.query_one("Screen > RadioButton", RadioButton).label = "After"
+        pilot.app.query_one("RadioSet > RadioButton", RadioButton).label = "After"
+        await pilot.pause()
+        assert pilot.app.query_one(Checkbox).label == Text("After")
+        assert pilot.app.query_one("Screen > RadioButton", RadioButton).label == Text(
+            "After"
+        )
+        assert pilot.app.query_one("RadioSet > RadioButton", RadioButton).label == Text(
+            "After"
+        )


### PR DESCRIPTION
Until now `CheckBox` and `RadioButton` labels have been fixed after the widgets have been created. Prompted by #3764 and seeing no reasonable reason to not allow updating the labels later on, this adds that ability.
