### PR TITLE
Fix DirectoryTree.path no longer reacting to new values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Sparkline` not working with data in a `deque` https://github.com/Textualize/textual/issues/3899
 - Tooltips are now cleared when the related widget is no longer under them https://github.com/Textualize/textual/issues/3045
 - Simplified tree-sitter highlight queries for HTML, which also seems to fix segfault issue https://github.com/Textualize/textual/pull/4195
+- Fixed `DirectoryTree.path` no longer reacting to new values https://github.com/Textualize/textual/issues/4208
 
 ## [0.52.1] - 2024-02-20
 

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -332,6 +332,7 @@ class DirectoryTree(Tree[DirEntry]):
         If the path is changed the directory tree will be repopulated using
         the new value as the root.
         """
+        self.reset_node(self.root, str(self.path), DirEntry(self.PATH(self.path)))
         await self.reload()
 
     def process_label(self, label: TextType) -> Text:

--- a/tests/directory_tree/test_change_path.py
+++ b/tests/directory_tree/test_change_path.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.widgets import DirectoryTree
+
+
+class DirectoryTreeApp(App[None]):
+
+    def compose(self) -> ComposeResult:
+        yield DirectoryTree(".")
+
+
+async def test_change_directory_tree_path(tmpdir: Path) -> None:
+    """The DirectoryTree should react to the path changing."""
+
+    async with DirectoryTreeApp().run_test() as pilot:
+        assert pilot.app.query_one(DirectoryTree).root.data.path == Path(".")
+        pilot.app.query_one(DirectoryTree).path = tmpdir
+        await pilot.pause()
+        assert pilot.app.query_one(DirectoryTree).root.data.path == tmpdir


### PR DESCRIPTION
Fixes #4208

It looks like #4123 caused the `DirectoryTree` to no longer load the new path when `DirectoryTree.path` is assigned. I suspect this is the fix to apply.

Tagging @rodrigogiraoserrao in case I might have misunderstood how the new reload approach works.

*(also fixing this without doing the triage thing as it's a pretty fundamental breakage and looks to be a one-liner fix)*