### PR TITLE
Text area read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- TextArea now has `read_only` mode https://github.com/Textualize/textual/pull/4151
 
 ## [0.51.1] - 2024-02-09
 

--- a/src/textual/_text_area_theme.py
+++ b/src/textual/_text_area_theme.py
@@ -100,17 +100,16 @@ class TextAreaTheme:
                 self.gutter_style = self.base_style.copy()
 
         background_color = Color.from_rich_color(self.base_style.bgcolor)
-        if self.cursor_style is None:
-            # If the theme doesn't contain a cursor style, fallback to component styles.
-            cursor_style = get_style("text-area--cursor")
-            if cursor_style:
-                self.cursor_style = cursor_style
-            else:
-                # There's no component style either, fallback to a default.
-                self.cursor_style = Style(
-                    color=background_color.rich_color,
-                    bgcolor=background_color.inverse.rich_color,
-                )
+        # If the theme doesn't contain a cursor style, fallback to component styles.
+        cursor_style = get_style("text-area--cursor")
+        if cursor_style:
+            self.cursor_style = cursor_style
+        else:
+            # There's no component style either, fallback to a default.
+            self.cursor_style = Style(
+                color=background_color.rich_color,
+                bgcolor=background_color.inverse.rich_color,
+            )
 
         # Apply fallbacks for the styles of the active line and active line gutter.
         if self.cursor_line_style is None:

--- a/src/textual/_text_area_theme.py
+++ b/src/textual/_text_area_theme.py
@@ -100,16 +100,17 @@ class TextAreaTheme:
                 self.gutter_style = self.base_style.copy()
 
         background_color = Color.from_rich_color(self.base_style.bgcolor)
-        # If the theme doesn't contain a cursor style, fallback to component styles.
-        cursor_style = get_style("text-area--cursor")
-        if cursor_style:
-            self.cursor_style = cursor_style
-        else:
-            # There's no component style either, fallback to a default.
-            self.cursor_style = Style(
-                color=background_color.rich_color,
-                bgcolor=background_color.inverse.rich_color,
-            )
+        if self.cursor_style is None:
+            # If the theme doesn't contain a cursor style, fallback to component styles.
+            cursor_style = get_style("text-area--cursor")
+            if cursor_style:
+                self.cursor_style = cursor_style
+            else:
+                # There's no component style either, fallback to a default.
+                self.cursor_style = Style.from_color(
+                    color=background_color.rich_color,
+                    bgcolor=background_color.inverse.rich_color,
+                )
 
         # Apply fallbacks for the styles of the active line and active line gutter.
         if self.cursor_line_style is None:

--- a/src/textual/document/_document_navigator.py
+++ b/src/textual/document/_document_navigator.py
@@ -109,7 +109,7 @@ class DocumentNavigator:
             location: The location to examine.
 
         Returns:
-            True if and only if the document is on the last line of the document.
+            True if and only if the document is at the end of a line in the document.
         """
         row, column = location
         row_length = len(self._document[row])

--- a/src/textual/document/_document_navigator.py
+++ b/src/textual/document/_document_navigator.py
@@ -101,6 +101,10 @@ class DocumentNavigator:
     def is_end_of_document_line(self, location: Location) -> bool:
         """True if the location is at the end of a line in the document.
 
