### PR TITLE
Namespace IDs for `ContentTab` in `TabbedContent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- The tabs within a `TabbedContent` now prefix their IDs to stop any clash with their associated `TabPane` https://github.com/Textualize/textual/pull/3815
+- Breaking change: `tab` is no longer a `@on` decorator selector for `TabbedContent.TabActivated` -- use `pane` instead https://github.com/Textualize/textual/pull/3815
+
+### Added
+
+- Added a `pane` attribute to `TabbedContent.TabActivated` https://github.com/Textualize/textual/pull/3815
+
 ### Fixed
 
 - Fixed `DataTable.update_cell` not raising an error with an invalid column key https://github.com/Textualize/textual/issues/3335

--- a/docs/examples/widgets/tabbed_content_label_color.py
+++ b/docs/examples/widgets/tabbed_content_label_color.py
@@ -1,0 +1,25 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Label, TabbedContent, TabPane
+
+
+class ColorTabsApp(App):
+    CSS = """
+    TabbedContent #--content-tab-green {
+        color: green;
+    }
+
+    TabbedContent #--content-tab-red {
+        color: red;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            with TabPane("Red", id="red"):
+                yield Label("Red!")
+            with TabPane("Green", id="green"):
+                yield Label("Green!")
+
+
+if __name__ == "__main__":
+    ColorTabsApp().run()

--- a/docs/widgets/tabbed_content.md
+++ b/docs/widgets/tabbed_content.md
@@ -94,6 +94,30 @@ The following example contains a `TabbedContent` with three tabs.
     --8<-- "docs/examples/widgets/tabbed_content.py"
     ```
 
+## Styling
+
+The `TabbedContent` widget is composed of two main sub-widgets: a
+[`Tabs`](tabs.md) and a [`ContentSwitcher`]((content_switcher.md)); you can
+style them accordingly.
+
+The tabs within the `Tabs` widget will have prefixed IDs; each ID being the
+ID of the `TabPane` the `Tab` is for, prefixed with `--content-tab-`. If you
+wish to style individual tabs within the `TabbedContent` widget you will
+need to use that prefix for the `Tab` IDs.
+
+For example, to create a `TabbedContent` that has red and green labels:
+
+=== "Output"
+
+    ```{.textual path="docs/examples/widgets/tabbed_content_label_color.py"}
+    ```
+
+=== "tabbed_content.py"
+
+    ```python
+    --8<-- "docs/examples/widgets/tabbed_content_label_color.py"
+    ```
+
 ## Reactive Attributes
 
 | Name     | Type  | Default | Description                                                    |

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from asyncio import gather
 from dataclasses import dataclass
 from itertools import zip_longest
+from typing import cast
 
 from rich.repr import Result
 from rich.text import Text, TextType
@@ -242,7 +243,7 @@ class TabbedContent(Widget):
     class TabActivated(Message):
         """Posted when the active tab changes."""
 
-        ALLOW_SELECTOR_MATCH = {"tab"}
+        ALLOW_SELECTOR_MATCH = {"pane"}
         """Additional message attributes that can be used with the [`on` decorator][textual.on]."""
 
         def __init__(self, tabbed_content: TabbedContent, tab: ContentTab) -> None:
@@ -256,6 +257,11 @@ class TabbedContent(Widget):
             """The `TabbedContent` widget that contains the tab activated."""
             self.tab = tab
             """The `Tab` widget that was selected (contains the tab label)."""
+            self.pane: TabPane = cast(
+                TabPane,
+                tabbed_content.get_child_by_type(ContentSwitcher).visible_content,
+            )
+            """The `TabPane` widget that was activated by selecting the tab."""
             super().__init__()
 
         @property
@@ -270,6 +276,7 @@ class TabbedContent(Widget):
         def __rich_repr__(self) -> Result:
             yield self.tabbed_content
             yield self.tab
+            yield self.pane
 
     class Cleared(Message):
         """Posted when there are no more tab panes."""

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -51,7 +51,11 @@ class ContentTab(Tab):
         Returns:
             The ID with the prefix removed.
         """
-        return content_id[len(cls._PREFIX):] if content_id.startswith(cls._PREFIX) else content_id
+        return (
+            content_id[len(cls._PREFIX) :]
+            if content_id.startswith(cls._PREFIX)
+            else content_id
+        )
 
     def __init__(self, label: Text, content_id: str, disabled: bool = False) -> None:
         """Initialize a ContentTab.
