### PR TITLE
always perform ansi filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.49.0] - 2023-02-08
+## [0.49.1] - 2023-02-08
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.49.0] - 2023-02-08
+
+### Fixed
+
+- Fixed issue with ANSI colors not being converted to truecolor https://github.com/Textualize/textual/pull/4138
+
 ## [0.49.0] - 2024-02-07
 
 ### Fixed
@@ -1664,6 +1670,7 @@ https://textual.textualize.io/blog/2022/11/08/version-040/#version-040
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
 
+[0.49.1]: https://github.com/Textualize/textual/compare/v0.49.0...v0.49.1
 [0.49.0]: https://github.com/Textualize/textual/compare/v0.48.2...v0.49.0
 [0.48.2]: https://github.com/Textualize/textual/compare/v0.48.1...v0.48.2
 [0.48.1]: https://github.com/Textualize/textual/compare/v0.48.0...v0.48.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "0.49.0"
+version = "0.49.1"
 homepage = "https://github.com/Textualize/textual"
 repository = "https://github.com/Textualize/textual"
 documentation = "https://textual.textualize.io/"

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -94,6 +94,7 @@ from .drivers.headless_driver import HeadlessDriver
 from .errors import NoWidget
 from .features import FeatureFlag, parse_features
 from .file_monitor import FileMonitor
+from .filter import ANSIToTruecolor, DimFilter, Monochrome
 from .geometry import Offset, Region, Size
 from .keys import (
     REPLACED_KEYS,
@@ -420,21 +421,17 @@ class App(Generic[ReturnType], DOMNode):
         super().__init__()
         self.features: frozenset[FeatureFlag] = parse_features(os.getenv("TEXTUAL", ""))
 
-        self._filters: list[LineFilter] = []
+        self._filters: list[LineFilter] = [
+            ANSIToTruecolor(terminal_theme.DIMMED_MONOKAI)
+        ]
         environ = dict(os.environ)
         no_color = environ.pop("NO_COLOR", None)
         if no_color is not None:
-            from .filter import ANSIToTruecolor, Monochrome
-
-            self._filters.append(ANSIToTruecolor(terminal_theme.DIMMED_MONOKAI))
             self._filters.append(Monochrome())
 
         for filter_name in constants.FILTERS.split(","):
             filter = filter_name.lower().strip()
             if filter == "dim":
-                from .filter import ANSIToTruecolor, DimFilter
-
-                self._filters.append(ANSIToTruecolor(terminal_theme.DIMMED_MONOKAI))
                 self._filters.append(DimFilter())
 
         self.console = Console(

--- a/src/textual/renderables/background_screen.py
+++ b/src/textual/renderables/background_screen.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable
 
-from rich import terminal_theme
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.segment import Segment
 from rich.style import Style
 
 from ..color import Color
-from ..filter import ANSIToTruecolor
 
 if TYPE_CHECKING:
     from ..screen import Screen
@@ -51,17 +49,13 @@ class BackgroundScreen:
         _Segment = Segment
 
         NULL_STYLE = Style()
-        truecolor_style = ANSIToTruecolor(terminal_theme.DIMMED_MONOKAI).truecolor_style
+
         for segment in segments:
             text, style, control = segment
             if control:
                 yield segment
             else:
-                style = (
-                    NULL_STYLE
-                    if style is None
-                    else truecolor_style(style.clear_meta_and_links())
-                )
+                style = NULL_STYLE if style is None else style.clear_meta_and_links()
                 yield _Segment(
                     text,
                     (

--- a/src/textual/renderables/tint.py
+++ b/src/textual/renderables/tint.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from rich import terminal_theme
 from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
 from rich.segment import Segment
 from rich.style import Style
 
 from ..color import Color
-from ..filter import ANSIToTruecolor
 
 
 class Tint:
@@ -45,19 +43,13 @@ class Tint:
         style_from_color = Style.from_color
         _Segment = Segment
 
-        ansi_filter = ANSIToTruecolor(terminal_theme.DIMMED_MONOKAI)
-
         NULL_STYLE = Style()
         for segment in segments:
             text, style, control = segment
             if control:
                 yield segment
             else:
-                style = (
-                    ansi_filter.truecolor_style(style)
-                    if style is not None
-                    else NULL_STYLE
-                )
+                style = style if style is not None else NULL_STYLE
                 yield _Segment(
                     text,
                     (


### PR DESCRIPTION
Enforces ANSI to unicode.

Some snapshot tests broke, but did not visually change
