### PR TITLE
Adds a `Widget.batch` async context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added an `asyncio` lock attribute `Widget.lock` to be used to synchronize widget state https://github.com/Textualize/textual/issues/4134
+- `Widget.remove_children` now accepts a CSS selector to specify which children to remove https://github.com/Textualize/textual/issues/4133
 
 ## [0.51.0] - 2024-02-15
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -77,6 +77,7 @@ from .walk import walk_depth_first
 
 if TYPE_CHECKING:
     from .app import App, ComposeResult
+    from .css.query import QueryType
     from .message_pump import MessagePump
     from .scrollbar import (
         ScrollBar,
@@ -3223,13 +3224,22 @@ class Widget(DOMNode):
         await_remove = self.app._remove_nodes([self], self.parent)
         return await_remove
 
-    def remove_children(self) -> AwaitRemove:
-        """Remove all children of this Widget from the DOM.
+    def remove_children(
+        self, selector: str | type[QueryType] | None = None
+    ) -> AwaitRemove:
+        """Remove the children of this Widget from the DOM.
+
+        Args:
+            selector: A CSS selector to specify which children to remove.
 
         Returns:
             An awaitable object that waits for the children to be removed.
         """
-        await_remove = self.app._remove_nodes(list(self.children), self)
+        if isinstance(selector, str) or selector is None:
+            children_to_remove = self.query(selector)
+        else:
+            children_to_remove = self.query(selector.__name__)
+        await_remove = self.app._remove_nodes(list(children_to_remove), self)
         return await_remove
 
     def render(self) -> RenderableType:

--- a/tests/test_widget_removing.py
+++ b/tests/test_widget_removing.py
@@ -141,6 +141,79 @@ async def test_widget_remove_children_container():
         assert len(container.children) == 0
 
 
+async def test_widget_remove_children_with_star_selector():
+    app = ExampleApp()
+    async with app.run_test():
+        container = app.query_one(Vertical)
+
+        # 6 labels in total, with 5 of them inside the container.
+        assert len(app.query(Label)) == 6
+        assert len(container.children) == 5
+
+        await container.remove_children("*")
+
+        # The labels inside the container are gone, and the 1 outside remains.
+        assert len(app.query(Label)) == 1
+        assert len(container.children) == 0
+
+
+async def test_widget_remove_children_with_string_selector():
+    app = ExampleApp()
+    async with app.run_test():
+        container = app.query_one(Vertical)
+
+        # 6 labels in total, with 5 of them inside the container.
+        assert len(app.query(Label)) == 6
+        assert len(container.children) == 5
+
+        await app.screen.remove_children("Label")
+
+        # All labels are gone but the button and the container remain.
+        assert len(app.query(Button)) == 1
+        assert len(app.query(Vertical)) == 1
+        assert len(app.query(Label)) == 0
+
+
+async def test_widget_remove_children_with_type_selector():
+    app = ExampleApp()
+    async with app.run_test():
+        assert len(app.query(Button)) == 1  # Sanity check.
+        await app.screen.remove_children(Button)
+        assert len(app.query(Button)) == 0
+
+
+async def test_widget_remove_children_with_selector_does_not_leak():
+    app = ExampleApp()
+    async with app.run_test():
+        container = app.query_one(Vertical)
+
+        # 6 labels in total, with 5 of them inside the container.
+        assert len(app.query(Label)) == 6
+        assert len(container.children) == 5
+
+        await container.remove_children("Label")
+
+        # The labels inside the container are gone, and the 1 outside remains.
+        assert len(app.query(Label)) == 1
+        assert len(container.children) == 0
+
+
+async def test_widget_remove_children_with_compound_selector():
+    app = ExampleApp()
+    async with app.run_test():
+        container = app.query_one(Vertical)
+
+        # 6 labels in total, with 5 of them inside the container.
+        assert len(app.query(Label)) == 6
+        assert len(container.children) == 5
+
+        await app.screen.remove_children("Vertical > Label")
+
+        # The labels inside the container are gone, and the 1 outside remains.
+        assert len(app.query(Label)) == 1
+        assert len(container.children) == 0
+
+
 async def test_widget_remove_children_no_children():
     app = ExampleApp()
     async with app.run_test():
@@ -154,3 +227,17 @@ async def test_widget_remove_children_no_children():
         assert (
             count_before == count_after
         )  # No widgets have been removed, since Button has no children.
+
+
+async def test_widget_remove_children_no_children_match_selector():
+    app = ExampleApp()
+    async with app.run_test():
+        container = app.query_one(Vertical)
+        assert len(container.query("Button")) == 0  # Sanity check.
+
+        count_before = len(app.query("*"))
+        container_children_before = list(container.children)
+        await container.remove_children("Button")
+
+        assert count_before == len(app.query("*"))
+        assert container_children_before == list(container.children)

--- a/tests/test_widget_removing.py
+++ b/tests/test_widget_removing.py
@@ -168,10 +168,10 @@ async def test_widget_remove_children_with_string_selector():
 
         await app.screen.remove_children("Label")
 
-        # All labels are gone but the button and the container remain.
+        # Only the Screen > Label widget is gone, everything else remains.
         assert len(app.query(Button)) == 1
         assert len(app.query(Vertical)) == 1
-        assert len(app.query(Label)) == 0
+        assert len(app.query(Label)) == 5
 
 
 async def test_widget_remove_children_with_type_selector():
@@ -192,22 +192,6 @@ async def test_widget_remove_children_with_selector_does_not_leak():
         assert len(container.children) == 5
 
         await container.remove_children("Label")
-
-        # The labels inside the container are gone, and the 1 outside remains.
-        assert len(app.query(Label)) == 1
-        assert len(container.children) == 0
-
-
-async def test_widget_remove_children_with_compound_selector():
-    app = ExampleApp()
-    async with app.run_test():
-        container = app.query_one(Vertical)
-
-        # 6 labels in total, with 5 of them inside the container.
-        assert len(app.query(Label)) == 6
-        assert len(container.children) == 5
-
-        await app.screen.remove_children("Vertical > Label")
 
         # The labels inside the container are gone, and the 1 outside remains.
         assert len(app.query(Label)) == 1


### PR DESCRIPTION
The `Widget.batch` context manager locks the widget and batches app updates too.
This fixes #4133.

This PR depends on #4139 and shouldn't be merged while #4139 doesn't get the OK to be merged.