### PR TITLE
fix sizing of middle-aligned, auto-sized widgets in auto-sized containers

### DIFF
--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -183,17 +183,7 @@ class Layout(ABC):
             height = 0
         else:
             # Use a height of zero to ignore relative heights
-            styles_height = widget.styles.height
-            if widget._parent and len(widget._nodes) == 1:
-                # If it is an only child with height auto we want it to expand
-                height = (
-                    container.height
-                    if styles_height is not None and styles_height.is_auto
-                    else 0
-                )
-            else:
-                height = 0
-            arrangement = widget._arrange(Size(width, height))
+            arrangement = widget._arrange(Size(width, 0))
             height = arrangement.total_region.bottom
 
         return height

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -425,6 +425,15 @@ class Widget(DOMNode):
         return siblings
 
     @property
+    def _layer_siblings(self) -> list[Widget]:
+        """A list of siblings on the same layer as this widget.
+
+        Returns:
+            List of siblings.
+        """
+        return [widget for widget in self.siblings if widget.layer == self.layer]
+
+    @property
     def allow_vertical_scroll(self) -> bool:
         """Check if vertical scroll is permitted.
 
@@ -1107,6 +1116,17 @@ class Widget(DOMNode):
                 content_height < content_container.height
                 and self._has_relative_children_height
             ):
+                content_height = Fraction(content_container.height)
+            if (
+                content_height == 0
+                and self._parent
+                and len(self._layer_siblings) == 0
+                and len(self._nodes) == 1
+                and self._nodes[0].styles.height
+                and self._nodes[0].styles.height.is_auto
+            ):
+                # If this is an auto-sized widget with no siblings and a single auto-sized child
+                # that has no inherent size, expand to parent height
                 content_height = Fraction(content_container.height)
         else:
             styles_height = styles.height

--- a/tests/snapshot_tests/snapshot_apps/auto_align_middle.py
+++ b/tests/snapshot_tests/snapshot_apps/auto_align_middle.py
@@ -1,0 +1,35 @@
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Label
+
+
+class AutoAlignMiddleApp(App[None]):
+    CSS = """
+    .outer > * {
+        height: auto;
+        align: center middle;
+    }
+
+    .outer > * > * {
+        height: auto;
+    }
+
+    .even {
+        background: $primary;
+    }
+    
+    .odd {
+        background: $primary-lighten-3;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="outer"):
+            for i in range(5):
+                with Horizontal(classes="even" if i % 2 == 0 else "odd"):
+                    yield Label("This is line {}".format(i + 1))
+
+
+if __name__ == "__main__":
+    app = AutoAlignMiddleApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -943,6 +943,11 @@ def test_max_height_100(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "max_height_100.py")
 
 
+def test_auto_align_middle(snap_compare):
+    """Test sizing of auto-sized children in auto-sized containers with middle alignment."""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "auto_align_middle.py")
+
+
 def test_loading_indicator(snap_compare):
     """Test loading indicator."""
     # https://github.com/Textualize/textual/pull/3816


### PR DESCRIPTION
Changes how auto-sized children in auto-sized containers are expanded

* only expand if the child widget would have had a height of 0 otherwise
    * this avoids breaking the `DataTable` in a `Static` example from #3814, while still having the container fit to its contents in most cases which is the behaviour implied [by the documentation](https://textual.textualize.io/guide/styles/#auto-dimensions)
* use the actual container size as the height when expanding rather than `arrangement.total_region.bottom`
    * using `arrangement.total_region.bottom` breaks when using middle or bottom alignment - see examples below
* only expand if the container has no siblings on the same layer
    * otherwise any container with an auto-sized child will end up taking up the entire height of the parent container, overlapping any siblings
    * also experimented with having expanded containers be treated as `1fr`, but the way that fractional sizes are handled makes this a bit tricky without more extensive changes - `Widget._get_box_model` would have to return `None` on the first pass to work with the logic of `resolve_box_models`, and it's unclear how this would affect other code that calls the method

note: I'm not sure why you would want to use middle/bottom alignment for the child widget in an arrangement like this to begin with, but the way the sizing behaved when changing the alignment seemed so obviously unintended that I decided to have a stab myself since it seemed straightforward enough

Consider the following example (five `Label`s, each in its own `Horizontal`):

```py
class MyApp(App[None]):
    CSS = """
    .outer > * {
        height: auto;
        align: center middle;
    }

    .outer > * > * {
        height: auto;
    }

    .even {
        background: $primary;
    }
    
    .odd {
        background: $primary-lighten-3;
    }
    """

    def compose(self) -> ComposeResult:
        with Vertical(classes="outer"):
            for i in range(5):
                with Horizontal(classes="even" if i % 2 == 0 else "odd"):
                    yield Label("This is line {}".format(i + 1))


if __name__ == "__main__":
    app = MyApp()
    app.run()
```

This currently renders as:
![image](https://github.com/Textualize/textual/assets/885076/5198fe6a-3b74-4a7f-9454-42f1751b20cf)

If I use `align: center bottom` instead:
![image](https://github.com/Textualize/textual/assets/885076/d5d31201-f6ef-4f67-bf01-7745d4b0442c)

`align: center top` does render correctly, however:
![image](https://github.com/Textualize/textual/assets/885076/7aad923d-0319-4cca-8f77-eb8d799b0fbe)

The reason for this behaviour is that `arrangement.total_region.bottom` will return the bottom of the bottom-most widget, but this is not necessarily the same as what we should use for the bottom of the container. E.g. when the widget is a middle-aligned label with one row, the bottom ends up being about half the height of the parent container, while if the label is bottom-aligned it's the entire parent container height.

**With these fixes**, this now renders like this even with `alignment: center middle`:
![image](https://github.com/Textualize/textual/assets/885076/7d4f1a2d-9dcf-4190-b375-3a31d59be394)
(without breaking the `Static > DataTable` example)

**Please review the following checklist.**

- [X] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [X] Updated CHANGELOG.md (where appropriate)
