### PR TITLE
Fix box model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `SelectionList` option IDs are usable as soon as the widget is instantiated https://github.com/Textualize/textual/issues/3903
 - Fix issue with `Strip.crop` when crop window start aligned with strip end https://github.com/Textualize/textual/pull/3998
 - Fixed Strip.crop_extend https://github.com/Textualize/textual/pull/4011
+- `width`, `max-width`, `min-width`, `height`, `max-height`, and `min-height`, calculations were off for certain combinations of padding, margin, and units https://github.com/Textualize/textual/issues/3721
 
 
 ## [0.47.1] - 2023-01-05

--- a/docs/examples/styles/border.tcss
+++ b/docs/examples/styles/border.tcss
@@ -21,7 +21,7 @@ Screen {
 }
 
 Screen > Label {
-    width: 100%;
+    width: 1fr;
     height: 5;
     content-align: center middle;
     color: white;

--- a/docs/examples/styles/border_subtitle_align.tcss
+++ b/docs/examples/styles/border_subtitle_align.tcss
@@ -14,7 +14,7 @@
 }
 
 Screen > Label {
-    width: 100%;
+    width: 1fr;
     height: 5;
     content-align: center middle;
     color: white;

--- a/docs/examples/styles/border_title_align.tcss
+++ b/docs/examples/styles/border_title_align.tcss
@@ -14,7 +14,7 @@
 }
 
 Screen > Label {
-    width: 100%;
+    width: 1fr;
     height: 5;
     content-align: center middle;
     color: white;

--- a/docs/examples/styles/margin.tcss
+++ b/docs/examples/styles/margin.tcss
@@ -7,5 +7,5 @@ Label {
     margin: 4 8;
     background: blue 20%;
     border: blue wide;
-    width: 100%;
+    width: 1fr;
 }

--- a/docs/examples/styles/margin_all.tcss
+++ b/docs/examples/styles/margin_all.tcss
@@ -8,13 +8,13 @@ Grid {
 }
 
 Placeholder {
-    width: 100%;
-    height: 100%;
+    width: 1fr;
+    height: 1fr;
 }
 
 Container {
-    width: 100%;
-    height: 100%;
+    width: 1fr;
+    height: 1fr;
 }
 
 .bordered {

--- a/docs/examples/styles/outline.tcss
+++ b/docs/examples/styles/outline.tcss
@@ -7,5 +7,5 @@ Label {
     margin: 4 8;
     background: green 20%;
     outline: wide green;
-    width: 100%;
+    width: 1fr;
 }

--- a/docs/examples/widgets/sparkline.tcss
+++ b/docs/examples/widgets/sparkline.tcss
@@ -1,4 +1,4 @@
 Sparkline {
-    width: 100%;
+    width: 1fr;
     margin: 2;
 }

--- a/docs/examples/widgets/sparkline_colors.tcss
+++ b/docs/examples/widgets/sparkline_colors.tcss
@@ -1,5 +1,5 @@
 Sparkline {
-    width: 100%;
+    width: 1fr;
     margin: 1;
 }
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1075,8 +1075,6 @@ class Widget(DOMNode):
 
         # Container minus padding and border
         content_container = container - gutter.totals
-        # The container including the content
-        sizing_container = content_container if is_border_box else container
 
         if styles.width is None:
             # No width specified, fill available space
@@ -1096,28 +1094,20 @@ class Widget(DOMNode):
             ):
                 content_width = Fraction(content_container.width)
         else:
-            # An explicit width
-            styles_width = styles.width
-            content_width = styles_width.resolve(
-                sizing_container - styles.margin.totals, viewport, width_fraction
-            )
-            if is_border_box and styles_width.excludes_border:
+            content_width = styles.width.resolve(container, viewport, width_fraction)
+            if is_border_box:
                 content_width -= gutter.width
 
         if styles.min_width is not None:
             # Restrict to minimum width, if set
-            min_width = styles.min_width.resolve(
-                content_container, viewport, width_fraction
-            )
+            min_width = styles.min_width.resolve(container, viewport, width_fraction)
             if is_border_box:
                 min_width -= gutter.width
             content_width = max(content_width, min_width, Fraction(0))
 
         if styles.max_width is not None:
             # Restrict to maximum width, if set
-            max_width = styles.max_width.resolve(
-                content_container, viewport, width_fraction
-            )
+            max_width = styles.max_width.resolve(container, viewport, width_fraction)
             if is_border_box:
                 max_width -= gutter.width
             content_width = min(content_width, max_width)
@@ -1130,7 +1120,11 @@ class Widget(DOMNode):
         elif is_auto_height:
             # Calculate dimensions based on content
             content_height = Fraction(
-                self.get_content_height(content_container, viewport, int(content_width))
+                self.get_content_height(
+                    content_container - styles.margin.totals,
+                    viewport,
+                    int(content_width),
+                )
             )
             if styles.scrollbar_gutter == "stable" and styles.overflow_y == "auto":
                 content_height += styles.scrollbar_size_horizontal
@@ -1140,28 +1134,20 @@ class Widget(DOMNode):
             ):
                 content_height = Fraction(content_container.height)
         else:
