### PR TITLE
Remove double-up scrolling of active tab

### DIFF
--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -699,7 +699,6 @@ class Tabs(Widget, can_focus=True):
         tab_count = len(tabs)
         new_tab_index = (tabs.index(active_tab) + direction) % tab_count
         self.active = tabs[new_tab_index].id or ""
-        self._scroll_active_tab()
 
     def _on_tab_disabled(self, event: Tab.Disabled) -> None:
         """Re-post the disabled message."""

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -644,7 +644,6 @@ class Tabs(Widget, can_focus=True):
         self.query("#tabs-list Tab.-active").remove_class("-active")
         tab.add_class("-active")
         self.active = tab.id or ""
-        self.query_one("#tabs-scroll").scroll_to_center(tab, force=True)
 
     def _on_underline_clicked(self, event: Underline.Clicked) -> None:
         """The underline was clicked.


### PR DESCRIPTION
Follows on from #4159; in that PR we do the scrolling when seeing the active tab (because that could be done from code and it might not be in view and it needs to be dragged into view); this resulted in the unintended consequence of the animation being kicked off twice, presumably causing the previous instance to be forced to finish instantly, thus making it look like it didn't animate at all.

Fixes #4169

(or at least, as I'm testing it, it fixes #4169, but some doubt has be raised about this so this is first offered as a double-check)

In this video, 0.51 tab click is on the left, this PR's effect is on the right.

https://github.com/Textualize/textual/assets/28237/be75de8f-b2d9-4375-b5e2-e4526360ef26
