### PR TITLE
Directory tree reload now preserves state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `DirectoryTree.clear_node` not clearing the node specified https://github.com/Textualize/textual/issues/4122
+
 ## [0.48.2] - 2024-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `DirectoryTree.clear_node` not clearing the node specified https://github.com/Textualize/textual/issues/4122
 
+### Added
+
+- `Tree` (and `DirectoryTree`) grew an attribute `lock` that can be used for synchronization across coroutines https://github.com/Textualize/textual/issues/4056
+
+### Changed
+
+- `DirectoryTree.reload` and `DirectoryTree.reload_node` now preserve state when reloading https://github.com/Textualize/textual/issues/4056
+
 ## [0.48.2] - 2024-02-02
 
 ### Fixed

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -192,17 +192,7 @@ class DirectoryTree(Tree[DirEntry]):
             The `Tree` instance.
         """
         self._clear_line_cache()
-        node_label = node._label
-        node_data = node.data
-        node_parent = node.parent
-        node = TreeNode(
-            self,
-            node_parent,
-            self._new_id(),
-            node_label,
-            node_data,
-            expanded=True,
-        )
+        node.remove_children()
         self._updates += 1
         self.refresh()
         return self

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -5,19 +5,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, ClassVar, Iterable, Iterator
 
-from ..await_complete import AwaitComplete
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
-
 from rich.style import Style
 from rich.text import Text, TextType
 
 from .. import work
+from ..await_complete import AwaitComplete
 from ..message import Message
 from ..reactive import var
 from ..worker import Worker, WorkerCancelled, WorkerFailed, get_current_worker
 from ._tree import TOGGLE_STYLE, Tree, TreeNode
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 @dataclass
@@ -164,7 +163,7 @@ class DirectoryTree(Tree[DirEntry]):
 
         Returns:
             An optionally awaitable object that can be awaited until the
-            load queue has finished processing.
+                load queue has finished processing.
         """
         assert node.data is not None
         if not node.data.loaded:
@@ -174,16 +173,18 @@ class DirectoryTree(Tree[DirEntry]):
         return AwaitComplete(self._load_queue.join())
 
     def reload(self) -> AwaitComplete:
-        """Reload the `DirectoryTree` contents."""
-        self.reset(str(self.path), DirEntry(self.PATH(self.path)))
+        """Reload the `DirectoryTree` contents.
+
+        Returns:
+            An optionally awaitable that ensures the tree has finished reloading.
+        """
         # Orphan the old queue...
         self._load_queue = Queue()
+        # ... reset the root node ...
+        processed = self.reload_node(self.root)
         # ...and replace the old load with a new one.
         self._loader()
-        # We have a fresh queue, we have a fresh loader, get the fresh root
-        # loading up.
-        queue_processed = self._add_to_load_queue(self.root)
-        return queue_processed
+        return processed
 
     def clear_node(self, node: TreeNode[DirEntry]) -> Self:
         """Clear all nodes under the given node.
@@ -215,6 +216,88 @@ class DirectoryTree(Tree[DirEntry]):
         node.data = data
         return self
 
+    async def _reload(self, node: TreeNode[DirEntry]) -> None:
+        """Reloads the subtree rooted at the given node while preserving state.
+
+        After reloading the subtree, nodes that were expanded and still exist
+        will remain expanded and the highlighted node will be preserved, if it
+        still exists. If it doesn't, highlighting goes up to the first parent
+        directory that still exists.
+
+        Args:
+            node: The root of the subtree to reload.
+        """
+        async with self.lock:
+            # Track nodes that were expanded before reloading.
+            currently_open: set[Path] = set()
+            to_check: list[TreeNode[DirEntry]] = [node]
+            while to_check:
+                checking = to_check.pop()
+                if checking.allow_expand and checking.is_expanded:
+                    if checking.data:
+                        currently_open.add(checking.data.path)
+                    to_check.extend(checking.children)
+
+            # Track node that was highlighted before reloading.
+            highlighted_path: None | Path = None
+            if self.cursor_line > -1:
+                highlighted_node = self.get_node_at_line(self.cursor_line)
+                if highlighted_node is not None and highlighted_node.data is not None:
+                    highlighted_path = highlighted_node.data.path
+
+            if node.data is not None:
+                self.reset_node(
+                    node, str(node.data.path.name), DirEntry(self.PATH(node.data.path))
+                )
+
+            # Reopen nodes that were expanded and still exist.
+            to_reopen = [node]
+            while to_reopen:
+                reopening = to_reopen.pop()
+                if not reopening.data:
+                    continue
+                if (
+                    reopening.allow_expand
+                    and (reopening.data.path in currently_open or reopening == node)
+                    and reopening.data.path.exists()
+                ):
+                    try:
+                        content = await self._load_directory(reopening).wait()
+                    except (WorkerCancelled, WorkerFailed):
+                        continue
+                    reopening.data.loaded = True
+                    self._populate_node(reopening, content)
+                    to_reopen.extend(reopening.children)
+                    reopening.expand()
+
+            if highlighted_path is None:
+                return
+
+            # Restore the highlighted path and consider the parents as fallbacks.
+            looking = [node]
+            highlight_candidates = set(highlighted_path.parents)
+            highlight_candidates.add(highlighted_path)
+            best_found: None | TreeNode[DirEntry] = None
+            while looking:
+                checking = looking.pop()
+                checking_path = (
+                    checking.data.path if checking.data is not None else None
+                )
+                if checking_path in highlight_candidates:
+                    best_found = checking
+                    if checking_path == highlighted_path:
+                        break
+                if (
+                    checking.allow_expand
+                    and checking.is_expanded
+                    and checking_path in highlighted_path.parents
+                ):
+                    looking.extend(checking.children)
+            if best_found is not None:
+                # We need valid lines. Make sure the tree lines have been computed:
+                _ = self._tree_lines
+                self.cursor_line = best_found.line
+
     def reload_node(self, node: TreeNode[DirEntry]) -> AwaitComplete:
         """Reload the given node's contents.
 
