### PR TITLE
Better tab relabelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Breaking change: `DOMNode.has_pseudo_class` now accepts a single name only https://github.com/Textualize/textual/pull/3970
 - Made `textual.cache` (formerly `textual._cache`) public https://github.com/Textualize/textual/pull/3976
+- `Tab.label` can now be used to change the label of a tab
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Breaking change: `DOMNode.has_pseudo_class` now accepts a single name only https://github.com/Textualize/textual/pull/3970
 - Made `textual.cache` (formerly `textual._cache`) public https://github.com/Textualize/textual/pull/3976
-- `Tab.label` can now be used to change the label of a tab
+- `Tab.label` can now be used to change the label of a tab https://github.com/Textualize/textual/pull/3979
 
 ### Added
 

--- a/tests/snapshot_tests/snapshot_apps/tab_rename.py
+++ b/tests/snapshot_tests/snapshot_apps/tab_rename.py
@@ -1,0 +1,16 @@
+from textual.app import App, ComposeResult
+from textual.widgets import TabbedContent, TabPane
+
+class TabRenameApp(App[None]):
+
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            yield TabPane("!", id="test")
+            for n in range(5):
+                yield TabPane(str(n) * (n+1))
+
+    def on_mount(self) -> None:
+        self.query_one(TabbedContent).get_tab("test").label = "This is a much longer label for the tab"
+
+if __name__ == "__main__":
+    TabRenameApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -979,3 +979,8 @@ def test_nested_specificity(snap_compare):
     """Test specificity of nested rules is working."""
     # https://github.com/Textualize/textual/issues/3961
     assert snap_compare(SNAPSHOT_APPS_DIR / "nested_specificity.py")
+
+
+def test_tab_rename(snap_compare):
+    """Test setting a new label for a tab amongst a TabbedContent."""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "tab_rename.py")

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -13,6 +13,14 @@ async def test_tab_label():
     assert Tab("Pilot").label_text == "Pilot"
 
 
+async def test_tab_relabel():
+    """It should be possible to relabel a tab."""
+    tab = Tab("Pilot")
+    assert tab.label_text == "Pilot"
+    tab.label = "Aeryn"
+    assert tab.label_text == "Aeryn"
+
+
 async def test_compose_empty_tabs():
     """It should be possible to create an empty Tabs."""
 


### PR DESCRIPTION
Implements a better method of changing the label of a `Tab`; fixes #3901.

This is a fairly small change, which turns `Tab.label` into a safe way of setting a new label for a `Tab`. So the question in the original issue would end up being answered with this:

```python
self.query_one(TabbedContent).get_tab("one").label = "Renamed!"
```

It also quietly supports going via `Tab.update` too but doesn't advertise it as *the* approach to take.

The PR also, of course, addresses the issue of the underline not redrawing correctly.

https://github.com/Textualize/textual/assets/28237/3c3a146e-81ef-44a3-87d9-8772982a2815

