### PR TITLE
Fix link previews on Twitter

### DIFF
--- a/docs/custom_theme/main.html
+++ b/docs/custom_theme/main.html
@@ -7,7 +7,7 @@
 <!-- / Fathom -->
 
 
-<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@textualizeio">
 <meta name="twitter:creator" content="@willmcgugan">
 <meta property="og:title" content="Textual - {{ page.title }}">


### PR DESCRIPTION
Because Elon broke the large summary card https://twitter.com/willmcgugan/status/1734586762863710659 looks like this:

![IMG_6832](https://github.com/Textualize/textual/assets/9599/5c2f59c7-d1e9-4b39-b563-097bb8e5cab3)

Switching the card type to `summary` improves things a bit:

![IMG_6833](https://github.com/Textualize/textual/assets/9599/8750d926-f3c8-4997-88d6-6d8b7010fa5d)
