### PR TITLE
fix ListView not scrolling correctly when updating its index before its children have been refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Widget.move_child` would break if `before`/`after` is set to the index of the widget in `child` https://github.com/Textualize/textual/issues/1743
 - Fixed auto width text not processing markup https://github.com/Textualize/textual/issues/3918
+- Fixed `ListView` not scrolling correctly after adding new children and then immediately setting its index to one of the new children https://github.com/Textualize/textual/pull/3929
 
 ### Changed
 

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -172,7 +172,7 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
         else:
             new_child = None
 
-        self._scroll_highlighted_region()
+        self.call_after_refresh(self._scroll_highlighted_region)
         self.post_message(self.Highlighted(self, new_child))
 
     def extend(self, items: Iterable[ListItem]) -> AwaitMount:

--- a/tests/snapshot_tests/snapshot_apps/listview_index.py
+++ b/tests/snapshot_tests/snapshot_apps/listview_index.py
@@ -1,0 +1,33 @@
+from textual.app import App, ComposeResult
+from textual.reactive import reactive
+from textual.widgets import Label, ListItem, ListView
+
+
+class ListViewIndexApp(App):
+    CSS = """
+    ListView {
+        height: 10;
+    }
+    """
+
+    data = reactive(list(range(6)))
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._menu = ListView()
+
+    def compose(self) -> ComposeResult:
+        yield self._menu
+
+    async def watch_data(self, data: list[int]) -> None:
+        await self._menu.remove_children()
+        await self._menu.extend((ListItem(Label(str(value))) for value in data))
+        self._menu.index = len(self._menu) - 1
+
+    async def on_ready(self):
+        self.data = list(range(0, 30, 2))
+
+
+if __name__ == "__main__":
+    app = ListViewIndexApp()
+    app.run()

--- a/tests/snapshot_tests/snapshot_apps/listview_index.py
+++ b/tests/snapshot_tests/snapshot_apps/listview_index.py
@@ -19,7 +19,7 @@ class ListViewIndexApp(App):
     def compose(self) -> ComposeResult:
         yield self._menu
 
-    async def watch_data(self, data: list[int]) -> None:
+    async def watch_data(self, data: "list[int]") -> None:
         await self._menu.remove_children()
         await self._menu.extend((ListItem(Label(str(value))) for value in data))
         self._menu.index = len(self._menu) - 1

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -967,3 +967,8 @@ def test_zero_scrollbar_size(snap_compare):
     """Regression test for missing content with 0 sized scrollbars"""
     # https://github.com/Textualize/textual/issues/3886
     assert snap_compare(SNAPSHOT_APPS_DIR / "zero_scrollbar_size.py")
+
+
+def test_listview_index(snap_compare):
+    """Tests that ListView scrolls correctly after updating its index."""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "listview_index.py")


### PR DESCRIPTION
Currently `ListView` fails to scroll to a new index if you add new children and then immediately update its index to one of the new children, even if you `await` the `ListView.extend` method, because the sizing of the children isn't updated until the next refresh. This defers the scroll until after the next refresh.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [X] Updated CHANGELOG.md (where appropriate)