@@ -223,12 +306,12 @@ class DirectoryTree(Tree[DirEntry]):
         or any other nodes).
 
         Args:
-            node: The node to reload.
+            node: The root of the subtree to reload.
+
+        Returns:
+            An optionally awaitable that ensures the subtree has finished reloading.
         """
-        self.reset_node(
-            node, str(node.data.path.name), DirEntry(self.PATH(node.data.path))
-        )
-        return self._add_to_load_queue(node)
+        return AwaitComplete(self._reload(node))
 
     def validate_path(self, path: str | Path) -> Path:
         """Ensure that the path is of the `Path` type.
@@ -415,28 +498,29 @@ class DirectoryTree(Tree[DirEntry]):
             # this blocks if the queue is empty.
             node = await self._load_queue.get()
             content: list[Path] = []
-            try:
-                # Spin up a short-lived thread that will load the content of
-                # the directory associated with that node.
-                content = await self._load_directory(node).wait()
-            except WorkerCancelled:
-                # The worker was cancelled, that would suggest we're all
-                # done here and we should get out of the loader in general.
-                break
-            except WorkerFailed:
-                # This particular worker failed to start. We don't know the
-                # reason so let's no-op that (for now anyway).
-                pass
-            else:
-                # We're still here and we have directory content, get it into
-                # the tree.
-                if content:
-                    self._populate_node(node, content)
-            finally:
-                # Mark this iteration as done.
-                self._load_queue.task_done()
+            async with self.lock:
+                try:
+                    # Spin up a short-lived thread that will load the content of
+                    # the directory associated with that node.
+                    content = await self._load_directory(node).wait()
+                except WorkerCancelled:
+                    # The worker was cancelled, that would suggest we're all
+                    # done here and we should get out of the loader in general.
+                    break
+                except WorkerFailed:
+                    # This particular worker failed to start. We don't know the
+                    # reason so let's no-op that (for now anyway).
+                    pass
+                else:
+                    # We're still here and we have directory content, get it into
+                    # the tree.
+                    if content:
+                        self._populate_node(node, content)
+                finally:
+                    # Mark this iteration as done.
+                    self._load_queue.task_done()
 
-    async def _on_tree_node_expanded(self, event: Tree.NodeExpanded) -> None:
+    async def _on_tree_node_expanded(self, event: Tree.NodeExpanded[DirEntry]) -> None:
         event.stop()
         dir_entry = event.node.data
         if dir_entry is None:
@@ -446,7 +530,7 @@ class DirectoryTree(Tree[DirEntry]):
         else:
             self.post_message(self.FileSelected(event.node, dir_entry.path))
 
-    def _on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
+    def _on_tree_node_selected(self, event: Tree.NodeSelected[DirEntry]) -> None:
         event.stop()
         dir_entry = event.node.data
         if dir_entry is None:

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -256,10 +256,8 @@ class DirectoryTree(Tree[DirEntry]):
                 reopening = to_reopen.pop()
                 if not reopening.data:
                     continue
