### PR TITLE
Handle subscripted generics in query selector

### DIFF
--- a/src/textual/css/query.py
+++ b/src/textual/css/query.py
@@ -218,7 +218,13 @@ class DOMQuery(Generic[QueryType]):
         if self.nodes:
             first = self.nodes[0]
             if expect_type is not None:
-                if not isinstance(first, expect_type):
+                try:
+                    type_match = isinstance(first, expect_type)
+                except TypeError:
+                    # to handle subscripted generics like DataTable[float]
+                    type_match = isinstance(first, expect_type.__origin__)
+
+                if not type_match:
                     raise WrongType(
                         f"Query value is wrong type; expected {expect_type}, got {type(first)}"
                     )


### PR DESCRIPTION
Fixes #2867

```
TypeError: Subscripted generics cannot be used with class and instance checks
```

Requires Python 3.9 for `__origin__`: https://peps.python.org/pep-0585/
but currently is a crash anyway, so this is no worse.



**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
