### PR TITLE
Roll back ALLOW_CHILDREN and max height fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Removed renderables/align.py which was no longer used
 
+### Changed
+
+- Dropped ALLOW_CHILDREN flag introduced in 0.43.0
+
 ## [0.44.1] - 2023-12-4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Dropped ALLOW_CHILDREN flag introduced in 0.43.0
+- Dropped ALLOW_CHILDREN flag introduced in 0.43.0 https://github.com/Textualize/textual/pull/3814
+- Widgets with an auto height in an auto height container, and a max height, will now expand https://github.com/Textualize/textual/pull/3814
 
 ## [0.44.1] - 2023-12-4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Dropped ALLOW_CHILDREN flag introduced in 0.43.0 https://github.com/Textualize/textual/pull/3814
-- Widgets with an auto height in an auto height container, and a max height, will now expand https://github.com/Textualize/textual/pull/3814
+- Widgets with an auto height in an auto height container will now expand if they have no siblings https://github.com/Textualize/textual/pull/3814
 
 ## [0.44.1] - 2023-12-4
 

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -185,6 +185,7 @@ class Layout(ABC):
             # Use a height of zero to ignore relative heights
             styles_height = widget.styles.height
             if widget._parent and len(widget._nodes) == 1:
+                # If it is an only child with height auto we want it to expand
                 height = (
                     container.height
                     if styles_height is not None and styles_height.is_auto

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -183,7 +183,16 @@ class Layout(ABC):
             height = 0
         else:
             # Use a height of zero to ignore relative heights
-            arrangement = widget._arrange(Size(width, 0))
+            styles_height = widget.styles.height
+            if widget._parent and len(widget._nodes) == 1:
+                height = (
+                    container.height
+                    if styles_height is not None and styles_height.is_auto
+                    else 0
+                )
+            else:
+                height = 0
+            arrangement = widget._arrange(Size(width, height))
             height = arrangement.total_region.bottom
 
         return height

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -18,8 +18,6 @@ class ScrollView(ScrollableContainer):
     on the compositor to render children).
     """
 
-    ALLOW_CHILDREN = False
-
     DEFAULT_CSS = """
     ScrollView {
         overflow-y: auto;

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -267,9 +267,6 @@ class Widget(DOMNode):
     BORDER_SUBTITLE: ClassVar[str] = ""
     """Initial value for border_subtitle attribute."""
 
-    ALLOW_CHILDREN: ClassVar[bool] = True
-    """Set to `False` to prevent adding children to this widget."""
-
     can_focus: bool = False
     """Widget may receive focus."""
     can_focus_children: bool = True
@@ -505,8 +502,6 @@ class Widget(DOMNode):
             widget: A Widget to add.
         """
         _rich_traceback_omit = True
-        if not self.ALLOW_CHILDREN:
-            raise NotAContainer(f"Can't add children to {type(widget)} widgets")
         self._nodes._append(widget)
 
     def __enter__(self) -> Self:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -86,10 +86,6 @@ _JUSTIFY_MAP: dict[str, JustifyMethod] = {
 }
 
 
-class NotAContainer(Exception):
-    """Exception raised if you attempt to add a child to a widget which doesn't permit child nodes."""
-
-
 _NULL_STYLE = Style()
 
 

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -153,8 +153,6 @@ class Button(Widget, can_focus=True):
 
     BINDINGS = [Binding("enter", "press", "Press Button", show=False)]
 
-    ALLOW_CHILDREN = False
-
     label: reactive[TextType] = reactive[TextType]("")
     """The text label that appears within the button."""
 

--- a/src/textual/widgets/_static.py
+++ b/src/textual/widgets/_static.py
@@ -44,8 +44,6 @@ class Static(Widget, inherit_bindings=False):
     }
     """
 
-    ALLOW_CHILDREN = False
-
     _renderable: RenderableType
 
     def __init__(

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -51,8 +51,6 @@ class ToggleButton(Static, can_focus=True):
     | `toggle--label` | Targets the text label of the toggle button. |
     """
 
