### PR TITLE
fix(select): stop option highlighted bubbling

### DIFF
--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -271,6 +271,26 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
             """The Select that sent the message."""
             return self.select
 
+    class SelectionHighlighted(Message):
+        """Posted when the highlighted option changes.
+
+        This message can be handled using a `on_select_selection_highlighted` method.
+        """
+
+        def __init__(
+            self, select: Select[SelectType], value: SelectType | NoSelection
+        ) -> None:
+            super().__init__()
+            self.select = select
+            """The select widget."""
+            self.value = value
+            """The value of the highlighted option."""
+
+        @property
+        def control(self) -> Select[SelectType]:
+            """The Select that sent the message."""
+            return self.select
+
     def __init__(
         self,
         options: Iterable[tuple[RenderableType, SelectType]],
@@ -517,6 +537,14 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
             self.expanded = False
 
         self.call_after_refresh(update_focus)  # Prevents a little flicker
+
+    @on(SelectOverlay.OptionHighlighted)
+    def _on_select_overlay_option_highlighted(
+        self, event: SelectOverlay.OptionHighlighted
+    ) -> None:
+        event.stop()
+        value = self._options[event.option_index][1]
+        self.post_message(self.SelectionHighlighted(self, value))
 
     def action_show_overlay(self) -> None:
         """Show the overlay."""

--- a/tests/select/test_highlighted_message.py
+++ b/tests/select/test_highlighted_message.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from textual import on
 from textual.app import App
 from textual.widgets import OptionList, Select

--- a/tests/select/test_highlighted_message.py
+++ b/tests/select/test_highlighted_message.py
@@ -1,0 +1,33 @@
+from textual import on
+from textual.app import App
+from textual.widgets import OptionList, Select
+
+
+class SelectApp(App[None]):
+    def __init__(self):
+        super().__init__()
+        self.highlighted_messages: list[str] = []
+
+    def compose(self):
+        yield Select[int]([(str(n), n) for n in range(3)])
+
+    @on(OptionList.OptionHighlighted)
+    @on(Select.SelectionHighlighted)
+    def add_message(
+        self,
+        event: OptionList.OptionHighlighted | Select.SelectionHighlighted,
+    ):
+        self.highlighted_messages.append(event.__class__.__name__)
+
+
+async def test_selection_highlighted_message():
+    """Regression test for https://github.com/Textualize/textual/issues/4224
+
+    A `Select.SelectionHighlighted` message should be posted when the
+    highlighted option changes, instead of `OptionList.OptionHighlighted`
+    bubbling."""
+
+    app = SelectApp()
+    async with app.run_test() as pilot:
+        await pilot.press("down")
+        assert app.highlighted_messages == ["SelectionHighlighted"]


### PR DESCRIPTION
Fixes #4224 by posting a `Select.SelectionHighlighted` message  when the highlighted option changes, instead of `OptionList.OptionHighlighted`  bubbling.

I've followed the suggestion in the linked issue for the name of the message, but I wonder if this could simply be `Select.Highlighted`, similar to the `ListView` widget? I think using mixed terminology of "option" and "selection" might be a little confusing.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
