### PR TITLE
Fix the double-detection of `escape` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - ID and class validation was too lenient https://github.com/Textualize/textual/issues/3954
 - Fixed CSS watcher crash if file becomes unreadable (even temporarily) https://github.com/Textualize/textual/pull/4079
 - Fixed display of keys when used in conjunction with other keys https://github.com/Textualize/textual/pull/3050
+- Fixed double detection of <kbd>Escape</kbd> on Windows https://github.com/Textualize/textual/issues/4038
 
 ## [0.47.1] - 2023-01-05
 

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -264,7 +264,7 @@ class EventMonitor(threading.Thread):
                         # Key event, store unicode char in keys list
                         key_event = input_record.Event.KeyEvent
                         key = key_event.uChar.UnicodeChar
-                        if key_event.bKeyDown or key == "\x1b":
+                        if key_event.bKeyDown:
                             if (
                                 key_event.dwControlKeyState
                                 and key_event.wVirtualKeyCode == 0

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -28,7 +28,7 @@ async def test_character_bindings():
     counter = 0
 
     class BindApp(App):
-        BINDINGS = [(".,~,space", "increment", "foo")]
+        BINDINGS = [(".,~,space,escape", "increment", "foo")]
 
         def action_increment(self) -> None:
             nonlocal counter
@@ -45,9 +45,12 @@ async def test_character_bindings():
         await pilot.press(" ")
         await pilot.pause()
         assert counter == 3
+        await pilot.press("escape")  # https://github.com/Textualize/textual/issues/4038
+        await pilot.pause()
+        assert counter == 4
         await pilot.press("x")
         await pilot.pause()
-        assert counter == 3
+        assert counter == 4
 
 
 def test_get_key_display():

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -28,7 +28,7 @@ async def test_character_bindings():
     counter = 0
 
     class BindApp(App):
-        BINDINGS = [(".,~,space,escape", "increment", "foo")]
+        BINDINGS = [(".,~,space", "increment", "foo")]
 
         def action_increment(self) -> None:
             nonlocal counter
@@ -45,12 +45,9 @@ async def test_character_bindings():
         await pilot.press(" ")
         await pilot.pause()
         assert counter == 3
-        await pilot.press("escape")  # https://github.com/Textualize/textual/issues/4038
-        await pilot.pause()
-        assert counter == 4
         await pilot.press("x")
         await pilot.pause()
-        assert counter == 4
+        assert counter == 3
 
 
 def test_get_key_display():


### PR DESCRIPTION
Fixes #4038.

No tests added for this because, unless we have a way of *actually* pressing keys, there's no reasonable method of causing the cause in an automated test environment.