### PR TITLE
Add workarounds for foot terminal

### DIFF
--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -370,6 +370,10 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...] | str] = {
     "\x1bOx": "8",
     "\x1bOy": "9",
     "\x1bOM": (Keys.Enter,),
+    # Foot terminal specific
+    # https://codeberg.org/dnkl/foot/issues/628
+    "\x1b[27;2;13~": (Keys.Enter,),  # Shift+Enter
+    "\x1b[27;5;13~": (Keys.Enter,),  # Ctrl+Enter
 }
 
 # https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036


### PR DESCRIPTION
See https://codeberg.org/dnkl/foot/issues/628 for why foot terminal handles Shift+Enter and Control+Enter differently than other terminals.

Without these 2 fixes pressing Shift+Enter/Control+Enter in a TextArea causes the whole App to hang for ~10 seconds before inserting the raw escape sequence.

With these 2 fixes Shift+Enter/Control+Enter insert a carriage return.