### PR TITLE
Clean render return type

### DIFF
--- a/docs/examples/how-to/render_compose.py
+++ b/docs/examples/how-to/render_compose.py
@@ -1,6 +1,6 @@
 from time import time
 
-from textual.app import App, ComposeResult, RenderableType
+from textual.app import App, ComposeResult, RenderResult
 from textual.containers import Container
 from textual.renderables.gradient import LinearGradient
 from textual.widgets import Static
@@ -41,7 +41,7 @@ class Splash(Container):
     def compose(self) -> ComposeResult:
         yield Static("Making a splash with Textual!")  # (2)!
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         return LinearGradient(time() * 90, STOPS)  # (3)!
 
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1593,7 +1593,7 @@ class App(Generic[ReturnType], DOMNode):
                 for screen in self.screen_stack:
                     self.stylesheet.update(screen)
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         return Blank(self.styles.background)
 
     ExpectType = TypeVar("ExpectType", bound=Widget)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -32,14 +32,17 @@ from rich.console import (
     ConsoleRenderable,
     JustifyMethod,
     RenderableType,
-    RenderResult,
-    RichCast,
 )
+from rich.console import RenderResult as RichRenderResult
+from rich.console import RichCast
 from rich.measure import Measurement
 from rich.segment import Segment
 from rich.style import Style
 from rich.text import Text
 from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from .app import RenderResult
 
 from . import constants, errors, events, messages
 from ._animator import DEFAULT_EASING, Animatable, BoundAnimator, EasingFunction
@@ -152,7 +155,7 @@ class _Styled:
 
     def __rich_console__(
         self, console: "Console", options: "ConsoleOptions"
-    ) -> "RenderResult":
+    ) -> "RichRenderResult":
         style = console.get_style(self.style)
         result_segments = console.render(self.renderable, options)
 
@@ -3375,7 +3378,7 @@ class Widget(DOMNode):
             with self.app.batch_update():
                 yield
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         """Get text or Rich renderable for this widget.
 
         Implement this for custom widgets.

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import rich.repr
 from rich.console import ConsoleRenderable, RenderableType
@@ -9,6 +9,10 @@ from rich.text import Text, TextType
 from typing_extensions import Literal, Self
 
 from .. import events
+
+if TYPE_CHECKING:
+    from ..app import RenderResult
+
 from ..binding import Binding
 from ..css._error_tools import friendly_list
 from ..message import Message
@@ -220,7 +224,7 @@ class Button(Widget, can_focus=True):
             return Text.from_markup(label)
         return label
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         assert isinstance(self.label, Text)
         label = self.label.copy()
         label.stylize(self.rich_style)

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -61,16 +61,16 @@ class Button(Widget, can_focus=True):
             tint: $background 30%;
         }
 
-        &.-primary {            
+        &.-primary {
             background: $primary;
             color: $text;
             border-top: tall $primary-lighten-3;
-            border-bottom: tall $primary-darken-3;      
-                  
+            border-bottom: tall $primary-darken-3;
+
             &:hover {
                 background: $primary-darken-2;
                 color: $text;
-                border-top: tall $primary;                
+                border-top: tall $primary;
             }
 
             &.-active {

--- a/src/textual/widgets/_digits.py
+++ b/src/textual/widgets/_digits.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from rich.align import Align, AlignMethod
-from rich.console import RenderableType
 
+if TYPE_CHECKING:
+    from ..app import RenderResult
 from ..geometry import Size
 from ..renderables.digits import Digits as DigitsRenderable
 from ..widget import Widget
@@ -68,7 +69,7 @@ class Digits(Widget):
         self._value = value
         self.refresh(layout=layout_required)
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         """Render digits."""
         rich_style = self.rich_style
         digits = DigitsRenderable(self._value, rich_style)

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 import rich.repr
-from rich.console import RenderableType
 from rich.text import Text
 
 from .. import events
+
+if TYPE_CHECKING:
+    from ..app import RenderResult
+
 from ..reactive import reactive
 from ..widget import Widget
 
@@ -138,7 +141,7 @@ class Footer(Widget):
     def post_render(self, renderable):
         return renderable
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         if self._key_text is None:
             self._key_text = self._make_key_text()
         return self._key_text

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -52,7 +52,7 @@ class _InputRenderable:
 
     def __rich_console__(
         self, console: "Console", options: "ConsoleOptions"
-    ) -> "RichRenderResult":
+    ) -> RichRenderResult:
         input = self.input
         result = input._value
         width = input.content_size.width

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import ClassVar, Iterable
+from typing import TYPE_CHECKING, ClassVar, Iterable
 
 from rich.cells import cell_len, get_character_cell_size
-from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+from rich.console import Console, ConsoleOptions
+from rich.console import RenderResult as RichRenderResult
 from rich.highlighter import Highlighter
 from rich.segment import Segment
 from rich.text import Text
@@ -13,6 +14,10 @@ from typing_extensions import Literal
 
 from .. import events
 from .._segment_tools import line_crop
+
+if TYPE_CHECKING:
+    from ..app import RenderResult
+
 from ..binding import Binding, BindingType
 from ..css._error_tools import friendly_list
 from ..events import Blur, Focus, Mount
@@ -47,7 +52,7 @@ class _InputRenderable:
 
     def __rich_console__(
         self, console: "Console", options: "ConsoleOptions"
-    ) -> "RenderResult":
+    ) -> "RichRenderResult":
         input = self.input
         result = input._value
         width = input.content_size.width
@@ -460,7 +465,7 @@ class Input(Widget, can_focus=True):
             return cell_len(self.placeholder)
         return self._position_to_cell(len(self.value)) + 1
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         self.view_position = self.view_position
         if not self.value:
             placeholder = Text(self.placeholder, justify="left")

--- a/src/textual/widgets/_loading_indicator.py
+++ b/src/textual/widgets/_loading_indicator.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from time import time
+from typing import TYPE_CHECKING
 
-from rich.console import RenderableType
 from rich.style import Style
 from rich.text import Text
 
+if TYPE_CHECKING:
+    from ..app import RenderResult
 from ..color import Gradient
 from ..events import Mount
 from ..widget import Widget
@@ -53,7 +55,7 @@ class LoadingIndicator(Widget):
         self._start_time = time()
         self.auto_refresh = 1 / 16
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         if self.app.animation_level == "none":
             return Text("Loading...")
 

--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -6,10 +6,13 @@ from itertools import cycle
 from typing import TYPE_CHECKING, Iterator
 from weakref import WeakKeyDictionary
 
-from rich.console import RenderableType
 from typing_extensions import Literal, Self
 
 from .. import events
+
+if TYPE_CHECKING:
+    from ..app import RenderResult
+
 from ..css._error_tools import friendly_list
 from ..reactive import Reactive, reactive
 from ..widget import Widget
@@ -128,7 +131,7 @@ class Placeholder(Widget):
         )
         self.styles.background = f"{next(colors)} 50%"
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         """Render the placeholder.
 
         Returns:

