### PR TITLE
Retain `Tree.root`'s expanded state when performing a `Tree.clear`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Widget.move_child` would break if `before`/`after` is set to the index of the widget in `child` https://github.com/Textualize/textual/issues/1743
 - Fixed auto width text not processing markup https://github.com/Textualize/textual/issues/3918
+- Fixed `Tree.clear` not retaining the root's expanded state https://github.com/Textualize/textual/issues/3557
 
 ### Changed
 

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -717,13 +717,14 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         self._current_id = 0
         root_label = self.root._label
         root_data = self.root.data
+        root_expanded = self.root.is_expanded
         self.root = TreeNode(
             self,
             None,
             self._new_id(),
             root_label,
             root_data,
-            expanded=True,
+            expanded=root_expanded,
         )
         self._updates += 1
         self.refresh()

--- a/tests/snapshot_tests/snapshot_apps/tree_clearing.py
+++ b/tests/snapshot_tests/snapshot_apps/tree_clearing.py
@@ -1,0 +1,30 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Tree
+
+class TreeClearingSnapshotApp(App[None]):
+
+    CSS = """
+    Screen {
+        layout: horizontal;
+    }
+    """
+
+    @staticmethod
+    def _populate(tree: Tree) -> Tree:
+        for n in range(5):
+            branch = tree.root.add(str(n))
+            for m in range(5):
+                branch.add_leaf(f"{n}-{m}")
+        return tree
+
+    def compose(self) -> ComposeResult:
+        yield self._populate(Tree("Left", id="left"))
+        yield self._populate(Tree("Right", id="right"))
+
+    def on_mount(self) -> None:
+        self.query_one("#left", Tree).root.expand()
+        self.query_one("#left", Tree).clear()
+        self.query_one("#right", Tree).clear()
+
+if __name__ == "__main__":
+    TreeClearingSnapshotApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -967,3 +967,10 @@ def test_zero_scrollbar_size(snap_compare):
     """Regression test for missing content with 0 sized scrollbars"""
     # https://github.com/Textualize/textual/issues/3886
     assert snap_compare(SNAPSHOT_APPS_DIR / "zero_scrollbar_size.py")
+
+
+def test_tree_clearing_and_expansion(snap_compare):
+    """Test the Tree.root.is_expanded state after a Tree.clear"""
+    # https://github.com/Textualize/textual/issues/3557
+    assert snap_compare(SNAPSHOT_APPS_DIR / "tree_clearing.py")
+


### PR DESCRIPTION
Fixes #3557.