### PR TITLE
Write to RichLog at last known width if widget is not visible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed content size cache with Pretty widget https://github.com/Textualize/textual/pull/4211
 - Fixed `grid-gutter` interaction with Pretty widget https://github.com/Textualize/textual/pull/4219
 - Fixed `TextArea` styling issue on alternate screens https://github.com/Textualize/textual/pull/4220
+- Fixed writing to invisible `RichLog` https://github.com/Textualize/textual/pull/4223
+- Fixed `RichLog.min_width` not being used https://github.com/Textualize/textual/pull/4223
 
 ### Added
 

--- a/src/textual/widgets/_rich_log.py
+++ b/src/textual/widgets/_rich_log.py
@@ -94,6 +94,9 @@ class RichLog(ScrollView, can_focus=True):
     def notify_style_update(self) -> None:
         self._line_cache.clear()
 
+    def on_resize(self) -> None:
+        self._last_container_width = self.scrollable_content_region.width
+
     def _make_renderable(self, content: RenderableType | object) -> RenderableType:
         """Make content renderable.
 
@@ -165,7 +168,6 @@ class RichLog(ScrollView, can_focus=True):
         container_width = (
             container_width if container_width else self._last_container_width
         )
-        self._last_container_width = container_width
 
         if expand and render_width < container_width:
             render_width = container_width

--- a/tests/snapshot_tests/snapshot_apps/richlog_width.py
+++ b/tests/snapshot_tests/snapshot_apps/richlog_width.py
@@ -1,0 +1,12 @@
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import RichLog
+
+
+class RichLogWidth(App[None]):
+    def compose(self) -> ComposeResult:
+        yield RichLog(min_width=20)
+
+app = RichLogWidth()
+if __name__ == "__main__":
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -585,7 +585,7 @@ def test_richlog_width(snap_compare):
         rich_log.display = False
         rich_log.write(Text("world4", style="on yellow", justify="right"), expand=True)
         rich_log.display = True
-        
+
     assert snap_compare(SNAPSHOT_APPS_DIR / "richlog_width.py",
                         run_before=setup)
 

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.snapshot_tests.language_snippets import SNIPPETS
 from textual.widgets.text_area import Selection, BUILTIN_LANGUAGES
-from textual.widgets import TextArea, Input, Button
+from textual.widgets import RichLog, TextArea, Input, Button
 from textual.widgets.text_area import TextAreaTheme
 
 # These paths should be relative to THIS directory.
@@ -568,6 +568,26 @@ def test_table_markup(snap_compare):
 
 def test_richlog_scroll(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "richlog_scroll.py")
+
+
+def test_richlog_width(snap_compare):
+    """Check that min_width applies in RichLog and that we can write
+    to the RichLog when it's not visible, and it still renders as expected
+    when made visible again."""
+    async def setup(pilot):
+        from rich.text import Text
+        rich_log: RichLog = pilot.app.query_one(RichLog)
+        rich_log.write(Text("hello1", style="on red", justify="right"), expand=True)
+        rich_log.visible = False
+        rich_log.write(Text("world2", style="on green", justify="right"), expand=True)
+        rich_log.visible = True
+        rich_log.write(Text("hello3", style="on blue", justify="right"), expand=True)
+        rich_log.display = False
+        rich_log.write(Text("world4", style="on yellow", justify="right"), expand=True)
+        rich_log.display = True
+        
+    assert snap_compare(SNAPSHOT_APPS_DIR / "richlog_width.py",
+                        run_before=setup)
 
 
 def test_tabs_invalidate(snap_compare):


### PR DESCRIPTION
Closes #4118 

- Fix min_width reactive/constructor parameter not being used in RichLog.
- Fix content not expanding when written to a RichLog with display=False or visible=False (last known render width is used).

In the snapshot test shown below, the content is written at the expected width (20). Some of these writes are done with display=False and some with visible=False.

<img width="848" alt="image" src="https://github.com/Textualize/textual/assets/5740731/54148bde-1b47-43b0-b722-355362933751">




- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
