### PR TITLE
docs(button): update spacing note

### DIFF
--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -51,7 +51,7 @@ This widget has no component classes.
 
 ## Additional Notes
 
-- The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` has a `min-width` of 16 columns. To create a button with zero visible padding, you will need to change this value and also remove the border with `border: none;`.
+- The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` has a `min-width` of 16 columns. To create a button without this spacing, you will need to change this value and also remove the border with `border: none;`.
 
 ---
 

--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -51,7 +51,7 @@ This widget has no component classes.
 
 ## Additional Notes
 
-- The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` has the `height` set to 3 lines and a `min-width` of 16 columns. To create a button with zero visible padding, you will need to change these values and also remove the border with `border: none;`.
+- The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` has a `min-width` of 16 columns. To create a button with zero visible padding, you will need to change this value and also remove the border with `border: none;`.
 
 ---
 


### PR DESCRIPTION
Update the note in the `Button` docs about the spacing, as the default CSS for this widget was changed in #3539.

Closes #3793.

**Please review the following checklist.** 

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
