### PR TITLE
Fix TextArea cursor being visible before it has focus for first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Breaking change: `TextArea` will not use `Escape` to shift focus if the `tab_behaviour` is the default https://github.com/Textualize/textual/issues/4110
+- `TextArea` cursor will now be invisible before first focus https://github.com/Textualize/textual/pull/4128
+- Fix toggling `TextArea.cursor_blink` reactive when widget does not have focus https://github.com/Textualize/textual/pull/4128
 
 ## [0.48.2] - 2024-02-02
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -553,6 +553,14 @@ TextArea:light .text-area--cursor {
         if previous_selection != selection:
             self.post_message(self.SelectionChanged(selection, self))
 
+    def _watch_cursor_blink(self, blink: bool) -> None:
+        if not self.is_mounted:
+            return None
+        if blink and self.has_focus:
+            self._restart_blink()
+        else:
+            self._pause_blink(visible=self.has_focus)
+
     def _recompute_cursor_offset(self):
         """Recompute the (x, y) coordinate of the cursor in the wrapped document."""
         self._cursor_offset = self.wrapped_document.location_to_offset(
@@ -1033,8 +1041,10 @@ TextArea:light .text-area--cursor {
         )
 
         if cursor_row == line_index:
-            draw_cursor = not self.cursor_blink or (
-                self.cursor_blink and self._cursor_visible
+            draw_cursor = (
+                self.has_focus
+                and not self.cursor_blink
+                or (self.cursor_blink and self._cursor_visible)
             )
             if draw_matched_brackets:
                 matching_bracket_style = theme.bracket_matching_style if theme else None


### PR DESCRIPTION
Previously, the cursor hiding logic only worked after the TextArea received focus for the first time.

There was also an issue where if you toggled the cursor_blink reactive to True when the cursor did not have focus, the cursor reappeared and started blinking even though there was no focus.