### PR TITLE
Add default syntax mapping to CSS theme in TextArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Add some syntax highlighting to TextArea default theme https://github.com/Textualize/textual/pull/4149
 
 ## [0.51.1] - 2024-02-09
 

--- a/src/textual/_text_area_theme.py
+++ b/src/textual/_text_area_theme.py
@@ -379,7 +379,7 @@ _GITHUB_LIGHT = TextAreaTheme(
     },
 )
 
-_CSS_THEME = TextAreaTheme(name="css")
+_CSS_THEME = TextAreaTheme(name="css", syntax_styles=_DARK_VS.syntax_styles)
 
 _BUILTIN_THEMES = {
     "css": _CSS_THEME,

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -983,21 +983,6 @@ TextArea:light .text-area--cursor {
         selection_top_row, selection_top_column = selection_top
         selection_bottom_row, selection_bottom_column = selection_bottom
 
-        highlights = self._highlights
-        if highlights and theme:
-            line_bytes = _utf8_encode(line_string)
-            byte_to_codepoint = build_byte_to_codepoint_dict(line_bytes)
-            get_highlight_from_theme = theme.syntax_styles.get
-            line_highlights = highlights[line_index]
-            for highlight_start, highlight_end, highlight_name in line_highlights:
-                node_style = get_highlight_from_theme(highlight_name)
-                if node_style is not None:
-                    line.stylize(
-                        node_style,
-                        byte_to_codepoint.get(highlight_start, 0),
-                        byte_to_codepoint.get(highlight_end) if highlight_end else None,
-                    )
-
         cursor_line_style = theme.cursor_line_style if theme else None
         if cursor_line_style and cursor_row == line_index:
             line.stylize(cursor_line_style)
@@ -1031,6 +1016,21 @@ TextArea:light .text-area--cursor {
                             line.stylize(selection_style, end=selection_bottom_column)
                         else:
                             line.stylize(selection_style, end=line_character_count)
+
+        highlights = self._highlights
+        if highlights and theme:
+            line_bytes = _utf8_encode(line_string)
+            byte_to_codepoint = build_byte_to_codepoint_dict(line_bytes)
+            get_highlight_from_theme = theme.syntax_styles.get
+            line_highlights = highlights[line_index]
+            for highlight_start, highlight_end, highlight_name in line_highlights:
+                node_style = get_highlight_from_theme(highlight_name)
+                if node_style is not None:
+                    line.stylize(
+                        node_style,
+                        byte_to_codepoint.get(highlight_start, 0),
+                        byte_to_codepoint.get(highlight_end) if highlight_end else None,
+                    )
 
         # Highlight the cursor
         matching_bracket = self._matching_bracket_location


### PR DESCRIPTION
Copies the syntax highlighting from the dark VSCode theme in to the default CSS theme.

So now, if you set the `language` parameter on the plain `TextArea` (not using `code_editor`), you'll get some highlighting:

<img width="238" alt="image" src="https://github.com/Textualize/textual/assets/5740731/efb36aaf-72a4-4fc1-9787-29b15a091491">

Previously, since there was no syntax highlighting style mapping, tree-sitter was parsing the file but there was no visual indication of that.

This was created with `TextArea(text=TEXT, language="markdown")` (and line numbers enabled).