### PR TITLE
Expose `Message._set_sender` as a utility method

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1286,7 +1286,7 @@ class App(Generic[ReturnType], DOMNode):
                 except KeyError:
                     char = key if len(key) == 1 else None
                 key_event = events.Key(key, char)
-                key_event._set_sender(app)
+                key_event.set_sender(app)
                 driver.send_event(key_event)
                 await wait_for_idle(0)
                 await app._animator.wait_until_complete()

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -66,7 +66,7 @@ class Driver(ABC):
         """
         # NOTE: This runs in a thread.
         # Avoid calling methods on the app.
-        event._set_sender(self._app)
+        event.set_sender(self._app)
         if isinstance(event, events.MouseDown):
             if event.button:
                 self._down_buttons.append(event.button)

--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -98,8 +98,8 @@ class Message:
             sender: The sender.
 
         Note:
-            When creating a message the sender is automatically set;
-            normally there will be no need for this method to be called.
+            When creating a message the sender is automatically set.
+            Normally there will be no need for this method to be called.
             This method will be used when strict control is required over
             the sender of a message.
 

--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 import rich.repr
+from typing_extensions import Self
 
 from . import _time
 from ._context import active_message_pump
@@ -90,9 +91,17 @@ class Message:
         """Mark this event as being forwarded."""
         self._forwarded = True
 
-    def _set_sender(self, sender: MessagePump) -> None:
-        """Set the sender."""
+    def set_sender(self, sender: MessagePump) -> Self:
+        """Set the sender.
+
+        Args:
+            sender: The sender.
+
+        Returns:
+            Self.
+        """
         self._sender = sender
+        return self
 
     def can_replace(self, message: "Message") -> bool:
         """Check if another message may supersede this one.

--- a/src/textual/message.py
+++ b/src/textual/message.py
@@ -92,10 +92,16 @@ class Message:
         self._forwarded = True
 
     def set_sender(self, sender: MessagePump) -> Self:
-        """Set the sender.
+        """Set the sender of the message.
 
         Args:
             sender: The sender.
+
+        Note:
+            When creating a message the sender is automatically set;
+            normally there will be no need for this method to be called.
+            This method will be used when strict control is required over
+            the sender of a message.
 
         Returns:
             Self.


### PR DESCRIPTION
Also have it return `self` to allow for useful chaining.

This will be useful in at least one situation that will be fixed once #3869 concludes (in that case a `TreeNode` sends a message on behalf of `Tree`, via `Tree`, but when the caller of that message is the active message pump and so ends up being seen as the sender -- the `TreeNode` method really needs to say that its parent `Tree` is the sender).