### PR TITLE
signals env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Textual now writes to stderr rather than stdout
+
 ## [0.51.0] - 2024-02-15
 
 ### Added

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -259,6 +259,16 @@ class LinuxDriver(Driver):
 
     @classmethod
     def _patch_lflag(cls, attrs: int) -> int:
+        """Patch termios lflag.
+
+        Args:
+            attributes: New set attributes.
+
+        Returns:
+            New lflag.
+
+        """
+        # if TEXTUAL_ALLOW_SIGNALS env var is set, then allow Ctrl+C to send signals
         ISIG = 0 if os.environ.get("TEXTUAL_ALLOW_SIGNALS") else termios.ISIG
 
         return attrs & ~(termios.ECHO | termios.ICANON | termios.IEXTEN | ISIG)

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -42,8 +42,8 @@ class LinuxDriver(Driver):
             size: Initial size of the terminal or `None` to detect.
         """
         super().__init__(app, debug=debug, size=size)
-        self._file = sys.__stdout__
-        self.fileno = sys.stdin.fileno()
+        self._file = sys.__stderr__
+        self.fileno = sys.__stdin__.fileno()
         self.attrs_before: list[Any] | None = None
         self.exit_event = Event()
         self._key_thread: Thread | None = None
@@ -259,7 +259,9 @@ class LinuxDriver(Driver):
 
     @classmethod
     def _patch_lflag(cls, attrs: int) -> int:
-        return attrs & ~(termios.ECHO | termios.ICANON | termios.IEXTEN | termios.ISIG)
+        ISIG = 0 if os.environ.get("TEXTUAL_ALLOW_SIGNALS") else termios.ISIG
+
+        return attrs & ~(termios.ECHO | termios.ICANON | termios.IEXTEN | ISIG)
 
     @classmethod
     def _patch_iflag(cls, attrs: int) -> int:
@@ -328,15 +330,16 @@ class LinuxDriver(Driver):
 
     def run_input_thread(self) -> None:
         """Wait for input and dispatch events."""
-        selector = selectors.DefaultSelector()
+        selector = selectors.SelectSelector()
         selector.register(self.fileno, selectors.EVENT_READ)
 
         fileno = self.fileno
+        EVENT_READ = selectors.EVENT_READ
 
         def more_data() -> bool:
             """Check if there is more data to parse."""
-            EVENT_READ = selectors.EVENT_READ
-            for key, events in selector.select(0.01):
+
+            for _key, events in selector.select(0.01):
                 if events & EVENT_READ:
                     return True
             return False
@@ -347,14 +350,15 @@ class LinuxDriver(Driver):
         utf8_decoder = getincrementaldecoder("utf-8")().decode
         decode = utf8_decoder
         read = os.read
-        EVENT_READ = selectors.EVENT_READ
 
         try:
             while not self.exit_event.is_set():
                 selector_events = selector.select(0.1)
                 for _selector_key, mask in selector_events:
                     if mask & EVENT_READ:
-                        unicode_data = decode(read(fileno, 1024))
+                        unicode_data = decode(
+                            read(fileno, 1024), final=self.exit_event.is_set()
+                        )
                         for event in feed(unicode_data):
                             self.process_event(event)
         finally:


### PR DESCRIPTION
Some changes to allow piping data in to a Textual app.

Basically when piping data in to a Textual app you don't want to the app to capture ctrl+C. This adds an env var to prevent that.