### PR TITLE
simplify loading

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -776,7 +776,10 @@ class App(Generic[ReturnType], DOMNode):
         Returns:
             The currently focused widget, or `None` if nothing is focused.
         """
-        return self.screen.focused
+        focused = self.screen.focused
+        if focused is not None and focused.loading:
+            return None
+        return focused
 
     @property
     def namespace_bindings(self) -> dict[str, tuple[DOMNode, Binding]]:

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -354,7 +354,7 @@ class Screen(Generic[ScreenResultType], Widget):
             if node is None:
                 pop()
             else:
-                if node.disabled:
+                if node._check_disabled():
                     continue
                 node_styles_visibility = node.styles.get_rule("visibility")
                 node_is_visible = (

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -258,7 +258,7 @@ class Button(Widget, can_focus=True):
 
         Returns:
             The button instance."""
-        if self.disabled or not self.display:
+        if self._check_disabled() or not self.display:
             return self
         # Manage the "active" effect:
         self._start_active_affect()

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from time import time
-from typing import Awaitable, ClassVar
-from weakref import WeakKeyDictionary
+from typing import Awaitable
 
 from rich.console import RenderableType
 from rich.style import Style
@@ -23,23 +22,13 @@ class LoadingIndicator(Widget):
         height: 100%;
         min-height: 1;
         content-align: center middle;
-        color: $accent;
+        color: $accent;        
     }
     LoadingIndicator.-overlay {
         layer: _loading;
-        background: $boost;
+        background: $boost;     
+        dock: top;
     }
-    """
-
-    _widget_state: ClassVar[
-        WeakKeyDictionary[Widget, tuple[bool, str, str]]
-    ] = WeakKeyDictionary()
-    """Widget state that must be restore after loading.
-    
-    The tuples indicate the original values of the:
-     - widget disabled state;
-     - widget style overflow_x rule; and
-     - widget style overflow_y rule.
     """
 
     def __init__(
@@ -74,15 +63,8 @@ class LoadingIndicator(Widget):
             An awaitable for mounting the indicator.
         """
         self.add_class("-overlay")
+        widget.add_class("-loading")
         await_mount = widget.mount(self)
-        self._widget_state[widget] = (
-            widget.disabled,
-            widget.styles.overflow_x,
-            widget.styles.overflow_y,
-        )
-        widget.styles.overflow_x = "hidden"
-        widget.styles.overflow_y = "hidden"
-        widget.disabled = True
         return await_mount
 
     @classmethod
@@ -95,6 +77,7 @@ class LoadingIndicator(Widget):
         Returns:
             Optional awaitable.
         """
+        widget.remove_class("-loading")
         try:
             await_remove = widget.get_child_by_type(cls).remove()
         except NoMatches:
@@ -104,12 +87,6 @@ class LoadingIndicator(Widget):
                 return None
 
             await_remove = null()
-
-        if widget in cls._widget_state:
-            disabled, overflow_x, overflow_y = cls._widget_state[widget]
-            widget.disabled = disabled
-            widget.styles.overflow_x = overflow_x
-            widget.styles.overflow_y = overflow_y
 
         return await_remove
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -25,12 +25,9 @@ async def test_loading_disables_and_remove_scrollbars():
     async with app.run_test() as pilot:
         vs = app.query_one(VerticalScroll)
         # Sanity checks:
-        assert not vs.disabled
-        assert vs.styles.overflow_y != "hidden"
+        assert not vs._check_disabled()
 
         await pilot.press("l")
         await pilot.pause()
 
-        assert vs.disabled
-        assert vs.styles.overflow_x == "hidden"
-        assert vs.styles.overflow_y == "hidden"
+        assert vs._check_disabled()


### PR DESCRIPTION
Changes how `loading` is implemented.

Rather than save and restore state (which has the potential to be brittle), this adds a `loading` state.

Fixes https://github.com/Textualize/textual/issues/3733