@@ -80,7 +84,9 @@ class ContentTabs(Tabs):
             active: ID of the tab which should be active on start.
             tabbed_content: The associated TabbedContent instance.
         """
-        super().__init__(*tabs, active=active if active is None else ContentTab.add_prefix(active))
+        super().__init__(
+            *tabs, active=active if active is None else ContentTab.add_prefix(active)
+        )
         self.tabbed_content = tabbed_content
 
     def get_content_tab(self, tab_id: str) -> ContentTab:
@@ -149,6 +155,7 @@ class ContentTabs(Tabs):
             TabError: If there are any issues with the request.
         """
         return super().show(ContentTab.add_prefix(tab_id))
+
 
 class TabPane(Widget):
     """A container for switchable content, with additional title.
@@ -413,7 +420,7 @@ class TabbedContent(Widget):
             tabs.add_tab(
                 ContentTab(pane._title, pane.id),
                 before=before if before is None else ContentTab.add_prefix(before),
-                after=after if after is None else ContentTab.add_prefix(after)
+                after=after if after is None else ContentTab.add_prefix(after),
             ),
             self.get_child_by_type(ContentSwitcher).mount(pane),
         )
@@ -428,7 +435,11 @@ class TabbedContent(Widget):
             An optionally awaitable object that waits for the pane to be removed
                 and the Cleared message to be posted.
         """
