### PR TITLE
Fix docs order.

### DIFF
--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -67,6 +67,7 @@ nav:
           - "events/screen_suspend.md"
           - "events/show.md"
       - Styles:
+          - "styles/index.md"
           - "styles/align.md"
           - "styles/background.md"
           - "styles/border.md"
@@ -83,8 +84,6 @@ nav:
           - "styles/content_align.md"
           - "styles/display.md"
           - "styles/dock.md"
-          - "styles/index.md"
-          - "styles/keyline.md"
           - Grid:
               - "styles/grid/index.md"
               - "styles/grid/column_span.md"
@@ -94,6 +93,7 @@ nav:
               - "styles/grid/grid_size.md"
               - "styles/grid/row_span.md"
           - "styles/height.md"
+          - "styles/keyline.md"
           - "styles/layer.md"
           - "styles/layers.md"
           - "styles/layout.md"


### PR DESCRIPTION
Puts `keyline` in its correct place.