### PR TITLE
Decorator madness

### DIFF
--- a/examples/calculator.py
+++ b/examples/calculator.py
@@ -47,8 +47,7 @@ class CalculatorApp(App):
         """Compute switch to show AC or C button"""
         return self.value in ("", "0") and self.numbers == "0"
 
-    @show_ac.watch
-    def _show_ac(self, show_ac: bool) -> None:
+    def watch_show_ac(self, show_ac: bool) -> None:
         """Called when show_ac changes."""
         self.query_one("#c").display = not show_ac
         self.query_one("#ac").display = show_ac

--- a/examples/calculator.py
+++ b/examples/calculator.py
@@ -47,7 +47,8 @@ class CalculatorApp(App):
         """Compute switch to show AC or C button"""
         return self.value in ("", "0") and self.numbers == "0"
 
-    def watch_show_ac(self, show_ac: bool) -> None:
+    @show_ac.watch
+    def _show_ac(self, show_ac: bool) -> None:
         """Called when show_ac changes."""
         self.query_one("#c").display = not show_ac
         self.query_one("#ac").display = show_ac


### PR DESCRIPTION
Decorators for both watch and compute. Works like this:

```python
class MyWidget(Widget):

    count = reactive(0)

    @count.watch
    def _watch(self, new_count:int):
        ...
```

The old naming convention will continue to work.

No docs update in this PR. This is part of a body of work that includes a new Action mechanism. Will update to docs together.