### PR TITLE
docs: update minimum python version

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,7 +2,7 @@ All you need to get started building Textual apps.
 
 ## Requirements
 
-Textual requires Python 3.7 or later (if you have a choice, pick the most recent Python). Textual runs on Linux, macOS, Windows and probably any OS where Python also runs.
+Textual requires Python 3.8 or later (if you have a choice, pick the most recent Python). Textual runs on Linux, macOS, Windows and probably any OS where Python also runs.
 
 !!! info inline end "Your platform"
 

--- a/docs/widgets/text_area.md
+++ b/docs/widgets/text_area.md
@@ -57,9 +57,6 @@ text_area.language = "markdown"
 ```
 
 !!! note
-    Syntax highlighting is unavailable on Python 3.7.
-
-!!! note
     More built-in languages will be added in the future. For now, you can [add your own](#adding-support-for-custom-languages).
 
 

--- a/docs/widgets/text_area.md
+++ b/docs/widgets/text_area.md
@@ -388,10 +388,6 @@ from tree_sitter_languages import get_language
 java_language = get_language("java")
 ```
 
-!!! note
-
-    `py-tree-sitter-languages` may not be available on some architectures (e.g. Macbooks with Apple Silicon running Python 3.7).
-
 The exact version of the parser used when you call `get_language` can be checked via
 the [`repos.txt` file](https://github.com/grantjenks/py-tree-sitter-languages/blob/a6d4f7c903bf647be1bdcfa504df967d13e40427/repos.txt) in
 the version of `py-tree-sitter-languages` you're using. This file contains links to the GitHub


### PR DESCRIPTION
Closes #3864. These are the only mentions of Python 3.7 in the docs from a quick grep.

Perhaps also worth investigating where workarounds were added for 3.7:

- src/textual/renderables/text_opacity.py
- src/textual/document/_syntax_aware_document.py

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
