### PR TITLE
Force the call to scroll to the region of a node's label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - `link-hover-background` renamed to `link-background-hover`
  - `link-hover-color` renamed to `link-color-hover`
  - `link-hover-style` renamed to `link-style-hover`
+- `Tree` now forces a scroll when `scroll_to_node` is called https://github.com/Textualize/textual/pull/3786
 
 ### Added
 

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -904,7 +904,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         """
         region = self._get_label_region(line)
         if region is not None:
-            self.scroll_to_region(region, animate=animate)
+            self.scroll_to_region(region, animate=animate, force=True)
 
     def scroll_to_node(
         self, node: TreeNode[TreeDataType], animate: bool = True


### PR DESCRIPTION
Re: https://discord.com/channels/1026214085173461072/1033754296224841768/1179803173498658966

It is possible that the developer may be making a call to scroll to a node, while the scrollbar isn't quite in play yet; without a force to scroll the scroll won't happen.

To illustrate the issue, take this code:

```python
from textual import on
from textual.app import App, ComposeResult
from textual.widgets import Tree, Button

class ScrollToNode(App[None]):

    def compose(self) -> ComposeResult:
        yield Button("Expand and scroll to last")
        yield Tree("Root")

    def on_mount(self) -> None:
        tree = self.query_one(Tree)
        for n in range(10):
            outer = tree.root.add(str(n))
            for m in range(10):
                outer.add_leaf(str(m))

    @on(Button.Pressed)
    def show_problem(self) -> None:
        tree = self.query_one(Tree)
        tree.root.expand_all()
        self.call_after_refresh(
            tree.scroll_to_node, tree.root.children[-1].children[-1]
        )

if __name__ == "__main__":
    ScrollToNode().run()
```

When the button is pressed, the nodes are expanded but the scroll doesn't happen. With this PR the scroll does happen. It seems to be a reasonable expectation that the scroll *does* happen.