### PR TITLE
fix threading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.42.2] - 2023-11-29
+
+### Fixed
+
+- Fixed NoWidget error https://github.com/Textualize/textual/pull/3779
+
 ## [0.43.1] - 2023-11-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1471,6 +1471,7 @@ https://textual.textualize.io/blog/2022/11/08/version-040/#version-040
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
 
+[0.43.2]: https://github.com/Textualize/textual/compare/v0.43.1...v0.43.2
 [0.43.1]: https://github.com/Textualize/textual/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/Textualize/textual/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Textualize/textual/compare/v0.41.0...v0.42.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "0.43.1"
+version = "0.43.2"
 homepage = "https://github.com/Textualize/textual"
 repository = "https://github.com/Textualize/textual"
 documentation = "https://textual.textualize.io/"

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2692,8 +2692,8 @@ class App(Generic[ReturnType], DOMNode):
                         self._mouse_down_widget, _ = self.get_widget_at(
                             event.x, event.y
                         )
-                        print("MOUSE DOWN", self._mouse_down_widget)
                     except NoWidget:
+                        # Shouldn't occur, since at the very least this will find the Screen
                         self._mouse_down_widget = None
 
                 self.screen._forward_event(event)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -446,6 +446,7 @@ class App(Generic[ReturnType], DOMNode):
         self.mouse_position = Offset(0, 0)
 
         self._mouse_down_widget: Widget | None = None
+        """The widget that was most recently mouse downed (used to create click events)."""
 
         self.cursor_position = Offset(0, 0)
         """The position of the terminal cursor in screen-space.

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -56,6 +56,8 @@ class Driver(ABC):
         Args:
             event: An event to send.
         """
+        # NOTE: This runs in a thread.
+        # Avoid calling methods on the app.
         event._set_sender(self._app)
         if isinstance(event, events.MouseDown):
             if event.button:
@@ -63,7 +65,6 @@ class Driver(ABC):
         elif isinstance(event, events.MouseUp):
             if event.button and event.button in self._down_buttons:
                 self._down_buttons.remove(event.button)
-
         elif isinstance(event, events.MouseMove):
             if (
                 self._down_buttons

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -323,12 +323,12 @@ class Pilot(Generic[ReturnType]):
             # Get the widget under the mouse before the event because the app might
             # react to the event and move things around. We override on each iteration
             # because we assume the final event in `events` is the actual event we care
-            # about and that all the preceeding events are just setup.
-            # E.g., the click event is preceeded by MouseDown/MouseUp to emulate how
+            # about and that all the preceding events are just setup.
+            # E.g., the click event is preceded by MouseDown/MouseUp to emulate how
             # the driver works and emits a click event.
             widget_at, _ = app.get_widget_at(*offset)
             event = mouse_event_cls(**message_arguments)
-            app.post_message(event)
+            app.screen._forward_event(event)
             await self.pause()
 
         return selector is None or widget_at is target_widget


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/3777

The driver was calling `get_widget_at` which is not thread-safe. If called while the compositor is building the map it could fail.

The solution was to move this logic from the driver to the app, which is ultimately a better place for it.