--- a/src/textual/widgets/_static.py
+++ b/src/textual/widgets/_static.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from rich.console import RenderableType
 from rich.protocol import is_renderable
 from rich.text import Text
+
+if TYPE_CHECKING:
+    from ..app import RenderResult
 
 from ..errors import RenderError
 from ..widget import Widget
@@ -80,7 +85,7 @@ class Static(Widget, inherit_bindings=False):
             self._renderable = renderable
         self.clear_cached_dimensions()
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         """Get a rich renderable for the widget's content.
 
         Returns:

--- a/src/textual/widgets/_switch.py
+++ b/src/textual/widgets/_switch.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from rich.console import RenderableType
-
+if TYPE_CHECKING:
+    from ..app import RenderResult
 from ..binding import Binding, BindingType
 from ..events import Click
 from ..geometry import Size
@@ -143,7 +143,7 @@ class Switch(Widget, can_focus=True):
     def watch_slider_pos(self, slider_pos: float) -> None:
         self.set_class(slider_pos == 1, "-on")
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         style = self.get_component_rich_style("switch--slider")
         return ScrollBarRender(
             virtual_size=100,

--- a/src/textual/widgets/_toast.py
+++ b/src/textual/widgets/_toast.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
-from rich.console import RenderableType
 from rich.text import Text
 
 from .. import on
+
+if TYPE_CHECKING:
+    from ..app import RenderResult
+
 from ..containers import Container
 from ..css.query import NoMatches
 from ..events import Click, Mount
@@ -105,7 +108,7 @@ class Toast(Static, inherit_css=False):
         self._notification = notification
         self._timeout = notification.time_left
 
-    def render(self) -> RenderableType:
+    def render(self) -> RenderResult:
         """Render the toast's content.
 
         Returns:


### PR DESCRIPTION
This PR tweaks the type hinting for the `render` methods of various widgets, to ensure they follow the same hinting as is used [in our documentation](https://textual.textualize.io/guide/widgets/#custom-widgets); the aim being to make the code a little less surprising to the reader and also to ensure that any type hint information shown in an IDE, or auto-completed when inheriting from a Textual widget and overriding the `render` method, matches what would be expected.

Fixes #4063.