### PR TITLE
Fix issue when crop start == cell length of a Strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Parameter `animate` from `DataTable.move_cursor` was being ignored https://github.com/Textualize/textual/issues/3840
 - Fixed a crash if `DirectoryTree.show_root` was set before the DOM was fully available https://github.com/Textualize/textual/issues/2363
-- Live reloading of TCSS wouldn't apply CSS changes to screens under the top screen of the stack https://github.com/Textualize/textual/issues/3931
+- Live reloading of TCSS wouldn't apply CSS changes to screens under the top screen of the stack https://github.com/Textualize/textual/issues/3931\
+- Fix issue with `Strip.crop` when crop window start aligned with strip end https://github.com/Textualize/textual/pull/3998
 
 
 ## [0.47.1] - 2023-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Parameter `animate` from `DataTable.move_cursor` was being ignored https://github.com/Textualize/textual/issues/3840
 - Fixed a crash if `DirectoryTree.show_root` was set before the DOM was fully available https://github.com/Textualize/textual/issues/2363
-- Live reloading of TCSS wouldn't apply CSS changes to screens under the top screen of the stack https://github.com/Textualize/textual/issues/3931\
+- Live reloading of TCSS wouldn't apply CSS changes to screens under the top screen of the stack https://github.com/Textualize/textual/issues/3931
 - Fix issue with `Strip.crop` when crop window start aligned with strip end https://github.com/Textualize/textual/pull/3998
 
 

--- a/src/textual/strip.py
+++ b/src/textual/strip.py
@@ -385,7 +385,7 @@ class Strip:
         add_segment = output_segments.append
         iter_segments = iter(self._segments)
         segment: Segment | None = None
-        if start > self.cell_length:
+        if start >= self.cell_length:
             strip = Strip([], 0)
         else:
             for segment in iter_segments:

--- a/tests/test_strip.py
+++ b/tests/test_strip.py
@@ -65,23 +65,22 @@ def test_eq():
 
 
 def test_adjust_cell_length():
-    for repeat in range(3):
-        assert Strip([]).adjust_cell_length(3) == Strip([Segment("   ")])
-        assert Strip([Segment("f")]).adjust_cell_length(3) == Strip(
-            [Segment("f"), Segment("  ")]
-        )
-        assert Strip([Segment("💩")]).adjust_cell_length(3) == Strip(
-            [Segment("💩"), Segment(" ")]
-        )
+    assert Strip([]).adjust_cell_length(3) == Strip([Segment("   ")])
+    assert Strip([Segment("f")]).adjust_cell_length(3) == Strip(
+        [Segment("f"), Segment("  ")]
+    )
+    assert Strip([Segment("💩")]).adjust_cell_length(3) == Strip(
+        [Segment("💩"), Segment(" ")]
+    )
 
-        assert Strip([Segment("💩💩")]).adjust_cell_length(3) == Strip([Segment("💩 ")])
-        assert Strip([Segment("💩💩")]).adjust_cell_length(4) == Strip([Segment("💩💩")])
-        assert Strip([Segment("💩"), Segment("💩💩")]).adjust_cell_length(2) == Strip(
-            [Segment("💩")]
-        )
-        assert Strip([Segment("💩"), Segment("💩💩")]).adjust_cell_length(4) == Strip(
-            [Segment("💩"), Segment("💩")]
-        )
+    assert Strip([Segment("💩💩")]).adjust_cell_length(3) == Strip([Segment("💩 ")])
+    assert Strip([Segment("💩💩")]).adjust_cell_length(4) == Strip([Segment("💩💩")])
+    assert Strip([Segment("💩"), Segment("💩💩")]).adjust_cell_length(2) == Strip(
+        [Segment("💩")]
+    )
+    assert Strip([Segment("💩"), Segment("💩💩")]).adjust_cell_length(4) == Strip(
+        [Segment("💩"), Segment("💩")]
+    )
 
 
 def test_extend_cell_length():
@@ -101,8 +100,6 @@ def test_simplify():
 def test_apply_filter():
     strip = Strip([Segment("foo", Style.parse("red"))])
     expected = Strip([Segment("foo", Style.parse("#1b1b1b"))])
-    print(repr(strip))
-    print(repr(expected))
     assert strip.apply_filter(Monochrome(), Color(0, 0, 0)) == expected
 
 
@@ -128,26 +125,37 @@ def test_style_links():
 
 
 def test_crop():
-    for repeat in range(3):
-        assert Strip([Segment("foo")]).crop(0, 3) == Strip([Segment("foo")])
-        assert Strip([Segment("foo")]).crop(0, 2) == Strip([Segment("fo")])
-        assert Strip([Segment("foo")]).crop(0, 1) == Strip([Segment("f")])
+    assert Strip([Segment("foo")]).crop(0, 3) == Strip([Segment("foo")])
+    assert Strip([Segment("foo")]).crop(0, 2) == Strip([Segment("fo")])
+    assert Strip([Segment("foo")]).crop(0, 1) == Strip([Segment("f")])
 
-        assert Strip([Segment("foo")]).crop(1, 3) == Strip([Segment("oo")])
-        assert Strip([Segment("foo")]).crop(1, 2) == Strip([Segment("o")])
-        assert Strip([Segment("foo")]).crop(1, 1) == Strip([Segment("")])
+    assert Strip([Segment("foo")]).crop(1, 3) == Strip([Segment("oo")])
+    assert Strip([Segment("foo")]).crop(1, 2) == Strip([Segment("o")])
+    assert Strip([Segment("foo")]).crop(1, 1) == Strip([Segment("")])
 
-        assert Strip([Segment("foo💩"), Segment("b💩ar"), Segment("ba💩z")]).crop(
-            1, 6
-        ) == Strip([Segment("oo💩"), Segment("b")])
+    assert Strip([Segment("foo💩"), Segment("b💩ar"), Segment("ba💩z")]).crop(
+        1, 6
+    ) == Strip([Segment("oo💩"), Segment("b")])
+
+
+@pytest.mark.parametrize(
+    "text,crop,output",
+    [
+        ["foo", (0, 5), [Segment("foo")]],
+        ["foo", (2, 5), [Segment("o")]],
+        ["foo", (3, 5), []],
+        ["foo", (4, 6), []],
+    ],
+)
+def test_crop_out_of_bounds(text, crop, output):
+    assert Strip([Segment(text)]).crop(*crop) == Strip(output)
 
 
 def test_divide():
-    for repeat in range(3):
-        assert Strip([Segment("foo")]).divide([1, 2]) == [
-            Strip([Segment("f")]),
-            Strip([Segment("o")]),
-        ]
+    assert Strip([Segment("foo")]).divide([1, 2]) == [
+        Strip([Segment("f")]),
+        Strip([Segment("o")]),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When the start of the crop window aligned perfectly with the end of the Strip, the entire Strip was incorrectly being returned

Before this change:

```python
Strip([Segment("foo")]).crop(3, 8) == Strip([Segment("foo")]) 🔴 
Strip([Segment("foo")]).crop(4, 8) == Strip([]) 🟢 
```

After this change:

```python
Strip([Segment("foo")]).crop(3, 8) == Strip([]) 🟢 
Strip([Segment("foo")]).crop(4, 8) == Strip([]) 🟢 
```