### PR TITLE
calculate message namespace from __qualname__ when not specified

### DIFF
--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -73,8 +73,13 @@ class Message:
             cls.no_dispatch = no_dispatch
         if namespace is not None:
             cls.namespace = namespace
-        name = camel_to_snake(cls.__name__)
-        cls.handler_name = f"on_{namespace}_{name}" if namespace else f"on_{name}"
+            name = f"{namespace}_{camel_to_snake(cls.__name__)}"
+        else:
+            # a class defined inside of a function will have a qualified name like func.<locals>.Class,
+            # so make sure we only use the actual class name(s)
+            qualname = cls.__qualname__.split("<locals>.")[-1]
+            name = camel_to_snake(qualname).replace(".", "_")
+        cls.handler_name = f"on_{name}"
 
     @property
     def control(self) -> Widget | None:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -10,7 +10,6 @@ A `MessagePump` is a base class for any object which processes messages, which i
 from __future__ import annotations
 
 import asyncio
-import inspect
 import threading
 from asyncio import CancelledError, Queue, QueueEmpty, Task, create_task
 from contextlib import contextmanager
@@ -25,7 +24,6 @@ from ._context import message_hook as message_hook_context_var
 from ._context import prevent_message_types_stack
 from ._on import OnNoWidget
 from ._time import time
-from .case import camel_to_snake
 from .css.match import match
 from .errors import DuplicateKeyHandlers
 from .events import Event
@@ -63,8 +61,6 @@ class _MessagePumpMeta(type):
         class_dict: dict[str, Any],
         **kwargs,
     ):
-        namespace = camel_to_snake(name)
-        isclass = inspect.isclass
         handlers: dict[
             type[Message], list[tuple[Callable, dict[str, tuple[SelectorSet, ...]]]]
         ] = class_dict.get("_decorated_handlers", {})
@@ -78,13 +74,6 @@ class _MessagePumpMeta(type):
                 ] = getattr(value, "_textual_on")
                 for message_type, selectors in textual_on:
                     handlers.setdefault(message_type, []).append((value, selectors))
-            if isclass(value) and issubclass(value, Message):
-                if "namespace" in value.__dict__:
-                    value.handler_name = f"on_{value.__dict__['namespace']}_{camel_to_snake(value.__name__)}"
-                else:
-                    value.handler_name = (
-                        f"on_{namespace}_{camel_to_snake(value.__name__)}"
-                    )
 
         # Look for reactives with public AND private compute methods.
         prefix = "compute_"

--- a/tests/test_message_handling.py
+++ b/tests/test_message_handling.py
@@ -24,6 +24,11 @@ async def test_message_inheritance_namespace():
         class Fired(BaseWidget.Fired):
             pass
 
+    class DummyWidget(Widget):
+        # ensure that referencing a message type in other class scopes
+        # doesn't break the namespace
+        _event = Left.Fired
+
     handlers_called = []
 
     class MessageInheritanceApp(App[None]):


### PR DESCRIPTION
Fixes #3939

Use `__qualname__` for the message namespace since it already contains the outer class, making the `handler_name` processing in `_MessagePumpMeta` unnecessary

**Please review the following checklist.**

- [x] Updated CHANGELOG.md (where appropriate)
