### PR TITLE
delay underline in tabs

### DIFF
--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -425,8 +425,8 @@ class TabbedContent(Widget):
     def _watch_active(self, active: str) -> None:
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated):
-            self.get_child_by_type(ContentTabs).active = active
             self.get_child_by_type(ContentSwitcher).current = active
+            self.get_child_by_type(ContentTabs).active = active
 
     @property
     def tab_count(self) -> int:

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -425,8 +425,8 @@ class TabbedContent(Widget):
     def _watch_active(self, active: str) -> None:
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated):
-            self.get_child_by_type(ContentSwitcher).current = active
             self.get_child_by_type(ContentTabs).active = active
+            self.get_child_by_type(ContentSwitcher).current = active
 
     @property
     def tab_count(self) -> int:

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -593,12 +593,10 @@ class Tabs(Widget, can_focus=True):
 
                 def animate_underline() -> None:
                     """Animate the underline."""
-                    underline.animate(
-                        "highlight_start", start, duration=0.3, delay=0.05
-                    )
-                    underline.animate("highlight_end", end, duration=0.3, delay=0.05)
+                    underline.animate("highlight_start", start, duration=0.3)
+                    underline.animate("highlight_end", end, duration=0.3)
 
-                self.call_after_refresh(animate_underline)
+                self.set_timer(0.01, lambda: self.call_after_refresh(animate_underline))
             else:
                 underline.highlight_start = start
                 underline.highlight_end = end

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -590,8 +590,15 @@ class Tabs(Widget, can_focus=True):
             tab_region = active_tab.virtual_region.shrink(active_tab.styles.gutter)
             start, end = tab_region.column_span
             if animate:
-                underline.animate("highlight_start", start, duration=0.3)
-                underline.animate("highlight_end", end, duration=0.3)
+
+                def animate_underline() -> None:
+                    """Animate the underline."""
+                    underline.animate(
+                        "highlight_start", start, duration=0.3, delay=0.05
+                    )
+                    underline.animate("highlight_end", end, duration=0.3, delay=0.05)
+
+                self.call_after_refresh(animate_underline)
             else:
                 underline.highlight_start = start
                 underline.highlight_end = end


### PR DESCRIPTION
This adds a small delay to the underlines in tabs, to masked the pause caused when tabbed_content mounts a tab pane with many widgets.

You can see this in `textual colors`. The underline would jump half way then animate smoothly. With this change the animation is smooth from the start.