### PR TITLE
Test discovery would modify tcss file by mistake.

### DIFF
--- a/tests/css/test_css_reloading.py
+++ b/tests/css/test_css_reloading.py
@@ -10,15 +10,6 @@ from textual.widgets import Label
 
 CSS_PATH = (Path(__file__) / "../css_reloading.tcss").resolve()
 
-Path(CSS_PATH).write_text(
-    """\
-Label {
-    height: 5;
-    border: panel white;
-}
-"""
-)
-
 
 class BaseScreen(Screen[None]):
     def compose(self) -> ComposeResult:
@@ -48,6 +39,16 @@ async def test_css_reloading_applies_to_non_top_screen(monkeypatch) -> None:  # 
     monkeypatch.setenv(
         "TEXTUAL", "debug"
     )  # This will make sure we create a file monitor.
+
+    # Write some initial CSS.
+    Path(CSS_PATH).write_text(
+        """\
+Label {
+    height: 5;
+    border: panel white;
+}
+"""
+    )
 
     app = MyApp()
     async with app.run_test() as pilot:


### PR DESCRIPTION
We only want to write that CSS when the test runs, not during test discovery.