### PR TITLE
Cancelling scrolling animations on new scroll_to calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Made `textual.cache` (formerly `textual._cache`) public https://github.com/Textualize/textual/pull/3976
 - `Tab.label` can now be used to change the label of a tab https://github.com/Textualize/textual/pull/3979
 - Changed the default notification timeout from 3 to 5 seconds https://github.com/Textualize/textual/pull/4059
+- Prior scroll animations are now cancelled on new scrolls https://github.com/Textualize/textual/pull/4081
 
 ### Added
 

--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -409,7 +409,11 @@ class Animator:
                 end_value=value,
                 final_value=final_value,
                 easing=easing_function,
-                on_complete=on_complete,
+                on_complete=(
+                    partial(self.app.call_later, on_complete)
+                    if on_complete is not None
+                    else None
+                ),
             )
         assert animation is not None, "animation expected to be non-None"
 
@@ -485,8 +489,7 @@ class Animator:
 
     def force_stop_animation(self, obj: object, attribute: str) -> None:
         """Force stop an animation on an attribute. This will immediately stop the animation,
-        without running any associated callbacks and without setting the animation to its
-        final value.
+        without running any associated callbacks, setting the attribute to its final value.
 
         Args:
             obj: The object containing the attribute.
@@ -507,6 +510,9 @@ class Animator:
             setattr(obj, attribute, animation.end_value)
         elif isinstance(animation, ScalarAnimation):
             setattr(obj, attribute, animation.final_value)
+
+        if animation.on_complete is not None:
+            animation.on_complete()
 
     async def __call__(self) -> None:
         if not self._animations:

--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -514,7 +514,7 @@ class Animator:
         if animation.on_complete is not None:
             animation.on_complete()
 
-    async def __call__(self) -> None:
+    def __call__(self) -> None:
         if not self._animations:
             self._timer.pause()
             self._idle_event.set()
@@ -528,7 +528,8 @@ class Animator:
                 animation_complete = animation(animation_time)
                 if animation_complete:
                     del self._animations[animation_key]
-                    await animation.invoke_callback()
+                    if animation.on_complete is not None:
+                        animation.on_complete()
 
     def _get_time(self) -> float:
         """Get the current wall clock time, via the internal Timer.
