### PR TITLE
Make TextArea, MarkdownFence respect theme changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ensuring `TextArea.SelectionChanged` message only sends when the updated selection is different https://github.com/Textualize/textual/pull/3933
 - Fixed declaration after nested rule set causing a parse error https://github.com/Textualize/textual/pull/4012
 - ID and class validation was too lenient https://github.com/Textualize/textual/issues/3954
+- Fixed `MarkdownFence` not adapting to app theme changes https://github.com/Textualize/textual/issues/3997
 
 ## [0.47.1] - 2023-01-05
 

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -503,7 +503,9 @@ class MarkdownFence(MarkdownBlock):
         self.code = code
         self.lexer = lexer
         self.theme = (
-            self._markdown.code_dark_theme if self.app.dark else self._markdown.code_light_theme
+            self._markdown.code_dark_theme
+            if self.app.dark
+            else self._markdown.code_light_theme
         )
 
     def _block(self) -> Syntax:
@@ -523,7 +525,9 @@ class MarkdownFence(MarkdownBlock):
     def _retheme(self) -> None:
         """Rerender when the theme changes."""
         self.theme = (
-            self._markdown.code_dark_theme if self.app.dark else self._markdown.code_light_theme
+            self._markdown.code_dark_theme
+            if self.app.dark
+            else self._markdown.code_light_theme
         )
         code_block = self.query_one(Static)
         code_block.update(self._block())

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -18,7 +18,7 @@ from ..await_complete import AwaitComplete
 from ..containers import Horizontal, Vertical, VerticalScroll
 from ..events import Mount
 from ..message import Message
-from ..reactive import Reactive, reactive, var
+from ..reactive import reactive, var
 from ..widget import Widget
 from ..widgets import Static, Tree
 

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -584,8 +584,11 @@ class Markdown(Widget):
 
     BULLETS = ["\u25CF ", "▪ ", "‣ ", "• ", "⭑ "]
 
-    light_theme: Reactive[str] = reactive("material-light")
     dark_theme: reactive[str] = reactive("material")
+    """The theme to use for code blocks when in [dark mode][textual.app.App.dark]."""
+
+    light_theme: reactive[str] = reactive("material-light")
+    """The theme to use for code blocks when in [light mode][textual.app.App.dark]."""
 
     def __init__(
         self,

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -529,8 +529,7 @@ class MarkdownFence(MarkdownBlock):
             if self.app.dark
             else self._markdown.code_light_theme
         )
-        code_block = self.query_one(Static)
-        code_block.update(self._block())
+        self.get_child_by_type(Static).update(self._block())
 
     def compose(self) -> ComposeResult:
         yield Static(

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -584,8 +584,8 @@ class Markdown(Widget):
 
     BULLETS = ["\u25CF ", "▪ ", "‣ ", "• ", "⭑ "]
 
-    dark_theme: Reactive[str] = reactive("material", layout=True, repaint=True)
     light_theme: Reactive[str] = reactive("material-light")
+    dark_theme: reactive[str] = reactive("material")
 
     def __init__(
         self,

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -503,7 +503,7 @@ class MarkdownFence(MarkdownBlock):
         self.code = code
         self.lexer = lexer
         self.theme = (
-            self._markdown.dark_theme if self.app.dark else self._markdown.light_theme
+            self._markdown.code_dark_theme if self.app.dark else self._markdown.code_light_theme
         )
 
     def _block(self) -> Syntax:
@@ -523,7 +523,7 @@ class MarkdownFence(MarkdownBlock):
     def _retheme(self) -> None:
         """Rerender when the theme changes."""
         self.theme = (
-            self._markdown.dark_theme if self.app.dark else self._markdown.light_theme
+            self._markdown.code_dark_theme if self.app.dark else self._markdown.code_light_theme
         )
         code_block = self.query_one(Static)
         code_block.update(self._block())
@@ -584,10 +584,10 @@ class Markdown(Widget):
 
     BULLETS = ["\u25CF ", "▪ ", "‣ ", "• ", "⭑ "]
 
-    dark_theme: reactive[str] = reactive("material")
+    code_dark_theme: reactive[str] = reactive("material")
     """The theme to use for code blocks when in [dark mode][textual.app.App.dark]."""
 
-    light_theme: reactive[str] = reactive("material-light")
+    code_light_theme: reactive[str] = reactive("material-light")
     """The theme to use for code blocks when in [light mode][textual.app.App.dark]."""
 
     def __init__(
@@ -676,12 +676,14 @@ class Markdown(Widget):
         if self._markdown is not None:
             self.update(self._markdown)
 
-    def watch_dark_theme(self, dark_theme: str) -> None:
+    def _watch_code_dark_theme(self) -> None:
+        """React to the dark theme being changed."""
         if self.app.dark:
             for block in self.query(MarkdownFence):
                 block._retheme()
 
-    def watch_light_theme(self, light_theme: str) -> None:
+    def _watch_code_light_theme(self) -> None:
+        """React to the light theme being changed."""
         if not self.app.dark:
             for block in self.query(MarkdownFence):
                 block._retheme()

--- a/tests/snapshot_tests/snapshot_apps/markdown_theme_switcher.py
+++ b/tests/snapshot_tests/snapshot_apps/markdown_theme_switcher.py
@@ -19,11 +19,11 @@ class MarkdownThemeSwitchertApp(App[None]):
 
     def action_switch_dark(self) -> None:
         md = self.query_one(Markdown)
-        md.dark_theme = "solarized-dark"
+        md.code_dark_theme = "solarized-dark"
 
     def action_switch_light(self) -> None:
         md = self.query_one(Markdown)
-        md.light_theme = "solarized-light"
+        md.code_light_theme = "solarized-light"
 
     def compose(self) -> ComposeResult:
         yield Markdown(TEST_CODE_MARKDOWN)

--- a/tests/snapshot_tests/snapshot_apps/markdown_theme_switcher.py
+++ b/tests/snapshot_tests/snapshot_apps/markdown_theme_switcher.py
@@ -1,0 +1,33 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Markdown
+
+TEST_CODE_MARKDOWN = """
+# This is a H1
+```python
+def main():
+    print("Hello world!")
+```
+"""
+
+
+class MarkdownThemeSwitchertApp(App[None]):
+    BINDINGS = [
+        ("t", "toggle_dark"),
+        ("d", "switch_dark"),
+        ("l", "switch_light"),
+    ]
+
+    def action_switch_dark(self) -> None:
+        md = self.query_one(Markdown)
+        md.dark_theme = "solarized-dark"
+
+    def action_switch_light(self) -> None:
+        md = self.query_one(Markdown)
+        md.light_theme = "solarized-light"
+
+    def compose(self) -> ComposeResult:
+        yield Markdown(TEST_CODE_MARKDOWN)
+
+
+if __name__ == "__main__":
+    MarkdownThemeSwitchertApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -229,6 +229,22 @@ def test_markdown_viewer_example(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "markdown_viewer.py")
 
 
+def test_markdown_theme_switching(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "markdown_theme_switcher.py", press=["t"])
+
+
+def test_markdown_dark_theme_override(snap_compare):
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "markdown_theme_switcher.py", press=["d", "wait:100"]
+    )
+
+
+def test_markdown_light_theme_override(snap_compare):
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "markdown_theme_switcher.py", press=["l", "t", "wait:100"]
+    )
+
+
 def test_checkbox_example(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "checkbox.py")
 


### PR DESCRIPTION
Make `TextArea`, `MarkdownFence` update their theme when the app theme (`app.dark`) changes.
Happy to add tests if necessary, would help if you pointed out something similar.