### PR TITLE
docs: fix tcss syntax highlighting

### DIFF
--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -212,7 +212,7 @@ In the following example we have three buttons, each of which does something dif
 
 === "on_decorator.tcss"
 
-    ```python title="on_decorator.tcss"
+    ```css title="on_decorator.tcss"
     --8<-- "docs/examples/events/on_decorator.tcss"
     ```
 
@@ -241,7 +241,7 @@ The following example uses the decorator approach to write individual message ha
 
 === "on_decorator.tcss"
 
-    ```python title="on_decorator.tcss"
+    ```css title="on_decorator.tcss"
     --8<-- "docs/examples/events/on_decorator.tcss"
     ```
 
@@ -325,7 +325,7 @@ Let's look at an example which looks up word definitions from an [api](https://d
     ```
 === "dictionary.tcss"
 
-    ```python title="dictionary.tcss"
+    ```css title="dictionary.tcss"
     --8<-- "docs/examples/events/dictionary.tcss"
     ```
 

--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -96,7 +96,7 @@ The following example shows how focus works in practice.
 
 === "key03.tcss"
 
-    ```python title="key03.tcss" hl_lines="15-17"
+    ```css title="key03.tcss" hl_lines="15-17"
     --8<-- "docs/examples/guide/input/key03.tcss"
     ```
 
@@ -138,7 +138,7 @@ The following example binds the keys ++r++, ++g++, and ++b++ to an action which 
 
 === "binding01.tcss"
 
-    ```python title="binding01.tcss"
+    ```css title="binding01.tcss"
     --8<-- "docs/examples/guide/input/binding01.tcss"
     ```
 
@@ -208,7 +208,7 @@ The following example shows mouse movements being used to _attach_ a widget to t
 
 === "mouse01.tcss"
 
-    ```python title="mouse01.tcss"
+    ```css title="mouse01.tcss"
     --8<-- "docs/examples/guide/input/mouse01.tcss"
     ```
 

--- a/docs/widgets/option_list.md
+++ b/docs/widgets/option_list.md
@@ -27,7 +27,7 @@ options:
 
 === "option_list.tcss"
 
-    ~~~python
+    ~~~css
     --8<-- "docs/examples/widgets/option_list.tcss"
     ~~~
 
@@ -50,7 +50,7 @@ class can be used to add separator lines between options.
 
 === "option_list.tcss"
 
-    ~~~python
+    ~~~css
     --8<-- "docs/examples/widgets/option_list.tcss"
     ~~~
 
@@ -75,7 +75,7 @@ tables](https://rich.readthedocs.io/en/latest/tables.html):
 
 === "option_list.tcss"
 
-    ~~~python
+    ~~~css
     --8<-- "docs/examples/widgets/option_list.tcss"
     ~~~
 

--- a/docs/widgets/selection_list.md
+++ b/docs/widgets/selection_list.md
@@ -54,7 +54,7 @@ optionally contain a flag for the initial selected state of the option.
 
 === "selection_list.tcss"
 
-    ~~~python
+    ~~~css
     --8<-- "docs/examples/widgets/selection_list.tcss"
     ~~~
 
@@ -78,7 +78,7 @@ Alternatively, selections can be passed in as
 
 === "selection_list.tcss"
 
-    ~~~python
+    ~~~css
     --8<-- "docs/examples/widgets/selection_list.tcss"
     ~~~
 
@@ -105,7 +105,7 @@ collection of selected values:
 
 === "selection_list.tcss"
 
-    ~~~python
+    ~~~css
     --8<-- "docs/examples/widgets/selection_list_selected.tcss"
     ~~~
 


### PR DESCRIPTION
Sorry but I spotted that the syntax highlighting was wrong in my last PR to add tcss to the docs (#4171) where I had blindly copy pasted the code.

A quick grep found a few other places in the docs where the syntax highlighting was wrong. This PR corrects the language to css.