-                if (
-                    reopening.allow_expand
-                    and (reopening.data.path in currently_open or reopening == node)
-                    and reopening.data.path.exists()
+                if reopening.allow_expand and (
+                    reopening.data.path in currently_open or reopening == node
                 ):
                     try:
                         content = await self._load_directory(reopening).wait()
@@ -471,7 +469,7 @@ class DirectoryTree(Tree[DirEntry]):
         except PermissionError:
             pass
 
-    @work(thread=True)
+    @work(thread=True, exit_on_error=False)
     def _load_directory(self, node: TreeNode[DirEntry]) -> list[Path]:
         """Load the directory contents for a given node.
 

--- a/tests/snapshot_tests/snapshot_apps/directory_tree_reload.py
+++ b/tests/snapshot_tests/snapshot_apps/directory_tree_reload.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.widgets import DirectoryTree
+
+
+class DirectoryTreeReloadApp(App[None]):
+    BINDINGS = [
+        ("r", "reload"),
+        ("e", "expand"),
+        ("d", "delete"),
+    ]
+
+    async def setup(self, path_root: Path) -> None:
+        self.path_root = path_root
+
+        structure = [
+            "f1.txt",
+            "f2.txt",
+            "b1/f1.txt",
+            "b1/f2.txt",
+            "b2/f1.txt",
+            "b2/f2.txt",
+            "b1/c1/f1.txt",
+            "b1/c1/f2.txt",
+            "b1/c2/f1.txt",
+            "b1/c2/f2.txt",
+            "b1/c1/d1/f1.txt",
+            "b1/c1/d1/f2.txt",
+            "b1/c1/d2/f1.txt",
+            "b1/c1/d2/f2.txt",
+        ]
+        for file in structure:
+            path = path_root / Path(file)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch(exist_ok=True)
+
+        await self.mount(DirectoryTree(self.path_root))
+
+    async def action_reload(self) -> None:
+        dt = self.query_one(DirectoryTree)
+        await dt.reload()
+
+    def action_expand(self) -> None:
+        self.query_one(DirectoryTree).root.expand_all()
+
+    def action_delete(self) -> None:
+        self.rmdir(self.path_root / Path("b1/c1/d2"))
+        self.rmdir(self.path_root / Path("b1/c2"))
+        self.rmdir(self.path_root / Path("b2"))
+
+    def rmdir(self, path: Path) -> None:
+        for file in path.iterdir():
+            if file.is_file():
+                file.unlink()
+            elif file.is_dir():
+                self.rmdir(file)
+        path.rmdir()
+
+
+if __name__ == "__main__":
+    DirectoryTreeReloadApp(Path("playground")).run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -403,6 +403,19 @@ def test_collapsible_custom_symbol(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "collapsible_custom_symbol.py")
 
 
+def test_directory_tree_reloading(snap_compare, tmp_path):
+    async def run_before(pilot):
+        await pilot.app.setup(tmp_path)
+        await pilot.press(
+            "e", "e", "down", "down", "down", "down", "e", "down", "d", "r"
+        )
+
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "directory_tree_reload.py",
+        run_before=run_before,
+    )
+
+
 # --- CSS properties ---
 # We have a canonical example for each CSS property that is shown in their docs.
 # If any of these change, something has likely broken, so snapshot each of them.

--- a/tests/tree/test_directory_tree.py
+++ b/tests/tree/test_directory_tree.py
@@ -28,21 +28,6 @@ class DirectoryTreeApp(App[None]):
         self.messages.append(event.__class__.__name__)
 
 
-class RecordExpandDirectoryTreeApp(App[None]):
-    def __init__(self, path: Path):
-        super().__init__()
-        self.path = path
-        self.expanded: list[str] = []
-
-    def compose(self) -> ComposeResult:
-        yield DirectoryTree(self.path)
-
-    @on(DirectoryTree.DirectorySelected)
-    def record(self, event: DirectoryTree.DirectorySelected) -> None:
-        assert event.node.data is not None
-        self.expanded.append(str(event.node.data.path.name))
-
-
 async def test_directory_tree_file_selected_message(tmp_path: Path) -> None:
     """Selecting a file should result in a file selected message being emitted."""
 


### PR DESCRIPTION
Fixes #4056.

Adds an `asyncio.Lock` to `Tree`.
Adds a private coroutine `DirectoryTree._reload` used by `DirectoryTree.reload`/`.reload_node` that reloads a subtree and preserves expanded nodes + highlighted node.

Fixes #4122.
While working on the above I noticed this bug and I fixed it en passant.