### PR TITLE
Enable `AppFocus` and `AppBlur` in terminal emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Changed `Tabs`
   - Changed `TextArea`
   - Changed `Tree`
+- BREAKING: `AppFocus` and `AppBlur` are now posted when the terminal window gains or loses focus, if the terminal supports this https://github.com/Textualize/textual/pull/4265
+  - When the terminal window loses focus, the currently-focused widget will also lose focus.
+  - When the terminal window regains focus, the previously-focused widget will regain focus.
 
 ## [0.52.1] - 2024-02-20
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -20,6 +20,8 @@ _re_terminal_mode_response = re.compile(
 )
 _re_bracketed_paste_start = re.compile(r"^\x1b\[200~$")
 _re_bracketed_paste_end = re.compile(r"^\x1b\[201~$")
+_re_focusin = re.compile(r"^\x1b\[I$")
+_re_focusout = re.compile(r"^\x1b\[O$")
 
 
 class XTermParser(Parser[events.Event]):
@@ -201,6 +203,14 @@ class XTermParser(Parser[events.Event]):
                     sequence = new_sequence
 
                     self.debug_log(f"sequence={sequence!r}")
+
+                    if _re_focusin.match(sequence):
+                        on_token(events.AppFocus())
+                        break
+
+                    if _re_focusout.match(sequence):
+                        on_token(events.AppBlur())
+                        break
 
                     bracketed_paste_start_match = _re_bracketed_paste_start.match(
                         sequence

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -20,9 +20,11 @@ _re_mouse_event = re.compile("^" + re.escape("\x1b[") + r"(<?[\d;]+[mM]|M...)\Z"
 _re_terminal_mode_response = re.compile(
     "^" + re.escape("\x1b[") + r"\?(?P<mode_id>\d+);(?P<setting_parameter>\d)\$y"
 )
-_re_bracketed_paste_start = re.compile(r"^\x1b\[200~$")
-_re_bracketed_paste_end = re.compile(r"^\x1b\[201~$")
 
+BRACKETED_PASTE_START: Final[str] = "\x1b[200~"
+"""Sequence received when a bracketed paste event starts."""
+BRACKETED_PASTE_END: Final[str] = "\x1b[201~"
+"""Sequence received when a bracketed paste event ends."""
 FOCUSIN: Final[str] = "\x1b[I"
 """Sequence received when the terminal receives focus."""
 FOCUSOUT: Final[str] = "\x1b[O"
@@ -217,15 +219,11 @@ class XTermParser(Parser[events.Event]):
                         on_token(events.AppBlur())
                         break
 
-                    bracketed_paste_start_match = _re_bracketed_paste_start.match(
-                        sequence
-                    )
-                    if bracketed_paste_start_match is not None:
+                    if sequence == BRACKETED_PASTE_START:
                         bracketed_paste = True
                         break
 
-                    bracketed_paste_end_match = _re_bracketed_paste_end.match(sequence)
-                    if bracketed_paste_end_match is not None:
+                    if sequence == BRACKETED_PASTE_END:
                         bracketed_paste = False
                         break
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -4,6 +4,8 @@ import re
 import unicodedata
 from typing import Any, Callable, Generator, Iterable
 
+from typing_extensions import Final
+
 from . import events, messages
 from ._ansi_sequences import ANSI_SEQUENCES_KEYS, IGNORE_SEQUENCE
 from ._parser import Awaitable, Parser, TokenCallback
@@ -20,8 +22,11 @@ _re_terminal_mode_response = re.compile(
 )
 _re_bracketed_paste_start = re.compile(r"^\x1b\[200~$")
 _re_bracketed_paste_end = re.compile(r"^\x1b\[201~$")
-_re_focusin = re.compile(r"^\x1b\[I$")
-_re_focusout = re.compile(r"^\x1b\[O$")
+
+FOCUSIN: Final[str] = "\x1b[I"
+"""Sequence received when the terminal receives focus."""
+FOCUSOUT: Final[str] = "\x1b[O"
+"""Sequence received when focus is lost from the terminal."""
 
 
 class XTermParser(Parser[events.Event]):
@@ -204,11 +209,11 @@ class XTermParser(Parser[events.Event]):
 
                     self.debug_log(f"sequence={sequence!r}")
 
-                    if _re_focusin.match(sequence):
+                    if sequence == FOCUSIN:
                         on_token(events.AppFocus())
                         break
 
-                    if _re_focusout.match(sequence):
+                    if sequence == FOCUSOUT:
                         on_token(events.AppBlur())
                         break
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3205,11 +3205,13 @@ class App(Generic[ReturnType], DOMNode):
         """Respond to changes in app focus."""
         if focus:
             # If we've got a last-focused widget, if it still has a screen,
-            # and if the screen is still the current screen...
+            # and if the screen is still the current screen and if nothing
+            # is focused right now...
             try:
                 if (
                     self._last_focused_on_app_blur is not None
                     and self._last_focused_on_app_blur.screen is self.screen
+                    and self.screen.focused is None
                 ):
                     # ...settle focus back on that widget.
                     self.screen.set_focus(self._last_focused_on_app_blur)

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -232,6 +232,7 @@ class LinuxDriver(Driver):
 
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\033[?1003h\n")
+        self.write("\033[?1004h\n")  # Enable FocusIn/FocusOut.
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread)
         send_size_event()
@@ -316,6 +317,7 @@ class LinuxDriver(Driver):
 
             # Alt screen false, show cursor
             self.write("\x1b[?1049l" + "\x1b[?25h")
+            self.write("\033[?1004h\n")  # Disable FocusIn/FocusOut.
             self.flush()
 
     def close(self) -> None:

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -317,7 +317,7 @@ class LinuxDriver(Driver):
 
             # Alt screen false, show cursor
             self.write("\x1b[?1049l" + "\x1b[?25h")
-            self.write("\033[?1004h\n")  # Disable FocusIn/FocusOut.
+            self.write("\033[?1004l\n")  # Disable FocusIn/FocusOut.
             self.flush()
 
     def close(self) -> None:

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -90,6 +90,7 @@ class WindowsDriver(Driver):
         self._enable_mouse_support()
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\033[?1003h\n")
+        self.write("\033[?1004h\n")  # Enable FocusIn/FocusOut.
         self._enable_bracketed_paste()
 
         self._event_thread = win32.EventMonitor(
@@ -118,6 +119,7 @@ class WindowsDriver(Driver):
 
         # Disable alt screen, show cursor
         self.write("\x1b[?1049l" + "\x1b[?25h")
+        self.write("\033[?1004l\n")  # Disable FocusIn/FocusOut.
         self.flush()
 
     def close(self) -> None:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -563,7 +563,8 @@ class Blur(Event, bubble=False):
 class AppFocus(Event, bubble=False):
     """Sent when the app has focus.
 
-    Used by textual-web.
+    Only available when running within a terminal that supports `FocusIn`,
+    or when running via textual-web.
 
     - [ ] Bubbles
     - [ ] Verbose
@@ -573,7 +574,8 @@ class AppFocus(Event, bubble=False):
 class AppBlur(Event, bubble=False):
     """Sent when the app loses focus.
 
-    Used by textual-web.
+    Only available when running within a terminal that supports `FocusOut`,
+    or when running via textual-web.
 
     - [ ] Bubbles
     - [ ] Verbose

--- a/tests/snapshot_tests/snapshot_apps/app_blur.py
+++ b/tests/snapshot_tests/snapshot_apps/app_blur.py
@@ -1,0 +1,32 @@
+from textual.app import App, ComposeResult
+from textual.events import AppBlur
+from textual.widgets import Input
+
+class AppBlurApp(App[None]):
+
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+
+    Input {
+        width: 50%;
+        margin-bottom: 1;
+
+        &:focus {
+            width: 75%;
+            border: thick green;
+            background: pink;
+        }
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Input("This should be the blur style")
+        yield Input("This should also be the blur style")
+
+    def on_mount(self) -> None:
+        self.post_message(AppBlur())
+
+if __name__ == "__main__":
+    AppBlurApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1133,3 +1133,10 @@ def test_pretty_grid_gutter_interaction(snap_compare):
 def test_sort_children(snap_compare):
     """Test sort_children method."""
     assert snap_compare(SNAPSHOT_APPS_DIR / "sort_children.py", terminal_size=(80, 25))
+
+
+def test_app_blur(snap_compare):
+    """Test Styling after receiving an AppBlur message."""
+    async def run_before(pilot) -> None:
+        await pilot.pause()     # Allow the AppBlur message to get processed.
+    assert snap_compare(SNAPSHOT_APPS_DIR / "app_blur.py", run_before=run_before)

--- a/tests/test_app_focus_blur.py
+++ b/tests/test_app_focus_blur.py
@@ -62,3 +62,18 @@ async def test_app_focus_handles_missing_widget() -> None:
         pilot.app.post_message(AppFocus())
         await pilot.pause()
         assert pilot.app.focused is None
+
+
+async def test_app_focus_defers_to_new_focus() -> None:
+    """Test that AppFocus doesn't undo a fresh focus done while the app is in AppBlur state."""
+    async with FocusBlurApp().run_test() as pilot:
+        assert pilot.app.focused is not None
+        assert pilot.app.focused.id == "input-4"
+        pilot.app.post_message(AppBlur())
+        await pilot.pause()
+        assert pilot.app.focused is None
+        pilot.app.query_one("#input-1").focus()
+        await pilot.pause()
+        pilot.app.post_message(AppFocus())
+        await pilot.pause()
+        assert pilot.app.focused.id == "input-1"

--- a/tests/test_app_focus_blur.py
+++ b/tests/test_app_focus_blur.py
@@ -1,0 +1,64 @@
+"""Test the workings of reacting to AppFocus and AppBlur."""
+
+from textual.app import App, ComposeResult
+from textual.events import AppBlur, AppFocus
+from textual.widgets import Input
+
+
+class FocusBlurApp(App[None]):
+
+    AUTO_FOCUS = "#input-4"
+
+    def compose(self) -> ComposeResult:
+        for n in range(10):
+            yield Input(id=f"input-{n}")
+
+
+async def test_app_blur() -> None:
+    """Test that AppBlur removes focus."""
+    async with FocusBlurApp().run_test() as pilot:
+        assert pilot.app.focused is not None
+        assert pilot.app.focused.id == "input-4"
+        pilot.app.post_message(AppBlur())
+        await pilot.pause()
+        assert pilot.app.focused is None
+
+
+async def test_app_focus_restores_focus() -> None:
+    """Test that AppFocus restores the correct focus."""
+    async with FocusBlurApp().run_test() as pilot:
+        assert pilot.app.focused is not None
+        assert pilot.app.focused.id == "input-4"
+        pilot.app.post_message(AppBlur())
+        await pilot.pause()
+        assert pilot.app.focused is None
+        pilot.app.post_message(AppFocus())
+        await pilot.pause()
+        assert pilot.app.focused is not None
+        assert pilot.app.focused.id == "input-4"
+
+
+async def test_app_focus_restores_none_focus() -> None:
+    """Test that AppFocus doesn't set focus if nothing was focused."""
+    async with FocusBlurApp().run_test() as pilot:
+        pilot.app.screen.focused = None
+        pilot.app.post_message(AppBlur())
+        await pilot.pause()
+        assert pilot.app.focused is None
+        pilot.app.post_message(AppFocus())
+        await pilot.pause()
+        assert pilot.app.focused is None
+
+
+async def test_app_focus_handles_missing_widget() -> None:
+    """Test that AppFocus works even when the last-focused widget has gone away."""
+    async with FocusBlurApp().run_test() as pilot:
+        assert pilot.app.focused is not None
+        assert pilot.app.focused.id == "input-4"
+        pilot.app.post_message(AppBlur())
+        await pilot.pause()
+        assert pilot.app.focused is None
+        await pilot.app.query_one("#input-4").remove()
+        pilot.app.post_message(AppFocus())
+        await pilot.pause()
+        assert pilot.app.focused is None


### PR DESCRIPTION
This enables support for receiving and handling FocusIn and FocusOut sequences, and turns then into `AppFocus` and `AppBlur` events. Support for enabling this is added to both the "Linux" and Windows drivers. From now on, when a terminal emulator window that supports it sends the FocusIn and FocusOut sequences the app will receive `AppFocus` and `AppBlur`.

An automatic effect of this now is that, when the window loses focus, focus will be removed from the widget that has focus. This was already an established feature of Textual applications running via textual-web; it just now extends it to the drivers used on GNU/Linux, macOS and Windows.

The `AppFocus` and `AppBlur` events could be useful too.

https://github.com/Textualize/textual/assets/28237/33bf3b9e-ab05-4c8c-89de-01da79cccace

It should be noted that this is technically a breaking change.

Implements #4263 (which in turn stems from #4259).

It also fixes a problem with the current implementation of `AppFocus` and `AppBlur` that is mentioned in a comment in #4263.

---

A natural question is going to be, how widely supported is this? So far the following have been tested and shown to support this:

- macOS
  - Kitty
  - iTerm2
  - Contour
  - terminal.app
  - WezTerm
  - rio
  - Tabby
  - VSCode Terminal
- GNU/Linux
  - GNOME Terminal
  - alacritty (via @TomJGooding)
  - urxvt (via @TomJGooding)
  - xterm
  - Konsole
- Windows 11
  - Terminal
  - Hyper
  - conemu (via @TomJGooding)

It has been noted by @TomJGooding that iTerm2 has a setting for turning this off[^1]; when turned off the enable/disable sequence appears to be swallowed and ignored.

It would appear that vterm under Emacs doesn't support this, but running my test app had the same effect as running it under iTerm with support turned off (that is, the enable/disable sequences seem to be swallowed and ignored).

**NOTE:** This is marked as and should be treated as a breaking change. This can potentially affect application styling in a way that would not have been an issue before. For example, before this change, this application would always look the same no matter if the terminal emulator it was within had focus or not:

```python
from textual.app import App, ComposeResult
from textual.widgets import Input

class OneWidgetApp(App[None]):

    CSS = """
    Screen {
        align: center middle;
    }

    Input:focus {
        border: round red;
        width: 50%;
        background: pink;
    }
    """

    def compose(self) -> ComposeResult:
        yield Input(placeholder="Please give your answer")

if __name__ == "__main__":
    OneWidgetApp().run()
```

from now on the layout of the application will look very different when focus moves away form the window.

[^1]: Because of course it does! What doesn't iTerm have a setting for?!?