### PR TITLE
docs(faq): fix broken datatable scroll link

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -321,8 +321,8 @@ There is currently a light and dark version of the design system, but more are p
 
 ---
 
-<a name="why-doesn't-the-`datatable`-scroll-programmatically"></a>
-## Why doesn't the `DataTable` scroll programmatically?
+<a name="why-doesn't-the-datatable-scroll-programmatically"></a>
+## Why doesn't the DataTable scroll programmatically?
 
 If scrolling in your `DataTable` is _apparently_ broken, it may be because your `DataTable` is using the default value of `height: auto`.
 This means that the table will be sized to fit its rows without scrolling, which may cause the *container* (typically the screen) to scroll.

--- a/questions/datatable-doesnt-scroll.question.md
+++ b/questions/datatable-doesnt-scroll.question.md
@@ -1,5 +1,5 @@
 ---
-title: "Why doesn't the `DataTable` scroll programmatically?"
+title: "Why doesn't the DataTable scroll programmatically?"
 alt_titles:
   - "Scroll bindings from `DataTable` not working."
   - "Datatable cursor goes off screen and doesn't scroll."


### PR DESCRIPTION
The FAQ link for 'Why doesn't the DataTable scroll programmatically?' is broken because of the backticks, as tested here https://github.com/Textualize/textual/issues/4026#issuecomment-1892754619

I've never used FAQtory so hopefully this fix is right - should this package also be added a Textual dev dependency?
