### PR TITLE
Add support for specifying the screenshot location and filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for a `TEXTUAL_SCREENSHOT_LOCATION` environment variable to specify the location of an automated screenshot
-- Added support for a `TEXTUAL_SCREENSHOT_FILENAME` environment variable to specify the filename of an automated screenshot
+- Added support for a `TEXTUAL_SCREENSHOT_LOCATION` environment variable to specify the location of an automated screenshot https://github.com/Textualize/textual/pull/4181/
+- Added support for a `TEXTUAL_SCREENSHOT_FILENAME` environment variable to specify the filename of an automated screenshot https://github.com/Textualize/textual/pull/4181/
 
 ## [0.51.0] - 2024-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - TextArea now has `read_only` mode https://github.com/Textualize/textual/pull/4151
 - Add some syntax highlighting to TextArea default theme https://github.com/Textualize/textual/pull/4149
 - Add undo and redo to TextArea https://github.com/Textualize/textual/pull/4124
+- Added support for a `TEXTUAL_SCREENSHOT_LOCATION` environment variable to specify the location of an automated screenshot
+- Added support for a `TEXTUAL_SCREENSHOT_FILENAME` environment variable to specify the filename of an automated screenshot
 
 ### Changed
 
@@ -31,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed duplicate watch methods being attached to DOM nodes https://github.com/Textualize/textual/pull/4030
 - Fixed using `watch` to create additional watchers would trigger other watch methods https://github.com/Textualize/textual/issues/3878
 
-### Added 
+### Added
 
 - Added support for configuring dark and light themes for code in `Markdown` https://github.com/Textualize/textual/issues/3997
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2388,7 +2388,10 @@ class App(Generic[ReturnType], DOMNode):
 
         async def take_screenshot() -> None:
             """Take a screenshot and exit."""
-            self.save_screenshot()
+            self.save_screenshot(
+                path=constants.SCREENSHOT_LOCATION,
+                filename=constants.SCREENSHOT_FILENAME,
+            )
             self.exit()
 
         if constants.SCREENSHOT_DELAY >= 0:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1158,8 +1158,8 @@ class App(Generic[ReturnType], DOMNode):
         Returns:
             Filename of screenshot.
         """
-        path = "./" if path is None else path
-        if filename is None:
+        path = path or "./"
+        if not filename:
             if time_format is None:
                 dt = datetime.now().isoformat()
             else:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1143,7 +1143,7 @@ class App(Generic[ReturnType], DOMNode):
     def save_screenshot(
         self,
         filename: str | None = None,
-        path: str = "./",
+        path: str | None = None,
         time_format: str | None = None,
     ) -> str:
         """Save an SVG screenshot of the current screen.
@@ -1158,6 +1158,7 @@ class App(Generic[ReturnType], DOMNode):
         Returns:
             Filename of screenshot.
         """
+        path = "./" if path is None else path
         if filename is None:
             if time_format is None:
                 dt = datetime.now().isoformat()

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -5,7 +5,6 @@ Constants that we might want to expose via the public API.
 from __future__ import annotations
 
 import os
-import pathlib
 
 from typing_extensions import Final
 
@@ -66,9 +65,7 @@ DEVTOOLS_PORT: Final[int] = get_environ_int("TEXTUAL_DEVTOOLS_PORT", 8081)
 SCREENSHOT_DELAY: Final[int] = get_environ_int("TEXTUAL_SCREENSHOT", -1)
 """Seconds delay before taking screenshot."""
 
-SCREENSHOT_LOCATION: Final[pathlib.Path | None] = pathlib.Path(
-    get_environ("TEXTUAL_SCREENSHOT_LOCATION", ".")
-)
+SCREENSHOT_LOCATION: Final[str | None] = get_environ("TEXTUAL_SCREENSHOT_LOCATION")
 """The location where screenshots should be written."""
 
 PRESS: Final[str] = get_environ("TEXTUAL_PRESS", "")

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -68,6 +68,9 @@ SCREENSHOT_DELAY: Final[int] = get_environ_int("TEXTUAL_SCREENSHOT", -1)
 SCREENSHOT_LOCATION: Final[str | None] = get_environ("TEXTUAL_SCREENSHOT_LOCATION")
 """The location where screenshots should be written."""
 
+SCREENSHOT_FILENAME: Final[str | None] = get_environ("TEXTUAL_SCREENSHOT_FILENAME")
+"""The filename to use for the screenshot."""
+
 PRESS: Final[str] = get_environ("TEXTUAL_PRESS", "")
 """Keys to automatically press."""
 

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -5,6 +5,7 @@ Constants that we might want to expose via the public API.
 from __future__ import annotations
 
 import os
+import pathlib
 
 from typing_extensions import Final
 
@@ -64,6 +65,11 @@ DEVTOOLS_PORT: Final[int] = get_environ_int("TEXTUAL_DEVTOOLS_PORT", 8081)
 
 SCREENSHOT_DELAY: Final[int] = get_environ_int("TEXTUAL_SCREENSHOT", -1)
 """Seconds delay before taking screenshot."""
+
+SCREENSHOT_LOCATION: Final[pathlib.Path | None] = pathlib.Path(
+    get_environ("TEXTUAL_SCREENSHOT_LOCATION", ".")
+)
+"""The location where screenshots should be written."""
 
 PRESS: Final[str] = get_environ("TEXTUAL_PRESS", "")
 """Keys to automatically press."""


### PR DESCRIPTION
Implements the Textual side of #3795; adding two new environment variables that work alongside `TEXTUAL_SCREENSHOT`:

- `TEXTUAL_SCREENSHOT_LOCATION` -- the *directory* where the screenshot should be saved.
- `TEXTUAL_SCREENSHOT_FILENAME` -- the *filename* to give the screenshot.

With this change you can do something like this:

```sh
TEXTUAL_SCREENSHOT_LOCATION=/Users/davep TEXTUAL_SCREENSHOT_FILENAME=foo.svg TEXTUAL_SCREENSHOT=1 poetry run python -m textual
```

which will save a screenshot called `foo.svg` in `/Users/davep` after 1 second.

This change serves [an incoming PR to `textual-dev`](https://github.com/Textualize/textual-dev/pull/30).