### PR TITLE
WiP: HOWTO package a Textual application

### DIFF
--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -1,0 +1,78 @@
+# Package an application
+
+A common question on the [Textual Discord server](https://discord.gg/Enf6Z3qhVr) and [in the Textual discussion area](https://github.com/Textualize/textual/discussions) is how to package a Textual application for distribution. At its heart, this is a question of *"how do I package a Python application for distribution?"*; this a reasonably big subject that is covered by a number of tutorials on the web. A good place to start would be [in the Python documentation itself](https://packaging.python.org/en/latest/overview/).
+
+In this HOWTO we'll concentrate on the Textual-specific issues you need to keep in mind.
+
+## What packaging tool should I use?
+
+The choice of packaging tool will often come down to personal taste, and can be a polarising question. In this document we'll cover two currently-popular tools that help with this: [Hatch](https://hatch.pypa.io/latest/) and [Poetry](https://python-poetry.org/). There are a number of other choices but the issues to consider will be similar in all cases.
+
+We recommend first getting familiar with your choice of tool and working with its documentation to get your project set up for packing and distribution.
+
+## So what Textual-specifics do I need to worry about?
+
+While these are concerns for any packaged Python application (and so should be covered by the documentation of your chosen tool), there are two areas to consider with your Textual application that will result in a successful package, publish and install experience:
+
+### Application entry point and the runnable command
+
+We're going to turn the Textual [calculator example](https://github.com/Textualize/textual/blob/main/examples/calculator.py) into an application that can be packaged, deployed to [PyPi](https://pypi.org/), and installed by users using `pip` or `pipx`.
+
+The end result we want is that, after the user has installed the application, they can type `calculator` in the shell and the application will appear.
+
+#### Making the entry point
+
+Normally, somewhere in a Textual application, you'll have some code that looks like this:
+
+```python
+if __name__ == "__main__":
+    CalculatorApp().run()
+```
+
+We're going to make a small change to this to help us when it comes to telling the packaging tool how to run the application. The change is to turn the above into this:
+
+```python
+def run() -> None:
+    """Run the calculator application."""
+    CalculatorApp().run()
+
+if __name__ == "__main__":
+    run()
+```
+
+In other words: we've created a function called `run`, that runs the calculator application, and then we've chained the `__main__` test to run that function (we're keeping that as it's useful when running with `python -m`; often handy during development).
+
+#### Declaring the runnable command
+
+Having done the above, we're all set to tell the packaging tool what to call the final command that the user will run, and what it should do when they run it. For Hatch and Poetry it is a case of adding:
+
+```
+<application-name> = "<entry-point>"
+```
+
+to the correct section of `pyproject.toml`. In the case of our calculator example, the command we want is `calculator` and the entry point is the `run` function in `calculator.py` which is in `textual_calculator`; we specify this with `textual_calculator.calculator:run`.
+
+=== "pyproject.toml (Hatch)"
+
+    ```toml
+    [project.scripts]
+    calculator = "textual_calculator.calculator:run"
+    ```
+
+=== "pyproject.toml (Poetry)"
+
+    ```toml
+    [tool.poetry.scripts]
+    calculator = "textual_calculator.calculator:run"
+    ```
+
+### Package up the stylesheets
+
+If you are using [external stylesheets](/guide/CSS/#stylesheets) for your application it will be important that you ensure these get packaged. With Hatch and Poetry you don't need to do anything, both tools will include any files in your source directory unless you explicitly exclude them. If your package management tool needs you to list files that should be included, be sure to list your `tcss` files there.
+
+[//]: # (REMOVE (BEFORE FLIGHT!))
+[//]: # (Local Variables:)
+[//]: # (eval: (auto-fill-mode -1))
+[//]: # (eval: (visual-line-mode 1))
+[//]: # (End:)
+[//]: # (REMOVE BEFORE FLIGHT!)

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -66,7 +66,7 @@ to the correct section of `pyproject.toml`. In the case of our calculator exampl
     calculator = "textual_calculator.calculator:run"
     ```
 
-### Package up the stylesheets
+### Packaging the stylesheets
 
 If you are using [external stylesheets](/guide/CSS/#stylesheets) for your application it will be important that you ensure these get packaged. With Hatch and Poetry you don't need to do anything, both tools will include any files in your source directory unless you explicitly exclude them. If your package management tool needs you to list files that should be included, be sure to list your `tcss` files there.
 

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -1,7 +1,7 @@
 # Package an application
 
 A common question on the [Textual Discord server](https://discord.gg/Enf6Z3qhVr) and [in the Textual discussion area](https://github.com/Textualize/textual/discussions) is how to package a Textual application for distribution.
-At its heart, this is a question of *"how do I package a Python application for distribution?"*; this a reasonably big subject that is covered by a number of tutorials on the web.
+At its heart this is a question of *"how do I package a Python application for distribution?"*; this is a reasonably big subject that is covered by a number of tutorials on the web.
 A good place to start would be [in the Python documentation itself](https://packaging.python.org/en/latest/overview/).
 
 In this HOWTO we'll concentrate on the Textual-specific issues you need to keep in mind.
@@ -12,15 +12,15 @@ The choice of packaging tool will often come down to personal taste, and can be 
 In this document we'll cover two currently-popular tools that help with this: [Hatch](https://hatch.pypa.io/latest/) and [Poetry](https://python-poetry.org/).
 There are a number of other choices but the issues to consider will be similar in all cases.
 
-We recommend first getting familiar with your choice of tool and working with its documentation to get your project set up for packing and distribution.
+We recommend first getting familiar with your choice of tool, using its documentation to get your project set up for packaging and distribution.
 
 ## So what Textual-specifics do I need to worry about?
 
-While these are concerns for any packaged Python application (and so should be covered by the documentation of your chosen tool), there are two areas to consider with your Textual application that will result in a successful package, publish and install experience:
+While these are concerns for any packaged Python application (and so should be covered by the documentation of your chosen tool), there are some details to consider so that your efforts will result in a successful package, publish and install experience:
 
 ### Declaring Textual as a dependency
 
-Your deployed application will depend on Textual, so be sure to tell the packaging tool that this is the case; this way, when an end user installs your application with a tool like `pip` or `pipx`, Textual will also be installed.
+Your deployed application will depend on Textual, so be sure to tell the packaging tool that this is the case. This way, when an end user installs your application with a tool like `pip` or `pipx`, Textual will also be installed.
 The method used to add Textual as a dependency will differ depending on the tool you use, but the result will be an entry being added to `pyproject.toml`:
 
 === "pyproject.toml (Hatch)"
@@ -73,7 +73,9 @@ if __name__ == "__main__":
     run()
 ```
 
-In other words: we've created a function called `run` that runs the calculator application; then we've changed the `__main__` test to run that function (we keep that because it lets you run your application with `python -m`; this can be useful during development).
+In other words:
+we've created a function called `run` that runs the calculator application;
+then we've changed the `__main__` test to run that function (we keep that because it lets us run our application with `python -m`; this can be useful during development).
 
 #### Declaring the runnable command
 
@@ -85,7 +87,7 @@ For Hatch and Poetry it is a case of adding:
 ```
 
 to the correct section of `pyproject.toml`.
-In the case of our calculator example, the command we want is `calculator` and the entry point is the `run` function in `calculator.py` which is in `textual_calculator`;
+In the case of our calculator example, the command we want is `calculator` and the entry point is the `run` function in the module `calculator.py` which is in the package `textual_calculator`;
 we specify this with `textual_calculator.calculator:run`.
 
 === "pyproject.toml (Hatch)"
@@ -110,7 +112,7 @@ If your package management tool needs you to list files that should be included,
 
 ## Example repositories
 
-To illustrate the results of following the above guidelines, while also making a repository for the calculator example, we have a pair of repositories you can read through:
+To illustrate the results of following the above guidelines while also making a repository for the calculator example, we have a pair of repositories you can read through:
 
 - [`textual-calculator-hatch`](https://github.com/Textualize/textual-calculator-hatch)
 - [`textual-calculator-poetry`](https://github.com/Textualize/textual-calculator-poetry)

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -108,6 +108,13 @@ If you are using [external stylesheets](/guide/CSS/#stylesheets) for your applic
 With Hatch and Poetry you don't need to do anything, both tools will include any files in your source directory unless you explicitly exclude them.
 If your package management tool needs you to list files that should be included, be sure to list your `tcss` files there.
 
+## Example repositories
+
+To illustrate the results of following the above guidelines, while also making a repository for the calculator example, we have a pair of repositories you can read through:
+
+- [`textual-calculator-hatch`](https://github.com/Textualize/textual-calculator-hatch)
+- [`textual-calculator-poetry`](https://github.com/Textualize/textual-calculator-poetry)
+
 ## Summary
 
 Keep the following in mind when you want to package your Textual application:

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -1,12 +1,16 @@
 # Package an application
 
-A common question on the [Textual Discord server](https://discord.gg/Enf6Z3qhVr) and [in the Textual discussion area](https://github.com/Textualize/textual/discussions) is how to package a Textual application for distribution. At its heart, this is a question of *"how do I package a Python application for distribution?"*; this a reasonably big subject that is covered by a number of tutorials on the web. A good place to start would be [in the Python documentation itself](https://packaging.python.org/en/latest/overview/).
+A common question on the [Textual Discord server](https://discord.gg/Enf6Z3qhVr) and [in the Textual discussion area](https://github.com/Textualize/textual/discussions) is how to package a Textual application for distribution.
+At its heart, this is a question of *"how do I package a Python application for distribution?"*; this a reasonably big subject that is covered by a number of tutorials on the web.
+A good place to start would be [in the Python documentation itself](https://packaging.python.org/en/latest/overview/).
 
 In this HOWTO we'll concentrate on the Textual-specific issues you need to keep in mind.
 
 ## What packaging tool should I use?
 
-The choice of packaging tool will often come down to personal taste, and can be a polarising question. In this document we'll cover two currently-popular tools that help with this: [Hatch](https://hatch.pypa.io/latest/) and [Poetry](https://python-poetry.org/). There are a number of other choices but the issues to consider will be similar in all cases.
+The choice of packaging tool will often come down to personal taste, and can be a polarising question.
+In this document we'll cover two currently-popular tools that help with this: [Hatch](https://hatch.pypa.io/latest/) and [Poetry](https://python-poetry.org/).
+There are a number of other choices but the issues to consider will be similar in all cases.
 
 We recommend first getting familiar with your choice of tool and working with its documentation to get your project set up for packing and distribution.
 
@@ -57,7 +61,8 @@ if __name__ == "__main__":
     CalculatorApp().run()
 ```
 
-We're going to make a small change to this to help us when it comes to telling the packaging tool how to run the application. The change is to turn the above into this:
+We're going to make a small change to this to help us when it comes to telling the packaging tool how to run the application.
+The change is to turn the above into this:
 
 ```python
 def run() -> None:
@@ -72,13 +77,16 @@ In other words: we've created a function called `run`, that runs the calculator 
 
 #### Declaring the runnable command
 
-Having done the above, we're all set to tell the packaging tool what to call the final command that the user will run, and what it should do when they run it. For Hatch and Poetry it is a case of adding:
+Having done the above, we're all set to tell the packaging tool what to call the final command that the user will run, and what it should do when they run it.
+For Hatch and Poetry it is a case of adding:
 
 ```
 <application-name> = "<entry-point>"
 ```
 
-to the correct section of `pyproject.toml`. In the case of our calculator example, the command we want is `calculator` and the entry point is the `run` function in `calculator.py` which is in `textual_calculator`; we specify this with `textual_calculator.calculator:run`.
+to the correct section of `pyproject.toml`.
+In the case of our calculator example, the command we want is `calculator` and the entry point is the `run` function in `calculator.py` which is in `textual_calculator`;
+we specify this with `textual_calculator.calculator:run`.
 
 === "pyproject.toml (Hatch)"
 
@@ -96,7 +104,9 @@ to the correct section of `pyproject.toml`. In the case of our calculator exampl
 
 ### Packaging the stylesheets
 
-If you are using [external stylesheets](/guide/CSS/#stylesheets) for your application it will be important that you ensure these get packaged. With Hatch and Poetry you don't need to do anything, both tools will include any files in your source directory unless you explicitly exclude them. If your package management tool needs you to list files that should be included, be sure to list your `tcss` files there.
+If you are using [external stylesheets](/guide/CSS/#stylesheets) for your application it will be important that you ensure these get packaged.
+With Hatch and Poetry you don't need to do anything, both tools will include any files in your source directory unless you explicitly exclude them.
+If your package management tool needs you to list files that should be included, be sure to list your `tcss` files there.
 
 [//]: # (REMOVE (BEFORE FLIGHT!))
 [//]: # (Local Variables:)

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     run()
 ```
 
-In other words: we've created a function called `run`, that runs the calculator application, and then we've chained the `__main__` test to run that function (we're keeping that as it's useful when running with `python -m`; often handy during development).
+In other words: we've created a function called `run` that runs the calculator application; then we've changed the `__main__` test to run that function (we keep that because it lets you run your application with `python -m`; this can be useful during development).
 
 #### Declaring the runnable command
 

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -108,7 +108,20 @@ If you are using [external stylesheets](/guide/CSS/#stylesheets) for your applic
 With Hatch and Poetry you don't need to do anything, both tools will include any files in your source directory unless you explicitly exclude them.
 If your package management tool needs you to list files that should be included, be sure to list your `tcss` files there.
 
-[//]: # (REMOVE (BEFORE FLIGHT!))
+## Summary
+
+Keep the following in mind when you want to package your Textual application:
+
+- Remember to declare Textual as a dependency for your application.
+- Make sure you've written an entry point for your application.
+- Think of the command name the end user will run and declare that.
+- Ensure that any TCSS files that your application needs are packaged too.
+
+---
+
+If you need further help, we are here to [help](../help.md).
+
+[//]: # (REMOVE BEFORE FLIGHT!)
 [//]: # (Local Variables:)
 [//]: # (eval: (auto-fill-mode -1))
 [//]: # (eval: (visual-line-mode 1))

--- a/docs/how-to/package-an-application.md
+++ b/docs/how-to/package-an-application.md
@@ -14,6 +14,34 @@ We recommend first getting familiar with your choice of tool and working with it
 
 While these are concerns for any packaged Python application (and so should be covered by the documentation of your chosen tool), there are two areas to consider with your Textual application that will result in a successful package, publish and install experience:
 
+### Declaring Textual as a dependency
+
+Your deployed application will depend on Textual, so be sure to tell the packaging tool that this is the case; this way, when an end user installs your application with a tool like `pip` or `pipx`, Textual will also be installed.
+The method used to add Textual as a dependency will differ depending on the tool you use, but the result will be an entry being added to `pyproject.toml`:
+
+=== "pyproject.toml (Hatch)"
+
+    ```toml
+    [project]
+    ...
+    dependencies = [
+      "textual",
+    ]
+    ```
+
+=== "pyproject.toml (Poetry)"
+
+    ```toml
+    [tool.poetry.dependencies]
+    ...
+    textual = "*"
+    ```
+
+!!! note
+
+    You may wish to pin the version of Textual; perhaps to a minimum version, or even to the exact version you are using at that the time.
+    Opinions on best practice here do vary.
+
 ### Application entry point and the runnable command
 
 We're going to turn the Textual [calculator example](https://github.com/Textualize/textual/blob/main/examples/calculator.py) into an application that can be packaged, deployed to [PyPi](https://pypi.org/), and installed by users using `pip` or `pipx`.

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -215,6 +215,7 @@ nav:
       - "how-to/index.md"
       - "how-to/center-things.md"
       - "how-to/design-a-layout.md"
+      - "how-to/package-an-application.md"
       - "how-to/render-and-compose.md"
   - "FAQ.md"
   - "roadmap.md"


### PR DESCRIPTION
*Ignore the `(REMOVE BEFORE FLIGHT!)` text towards the end of the document, this is just for editor configuration while I edit the document; it'll be removed once ready for merge*

Provides a HOWTO document that highlights the main areas of concern when thinking about packaging a Textual application for deployment.

Because there are quite a lot of application management tools that provide packaging and publishing facilities we've decided to concentrate on relating to two of the more popular tools that people are likely to encounter, while allowing for the option to expand the document if we see fit. The main aim here however is to try and provide a fairly generic list of things to keep in mind and make sure you address.

Overall this comes down to:

- Remember to declare Textual as a dependency for your application.
- Make sure you've written an entry point for your application.
- Think of the command name the end user will run and declare that.
- Ensure that any TCSS files that your application needs are packaged too.

Two example repositories have been created to illustrate the the above:

- [`textual-calculator-hatch`](https://github.com/Textualize/textual-calculator-hatch)
- [`textual-calculator-poetry`](https://github.com/Textualize/textual-calculator-poetry)

Implements #3728.