+        Note that the "end" of a line is equal to its length (one greater
+        than the final index), since there is a space at the end of the line
+        for the cursor to rest.
+
         Args:
             location: The location to examine.
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1337,6 +1337,11 @@ TextArea {
         _, cursor_y = self._cursor_offset
         self.refresh_lines(cursor_y)
 
+    def _watch__cursor_visible(self) -> None:
+        """When the cursor visibility is toggled, ensure the row is refreshed."""
+        _, cursor_y = self._cursor_offset
+        self.refresh_lines(cursor_y)
+
     def _restart_blink(self) -> None:
         """Reset the cursor blink timer."""
         if self.cursor_blink:

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -306,7 +306,7 @@ TextArea {
     """True if text should soft wrap."""
 
     read_only: Reactive[bool] = reactive(False)
-    """True if the that content is read-only.
+    """True if the content is read-only.
     
     Read-only means end users cannot insert, delete or replace content.
     

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -584,6 +584,7 @@ TextArea {
 
     def _watch_read_only(self, read_only: bool) -> None:
         self.set_class(read_only, "-read-only")
+        self._set_theme(self._theme.name)
 
     def _recompute_cursor_offset(self):
         """Recompute the (x, y) coordinate of the cursor in the wrapped document."""
@@ -680,10 +681,10 @@ TextArea {
         if padding is applied, the colours match."""
         self._set_theme(theme)
 
-    def _app_dark_toggled(self):
+    def _app_dark_toggled(self) -> None:
         self._set_theme(self._theme.name)
 
-    def _set_theme(self, theme: str | None):
+    def _set_theme(self, theme: str | None) -> None:
         theme_object: TextAreaTheme | None
         if theme is None:
             # If the theme is None, use the default.

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1241,6 +1241,10 @@ TextArea {
 
     async def _on_key(self, event: events.Key) -> None:
         """Handle key presses which correspond to document inserts."""
+        self._restart_blink()
+        if self.read_only:
+            return
+
         key = event.key
         insert_values = {
             "enter": "\n",
@@ -1256,7 +1260,6 @@ TextArea {
             else:
                 insert_values["tab"] = " " * self._find_columns_to_next_tab_stop()
 
-        self._restart_blink()
         if event.is_printable or key in insert_values:
             event.stop()
             event.prevent_default()
@@ -1369,6 +1372,8 @@ TextArea {
 
     async def _on_paste(self, event: events.Paste) -> None:
         """When a paste occurs, insert the text from the paste event into the document."""
+        if self.read_only:
+            return
         result = self.replace(event.text, *self.selection)
         self.move_cursor(result.end_location)
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1901,8 +1901,8 @@ TextArea {
         """Handle a deletion performed using a keyboard (as opposed to the API).
 
         Args:
-            start: The start location of the text to delete (inclusive).
-            end: The end location of the text to delete (inclusive).
+            start: The start location of the text to delete.
+            end: The end location of the text to delete.
 
         Returns:
             An EditResult or None if no edit was performed (e.g. on read-only mode).
@@ -1921,8 +1921,8 @@ TextArea {
 
         Args:
             insert: The text to insert into the document.
-            start: The start location of the text to replace (inclusive).
-            end: The end location of the text to replace (inclusive).
+            start: The start location of the text to replace.
+            end: The end location of the text to replace.
 
         Returns:
             An EditResult or None if no edit was performed (e.g. on read-only mode).

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -110,7 +110,6 @@ TextArea {
        background: $boost;
     }
     
-    
     & .text-area--selection {
         background: $accent-lighten-1 40%;
     }
@@ -123,7 +122,16 @@ TextArea {
         border: tall $accent;
     }
     
+    &:dark {
+        &.-read-only .text-area--cursor {
+            background: $warning-darken-1;
+        }
+    }
+    
     &:light {
+        &.-read-only .text-area--cursor {
+            background: $warning-darken-1;
+        }
         .text-area--cursor {
             color: $text 90%;
             background: $foreground 70%;   
@@ -134,7 +142,6 @@ TextArea {
 
     COMPONENT_CLASSES: ClassVar[set[str]] = {
         "text-area--cursor",
-        "text-area--cursor-read-only",
         "text-area--gutter",
         "text-area--cursor-gutter",
         "text-area--cursor-line",
@@ -149,7 +156,6 @@ TextArea {
     | Class | Description |
     | :- | :- |
     | `text-area--cursor` | Target the cursor. |
-    | `text-area--cursor-read-only` | Target the cursor when `read_only=True`. |
     | `text-area--gutter` | Target the gutter (line number column). |
     | `text-area--cursor-gutter` | Target the gutter area of the line the cursor is on. |
     | `text-area--cursor-line` | Target the line the cursor is on. |
@@ -300,7 +306,7 @@ TextArea {
     soft_wrap: Reactive[bool] = reactive(True, init=False)
     """True if text should soft wrap."""
 
-    read_only: Reactive[bool] = reactive(False, init=False)
+    read_only: Reactive[bool] = reactive(False)
     """True if the that content is read-only.
     
     Read-only means end users cannot insert, delete or replace content.
@@ -573,6 +579,9 @@ TextArea {
             self._restart_blink()
         else:
             self._pause_blink(visible=self.has_focus)
+
+    def _watch_read_only(self, read_only: bool) -> None:
+        self.set_class(read_only, "-read-only")
 
     def _recompute_cursor_offset(self):
         """Recompute the (x, y) coordinate of the cursor in the wrapped document."""

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -91,46 +91,50 @@ TextArea {
     border: tall $background;
     padding: 0 1;
     
+    & .text-area--cursor {
+        color: $text 90%;
+        background: $foreground 90%;
+    }
+    
+    & .text-area--gutter {
+        color: $text 40%;
+    }
+    
+    & .text-area--cursor-gutter {
+        color: $text 60%;
+        background: $boost;
+        text-style: bold;
+    }
+    
+    & .text-area--cursor-line {
+       background: $boost;
+    }
+    
+    
+    & .text-area--selection {
+        background: $accent-lighten-1 40%;
+    }
+    
+    & .text-area--matching-bracket {
+        background: $foreground 30%;
+    }
+    
     &:focus {
         border: tall $accent;
     }
-}
-
-.text-area--cursor {
-    color: $text 90%;
-    background: $foreground 90%;
-}
-
-TextArea:light .text-area--cursor {
-    color: $text 90%;
-    background: $foreground 70%;
-}
-
-.text-area--gutter {
-    color: $text 40%;
-}
-
-.text-area--cursor-line {
-    background: $boost;
-}
-
-.text-area--cursor-gutter {
-    color: $text 60%;
-    background: $boost;
-    text-style: bold;
-}
-
-.text-area--selection {
-    background: $accent-lighten-1 40%;
-}
-
-.text-area--matching-bracket {
-    background: $foreground 30%;
+    
+    &:light {
+        .text-area--cursor {
+            color: $text 90%;
+            background: $foreground 70%;   
+        }
+    }
 }
 """
 
     COMPONENT_CLASSES: ClassVar[set[str]] = {
         "text-area--cursor",
+        "text-area--cursor-read-only",
         "text-area--gutter",
         "text-area--cursor-gutter",
         "text-area--cursor-line",
@@ -145,6 +149,7 @@ TextArea:light .text-area--cursor {
     | Class | Description |
     | :- | :- |
     | `text-area--cursor` | Target the cursor. |
+    | `text-area--cursor-read-only` | Target the cursor when `read_only=True`. |
     | `text-area--gutter` | Target the gutter (line number column). |
     | `text-area--cursor-gutter` | Target the gutter area of the line the cursor is on. |
     | `text-area--cursor-line` | Target the line the cursor is on. |

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1950,8 +1950,9 @@ TextArea {
         from_location = (start_row, 0)
         to_location = (end_row + 1, 0)
 
-        self._delete_via_keyboard(from_location, to_location)
-        self.move_cursor_relative(columns=end_column, record_width=False)
+        deletion = self._delete_via_keyboard(from_location, to_location)
+        if deletion is not None:
+            self.move_cursor_relative(columns=end_column, record_width=False)
 
     def action_delete_to_start_of_line(self) -> None:
         """Deletes from the cursor location to the start of the line."""

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1883,7 +1883,11 @@ TextArea {
         return self.edit(Edit(insert, start, end, maintain_selection_offset))
 
     def clear(self) -> EditResult:
-        """Delete all text from the document."""
+        """Delete all text from the document.
+
+        Returns:
+            An EditResult relating to the deletion of all content.
+        """
         document = self.document
         last_line = document[-1]
         document_end = (document.line_count, len(last_line))
@@ -1894,7 +1898,15 @@ TextArea {
         start: Location,
         end: Location,
     ) -> EditResult | None:
-        """Handle a deletion performed using a keyboard (as opposed to the API)."""
+        """Handle a deletion performed using a keyboard (as opposed to the API).
+
+        Args:
+            start: The start location of the text to delete (inclusive).
+            end: The end location of the text to delete (inclusive).
+
+        Returns:
+            An EditResult or None if no edit was performed (e.g. on read-only mode).
+        """
         if self.read_only:
             return None
         return self.delete(start, end, maintain_selection_offset=False)
@@ -1905,7 +1917,16 @@ TextArea {
         start: Location,
         end: Location,
     ) -> EditResult | None:
-        """Handle a replacement performed using a keyboard (as opposed to the API)."""
+        """Handle a replacement performed using a keyboard (as opposed to the API).
+
+        Args:
+            insert: The text to insert into the document.
+            start: The start location of the text to replace (inclusive).
+            end: The end location of the text to replace (inclusive).
+
+        Returns:
+            An EditResult or None if no edit was performed (e.g. on read-only mode).
+        """
         if self.read_only:
             return None
         return self.replace(insert, start, end, maintain_selection_offset=False)

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -295,6 +295,14 @@ TextArea:light .text-area--cursor {
     soft_wrap: Reactive[bool] = reactive(True, init=False)
     """True if text should soft wrap."""
 
+    read_only: Reactive[bool] = reactive(False, init=False)
+    """True if the that content is read-only.
+    
+    Read-only means end users cannot insert, delete or replace content.
+    
+    The document can still be edited programmatically via the API.
+    """
+
     _cursor_visible: Reactive[bool] = reactive(False, repaint=False, init=False)
     """Indicates where the cursor is in the blink cycle. If it's currently
     not visible due to blinking, this is False."""

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -879,6 +879,20 @@ I am the final line."""
     )
 
 
+def test_text_area_read_only_cursor_rendering(snap_compare):
+    def setup_selection(pilot):
+        text_area = pilot.app.query_one(TextArea)
+        text_area.theme = "css"
+        text_area.text = "Hello, world!"
+        text_area.read_only = True
+
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "text_area.py",
+        run_before=setup_selection,
+        terminal_size=(30, 5),
+    )
+
+
 @pytest.mark.syntax
 @pytest.mark.parametrize(
     "theme_name", [theme.name for theme in TextAreaTheme.builtin_themes()]

--- a/tests/text_area/test_edit_via_api.py
+++ b/tests/text_area/test_edit_via_api.py
@@ -5,6 +5,7 @@ than going via bindings.
 
 Note that more extensive testing for editing is done at the Document level.
 """
+
 import pytest
 
 from textual.app import App, ComposeResult
@@ -520,6 +521,7 @@ async def test_replace_fully_within_selection():
             end_location=(0, 4),
         )
         assert text_area.selected_text == "XX56"
+
 
 async def test_text_setter():
     app = TextAreaApp()

--- a/tests/text_area/test_edit_via_api.py
+++ b/tests/text_area/test_edit_via_api.py
@@ -530,3 +530,21 @@ async def test_text_setter():
         new_text = "hello\nworld\n"
         text_area.text = new_text
         assert text_area.text == new_text
+
+
+async def test_edits_on_read_only_mode():
+    """API edits should still be permitted on read-only mode."""
+    app = TextAreaApp()
+    async with app.run_test():
+        text_area = app.query_one(TextArea)
+        text_area.text = "0123456789"
+        text_area.read_only = True
+
+        text_area.replace("X", (0, 1), (0, 5))
+        assert text_area.text == "0X56789"
+
+        text_area.insert("X")
+        assert text_area.text == "X0X56789"
+
+        text_area.delete((0, 0), (0, 2))
+        assert text_area.text == "X56789"

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -476,3 +476,8 @@ async def test_paste_read_only_does_nothing():
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.read_only = True
+
+        app.post_message(Paste("hello"))
+        await pilot.pause()
+
+        assert text_area.text == TEXT  # No change

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -469,3 +469,10 @@ UVWXY
 Z"""
         assert text_area.text == expected_text
         assert text_area.selection == Selection.cursor((1, 1))
+
+
+async def test_paste_read_only_does_nothing():
+    app = TextAreaApp()
+    async with app.run_test() as pilot:
+        text_area = app.query_one(TextArea)
+        text_area.read_only = True

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -421,6 +421,37 @@ async def test_delete_word_right_at_end_of_line():
 
 
 @pytest.mark.parametrize(
+    "binding",
+    [
+        "enter",
+        "backspace",
+        "ctrl+u",
+        "ctrl+f",
+        "ctrl+w",
+        "ctrl+k",
+        "ctrl+x",
+        "space",
+        "1",
+        "tab",
+    ],
+)
+async def test_edit_read_only_mode_does_nothing(binding):
+    """Try out various key-presses and bindings and ensure they don't alter
+    the document when read_only=True."""
+    app = TextAreaApp()
+    async with app.run_test() as pilot:
+        text_area = app.query_one(TextArea)
+        text_area.read_only = True
+        selection = Selection.cursor((0, 2))
+        text_area.selection = selection
+
+        await pilot.press(binding)
+
+        assert text_area.text == TEXT
+        assert text_area.selection == selection
+
+
+@pytest.mark.parametrize(
     "selection",
     [
         Selection(start=(1, 0), end=(3, 0)),

--- a/tests/text_area/test_selection_bindings.py
+++ b/tests/text_area/test_selection_bindings.py
@@ -22,18 +22,11 @@ class TextAreaApp(App):
 
 
 @pytest.fixture(params=[True, False])
-async def read_only_mode(request):
-    """This parametrised fixture is injected into the app fixture.
-    It means every test that uses the app fixture will run twice - once
-    for read_only=True and once for read_only=False.
+async def app(request):
+    """Each test that receives an `app` will execute twice.
+    Once with read_only=True, and once with read_only=False.
     """
-    return request.param
-
-
-@pytest.fixture
-async def app(read_only_mode: bool):
-    text_area_app = TextAreaApp(read_only_mode)
-    yield text_area_app
+    return TextAreaApp(read_only=request.param)
 
 
 async def test_mouse_click(app: TextAreaApp):

--- a/tests/text_area/test_selection_bindings.py
+++ b/tests/text_area/test_selection_bindings.py
@@ -13,34 +13,48 @@ I will face my fear.
 
 
 class TextAreaApp(App):
+    def __init__(self, read_only: bool = False):
+        super().__init__()
+        self.read_only = read_only
+
     def compose(self) -> ComposeResult:
-        text_area = TextArea(show_line_numbers=True)
-        text_area.load_text(TEXT)
-        yield text_area
+        yield TextArea(TEXT, show_line_numbers=True, read_only=self.read_only)
 
 
-async def test_mouse_click():
+@pytest.fixture(params=[True, False])
+async def read_only_mode(request):
+    """This parametrised fixture is injected into the app fixture.
+    It means every test that uses the app fixture will run twice - once
+    for read_only=True and once for read_only=False.
+    """
+    return request.param
+
+
+@pytest.fixture
+async def app(read_only_mode: bool):
+    text_area_app = TextAreaApp(read_only_mode)
+    yield text_area_app
+
+
+async def test_mouse_click(app: TextAreaApp):
     """When you click the TextArea, the cursor moves to the expected location."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         await pilot.click(TextArea, Offset(x=5, y=2))
         assert text_area.selection == Selection.cursor((1, 0))
 
 
-async def test_mouse_click_clamp_from_right():
+async def test_mouse_click_clamp_from_right(app: TextAreaApp):
     """When you click to the right of the document bounds, the cursor is clamped
     to within the document bounds."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         await pilot.click(TextArea, Offset(x=8, y=20))
         assert text_area.selection == Selection.cursor((4, 0))
 
 
-async def test_mouse_click_gutter_clamp():
+async def test_mouse_click_gutter_clamp(app: TextAreaApp):
     """When you click the gutter, it selects the start of the line."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         await pilot.click(TextArea, Offset(x=0, y=3))
@@ -66,19 +80,17 @@ async def test_cursor_movement_basic():
         assert text_area.selection == Selection.cursor((0, 0))
 
 
-async def test_cursor_selection_right():
+async def test_cursor_selection_right(app: TextAreaApp):
     """When you press shift+right the selection is updated correctly."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         await pilot.press(*["shift+right"] * 3)
         assert text_area.selection == Selection((0, 0), (0, 3))
 
 
-async def test_cursor_selection_right_to_previous_line():
+async def test_cursor_selection_right_to_previous_line(app: TextAreaApp):
     """When you press shift+right resulting in the cursor moving to the next line,
     the selection is updated correctly."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.selection = Selection.cursor((0, 15))
@@ -86,9 +98,8 @@ async def test_cursor_selection_right_to_previous_line():
         assert text_area.selection == Selection((0, 15), (1, 2))
 
 
-async def test_cursor_selection_left():
+async def test_cursor_selection_left(app: TextAreaApp):
     """When you press shift+left the selection is updated correctly."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.selection = Selection.cursor((2, 5))
@@ -96,10 +107,9 @@ async def test_cursor_selection_left():
         assert text_area.selection == Selection((2, 5), (2, 2))
 
 
-async def test_cursor_selection_left_to_previous_line():
+async def test_cursor_selection_left_to_previous_line(app: TextAreaApp):
     """When you press shift+left resulting in the cursor moving back to the previous line,
     the selection is updated correctly."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.selection = Selection.cursor((2, 2))
@@ -110,9 +120,8 @@ async def test_cursor_selection_left_to_previous_line():
         assert text_area.selection == Selection((2, 2), (1, end_of_previous_line))
 
 
-async def test_cursor_selection_up():
+async def test_cursor_selection_up(app: TextAreaApp):
     """When you press shift+up the selection is updated correctly."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.move_cursor((2, 3))
@@ -121,9 +130,8 @@ async def test_cursor_selection_up():
         assert text_area.selection == Selection((2, 3), (1, 3))
 
 
-async def test_cursor_selection_up_when_cursor_on_first_line():
+async def test_cursor_selection_up_when_cursor_on_first_line(app: TextAreaApp):
     """When you press shift+up the on the first line, it selects to the start."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.move_cursor((0, 4))
@@ -134,8 +142,7 @@ async def test_cursor_selection_up_when_cursor_on_first_line():
         assert text_area.selection == Selection((0, 4), (0, 0))
 
 
-async def test_cursor_selection_down():
-    app = TextAreaApp()
+async def test_cursor_selection_down(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.move_cursor((2, 5))
@@ -144,8 +151,7 @@ async def test_cursor_selection_down():
         assert text_area.selection == Selection((2, 5), (3, 5))
 
 
-async def test_cursor_selection_down_when_cursor_on_last_line():
-    app = TextAreaApp()
+async def test_cursor_selection_down_when_cursor_on_last_line(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("ABCDEF\nGHIJK")
@@ -157,8 +163,7 @@ async def test_cursor_selection_down_when_cursor_on_last_line():
         assert text_area.selection == Selection((1, 2), (1, 5))
 
 
-async def test_cursor_word_right():
-    app = TextAreaApp()
+async def test_cursor_word_right(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("ABC DEF\nGHIJK")
@@ -168,8 +173,7 @@ async def test_cursor_word_right():
         assert text_area.selection == Selection.cursor((0, 3))
 
 
-async def test_cursor_word_right_select():
-    app = TextAreaApp()
+async def test_cursor_word_right_select(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("ABC DEF\nGHIJK")
@@ -179,8 +183,7 @@ async def test_cursor_word_right_select():
         assert text_area.selection == Selection((0, 0), (0, 3))
 
 
-async def test_cursor_word_left():
-    app = TextAreaApp()
+async def test_cursor_word_left(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("ABC DEF\nGHIJK")
@@ -191,8 +194,7 @@ async def test_cursor_word_left():
         assert text_area.selection == Selection.cursor((0, 4))
 
 
-async def test_cursor_word_left_select():
-    app = TextAreaApp()
+async def test_cursor_word_left_select(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("ABC DEF\nGHIJK")
@@ -204,9 +206,8 @@ async def test_cursor_word_left_select():
 
 
 @pytest.mark.parametrize("key", ["end", "ctrl+e"])
-async def test_cursor_to_line_end(key):
+async def test_cursor_to_line_end(key, app: TextAreaApp):
     """You can use the keyboard to jump the cursor to the end of the current line."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.selection = Selection.cursor((2, 2))
@@ -217,9 +218,8 @@ async def test_cursor_to_line_end(key):
 
 
 @pytest.mark.parametrize("key", ["home", "ctrl+a"])
-async def test_cursor_to_line_home_basic_behaviour(key):
+async def test_cursor_to_line_home_basic_behaviour(key, app: TextAreaApp):
     """You can use the keyboard to jump the cursor to the start of the current line."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.selection = Selection.cursor((2, 2))
@@ -239,11 +239,12 @@ async def test_cursor_to_line_home_basic_behaviour(key):
         ((0, 15), (0, 4)),
     ],
 )
-async def test_cursor_line_home_smart_home(cursor_start, cursor_destination):
+async def test_cursor_line_home_smart_home(
+    cursor_start, cursor_destination, app: TextAreaApp
+):
     """If the line begins with whitespace, pressing home firstly goes
     to the start of the (non-whitespace) content. Pressing it again takes you to column
     0. If you press it again, it goes back to the first non-whitespace column."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("    hello world")
@@ -252,9 +253,8 @@ async def test_cursor_line_home_smart_home(cursor_start, cursor_destination):
         assert text_area.selection == Selection.cursor(cursor_destination)
 
 
-async def test_cursor_page_down():
+async def test_cursor_page_down(app: TextAreaApp):
     """Pagedown moves the cursor down 1 page, retaining column index."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("XXX\n" * 200)
@@ -266,9 +266,8 @@ async def test_cursor_page_down():
         )
 
 
-async def test_cursor_page_up():
+async def test_cursor_page_up(app: TextAreaApp):
     """Pageup moves the cursor up 1 page, retaining column index."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("XXX\n" * 200)
@@ -280,10 +279,9 @@ async def test_cursor_page_up():
         )
 
 
-async def test_cursor_vertical_movement_visual_alignment_snapping():
+async def test_cursor_vertical_movement_visual_alignment_snapping(app: TextAreaApp):
     """When you move the cursor vertically, it should stay vertically
     aligned even when double-width characters are used."""
-    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.text = "こんにちは\n012345"
@@ -301,8 +299,7 @@ async def test_cursor_vertical_movement_visual_alignment_snapping():
         assert text_area.selection == Selection.cursor((1, 3))
 
 
-async def test_select_line_binding():
-    app = TextAreaApp()
+async def test_select_line_binding(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.move_cursor((2, 2))
@@ -312,8 +309,7 @@ async def test_select_line_binding():
         assert text_area.selection == Selection((2, 0), (2, 56))
 
 
-async def test_select_all_binding():
-    app = TextAreaApp()
+async def test_select_all_binding(app: TextAreaApp):
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
 


### PR DESCRIPTION
Adds a read_only attribute to TextArea.

When True, you cannot edit the content.

The bulk of the work here was more clearly defining the paths that edit operations take when they come in via the API vs via a users keyboard.
