### PR TITLE
Restrictors

### DIFF
--- a/docs/api/restriction.md
+++ b/docs/api/restriction.md
@@ -1,0 +1,1 @@
+::: textual.restriction

--- a/docs/examples/widgets/input_restriction.py
+++ b/docs/examples/widgets/input_restriction.py
@@ -1,0 +1,38 @@
+from textual.app import App, ComposeResult
+from textual.restriction import Restrictor
+from textual.widgets import Input, Label, Pretty
+
+
+class InputApp(App):
+    # (6)!
+    CSS = """
+    Input {
+        margin: 1 1;
+    }
+    Label {
+        margin: 1 2;
+    }
+    Pretty {
+        margin: 1 2;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Label("Enter uppercase text")
+        yield Input(
+            placeholder="Enter uppercase text...",
+            restrictors=[UppercaseRestrictor()],
+        )
+        yield Pretty([])
+
+
+# A custom restrictor
+class UppercaseRestrictor(Restrictor):
+    def allowed(self, value: str) -> bool:
+        return value.isupper()
+
+
+app = InputApp()
+
+if __name__ == "__main__":
+    app.run()

--- a/src/textual/restriction.py
+++ b/src/textual/restriction.py
@@ -1,0 +1,36 @@
+"""Framework for validating string values"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+class Restrictor(ABC):
+    """Base class for the restriction of values.
+
+    Commonly used in conjunction with the `Input` widget, which accepts a list
+    of restrictors via its constructor. The key difference between a Restrictor
+    and a Validator is, in the case of the `Input` widget, the new value will
+    not appear in the `Input` similar to the behavior of `max_length`.
+
+    To implement your own `Restrictor`, subclass this class.
+
+    Example:
+        ```python
+        class Palindrome(Restrictor):
+            def allowed(self, value: str) -> bool:
+                def is_palindrome(value: str) -> bool:
+                    return value == value[::-1]
+                return True if is_palindrome(value) else False
+        ```
+    """
+
+    @abstractmethod
+    def allowed(self, value: str) -> bool:
+        """Tests if the value is allowed or not.
+
+        Args:
+            value: The value to test.
+
+        Returns:
+            The result of the test.
+        """

--- a/src/textual/restriction.py
+++ b/src/textual/restriction.py
@@ -17,11 +17,9 @@ class Restrictor(ABC):
 
     Example:
         ```python
-        class Palindrome(Restrictor):
+        class UppercaseRestrictor(Restrictor):
             def allowed(self, value: str) -> bool:
-                def is_palindrome(value: str) -> bool:
-                    return value == value[::-1]
-                return True if is_palindrome(value) else False
+                return value.isupper()
         ```
     """
 

--- a/src/textual/restriction.py
+++ b/src/textual/restriction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+
 class Restrictor(ABC):
     """Base class for the restriction of values.
 

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -146,7 +146,7 @@ class Input(Widget, can_focus=True):
         padding: 0 2;
         border: tall $background;
         width: 100%;
-        height: 3;               
+        height: 3;
     }
     Input:focus {
         border: tall $accent;

--- a/tests/input/test_input_restrict.py
+++ b/tests/input/test_input_restrict.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from textual.app import App, ComposeResult
+from textual.restriction import Restrictor
 from textual.widgets import Input
 from textual.widgets._input import _RESTRICT_TYPES
 
@@ -143,3 +144,24 @@ async def test_restrict_type():
         text_input.focus()
         await pilot.press("!", "x", "9")
         assert text_input.value == "!x9"
+
+
+class UppercaseRestrictor(Restrictor):
+    def allowed(self, value: str) -> bool:
+        return value.isupper()
+
+
+async def test_restrictors():
+    class InputApp(App):
+        def compose(self) -> ComposeResult:
+            yield Input(type="text", id="text", restrictors=[UppercaseRestrictor()])
+
+    async with InputApp().run_test() as pilot:
+        text_input = pilot.app.query_one("#text", Input)
+
+        text_input.focus()
+        await pilot.press("A")
+        assert text_input.value == "A"
+
+        await pilot.press("a")
+        assert text_input.value == "A"

--- a/tests/test_restriction.py
+++ b/tests/test_restriction.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from textual.restriction import Restrictor
+
+
+class AllowedRestrictor(Restrictor):
+    def allowed(self, value: str) -> bool:
+        return True
+
+
+class DisallowedRestrictor(Restrictor):
+    def allowed(self, value: str) -> bool:
+        return False
+
+
+class UppercaseRestrictor(Restrictor):
+    def allowed(self, value: str) -> bool:
+        return value.isupper()
+
+
+def test_allowed_restrictor():
+    restrictor = AllowedRestrictor()
+    assert restrictor.allowed("string") == True
+
+
+def test_disallowed_restrictor():
+    restrictor = DisallowedRestrictor()
+    assert restrictor.allowed("string") == False
+
+
+def test_uppercase_restrictor():
+    restrictor = UppercaseRestrictor()
+    assert restrictor.allowed("STRINg") == False
+    assert restrictor.allowed("STRING") == True


### PR DESCRIPTION
I have a use case where I'd like essentially the same functionality as validators but in a restriction sense. The main difference I'm after is that rather than setting an invalid flag and thus giving the user visual and textual feedback, I'd like the text to just not show up. I've been using Textual for about 6 hours so if I'm way off base here in my solution I won't take offense. As I was writing the tests I came across the Function validator and thought that the existing restrict capabilities like type, max_length, and the restrict regex could probably be Restrictors and the Restrictor I wrote could be the Function restrictor, mirroring the validation pattern. I haven't implemented that latter part here but rather just a Restrictor class that essentially acts as a hybrid of the Function validator and restrict regex.

**Please review the following checklist.**

- [X] Docstrings on all new or modified functions / classes 
- [X] Updated documentation
- [X] Existing tests pass
- [X] New tests pass
- [ ] Updated CHANGELOG.md (where appropriate)