### PR TITLE
add missing generic types to Worker apis

### DIFF
--- a/src/textual/_worker_manager.py
+++ b/src/textual/_worker_manager.py
@@ -37,7 +37,7 @@ class WorkerManager:
         """
         self._app = app
         """A reference to the app."""
-        self._workers: set[Worker] = set()
+        self._workers: set[Worker[Any]] = set()
         """The workers being managed."""
 
     def __rich_repr__(self) -> rich.repr.Result:
@@ -64,7 +64,7 @@ class WorkerManager:
         return worker in self._workers
 
     def add_worker(
-        self, worker: Worker, start: bool = True, exclusive: bool = True
+        self, worker: Worker[Any], start: bool = True, exclusive: bool = True
     ) -> None:
         """Add a new worker.
 
@@ -91,7 +91,7 @@ class WorkerManager:
         start: bool = True,
         exclusive: bool = False,
         thread: bool = False,
-    ) -> Worker:
+    ) -> Worker[Any]:
         """Create a worker from a function, coroutine, or awaitable.
 
         Args:
@@ -119,7 +119,7 @@ class WorkerManager:
         self.add_worker(worker, start=start, exclusive=exclusive)
         return worker
 
-    def _remove_worker(self, worker: Worker) -> None:
+    def _remove_worker(self, worker: Worker[Any]) -> None:
         """Remove a worker from the manager.
 
         Args:
@@ -137,7 +137,7 @@ class WorkerManager:
         for worker in self._workers:
             worker.cancel()
 
-    def cancel_group(self, node: DOMNode, group: str) -> list[Worker]:
+    def cancel_group(self, node: DOMNode, group: str) -> list[Worker[Any]]:
         """Cancel a single group.
 
         Args:
@@ -156,7 +156,7 @@ class WorkerManager:
             worker.cancel()
         return workers
 
-    def cancel_node(self, node: DOMNode) -> list[Worker]:
+    def cancel_node(self, node: DOMNode) -> list[Worker[Any]]:
         """Cancel all workers associated with a given node
 
         Args:
@@ -170,7 +170,9 @@ class WorkerManager:
             worker.cancel()
         return workers
 
-    async def wait_for_complete(self, workers: Iterable[Worker] | None = None) -> None:
+    async def wait_for_complete(
+        self, workers: Iterable[Worker[Any]] | None = None
+    ) -> None:
         """Wait for workers to complete.
 
         Args:

--- a/src/textual/_worker_manager.py
+++ b/src/textual/_worker_manager.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator
 
 import rich.repr
 
-from .worker import Worker, WorkerState, WorkType
+from .worker import ResultType, Worker, WorkerState, WorkType
 
 if TYPE_CHECKING:
     from .app import App
@@ -81,7 +81,7 @@ class WorkerManager:
 
     def _new_worker(
         self,
-        work: WorkType,
+        work: WorkType[ResultType],
         node: DOMNode,
         *,
         name: str | None = "",
@@ -91,7 +91,7 @@ class WorkerManager:
         start: bool = True,
         exclusive: bool = False,
         thread: bool = False,
-    ) -> Worker[Any]:
+    ) -> Worker[ResultType]:
         """Create a worker from a function, coroutine, or awaitable.
 
         Args:
@@ -107,7 +107,7 @@ class WorkerManager:
         Returns:
             A Worker instance.
         """
-        worker: Worker[Any] = Worker(
+        worker: Worker[ResultType] = Worker(
             node,
             work,
             name=name or getattr(work, "__name__", "") or "",

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import Queue
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, ClassVar, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable, Iterator
 
 from ..await_complete import AwaitComplete
 
@@ -375,7 +375,7 @@ class DirectoryTree(Tree[DirEntry]):
             )
         node.expand()
 
-    def _directory_content(self, location: Path, worker: Worker) -> Iterator[Path]:
+    def _directory_content(self, location: Path, worker: Worker[Any]) -> Iterator[Path]:
         """Load the content of a given directory.
 
         Args:

--- a/src/textual/worker.py
+++ b/src/textual/worker.py
@@ -138,7 +138,7 @@ class Worker(Generic[ResultType]):
     def __init__(
         self,
         node: DOMNode,
-        work: WorkType | None = None,
+        work: WorkType[ResultType] | None = None,
         *,
         name: str = "",
         group: str = "default",

--- a/src/textual/worker.py
+++ b/src/textual/worker.py
@@ -11,6 +11,7 @@ from contextvars import ContextVar
 from time import monotonic
 from typing import (
     TYPE_CHECKING,
+    Any,
     Awaitable,
     Callable,
     Coroutine,
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
     from .dom import DOMNode
 
 
-active_worker: ContextVar[Worker] = ContextVar("active_worker")
+active_worker: ContextVar[Worker[Any]] = ContextVar("active_worker")
 """Currently active worker context var."""
 
 
@@ -58,7 +59,7 @@ class WorkerCancelled(WorkerError):
     """The worker was cancelled and did not complete."""
 
 
-def get_current_worker() -> Worker:
+def get_current_worker() -> Worker[Any]:
     """Get the currently active worker.
 
     Raises:
@@ -119,7 +120,7 @@ class Worker(Generic[ResultType]):
     class StateChanged(Message, bubble=False, namespace="worker"):
         """The worker state changed."""
 
-        def __init__(self, worker: Worker, state: WorkerState) -> None:
+        def __init__(self, worker: Worker[Any], state: WorkerState) -> None:
             """Initialize the StateChanged message.
 
             Args:
@@ -378,7 +379,9 @@ class Worker(Generic[ResultType]):
             app.log.worker(self)
 
     def _start(
-        self, app: App, done_callback: Callable[[Worker], None] | None = None
+        self,
+        app: App,
+        done_callback: Callable[[Worker[ResultType]], None] | None = None,
     ) -> None:
         """Start the worker.
 


### PR DESCRIPTION
makes pyright stop yelling at me

before:
```
> poetry run pyright
error: Type of "get_current_worker" is partially unknown
    Type of "get_current_worker" is "() -> Worker[Unknown]" (reportUnknownMemberType)
error: Type of "worker" is partially unknown
    Type of "worker" is "Worker[Unknown]" (reportUnknownVariableType)
error: Type of "get_current_worker" is partially unknown
    Type of "get_current_worker" is "() -> Worker[Unknown]" (reportUnknownMemberType)
error: Type of "worker" is partially unknown
    Type of "worker" is "Worker[Unknown]" (reportUnknownVariableType)
error: Type of "get_current_worker" is partially unknown
    Type of "get_current_worker" is "() -> Worker[Unknown]" (reportUnknownMemberType)
error: Type of "worker" is partially unknown
    Type of "worker" is "Worker[Unknown]" (reportUnknownVariableType)
error: Type of "cancel_node" is partially unknown
    Type of "cancel_node" is "(node: DOMNode) -> list[Worker[Unknown]]" (reportUnknownMemberType)
error: Type of "get_current_worker" is partially unknown
    Type of "get_current_worker" is "() -> Worker[Unknown]" (reportUnknownMemberType)
error: Type of "worker" is partially unknown
    Type of "worker" is "Worker[Unknown]" (reportUnknownVariableType)
error: Type of "cancel_node" is partially unknown
    Type of "cancel_node" is "(node: DOMNode) -> list[Worker[Unknown]]" (reportUnknownMemberType)
error: Type of "cancel_node" is partially unknown
    Type of "cancel_node" is "(node: DOMNode) -> list[Worker[Unknown]]" (reportUnknownMemberType)
11 errors, 0 warnings, 0 informations 
```

after:
```
> poetry run pyright
0 errors, 0 warnings, 0 informations
```