### PR TITLE
docs: Mention that `App.push_screen_wait` should only be called from a running worker.

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1959,6 +1959,7 @@ class App(Generic[ReturnType], DOMNode):
         self, screen: Screen[ScreenResultType] | str
     ) -> ScreenResultType | Any:
         """Push a screen and wait for the result (received from [`Screen.dismiss`][textual.screen.Screen.dismiss]).
+        Note that this should only be called when running in a worker.
 
         Args:
             screen: A screen or the name of an installed screen.


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
