### PR TITLE
mount error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added support for Ctrl+Fn and Ctrl+Shift+Fn keys in urxvt https://github.com/Textualize/textual/pull/3737
+- Friendly error messages when trying to mount non-widgets https://github.com/Textualize/textual/pull/3780
 
 ## [0.43.2] - 2023-11-29
 

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -328,6 +328,7 @@ class Pilot(Generic[ReturnType]):
             # the driver works and emits a click event.
             widget_at, _ = app.get_widget_at(*offset)
             event = mouse_event_cls(**message_arguments)
+            # Bypass event processing in App.on_event
             app.screen._forward_event(event)
             await self.pause()
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -807,9 +807,10 @@ class Widget(DOMNode):
             Only one of ``before`` or ``after`` can be provided. If both are
             provided a ``MountError`` will be raised.
         """
-
         # Check for duplicate IDs in the incoming widgets
+
         ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
+
         unique_ids = set(ids_to_mount)
         num_unique_ids = len(unique_ids)
         num_widgets_with_ids = len(ids_to_mount)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -808,9 +808,7 @@ class Widget(DOMNode):
             provided a ``MountError`` will be raised.
         """
         # Check for duplicate IDs in the incoming widgets
-
         ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
-
         unique_ids = set(ids_to_mount)
         num_unique_ids = len(unique_ids)
         num_widgets_with_ids = len(ids_to_mount)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -410,3 +410,30 @@ async def test_not_allow_children():
     with pytest.raises(NotAContainer):
         async with app.run_test():
             pass
+
+
+async def test_mount_error_not_widget():
+    class NotWidgetApp(App):
+        def compose(self) -> ComposeResult:
+            yield {}
+
+    app = NotWidgetApp()
+    with pytest.raises(MountError):
+        async with app.run_test():
+            pass
+
+
+async def test_mount_error_bad_widget():
+    class DaftWidget(Widget):
+        def __init__(self):
+            # intentionally missing super()
+            pass
+
+    class NotWidgetApp(App):
+        def compose(self) -> ComposeResult:
+            yield DaftWidget()
+
+    app = NotWidgetApp()
+    with pytest.raises(MountError):
+        async with app.run_test():
+            pass


### PR DESCRIPTION
Catch attempts to mount invalid objects, and provide a helpful error.

Catches both yielding a non-widget, and forgetting to call `super()` in a widget constructor

<img width="1066" alt="Screenshot 2023-11-29 at 14 39 27" src="https://github.com/Textualize/textual/assets/554369/00ab2142-4b51-4466-9f01-6617b23551e2">

Supersedes https://github.com/Textualize/textual/pull/3438
