### PR TITLE
Fix a TextArea crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a crash in the TextArea when performing a backward replace https://github.com/Textualize/textual/pull/4126
+- Fixed selection not updating correctly when pasting while there's a non-zero selection https://github.com/Textualize/textual/pull/4126
+
 ## [0.48.2] - 2024-02-02
 
 ### Fixed

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -2048,10 +2048,12 @@ class Edit:
 
     @property
     def top(self) -> Location:
+        """The Location impacted by this edit that is nearest the start of the document."""
         return min([self.from_location, self.to_location])
 
     @property
     def bottom(self) -> Location:
+        """The Location impacted by this edit that is nearest the end of the document."""
         return max([self.from_location, self.to_location])
 
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1337,7 +1337,8 @@ TextArea:light .text-area--cursor {
 
     async def _on_paste(self, event: events.Paste) -> None:
         """When a paste occurs, insert the text from the paste event into the document."""
-        self.replace(event.text, *self.selection)
+        result = self.replace(event.text, *self.selection)
+        self.move_cursor(result.end_location)
 
     def cell_width_to_column_index(self, cell_width: int, row_index: int) -> int:
         """Return the column that the cell width corresponds to on the given row.

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -6,6 +6,7 @@ location.
 
 Note that more extensive testing for editing is done at the Document level.
 """
+
 import pytest
 
 from textual.app import App, ComposeResult
@@ -416,3 +417,20 @@ async def test_delete_word_right_at_end_of_line():
 
         assert text_area.text == "0123456789"
         assert text_area.selection == Selection.cursor((0, 5))
+
+
+async def test_replace_lines_with_fewer_lines_backwards_selection():
+    app = TextAreaApp()
+    async with app.run_test() as pilot:
+        text_area = app.query_one(TextArea)
+        text_area.text = SIMPLE_TEXT
+        text_area.selection = Selection(start=(3, 0), end=(1, 0))
+
+        await pilot.press("a")
+
+        expected_text = """\
+ABCDE
+aPQRST
+UVWXY
+Z"""
+        assert text_area.text == expected_text


### PR DESCRIPTION
The TextArea widget could crash if a replacement operation occurred while a backward selection was made, and the inserted content contained fewer lines than the content being replaced.

I've fixed this and simplified some operations which don't care about the "direction" of the selection (i.e. did you click and drag from top to bottom or bottom to top with your mouse to select text).

Also fixes an issue where the selection wasn't being correctly updated after a paste occurred.