-    ALLOW_CHILDREN = False
-
     DEFAULT_CSS = """
     ToggleButton {
         width: auto;

--- a/tests/snapshot_tests/snapshot_apps/max_height_100.py
+++ b/tests/snapshot_tests/snapshot_apps/max_height_100.py
@@ -14,7 +14,7 @@ class HappyDataTableFunApp(App[None]):
     def populate(self, table: DataTable) -> DataTable:
         for n in range(20):
             table.add_column(f"Column {n}")
-        for row in range(1000):
+        for row in range(100):
             table.add_row(*[str(row * n) for n in range(20)])
         return table
 

--- a/tests/snapshot_tests/snapshot_apps/test_max_height_100.py
+++ b/tests/snapshot_tests/snapshot_apps/test_max_height_100.py
@@ -1,0 +1,27 @@
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Static
+
+
+class HappyDataTableFunApp(App[None]):
+    """The DataTable should expand as if it has height 1fr."""
+
+    CSS = """
+    DataTable {
+        max-height: 100%;        
+    }
+    """
+
+    def populate(self, table: DataTable) -> DataTable:
+        for n in range(20):
+            table.add_column(f"Column {n}")
+        for row in range(1000):
+            table.add_row(*[str(row * n) for n in range(20)])
+        return table
+
+    def compose(self) -> ComposeResult:
+        with Static(id="s"):
+            yield self.populate(DataTable())
+
+
+if __name__ == "__main__":
+    HappyDataTableFunApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -898,8 +898,10 @@ def test_unscoped_css(snap_compare) -> None:
 def test_big_buttons(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "big_button.py")
 
+
 def test_keyline(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "keyline.py")
+
 
 def test_button_outline(snap_compare):
     """Outline style rendered incorrectly when applied to a `Button` widget.
@@ -934,3 +936,7 @@ def test_vertical_max_height(snap_compare):
     """Test vertical max height takes border in to account."""
     assert snap_compare(SNAPSHOT_APPS_DIR / "vertical_max_height.py")
 
+
+def test_max_height_100(snap_compare):
+    """Test vertical max height takes border in to account."""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "test_max_height_100.py")

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -939,4 +939,4 @@ def test_vertical_max_height(snap_compare):
 
 def test_max_height_100(snap_compare):
     """Test vertical max height takes border in to account."""
-    assert snap_compare(SNAPSHOT_APPS_DIR / "test_max_height_100.py")
+    assert snap_compare(SNAPSHOT_APPS_DIR / "max_height_100.py")

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -9,8 +9,8 @@ from textual.css.errors import StyleValueError
 from textual.css.query import NoMatches
 from textual.geometry import Offset, Size
 from textual.message import Message
-from textual.widget import MountError, NotAContainer, PseudoClasses, Widget
-from textual.widgets import Label, LoadingIndicator, Static
+from textual.widget import MountError, PseudoClasses, Widget
+from textual.widgets import Label, LoadingIndicator
 
 
 @pytest.mark.parametrize(
@@ -394,22 +394,6 @@ async def test_is_mounted_property():
         assert widget.is_mounted is False
         await pilot.app.mount(widget)
         assert widget.is_mounted is True
-
-
-async def test_not_allow_children():
-    """Regression test for https://github.com/Textualize/textual/pull/3758"""
-
-    class TestAppExpectFail(App):
-        def compose(self) -> ComposeResult:
-            # Statics don't have children, so this should error
-            with Static():
-                yield Label("foo")
-
-    app = TestAppExpectFail()
-
-    with pytest.raises(NotAContainer):
-        async with app.run_test():
-            pass
 
 
 async def test_mount_error_not_widget():


### PR DESCRIPTION
Create a special case where you have a widget with auto height inside an auto height container, and no siblings. Previously it would collapse to a height of 0, making everything invisible. Now it will expand  as if it had a height of 1fr.

Also rolls back the ALLOW_CHILDREN change, which on reflection is an arbitrary restriction.

Fixes https://github.com/Textualize/textual/issues/2975
Fixes https://github.com/Textualize/textual/issues/3761