### PR TITLE
docs(text area): fix syntax highlighting in examples

### DIFF
--- a/docs/examples/widgets/text_area_custom_language.py
+++ b/docs/examples/widgets/text_area_custom_language.py
@@ -18,7 +18,7 @@ class HelloWorld {
 
 class TextAreaCustomLanguage(App):
     def compose(self) -> ComposeResult:
-        text_area = TextArea(text=java_code)
+        text_area = TextArea.code_editor(text=java_code)
         text_area.cursor_blink = False
 
         # Register the Java language and highlight query

--- a/docs/examples/widgets/text_area_example.py
+++ b/docs/examples/widgets/text_area_example.py
@@ -12,7 +12,7 @@ def goodbye(name):
 
 class TextAreaExample(App):
     def compose(self) -> ComposeResult:
-        yield TextArea(TEXT, language="python")
+        yield TextArea.code_editor(TEXT, language="python")
 
 
 app = TextAreaExample()

--- a/docs/examples/widgets/text_area_extended.py
+++ b/docs/examples/widgets/text_area_extended.py
@@ -15,7 +15,7 @@ class ExtendedTextArea(TextArea):
 
 class TextAreaKeyPressHook(App):
     def compose(self) -> ComposeResult:
-        yield ExtendedTextArea(language="python")
+        yield ExtendedTextArea.code_editor(language="python")
 
 
 app = TextAreaKeyPressHook()

--- a/docs/examples/widgets/text_area_extended.py
+++ b/docs/examples/widgets/text_area_extended.py
@@ -6,29 +6,6 @@ from textual.widgets import TextArea
 class ExtendedTextArea(TextArea):
     """A subclass of TextArea with parenthesis-closing functionality."""
 
-    def __init__(
-        self,
-        text: str = "",
-        *,
-        language: str | None = None,
-        name: str | None = None,
-        id: str | None = None,
-        classes: str | None = None,
-        disabled: bool = False
-    ) -> None:
-        super().__init__(
-            text=text,
-            language=language,
-            theme="monokai",
-            soft_wrap=False,
-            tab_behaviour="indent",
-            show_line_numbers=True,
-            name=name,
-            id=id,
-            classes=classes,
-            disabled=disabled,
-        )
-
     def _on_key(self, event: events.Key) -> None:
         if event.character == "(":
             self.insert("()")

--- a/docs/examples/widgets/text_area_extended.py
+++ b/docs/examples/widgets/text_area_extended.py
@@ -6,6 +6,29 @@ from textual.widgets import TextArea
 class ExtendedTextArea(TextArea):
     """A subclass of TextArea with parenthesis-closing functionality."""
 
+    def __init__(
+        self,
+        text: str = "",
+        *,
+        language: str | None = None,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False
+    ) -> None:
+        super().__init__(
+            text=text,
+            language=language,
+            theme="monokai",
+            soft_wrap=False,
+            tab_behaviour="indent",
+            show_line_numbers=True,
+            name=name,
+            id=id,
+            classes=classes,
+            disabled=disabled,
+        )
+
     def _on_key(self, event: events.Key) -> None:
         if event.character == "(":
             self.insert("()")

--- a/docs/examples/widgets/text_area_selection.py
+++ b/docs/examples/widgets/text_area_selection.py
@@ -13,7 +13,7 @@ def goodbye(name):
 
 class TextAreaSelection(App):
     def compose(self) -> ComposeResult:
-        text_area = TextArea(TEXT, language="python")
+        text_area = TextArea.code_editor(TEXT, language="python")
         text_area.selection = Selection(start=(0, 0), end=(2, 0))  # (1)!
         yield text_area
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -457,7 +457,7 @@ TextArea:light .text-area--cursor {
             classes: One or more Textual CSS compatible class names separated by spaces.
             disabled: True if the widget is disabled.
         """
-        return TextArea(
+        return cls(
             text,
             language=language,
             theme=theme,


### PR DESCRIPTION
Fixes #4094.

I do wonder if the docs should start with an example of a plain multi-line input now that is the default `TextArea` experience, but I'll leave that as an open question here (and out of scope for this PR).

This does slightly complicate the [Extending TextArea example](https://textual.textualize.io/widgets/text_area/#example-closing-parentheses-automatically) with the long `__init__` method, but I think leaving this as a plain TextArea might cause some confusion.
