### PR TITLE
fix(switch): rename clashing action toggle method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `RichLog.min_width` not being used https://github.com/Textualize/textual/pull/4223
 - Rename `CollapsibleTitle.action_toggle` to `action_toggle_collapsible` to fix clash with `DOMNode.action_toggle` https://github.com/Textualize/textual/pull/4221
 - Markdown component classes weren't refreshed when watching for CSS https://github.com/Textualize/textual/issues/3464
+- Rename `Switch.action_toggle` to `action_toggle_switch` to fix clash with `DOMNode.action_toggle` https://github.com/Textualize/textual/issues/4262
 
 ### Changed
 

--- a/src/textual/widgets/_switch.py
+++ b/src/textual/widgets/_switch.py
@@ -26,7 +26,7 @@ class Switch(Widget, can_focus=True):
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding("enter,space", "toggle", "Toggle", show=False),
+        Binding("enter,space", "toggle_switch", "Toggle", show=False),
     ]
     """
     | Key(s) | Description |
@@ -164,7 +164,7 @@ class Switch(Widget, can_focus=True):
         event.stop()
         self.toggle()
 
-    def action_toggle(self) -> None:
+    def action_toggle_switch(self) -> None:
         """Toggle the state of the switch."""
         self.toggle()
 

--- a/tests/animations/test_switch_animation.py
+++ b/tests/animations/test_switch_animation.py
@@ -21,7 +21,7 @@ async def test_switch_animates_on_full() -> None:
         animator = app.animator
         # Freeze time at 0 before triggering the animation.
         animator._get_time = lambda *_: 0
-        switch.action_toggle()
+        switch.action_toggle_switch()
         await pilot.pause()
         # Freeze time after the animation start and before animation end.
         animator._get_time = lambda *_: 0.01
@@ -40,7 +40,7 @@ async def test_switch_animates_on_basic() -> None:
         animator = app.animator
         # Freeze time at 0 before triggering the animation.
         animator._get_time = lambda *_: 0
-        switch.action_toggle()
+        switch.action_toggle_switch()
         await pilot.pause()
         # Freeze time after the animation start and before animation end.
         animator._get_time = lambda *_: 0.01
@@ -59,7 +59,7 @@ async def test_switch_does_not_animate_on_none() -> None:
         animator = app.animator
         # Freeze time at 0 before triggering the animation.
         animator._get_time = lambda *_: 0
-        switch.action_toggle()
+        switch.action_toggle_switch()
         await pilot.pause()
         # Freeze time after the animation start and before animation end.
         animator._get_time = lambda *_: 0.01


### PR DESCRIPTION
Rename `Switch.action_toggle` to `action_toggle_switch` to fix clash with `DOMNode.action_toggle`. Fixes #4262.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
