### PR TITLE
check parent focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Clicking a non focusable widget focus ancestors
-
-
+- Clicking a non focusable widget focus ancestors https://github.com/Textualize/textual/pull/4236
 
 ## [0.52.1] - 2024-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Mapping of ANSI colors to hex codes configurable via `App.ansi_theme_dark` and `App.ansi_theme_light` https://github.com/Textualize/textual/pull/4192
+- `Pilot.resize_terminal` to resize the terminal in testing https://github.com/Textualize/textual/issues/4212
 
 ### Fixed
 
@@ -26,9 +27,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Rename `CollapsibleTitle.action_toggle` to `action_toggle_collapsible` to fix clash with `DOMNode.action_toggle` https://github.com/Textualize/textual/pull/4221
 - Markdown component classes weren't refreshed when watching for CSS https://github.com/Textualize/textual/issues/3464
 
-### Added
+### Changed
 
-- `Pilot.resize_terminal` to resize the terminal in testing https://github.com/Textualize/textual/issues/4212
+- Clicking a non focusable widget focus ancestors
+
+
 
 ## [0.52.1] - 2024-02-20
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -310,8 +310,8 @@ class Screen(Generic[ScreenResultType], Widget):
     def get_focusable_widget_at(self, x: int, y: int) -> Widget | None:
         """Get the focusable widget under a given coordinate.
 
-        If the widget directly under the given coordinate, then this method will check if any of the ancestors
-        are focusable. If no ancestors are focusable, then `None` will be returned.
+        If the widget directly under the given coordinate is not focusable, then this method will check
+        if any of the ancestors are focusable. If no ancestors are focusable, then `None` will be returned.
 
         Args:
             x: X coordinate.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -307,6 +307,21 @@ class Screen(Generic[ScreenResultType], Widget):
         """
         return self._compositor.get_widgets_at(x, y)
 
+    def get_focusable_widget_at(self, x: int, y: int) -> Widget | None:
+        """Get the focusable widget under a given coordinate.
+
+        Args:
+            x: X coordinate.
+            y: Y coordinate.
+
+        Returns:
+            A `Widget`, or `None` if there is no focusable widget underneath the coordinate.
+        """
+        for widget, _region in self.get_widgets_at(x, y):
+            if widget.focusable:
+                return widget
+        return None
+
     def get_style_at(self, x: int, y: int) -> Style:
         """Get the style under a given coordinate.
 
@@ -1015,8 +1030,10 @@ class Screen(Generic[ScreenResultType], Widget):
             except errors.NoWidget:
                 self.set_focus(None)
             else:
-                if isinstance(event, events.MouseDown) and widget.focusable:
-                    self.set_focus(widget, scroll_visible=False)
+                if isinstance(event, events.MouseDown):
+                    focusable_widget = self.get_focusable_widget_at(event.x, event.y)
+                    if focusable_widget:
+                        self.set_focus(focusable_widget, scroll_visible=False)
                 event.style = self.get_style_at(event.screen_x, event.screen_y)
                 if widget is self:
                     event._set_forwarded()

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -310,6 +310,9 @@ class Screen(Generic[ScreenResultType], Widget):
     def get_focusable_widget_at(self, x: int, y: int) -> Widget | None:
         """Get the focusable widget under a given coordinate.
 
+        If the widget directly under the given coordinate, then this method will check if any of the ancestors
+        are focusable. If no ancestors are focusable, then `None` will be returned.
+
         Args:
             x: X coordinate.
             y: Y coordinate.
@@ -317,9 +320,14 @@ class Screen(Generic[ScreenResultType], Widget):
         Returns:
             A `Widget`, or `None` if there is no focusable widget underneath the coordinate.
         """
-        for widget, _region in self.get_widgets_at(x, y):
-            if widget.focusable:
-                return widget
+        try:
+            widget, _region = self.get_widget_at(x, y)
+        except NoWidget:
+            return None
+
+        for node in widget.ancestors_with_self:
+            if isinstance(node, Widget) and node.focusable:
+                return node
         return None
 
     def get_style_at(self, x: int, y: int) -> Style:

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -1,10 +1,10 @@
 import pytest
 
 from textual.app import App, ComposeResult
-from textual.containers import Container
+from textual.containers import Container, ScrollableContainer
 from textual.screen import Screen
 from textual.widget import Widget
-from textual.widgets import Button
+from textual.widgets import Button, Label
 
 
 class Focusable(Widget, can_focus=True):
@@ -409,3 +409,21 @@ async def test_focus_pseudo_class():
         classes = list(button.get_pseudo_classes())
         assert "blur" not in classes
         assert "focus" in classes
+
+
+async def test_get_focusable_widget_at() -> None:
+    """Check that clicking a non-focusable widget will check DOM ancestors."""
+
+    class FocusApp(App):
+        AUTO_FOCUS = None
+
+        def compose(self) -> ComposeResult:
+            with ScrollableContainer(id="container"):
+                yield Label("Foo", id="foo")
+
+    app = FocusApp()
+    async with app.run_test() as pilot:
+        assert app.screen.focused is None
+        await pilot.click("#foo")
+        assert app.screen.focused is not None
+        assert app.screen.focused.id == "container"

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -447,3 +447,4 @@ async def test_get_focusable_widget_at() -> None:
         # Click egg (outside of focusable widget)
         await pilot.click("#egg")
         # Confirm nothing focused
+        assert app.screen.focused is None


### PR DESCRIPTION
Clicking the screen should check for focusable ancestors, rather than just the widget underneath the mouse.