### PR TITLE
skip if not mounted

### DIFF
--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -758,7 +758,6 @@ class Styles(StylesBase):
         Returns:
             A list containing a tuple of <RULE NAME>, <SPECIFICITY> <RULE VALUE>.
         """
-
         is_important = self.important.__contains__
         default_rules = 0 if is_default_rules else 1
         rules: list[tuple[str, Specificity6, Any]] = [

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -713,13 +713,15 @@ class Styles(StylesBase):
     def refresh(
         self, *, layout: bool = False, children: bool = False, parent: bool = False
     ) -> None:
-        if parent and self.node and self.node.parent:
-            self.node.parent.refresh()
-        if self.node is not None:
-            self.node.refresh(layout=layout)
-            if children:
-                for child in self.node.walk_children(with_self=False, reverse=True):
-                    child.refresh(layout=layout)
+        node = self.node
+        if node is None or not node._is_mounted:
+            return
+        if parent and node.parent:
+            node.parent.refresh()
+        node.refresh(layout=layout)
+        if children:
+            for child in node.walk_children(with_self=False, reverse=True):
+                child.refresh(layout=layout)
 
     def reset(self) -> None:
         """Reset the rules to initial state."""

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -716,8 +716,8 @@ class Styles(StylesBase):
         node = self.node
         if node is None or not node._is_mounted:
             return
-        if parent and node.parent:
-            node.parent.refresh()
+        if parent and node._parent is not None:
+            node._parent.refresh()
         node.refresh(layout=layout)
         if children:
             for child in node.walk_children(with_self=False, reverse=True):
@@ -758,12 +758,14 @@ class Styles(StylesBase):
         Returns:
             A list containing a tuple of <RULE NAME>, <SPECIFICITY> <RULE VALUE>.
         """
+
         is_important = self.important.__contains__
+        default_rules = 0 if is_default_rules else 1
         rules: list[tuple[str, Specificity6, Any]] = [
             (
                 rule_name,
                 (
-                    0 if is_default_rules else 1,
+                    default_rules,
                     1 if is_important(rule_name) else 0,
                     *specificity,
                     tie_breaker,

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -448,7 +448,7 @@ class Stylesheet:
             for name in rules_map.keys() & node._selector_names
             for rule in rules_map[name]
         }
-        rules = [rule for rule in reversed(self.rules) if rule in limit_rules]
+        rules = list(filter(limit_rules.__contains__, reversed(self.rules)))
 
         # Collect the rules defined in the stylesheet
         node._has_hover_style = any("hover" in rule.pseudo_classes for rule in rules)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3121,6 +3121,8 @@ class Widget(DOMNode):
         Returns:
             The `Widget` instance.
         """
+        if not self._is_mounted:
+            return self
         if layout:
             self._layout_required = True
             self._stabilize_scrollbar = None


### PR DESCRIPTION
Glad I have something to show for today.

This change avoids calling `node.refresh` if the widget is not yet mounted (ie. the very first time it is updated). Given the entire widget will be refreshed anyway, there is no need to do this work.

This shaved off 60ms from `textual colors` startup. Not massive, but still a win.