### PR TITLE
`Widget.loading` scroll-related glitch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `DataTable.update_cell` not raising an error with an invalid column key https://github.com/Textualize/textual/issues/3335
 - Fixed `Input` showing suggestions when not focused https://github.com/Textualize/textual/pull/3808
-- Fixed `Widget.loading` overlay being affected by scroll position and scrollbar gutter
+- Fixed `Widget.loading` overlay being affected by scroll position and scrollbar gutter https://github.com/Textualize/textual/pull/3813
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `DataTable.update_cell` not raising an error with an invalid column key https://github.com/Textualize/textual/issues/3335
 - Fixed `Input` showing suggestions when not focused https://github.com/Textualize/textual/pull/3808
+- Fixed `Widget.loading` overlay being affected by scroll position and scrollbar gutter
 
 ### Removed
 

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -33,14 +33,15 @@ class LoadingIndicator(Widget):
     """
 
     _widget_state: ClassVar[
-        WeakKeyDictionary[Widget, tuple[bool, str, str]]
+        WeakKeyDictionary[Widget, tuple[bool, str, str, str]]
     ] = WeakKeyDictionary()
     """Widget state that must be restore after loading.
 
     The tuples indicate the original values of the:
      - widget disabled state;
-     - widget style overflow_x rule; and
-     - widget style overflow_y rule.
+     - widget style overflow_x rule;
+     - widget style overflow_y rule; and
+     - widget style scrollbar_gutter rule.
     """
 
     def __init__(
@@ -80,7 +81,9 @@ class LoadingIndicator(Widget):
             widget.disabled,
             widget.styles.overflow_x,
             widget.styles.overflow_y,
+            widget.styles.scrollbar_gutter,
         )
+        widget.styles.scrollbar_gutter = "auto"
         widget.styles.overflow_x = "hidden"
         widget.styles.overflow_y = "hidden"
         widget.disabled = True
@@ -107,10 +110,13 @@ class LoadingIndicator(Widget):
             await_remove = null()
 
         if widget in cls._widget_state:
-            disabled, overflow_x, overflow_y = cls._widget_state[widget]
-            widget.disabled = disabled
+            disabled, overflow_x, overflow_y, scrollbar_gutter = cls._widget_state[
+                widget
+            ]
+            widget.styles.scrollbar_gutter = scrollbar_gutter
             widget.styles.overflow_x = overflow_x
             widget.styles.overflow_y = overflow_y
+            widget.disabled = disabled
 
         return await_remove
 

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -35,7 +35,7 @@ class LoadingIndicator(Widget):
     _widget_state: ClassVar[
         WeakKeyDictionary[Widget, tuple[bool, str, str, str]]
     ] = WeakKeyDictionary()
-    """Widget state that must be restore after loading.
+    """Widget state that must be restored after loading.
 
     The tuples indicate the original values of the:
      - widget disabled state;

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -26,6 +26,7 @@ class LoadingIndicator(Widget):
         color: $accent;
     }
     LoadingIndicator.-overlay {
+        dock: top;
         layer: _loading;
         background: $boost;
     }
@@ -35,7 +36,7 @@ class LoadingIndicator(Widget):
         WeakKeyDictionary[Widget, tuple[bool, str, str]]
     ] = WeakKeyDictionary()
     """Widget state that must be restore after loading.
-    
+
     The tuples indicate the original values of the:
      - widget disabled state;
      - widget style overflow_x rule; and


### PR DESCRIPTION
This PR addresses a couple of issues when using `Widget.loading` to show a loading indicator on a widget:

- If the scrollbar gutter was fixed, it would cause some of the background widget to show through.
- If the underlying widget was scrollable, and was scrolled down some way, the loading indicator would either be partially visible or not visible at all.

Fixes #3733.