### PR TITLE
faster scrolling

### DIFF
--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -597,9 +597,6 @@ class Compositor:
                 # The region that contains the content (container region minus scrollbars)
                 child_region = widget._get_scrollable_region(container_region)
 
-                # Adjust the clip region accordingly
-                sub_clip = clip.intersection(child_region)
-
                 # The region covered by children relative to parent widget
                 total_region = child_region.reset_offset
 
@@ -611,7 +608,9 @@ class Compositor:
 
                     if visible_only:
                         placements = arrange_result.get_visible_placements(
-                            container_size.region + widget.scroll_offset
+                            child_region.intersection(clip)
+                            - child_region.offset
+                            + widget.scroll_offset
                         )
                     else:
                         placements = arrange_result.placements
@@ -621,12 +620,15 @@ class Compositor:
                     placement_offset = container_region.offset
                     placement_scroll_offset = placement_offset - widget.scroll_offset
 
-                    _layers = widget.layers
                     layers_to_index = {
-                        layer_name: index for index, layer_name in enumerate(_layers)
+                        layer_name: index
+                        for index, layer_name in enumerate(widget.layers)
                     }
 
                     get_layer_index = layers_to_index.get
+
+                    # Adjust the clip region accordingly
+                    sub_clip = clip.intersection(child_region)
 
                     # Add all the widgets
                     for sub_region, _, sub_widget, z, fixed, overlay in reversed(
@@ -661,7 +663,10 @@ class Compositor:
 
                 if visible:
                     # Add any scrollbars
-                    if any(widget.scrollbars_enabled):
+                    if (
+                        widget.show_vertical_scrollbar
+                        or widget.show_horizontal_scrollbar
+                    ):
                         for chrome_widget, chrome_region in widget._arrange_scrollbars(
                             container_region
                         ):


### PR DESCRIPTION
Looking to micro optimize the compositor produced a macro optimization.

There's some code (spatial_map) which does fast culling of widgets within the viewport. This was being called with the wrong region, so it didn't cull correctly. Now that is fixed, scrolling is a lot faster.

You can really see this on `textual colors`. The "Named Colors" tab was strangely slow, it is now butter smooth.