### PR TITLE
change quotes

### DIFF
--- a/src/textual/css/_help_text.py
+++ b/src/textual/css/_help_text.py
@@ -150,7 +150,7 @@ def property_invalid_value_help_text(
         suggested_property_name = _contextualize_property_name(
             suggested_property_name, context
         )
-        summary += f'. Did you mean "{suggested_property_name}"?'
+        summary += f". Did you mean '{suggested_property_name}'?"
     return HelpText(summary)
 
 
@@ -324,7 +324,7 @@ def color_property_help_text(
         error.suggested_color if error and isinstance(error, ColorParseError) else None
     )
     if suggested_color:
-        summary += f'. Did you mean "{suggested_color}"?'
+        summary += f". Did you mean '{suggested_color}'?"
     return HelpText(
         summary=summary,
         bullets=[

--- a/tests/css/test_stylesheet.py
+++ b/tests/css/test_stylesheet.py
@@ -203,7 +203,7 @@ def test_did_you_mean_for_css_property_names(
     displayed_css_property_name = css_property_name.replace("_", "-")
     expected_summary = f"Invalid CSS property {displayed_css_property_name!r}"
     if expected_property_name_suggestion:
-        expected_summary += f'. Did you mean "{expected_property_name_suggestion}"?'
+        expected_summary += f". Did you mean '{expected_property_name_suggestion}'?"
     assert help_text.summary == expected_summary
 
 
@@ -243,6 +243,6 @@ def test_did_you_mean_for_color_names(
     )
 
     if expected_color_suggestion is not None:
-        expected_error_summary += f'. Did you mean "{expected_color_suggestion}"?'
+        expected_error_summary += f". Did you mean '{expected_color_suggestion}'?"
 
     assert help_text.summary == expected_error_summary


### PR DESCRIPTION
Change double quotes in error messages, because we use single quotes elsewhere.