@@ -537,7 +538,7 @@ class Animator:
             The wall clock time.
         """
         # N.B. We could remove this method and always call `self._timer.get_time()` internally,
-        # but it's handy to have in mocking situations
+        # but it's handy to have in mocking situations.
         return _time.get_time()
 
     async def wait_for_idle(self) -> None:

--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -483,6 +483,31 @@ class Animator:
         elif key in self._animations:
             await self._stop_running_animation(key, complete)
 
+    def force_stop_animation(self, obj: object, attribute: str) -> None:
+        """Force stop an animation on an attribute. This will immediately stop the animation,
+        without running any associated callbacks and without setting the animation to its
+        final value.
+
+        Args:
+            obj: The object containing the attribute.
+            attribute: The name of the attribute.
+
+        Note:
+            If there is no animation scheduled or running, this is a no-op.
+        """
+        from .css.scalar_animation import ScalarAnimation
+
+        animation_key = (id(obj), attribute)
+        try:
+            animation = self._animations.pop(animation_key)
+        except KeyError:
+            return
+
+        if isinstance(animation, SimpleAnimation):
+            setattr(obj, attribute, animation.end_value)
+        elif isinstance(animation, ScalarAnimation):
+            setattr(obj, attribute, animation.final_value)
+
     async def __call__(self) -> None:
         if not self._animations:
             self._timer.pause()

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from functools import lru_cache
+from functools import lru_cache, partial
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Iterable, NamedTuple, cast
 
@@ -395,7 +395,11 @@ class StylesBase(ABC):
                 duration=duration,
                 speed=speed,
                 easing=easing,
-                on_complete=on_complete,
+                on_complete=(
+                    partial(self.node.app.call_later, on_complete)
+                    if on_complete is not None
+                    else None
+                ),
             )
         return None
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1915,6 +1915,11 @@ class Widget(DOMNode):
         maybe_scroll_x = x is not None and (self.allow_horizontal_scroll or force)
         maybe_scroll_y = y is not None and (self.allow_vertical_scroll or force)
         scrolled_x = scrolled_y = False
+
+        animator = self.app.animator
+        animator.force_stop_animation(self, "scroll_x")
+        animator.force_stop_animation(self, "scroll_y")
+
         if animate:
             # TODO: configure animation speed
             if duration is None and speed is None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1916,44 +1916,59 @@ class Widget(DOMNode):
         maybe_scroll_y = y is not None and (self.allow_vertical_scroll or force)
         scrolled_x = scrolled_y = False
 
-        if not animate:
-            duration = 0
-        elif duration is None and speed is None:
-            speed = 50
+        animator = self.app.animator
+        animator.force_stop_animation(self, "scroll_x")
+        animator.force_stop_animation(self, "scroll_y")
 
-        if easing is None:
-            easing = DEFAULT_SCROLL_EASING
+        if animate:
+            # TODO: configure animation speed
+            if duration is None and speed is None:
+                speed = 50
 
-        if maybe_scroll_x:
-            assert x is not None
-            self.scroll_target_x = x
-            if x != self.scroll_x:
-                self.animate(
-                    "scroll_x",
-                    self.scroll_target_x,
-                    speed=speed,
-                    duration=duration,
-                    easing=easing,
-                    on_complete=on_complete,
-                )
-                scrolled_x = True
+            if easing is None:
+                easing = DEFAULT_SCROLL_EASING
 
-        if maybe_scroll_y:
-            assert y is not None
-            self.scroll_target_y = y
-            if y != self.scroll_y:
-                self.animate(
-                    "scroll_y",
-                    self.scroll_target_y,
-                    speed=speed,
-                    duration=duration,
-                    easing=easing,
-                    on_complete=on_complete,
-                )
-                scrolled_y = True
+            if maybe_scroll_x:
+                assert x is not None
+                self.scroll_target_x = x
+                if x != self.scroll_x:
+                    self.animate(
+                        "scroll_x",
+                        self.scroll_target_x,
+                        speed=speed,
+                        duration=duration,
+                        easing=easing,
+                        on_complete=on_complete,
+                    )
+                    scrolled_x = True
+            if maybe_scroll_y:
+                assert y is not None
+                self.scroll_target_y = y
+                if y != self.scroll_y:
+                    self.animate(
+                        "scroll_y",
+                        self.scroll_target_y,
+                        speed=speed,
+                        duration=duration,
+                        easing=easing,
+                        on_complete=on_complete,
+                    )
+                    scrolled_y = True
 
-        if on_complete is not None:
-            self.call_after_refresh(on_complete)
+        else:
+            if maybe_scroll_x:
+                assert x is not None
+                scroll_x = self.scroll_x
+                self.scroll_target_x = self.scroll_x = x
+                scrolled_x = scroll_x != self.scroll_x
+            if maybe_scroll_y:
+                assert y is not None
+                scroll_y = self.scroll_y
+                self.scroll_target_y = self.scroll_y = y
+                scrolled_y = scroll_y != self.scroll_y
+
+            if on_complete is not None:
+                self.call_after_refresh(on_complete)
 
         return scrolled_x or scrolled_y
 

--- a/tests/test_animator.py
+++ b/tests/test_animator.py
@@ -267,3 +267,20 @@ async def test_animator_on_complete_callback_fired_at_duration():
     await animator()
 
     callback.assert_called_once_with()
+
+
+def test_force_stop():
+    callback = Mock()
+    animate_test = AnimateTest()
+    animator = MockAnimator(Mock())
+
+    animator.animate(animate_test, "foo", 200, duration=10, on_complete=callback)
+
+    assert animator.is_being_animated(animate_test, "foo")
+
+    animator.force_stop_animation(animate_test, "foo")
+
+    # The animation of the attribute was force cancelled. It's no longer
+    # animation and the callback was not fired.
+    assert not animator.is_being_animated(animate_test, "foo")
+    callback.assert_not_called()


### PR DESCRIPTION
Ensures that previous scrolling animations are cancelled when we call scroll_to.