### PR TITLE
Touch-up widget guide byte example.

### DIFF
--- a/docs/examples/guide/compound/byte02.py
+++ b/docs/examples/guide/compound/byte02.py
@@ -31,7 +31,7 @@ class BitSwitch(Widget):
             self.bit = bit
             self.value = value
 
-    value = reactive(0)  # (1)!
+    value = reactive(False)  # (1)!
 
     def __init__(self, bit: int) -> None:
         self.bit = bit
@@ -90,9 +90,12 @@ class ByteEditor(Widget):
 
     def on_bit_switch_bit_changed(self, event: BitSwitch.BitChanged) -> None:
         """When a switch changes, update the value."""
-        value = 0
-        for switch in self.query(BitSwitch):
-            value |= switch.value << switch.bit
+        current_value = int(self.query_one(Input).value or "0")
+        value_change = 1 << event.bit
+        if event.value:  # Bit changed from 0 to 1.
+            value = current_value + value_change
+        else:  # Bit changed from 1 to 0.
+            value = current_value - value_change
         self.query_one(Input).value = str(value)
 
 

--- a/docs/examples/guide/compound/byte03.py
+++ b/docs/examples/guide/compound/byte03.py
@@ -32,7 +32,7 @@ class BitSwitch(Widget):
             self.bit = bit
             self.value = value
 
-    value = reactive(0)
+    value = reactive(False)
 
     def __init__(self, bit: int) -> None:
         self.bit = bit
@@ -101,9 +101,12 @@ class ByteEditor(Widget):
 
     def on_bit_switch_bit_changed(self, event: BitSwitch.BitChanged) -> None:
         """When a switch changes, update the value."""
-        value = 0
-        for switch in self.query(BitSwitch):
-            value |= switch.value << switch.bit
+        current_value = int(self.query_one(Input).value or "0")
+        value_change = 1 << event.bit
+        if event.value:  # Bit changed from 0 to 1.
+            value = current_value + value_change
+        else:  # Bit changed from 1 to 0.
+            value = current_value - value_change
         self.query_one(Input).value = str(value)
 
     def on_input_changed(self, event: Input.Changed) -> None:  # (3)!

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -655,7 +655,7 @@ Let's extend the `ByteEditor` so that clicking any of the 8 `BitSwitch` widgets 
 
 === "byte02.py"
 
-    ```python title="byte02.py" hl_lines="5-6 26-32 34 44-48 91-96"
+    ```python title="byte02.py" hl_lines="5-6 26-32 34 44-48 91-99"
     --8<-- "docs/examples/guide/compound/byte02.py"
     ```
 
@@ -688,7 +688,7 @@ This is an example of "attributes down".
 
 === "byte03.py"
 
-    ```python title="byte03.py" hl_lines="5 45-47 90 92-94 109-114 116-120"
+    ```python title="byte03.py" hl_lines="5 45-47 90 92-94 112-117 119-123"
     --8<-- "docs/examples/guide/compound/byte03.py"
     ```
 


### PR DESCRIPTION
Fixes #3913.

Set `BitSwitch.value` to a Boolean because everywhere else in the code it's used as if it were a Boolean.

Change computation when value is changed to make use of the parameters of `BitChanged` event.
(Given the context of the guide, we want to show how to coordinate widgets; in a `XChanged` event it makes sense to add parameters to signal what was changed and it's very common to do that; this example does it but then doesn't use the parameters, so we'd need to remove them... or refactor the event handler to be less "wasteful" and actually use that information)