-        removal_awaitables = [self.get_child_by_type(ContentTabs).remove_tab(ContentTab.add_prefix(pane_id))]
+        removal_awaitables = [
+            self.get_child_by_type(ContentTabs).remove_tab(
+                ContentTab.add_prefix(pane_id)
+            )
+        ]
         try:
             removal_awaitables.append(
                 self.get_child_by_type(ContentSwitcher)
@@ -544,7 +555,9 @@ class TabbedContent(Widget):
         """
         if target_id := pane_id if isinstance(pane_id, str) else pane_id.id:
             return self.get_child_by_type(ContentTabs).get_content_tab(target_id)
-        raise ValueError("'pane_id' must be a non-empty string or a TabPane with an id.")
+        raise ValueError(
+            "'pane_id' must be a non-empty string or a TabPane with an id."
+        )
 
     def _on_tabs_tab_disabled(self, event: Tabs.TabDisabled) -> None:
         """Disable the corresponding tab pane."""

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -245,7 +245,7 @@ class TabbedContent(Widget):
         ALLOW_SELECTOR_MATCH = {"tab"}
         """Additional message attributes that can be used with the [`on` decorator][textual.on]."""
 
-        def __init__(self, tabbed_content: TabbedContent, tab: Tab) -> None:
+        def __init__(self, tabbed_content: TabbedContent, tab: ContentTab) -> None:
             """Initialize message.
 
             Args:

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -499,9 +499,7 @@ class TabbedContent(Widget):
             event.stop()
             switcher = self.get_child_by_type(ContentSwitcher)
             switcher.current = ContentTab.sans_prefix(event.tab.id)
-            self.notify(event.tab.id)
             self.active = ContentTab.sans_prefix(event.tab.id)
-            self.notify(self.active)
             self.post_message(
                 TabbedContent.TabActivated(
                     tabbed_content=self,
@@ -535,7 +533,6 @@ class TabbedContent(Widget):
     def _watch_active(self, old_active: str, active: str) -> None:
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated):
-            self.notify(f"{old_active} -> {active}")
             self.get_child_by_type(ContentTabs).active = ContentTab.add_prefix(active)
             self.get_child_by_type(ContentSwitcher).current = active
 

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -267,7 +267,7 @@ class TabbedContent(Widget):
         tabs = [
             ContentTab(
                 content._title,
-                content.id or "",
+                f"--content-tab-{content.id}" or "",
                 disabled=content.disabled,
             )
             for content in pane_content
@@ -390,7 +390,7 @@ class TabbedContent(Widget):
             # The message is relevant, so consume it and update state accordingly.
             event.stop()
             switcher = self.get_child_by_type(ContentSwitcher)
-            switcher.current = event.tab.id
+            switcher.current = event.tab.id[len("--content-tab-") :]
             self.active = event.tab.id
             self.post_message(
                 TabbedContent.TabActivated(
@@ -426,7 +426,9 @@ class TabbedContent(Widget):
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated):
             self.get_child_by_type(ContentTabs).active = active
-            self.get_child_by_type(ContentSwitcher).current = active
+            self.get_child_by_type(ContentSwitcher).current = active[
+                len("--content-tab-") :
+            ]
 
     @property
     def tab_count(self) -> int:

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -6,6 +6,7 @@ from itertools import zip_longest
 
 from rich.repr import Result
 from rich.text import Text, TextType
+from typing_extensions import Final
 
 from ..app import ComposeResult
 from ..await_complete import AwaitComplete
@@ -26,7 +27,7 @@ __all__ = [
 class ContentTab(Tab):
     """A Tab with an associated content id."""
 
-    _PREFIX = "--content-tab-"
+    _PREFIX: Final[str] = "--content-tab-"
     """The prefix given to the tab IDs."""
 
     @classmethod

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -534,7 +534,7 @@ class TabbedContent(Widget):
         """
         return isinstance(tabs, ContentTabs) and tabs.tabbed_content is self
 
-    def _watch_active(self, old_active: str, active: str) -> None:
+    def _watch_active(self, active: str) -> None:
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated):
             self.get_child_by_type(ContentTabs).active = ContentTab.add_prefix(active)

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -563,7 +563,7 @@ class TabbedContent(Widget):
         try:
             with self.prevent(TabPane.Disabled):
                 self.get_child_by_type(ContentSwitcher).get_child_by_id(
-                    tab_id, expect_type=TabPane
+                    ContentTab.sans_prefix(tab_id), expect_type=TabPane
                 ).disabled = True
         except NoMatches:
             return
@@ -584,7 +584,7 @@ class TabbedContent(Widget):
         try:
             with self.prevent(TabPane.Enabled):
                 self.get_child_by_type(ContentSwitcher).get_child_by_id(
-                    tab_id, expect_type=TabPane
+                    ContentTab.sans_prefix(tab_id), expect_type=TabPane
                 ).disabled = False
         except NoMatches:
             return

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -557,7 +557,7 @@ class TabbedContent(Widget):
         Raises:
             ValueError: Raised if no ID was available.
         """
-        if target_id := pane_id if isinstance(pane_id, str) else pane_id.id:
+        if target_id := (pane_id if isinstance(pane_id, str) else pane_id.id):
             return self.get_child_by_type(ContentTabs).get_content_tab(target_id)
         raise ValueError(
             "'pane_id' must be a non-empty string or a TabPane with an id."

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -553,6 +553,9 @@ class TabbedContent(Widget):
 
         Returns:
             The Tab associated with the ID.
+
+        Raises:
+            ValueError: Raised if no ID was available.
         """
         if target_id := pane_id if isinstance(pane_id, str) else pane_id.id:
             return self.get_child_by_type(ContentTabs).get_content_tab(target_id)

--- a/tests/snapshot_tests/snapshot_apps/modified_tabs.py
+++ b/tests/snapshot_tests/snapshot_apps/modified_tabs.py
@@ -18,9 +18,9 @@ class FiddleWithTabsApp(App[None]):
             yield Button()
 
     def on_mount(self) -> None:
-        self.query_one(TabbedContent).disable_tab(f"tab-1")
-        self.query_one(TabbedContent).disable_tab(f"tab-2")
-        self.query_one(TabbedContent).hide_tab(f"tab-3")
+        self.query_one(TabbedContent).disable_tab("tab-1")
+        self.query_one(TabbedContent).disable_tab("tab-2")
+        self.query_one(TabbedContent).hide_tab("tab-3")
 
 
 if __name__ == "__main__":

--- a/tests/test_on.py
+++ b/tests/test_on.py
@@ -134,11 +134,11 @@ async def test_on_arbitrary_attributes() -> None:
         def on_mount(self) -> None:
             self.query_one(TabbedContent).add_class("tabs")
 
-        @on(TabbedContent.TabActivated, tab="#one")
+        @on(TabbedContent.TabActivated, pane="#one")
         def one(self) -> None:
             log.append("one")
 
-        @on(TabbedContent.TabActivated, ".tabs", tab="#two")
+        @on(TabbedContent.TabActivated, pane="#two")
         def two(self) -> None:
             log.append("two")
 
@@ -188,7 +188,6 @@ async def test_fire_on_inherited_message() -> None:
         def on_mount(self) -> None:
             self.query_one(MessageSender).post_parent()
             self.query_one(MessageSender).post_child()
-
 
     async with InheritTestApp().run_test():
         pass

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -210,7 +210,10 @@ async def test_tabbed_content_add_before_id():
         await tabbed_content.add_pane(TabPane("Added", id="new-1"), before="initial-1")
         assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "initial-1"
-        assert [ContentTab.sans_prefix(tab.id) for tab in tabbed_content.query(Tab).results(Tab)] == [
+        assert [
+            ContentTab.sans_prefix(tab.id)
+            for tab in tabbed_content.query(Tab).results(Tab)
+        ] == [
             "new-1",
             "initial-1",
         ]
@@ -232,7 +235,10 @@ async def test_tabbed_content_add_before_pane():
         )
         assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "initial-1"
-        assert [ContentTab.sans_prefix(tab.id) for tab in tabbed_content.query(Tab).results(Tab)] == [
+        assert [
+            ContentTab.sans_prefix(tab.id)
+            for tab in tabbed_content.query(Tab).results(Tab)
+        ] == [
             "new-1",
             "initial-1",
         ]
@@ -267,7 +273,10 @@ async def test_tabbed_content_add_after():
         await tabbed_content.add_pane(TabPane("Added", id="new-1"), after="initial-1")
         assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "initial-1"
-        assert [ContentTab.sans_prefix(tab.id) for tab in tabbed_content.query(Tab).results(Tab)] == [
+        assert [
+            ContentTab.sans_prefix(tab.id)
+            for tab in tabbed_content.query(Tab).results(Tab)
+        ] == [
             "initial-1",
             "new-1",
         ]
@@ -290,7 +299,10 @@ async def test_tabbed_content_add_after_pane():
         await pilot.pause()
         assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "initial-1"
-        assert [ContentTab.sans_prefix(tab.id) for tab in tabbed_content.query(Tab).results(Tab)] == [
+        assert [
+            ContentTab.sans_prefix(tab.id)
+            for tab in tabbed_content.query(Tab).results(Tab)
+        ] == [
             "initial-1",
             "new-1",
         ]

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -211,8 +211,7 @@ async def test_tabbed_content_add_before_id():
         assert tabbed_content.tab_count == 2
         assert tabbed_content.active == "initial-1"
         assert [
-            ContentTab.sans_prefix(tab.id)
-            for tab in tabbed_content.query(Tab).results(Tab)
+            ContentTab.sans_prefix(tab.id) for tab in tabbed_content.query(Tab)
         ] == [
             "new-1",
             "initial-1",


### PR DESCRIPTION
To satisfy #3695 this PR adds an "internal" prefix to the tabs that go to make up a `TabbedContent`, thus ensuring that an ID for a `TabPane` doesn't end up being a duplicate ID amongst the descendants of the `TabbedContent`[^1]. All `ContentTab` instances now have and ID of `--content-tab-` followed by the ID of the `TabPane` they pertain to.

In doing this the following changes have been included:

- `TabbedContent.TabActivated` has grown a `pane` property, which is a reference to the `TabPane` that has been activated.
- `TabbedContent.TabActivated` has been added to `TabbedContent.TabActivated.ALLOW_SELECTOR_MATCH`, allowing it to be used with the `@on` decorator.
- `TabbedContent.TabActivated.tab` has been removed from `TabbedContent.TabActivated.ALLOW_SELECTOR_MATCH`, an intentional breaking change to encourage anyone using it to switch to `pane` (the reason being that the ID of the `tab` will be the "internally-prefixed" one so will be less easy to reason about).
- `ContentTab` has grown a couple of methods for handling the addition and removal of the prefix to IDs.
- `ContentTabs` has grown wrappers around `disable`, `enable`, `show` and `hide` to handle the transition between IDs.
- `TabbedContent` has grown `get_tab` and `get_pane` methods, partially in service of this PR, but also as a handy utility for the developer using `TabbedContent`.
- Added some extra information to the docs for `TabbedContent` that informs the developer how they can go about styling the tabs themselves. *(Note: this is as-yet unchecked with local docs serving as both myself and @rodrigogiraoserrao are unable to get the docs to build right now)*

[^1]: The initial complaint being that a `query_one("#some-tab-pane")` failing was surprising.