### PR TITLE
fix: handle missing tree-sitter-language binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `SelectionList` option IDs are usable as soon as the widget is instantiated https://github.com/Textualize/textual/issues/3903
 - Fix issue with `Strip.crop` when crop window start aligned with strip end https://github.com/Textualize/textual/pull/3998
 - Fixed Strip.crop_extend https://github.com/Textualize/textual/pull/4011
+- Fixed a crash if the `TextArea` language was set but tree-sitter lanuage binaries were not installed https://github.com/Textualize/textual/issues/4045
 
 
 ## [0.47.1] - 2023-01-05

--- a/src/textual/document/_syntax_aware_document.py
+++ b/src/textual/document/_syntax_aware_document.py
@@ -58,8 +58,16 @@ class SyntaxAwareDocument(Document):
         if isinstance(language, str):
             if language not in BUILTIN_LANGUAGES:
                 raise SyntaxAwareDocumentError(f"Invalid language {language!r}")
-            self.language = get_language(language)
-            self._parser = get_parser(language)
+            # If tree-sitter-languages is not installed properly, get_language
+            # and get_parser may raise an OSError when unable to load their
+            # resources
+            try:
+                self.language = get_language(language)
+                self._parser = get_parser(language)
+            except OSError as e:
+                raise SyntaxAwareDocumentError(
+                    f"Could not find binaries for {language!r}"
+                ) from e
         else:
             self.language = language
             self._parser = Parser()

--- a/tests/text_area/test_languages.py
+++ b/tests/text_area/test_languages.py
@@ -2,7 +2,11 @@ import pytest
 
 from textual.app import App, ComposeResult
 from textual.widgets import TextArea
-from textual.widgets.text_area import LanguageDoesNotExist
+from textual.widgets.text_area import (
+    Document,
+    LanguageDoesNotExist,
+    SyntaxAwareDocument,
+)
 
 
 class TextAreaApp(App):
@@ -95,4 +99,29 @@ async def test_register_language_existing_language():
         text_area.register_language("python", "")
 
         # We've overridden the highlight query with a blank one, so there are no highlights.
+        assert text_area._highlights == {}
+
+
+@pytest.mark.syntax
+async def test_language_binary_missing(monkeypatch: pytest.MonkeyPatch):
+    # mock a failed installation of tree-sitter-language binaries by
+    # raising an OSError from get_language
+    def raise_oserror(_):
+        raise OSError(
+            "/path/to/tree_sitter_languages/languages.so: "
+            "cannot open shared object file: No such file or directory"
+        )
+
+    monkeypatch.setattr(
+        "textual.document._syntax_aware_document.get_language", raise_oserror
+    )
+
+    app = TextAreaApp()
+    async with app.run_test():
+        text_area = app.query_one(TextArea)  # does not crash
+        assert text_area.language == "python"
+        # resulting document is not a SyntaxAwareDocument and does not
+        # support highlights
+        assert isinstance(text_area.document, Document)
+        assert not isinstance(text_area.document, SyntaxAwareDocument)
         assert text_area._highlights == {}


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

Closes https://github.com/Textualize/textual/issues/4045

I don't think new documentation is necessary. Happy to provide if you disagree.