### PR TITLE
Restore no-op default.

### DIFF
--- a/src/textual/widgets/_radio_set.py
+++ b/src/textual/widgets/_radio_set.py
@@ -299,7 +299,7 @@ class RadioSet(Container, can_focus=True, can_focus_children=False):
                 """
                 return direction * (index - selected) % len(self.children)
 
-            self._selected = min(candidate_indices, key=distance, default=None)
+            self._selected = min(candidate_indices, key=distance, default=selected)
 
     def action_toggle(self) -> None:
         """Toggle the state of the currently-selected button."""


### PR DESCRIPTION
When I accepted a review suggestion in #3872 I didn't notice that the default behaviour was actually being changed.

As it stands, if there's only one non-disabled radio button, using up/down to navigate will de-select it when nothing should happen.