### PR TITLE
Implement 'Pilot.resize_terminal'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `DirectoryTree.path` no longer reacting to new values https://github.com/Textualize/textual/issues/4208
 - Fixed content size cache with Pretty widget https://github.com/Textualize/textual/pull/4211
 
+### Added
+
+- `Pilot.resize_terminal` to resize the terminal in testing https://github.com/Textualize/textual/issues/4212
+
 ## [0.52.1] - 2024-02-20
 
 ### Fixed

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -15,8 +15,9 @@ import rich.repr
 
 from ._wait import wait_for_idle
 from .app import App, ReturnType
-from .events import Click, MouseDown, MouseEvent, MouseMove, MouseUp
-from .geometry import Offset
+from .drivers.headless_driver import HeadlessDriver
+from .events import Click, MouseDown, MouseEvent, MouseMove, MouseUp, Resize
+from .geometry import Offset, Size
 from .widget import Widget
 
 
@@ -80,6 +81,20 @@ class Pilot(Generic[ReturnType]):
         if keys:
             await self._app._press_keys(keys)
             await self._wait_for_screen()
+
+    async def resize_terminal(self, width: int, height: int) -> None:
+        """Resize the terminal to the given dimensions.
+
+        Args:
+            width: The new width of the terminal.
+            height: The new height of the terminal.
+        """
+        size = Size(width, height)
+        # If we're running with the headless driver, update the inherent app size.
+        if isinstance(self.app._driver, HeadlessDriver):
+            self.app._driver._size = size
+        self.app.post_message(Resize(size, size))
+        await self.pause()
 
     async def mouse_down(
         self,

--- a/tests/snapshot_tests/snapshot_apps/pilot_resize_terminal.py
+++ b/tests/snapshot_tests/snapshot_apps/pilot_resize_terminal.py
@@ -1,0 +1,13 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Label
+
+
+class SingleLabelApp(App[None]):
+    """An app with a single label that's 20 x 10."""
+
+    def compose(self) -> ComposeResult:
+        yield Label(("12345678901234567890\n" * 10).strip())
+
+
+if __name__ == "__main__":
+    SingleLabelApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -583,6 +583,18 @@ def test_scrollbar_thumb_height(snap_compare):
     )
 
 
+def test_pilot_resize_terminal(snap_compare):
+    async def run_before(pilot):
+        await pilot.resize_terminal(35, 20)
+        await pilot.resize_terminal(20, 10)
+
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "pilot_resize_terminal.py",
+        run_before=run_before,
+        terminal_size=(80, 25),
+    )
+
+
 def test_css_hot_reloading(snap_compare, monkeypatch):
     """Regression test for https://github.com/Textualize/textual/issues/2063."""
 
@@ -762,7 +774,9 @@ def test_command_palette_discovery(snap_compare) -> None:
         pilot.app.screen.query_one(Input).cursor_blink = False
         await pilot.app.screen.workers.wait_for_complete()
 
-    assert snap_compare(SNAPSHOT_APPS_DIR / "command_palette_discovery.py", run_before=run_before)
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "command_palette_discovery.py", run_before=run_before
+    )
 
 
 # --- textual-dev library preview tests ---

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -6,7 +6,6 @@ from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Middle
-from textual.events import MouseDown, MouseUp
 from textual.pilot import OutOfBounds
 from textual.widgets import Button, Label
 
@@ -352,3 +351,15 @@ async def test_pilot_target_screen_always_true(method, offset):
     async with app.run_test(size=(80, 24)) as pilot:
         pilot_method = getattr(pilot, method)
         assert (await pilot_method(offset=offset)) is True
+
+
+async def test_pilot_resize_terminal():
+    app = App()
+    async with app.run_test(size=(80, 24)) as pilot:
+        # Sanity checks.
+        assert app.size == (80, 24)
+        assert app.screen.size == (80, 24)
+        await pilot.resize_terminal(27, 15)
+        await pilot.pause()
+        assert app.size == (27, 15)
+        assert app.screen.size == (27, 15)


### PR DESCRIPTION
Adds a method `Pilot.resize_terminal` that allows the user to simulate a terminal resize.
This sends the appropriate `Resize` event to the app and it also notifies the `HeadlessDriver` instance of its new size.

Fixes #4212.