-            styles_height = styles.height
-            # Explicit height set
-            content_height = styles_height.resolve(
-                sizing_container - styles.margin.totals, viewport, height_fraction
-            )
-            if is_border_box and styles_height.excludes_border:
+            content_height = styles.height.resolve(container, viewport, height_fraction)
+            if is_border_box:
                 content_height -= gutter.height
 
         if styles.min_height is not None:
             # Restrict to minimum height, if set
-            min_height = styles.min_height.resolve(
-                content_container, viewport, height_fraction
-            )
+            min_height = styles.min_height.resolve(container, viewport, height_fraction)
             if is_border_box:
                 min_height -= gutter.height
             content_height = max(content_height, min_height, Fraction(0))
 
         if styles.max_height is not None:
             # Restrict maximum height, if set
-            max_height = styles.max_height.resolve(
-                content_container, viewport, height_fraction
-            )
+            max_height = styles.max_height.resolve(container, viewport, height_fraction)
             if is_border_box:
                 max_height -= gutter.height
             content_height = min(content_height, max_height)

--- a/tests/snapshot_tests/snapshot_apps/dimensions_height.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_height.py
@@ -1,0 +1,70 @@
+"""
+Regression test for https://github.com/Textualize/textual/issues/3721
+and follow-up issues that were discovered.
+"""
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Input, TextArea, Label, Button, DataTable
+
+
+class DimensionsApp(App[None]):
+    CSS = """
+    Vertical {
+        width: auto;
+    }
+
+    .ruler {
+        text-style: reverse;
+        height: 24;
+        width: 1;
+    }
+
+    .target {
+        width: 3;
+        height: 50%;
+        border: solid red;
+        box-sizing: border-box;
+    }
+
+    Input.target, Button.target, TextArea.target, DataTable.target {
+        width: 12;
+        min-width: 0;  # "Unset" Button's min-width.
+    }
+
+    .padding {
+        padding: 1 0;
+    }
+
+    .margin {
+        margin: 2 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Label("123456789012", classes="target")
+                yield Label("123456789012", classes="target")
+            with Vertical():
+                yield Label("123456789012", classes="target padding")
+                yield Label("123456789012", classes="target padding")
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Label("123456789012", classes="target margin")
+                yield Label("123456789012", classes="target")
+            with Vertical():
+                yield Label("123456789012", classes="target padding margin")
+                yield Label("123456789012", classes="target padding")
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Input(classes="target")
+                yield Button(classes="target")
+            with Vertical():
+                yield TextArea(classes="target")
+                yield DataTable(classes="target")
+
+
+if __name__ == "__main__":
+    DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_height.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_height.py
@@ -65,6 +65,10 @@ class DimensionsApp(App[None]):
                 yield TextArea(classes="target")
                 yield DataTable(classes="target")
 
+    def on_mount(self) -> None:
+        self.query_one(Input).cursor_blink = False
+        self.query_one(TextArea).cursor_blink = False
+
 
 if __name__ == "__main__":
     DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_max_height.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_max_height.py
@@ -1,0 +1,71 @@
+"""
+Regression test for https://github.com/Textualize/textual/issues/3721
+and follow-up issues that were discovered.
+"""
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Input, TextArea, Label, Button, DataTable
+
+
+class DimensionsApp(App[None]):
+    CSS = """
+    Vertical {
+        width: auto;
+    }
+
+    .ruler {
+        text-style: reverse;
+        height: 24;
+        width: 1;
+    }
+
+    .target {
+        width: 3;
+        height: 24;
+        max-height: 50%;
+        border: solid red;
+        box-sizing: border-box;
+    }
+
+    Input.target, Button.target, TextArea.target, DataTable.target {
+        width: 12;
+        min-width: 0;  # "Unset" Button's min-width.
+    }
+
+    .padding {
+        padding: 1 0;
+    }
+
+    .margin {
+        margin: 2 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Label("123456789012", classes="target")
+                yield Label("123456789012", classes="target")
+            with Vertical():
+                yield Label("123456789012", classes="target padding")
+                yield Label("123456789012", classes="target padding")
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Label("123456789012", classes="target margin")
+                yield Label("123456789012", classes="target")
+            with Vertical():
+                yield Label("123456789012", classes="target padding margin")
+                yield Label("123456789012", classes="target padding")
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Input(classes="target")
+                yield Button(classes="target")
+            with Vertical():
+                yield TextArea(classes="target")
+                yield DataTable(classes="target")
+
+
+if __name__ == "__main__":
+    DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_max_height.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_max_height.py
@@ -66,6 +66,10 @@ class DimensionsApp(App[None]):
                 yield TextArea(classes="target")
                 yield DataTable(classes="target")
 
+    def on_mount(self) -> None:
+        self.query_one(Input).cursor_blink = False
+        self.query_one(TextArea).cursor_blink = False
+
 
 if __name__ == "__main__":
     DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_max_width.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_max_width.py
@@ -1,0 +1,62 @@
+"""
+Regression test for https://github.com/Textualize/textual/issues/3721
+and follow-up issues that were discovered.
+"""
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Input, TextArea, Label, Button, DataTable
+
+
+class DimensionsApp(App[None]):
+    CSS = """
+    Horizontal {
+        height: auto;
+    }
+
+    .ruler {
+        text-style: reverse;
+    }
+
+    .target {
+        width: 80;
+        max-width: 50%;
+        height: 3;
+        border: solid red;
+        box-sizing: border-box;
+    }
+
+    .padding {
+        padding: 0 6;
+    }
+
+    .margin {
+        margin: 0 10;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Label("1234567890" * 8, classes="ruler")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target")
+            yield Label("1234567890" * 4, classes="target")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target padding")
+            yield Label("1234567890" * 4, classes="target padding")
+        yield Label("1234567890" * 8, classes="ruler")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target margin")
+            yield Label("1234567890" * 4, classes="target")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target padding margin")
+            yield Label("1234567890" * 4, classes="target padding")
+        with Horizontal():
+            yield Input(classes="target")
+            yield Button(classes="target")
+        with Horizontal():
+            yield TextArea(classes="target")
+            yield DataTable(classes="target")
+
+
+if __name__ == "__main__":
+    DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_max_width.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_max_width.py
@@ -57,6 +57,10 @@ class DimensionsApp(App[None]):
             yield TextArea(classes="target")
             yield DataTable(classes="target")
 
+    def on_mount(self) -> None:
+        self.query_one(Input).cursor_blink = False
+        self.query_one(TextArea).cursor_blink = False
+
 
 if __name__ == "__main__":
     DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_min_height.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_min_height.py
@@ -1,0 +1,71 @@
+"""
+Regression test for https://github.com/Textualize/textual/issues/3721
+and follow-up issues that were discovered.
+"""
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Input, TextArea, Label, Button, DataTable
+
+
+class DimensionsApp(App[None]):
+    CSS = """
+    Vertical {
+        width: auto;
+    }
+
+    .ruler {
+        text-style: reverse;
+        height: 24;
+        width: 1;
+    }
+
+    .target {
+        width: 3;
+        height: 0;
+        min-height: 50%;
+        border: solid red;
+        box-sizing: border-box;
+    }
+
+    Input.target, Button.target, TextArea.target, DataTable.target {
+        width: 12;
+        min-width: 0;  # "Unset" Button's min-width.
+    }
+
+    .padding {
+        padding: 1 0;
+    }
+
+    .margin {
+        margin: 2 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Label("123456789012", classes="target")
+                yield Label("123456789012", classes="target")
+            with Vertical():
+                yield Label("123456789012", classes="target padding")
+                yield Label("123456789012", classes="target padding")
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Label("123456789012", classes="target margin")
+                yield Label("123456789012", classes="target")
+            with Vertical():
+                yield Label("123456789012", classes="target padding margin")
+                yield Label("123456789012", classes="target padding")
+            yield Label("1234567890" * 3, classes="ruler")
+            with Vertical():
+                yield Input(classes="target")
+                yield Button(classes="target")
+            with Vertical():
+                yield TextArea(classes="target")
+                yield DataTable(classes="target")
+
+
+if __name__ == "__main__":
+    DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_min_height.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_min_height.py
@@ -66,6 +66,10 @@ class DimensionsApp(App[None]):
                 yield TextArea(classes="target")
                 yield DataTable(classes="target")
 
+    def on_mount(self) -> None:
+        self.query_one(Input).cursor_blink = False
+        self.query_one(TextArea).cursor_blink = False
+
 
 if __name__ == "__main__":
     DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_min_width.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_min_width.py
@@ -57,6 +57,10 @@ class DimensionsApp(App[None]):
             yield TextArea(classes="target")
             yield DataTable(classes="target")
 
+    def on_mount(self) -> None:
+        self.query_one(Input).cursor_blink = False
+        self.query_one(TextArea).cursor_blink = False
+
 
 if __name__ == "__main__":
     DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_min_width.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_min_width.py
@@ -1,0 +1,62 @@
+"""
+Regression test for https://github.com/Textualize/textual/issues/3721
+and follow-up issues that were discovered.
+"""
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Input, TextArea, Label, Button, DataTable
+
+
+class DimensionsApp(App[None]):
+    CSS = """
+    Horizontal {
+        height: auto;
+    }
+
+    .ruler {
+        text-style: reverse;
+    }
+
+    .target {
+        width: 0;
+        min-width: 50%;
+        height: 3;
+        border: solid red;
+        box-sizing: border-box;
+    }
+
+    .padding {
+        padding: 0 6;
+    }
+
+    .margin {
+        margin: 0 10;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Label("1234567890" * 8, classes="ruler")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target")
+            yield Label("1234567890" * 4, classes="target")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target padding")
+            yield Label("1234567890" * 4, classes="target padding")
+        yield Label("1234567890" * 8, classes="ruler")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target margin")
+            yield Label("1234567890" * 4, classes="target")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target padding margin")
+            yield Label("1234567890" * 4, classes="target padding")
+        with Horizontal():
+            yield Input(classes="target")
+            yield Button(classes="target")
+        with Horizontal():
+            yield TextArea(classes="target")
+            yield DataTable(classes="target")
+
+
+if __name__ == "__main__":
+    DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_width.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_width.py
@@ -56,6 +56,10 @@ class DimensionsApp(App[None]):
             yield TextArea(classes="target")
             yield DataTable(classes="target")
 
+    def on_mount(self) -> None:
+        self.query_one(Input).cursor_blink = False
+        self.query_one(TextArea).cursor_blink = False
+
 
 if __name__ == "__main__":
     DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/dimensions_width.py
+++ b/tests/snapshot_tests/snapshot_apps/dimensions_width.py
@@ -1,0 +1,61 @@
+"""
+Regression test for https://github.com/Textualize/textual/issues/3721
+and follow-up issues that were discovered.
+"""
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Input, TextArea, Label, Button, DataTable
+
+
+class DimensionsApp(App[None]):
+    CSS = """
+    Horizontal {
+        height: auto;
+    }
+
+    .ruler {
+        text-style: reverse;
+    }
+
+    .target {
+        width: 50%;
+        height: 3;
+        border: solid red;
+        box-sizing: border-box;
+    }
+
+    .padding {
+        padding: 0 6;
+    }
+
+    .margin {
+        margin: 0 10;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Label("1234567890" * 8, classes="ruler")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target")
+            yield Label("1234567890" * 4, classes="target")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target padding")
+            yield Label("1234567890" * 4, classes="target padding")
+        yield Label("1234567890" * 8, classes="ruler")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target margin")
+            yield Label("1234567890" * 4, classes="target")
+        with Horizontal():
+            yield Label("1234567890" * 4, classes="target padding margin")
+            yield Label("1234567890" * 4, classes="target padding")
+        with Horizontal():
+            yield Input(classes="target")
+            yield Button(classes="target")
+        with Horizontal():
+            yield TextArea(classes="target")
+            yield DataTable(classes="target")
+
+
+if __name__ == "__main__":
+    DimensionsApp().run()

--- a/tests/snapshot_tests/snapshot_apps/input_validation.py
+++ b/tests/snapshot_tests/snapshot_apps/input_validation.py
@@ -17,6 +17,7 @@ class InputApp(App):
     }
     Input {
         margin: 1 2;
+        width: 1fr;
     }
     """
 
@@ -41,5 +42,5 @@ class InputApp(App):
 
 app = InputApp()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -57,6 +57,30 @@ def test_alignment_containers(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "alignment_containers.py")
 
 
+def test_dimensions_width(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_width.py", terminal_size=(80, 24))
+
+
+def test_dimensions_max_width(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_max_width.py", terminal_size=(80, 24))
+
+
+def test_dimensions_min_width(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_min_width.py", terminal_size=(80, 24))
+
+
+def test_dimensions_height(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_height.py", terminal_size=(80, 24))
+
+
+def test_dimensions_max_height(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_max_height.py", terminal_size=(80, 24))
+
+
+def test_dimensions_min_height(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_min_height.py", terminal_size=(80, 24))
+
+
 # --- Widgets - rendering and basic interactions ---
 # Each widget should have a canonical example that is display in the docs.
 # When adding a new widget, ideally we should also create a snapshot test

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -58,27 +58,39 @@ def test_alignment_containers(snap_compare):
 
 
 def test_dimensions_width(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_width.py", terminal_size=(80, 24))
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "dimensions_width.py", terminal_size=(80, 24)
+    )
 
 
 def test_dimensions_max_width(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_max_width.py", terminal_size=(80, 24))
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "dimensions_max_width.py", terminal_size=(80, 24)
+    )
 
 
 def test_dimensions_min_width(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_min_width.py", terminal_size=(80, 24))
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "dimensions_min_width.py", terminal_size=(80, 24)
+    )
 
 
 def test_dimensions_height(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_height.py", terminal_size=(80, 24))
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "dimensions_height.py", terminal_size=(80, 24)
+    )
 
 
 def test_dimensions_max_height(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_max_height.py", terminal_size=(80, 24))
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "dimensions_max_height.py", terminal_size=(80, 24)
+    )
 
 
 def test_dimensions_min_height(snap_compare):
-    assert snap_compare(SNAPSHOT_APPS_DIR / "dimensions_min_height.py", terminal_size=(80, 24))
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "dimensions_min_height.py", terminal_size=(80, 24)
+    )
 
 
 # --- Widgets - rendering and basic interactions ---

--- a/tests/test_box_model.py
+++ b/tests/test_box_model.py
@@ -84,7 +84,7 @@ def test_width():
     styles.width = "100%"
 
     box_model = widget._get_box_model(Size(60, 20), Size(80, 24), one, one)
-    assert box_model == BoxModel(Fraction(54), Fraction(16), Spacing(1, 2, 3, 4))
+    assert box_model == BoxModel(Fraction(60), Fraction(16), Spacing(1, 2, 3, 4))
 
     styles.width = "100vw"
     styles.max_width = "50%"
@@ -127,7 +127,7 @@ def test_height():
     styles.height = "100%"
 
     box_model = widget._get_box_model(Size(60, 20), Size(80, 24), one, one)
-    assert box_model == BoxModel(Fraction(54), Fraction(16), Spacing(1, 2, 3, 4))
+    assert box_model == BoxModel(Fraction(54), Fraction(20), Spacing(1, 2, 3, 4))
 
     styles.height = "auto"
     styles.margin = 2


### PR DESCRIPTION
This fixes several “off by one” errors when computing `width`, `height`,  and their `max-`/`min-` variations for some combinations of unit, widget padding, and widget margin.

ASSUMPTION of this PR: the margin is _**not**_ taken into account when computing the dimensions of a given widget.

Example application where all red frames should have the same width running with the tip of `main`:

![Screenshot 2024-01-15 at 15 10 46](https://github.com/Textualize/textual/assets/5621605/2fcf0156-0dfa-428d-b871-572b51306fa0)

Now running with the fix implemented:

![Screenshot 2024-01-15 at 15 10 57](https://github.com/Textualize/textual/assets/5621605/3865b5de-c16c-4b55-974d-a8adce61a448)