### PR TITLE
improved eta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Changed `Tabs`
   - Changed `TextArea`
   - Changed `Tree`
+- Improved ETA calculation for ProgressBar https://github.com/Textualize/textual/pull/4271
 
 ## [0.52.1] - 2024-02-20
 

--- a/docs/examples/widgets/progress_bar_isolated_.py
+++ b/docs/examples/widgets/progress_bar_isolated_.py
@@ -11,13 +11,14 @@ class IndeterminateProgressBar(App[None]):
     """Timer to simulate progress happening."""
 
     def compose(self) -> ComposeResult:
+        self.time = 0
         with Center():
             with Middle():
-                yield ProgressBar()
+                yield ProgressBar(_get_time=lambda: self.time)
         yield Footer()
 
     def on_mount(self) -> None:
-        """Set up a timer to simulate progess happening."""
+        """Set up a timer to simulate progress happening."""
         self.progress_timer = self.set_interval(1 / 10, self.make_progress, pause=True)
 
     def make_progress(self) -> None:
@@ -31,14 +32,18 @@ class IndeterminateProgressBar(App[None]):
 
     def key_f(self) -> None:
         # Freeze time for the indeterminate progress bar.
-        self.query_one(ProgressBar).query_one("#bar")._get_elapsed_time = lambda: 5
+        self.time = 5
+        self.refresh()
 
     def key_t(self) -> None:
         # Freeze time to show always the same ETA.
-        self.query_one(ProgressBar).query_one("#eta")._get_elapsed_time = lambda: 3.9
-        self.query_one(ProgressBar).update(total=100, progress=39)
+        self.time = 0
+        self.query_one(ProgressBar).update(total=100, progress=0)
+        self.time = 3.9
+        self.query_one(ProgressBar).update(progress=39)
 
     def key_u(self) -> None:
+        self.refresh()
         self.query_one(ProgressBar).update(total=100, progress=100)
 
 

--- a/docs/examples/widgets/progress_bar_isolated_.py
+++ b/docs/examples/widgets/progress_bar_isolated_.py
@@ -1,4 +1,5 @@
 from textual.app import App, ComposeResult
+from textual.clock import MockClock
 from textual.containers import Center, Middle
 from textual.timer import Timer
 from textual.widgets import Footer, ProgressBar
@@ -11,10 +12,10 @@ class IndeterminateProgressBar(App[None]):
     """Timer to simulate progress happening."""
 
     def compose(self) -> ComposeResult:
-        self.time = 0
+        self.clock = MockClock()
         with Center():
             with Middle():
-                yield ProgressBar(_get_time=lambda: self.time)
+                yield ProgressBar(clock=self.clock)
         yield Footer()
 
     def on_mount(self) -> None:
@@ -32,14 +33,14 @@ class IndeterminateProgressBar(App[None]):
 
     def key_f(self) -> None:
         # Freeze time for the indeterminate progress bar.
-        self.time = 5
+        self.clock.set_time(5)
         self.refresh()
 
     def key_t(self) -> None:
         # Freeze time to show always the same ETA.
-        self.time = 0
+        self.clock.set_time(0)
         self.query_one(ProgressBar).update(total=100, progress=0)
-        self.time = 3.9
+        self.clock.set_time(3.9)
         self.query_one(ProgressBar).update(progress=39)
 
     def key_u(self) -> None:

--- a/docs/examples/widgets/progress_bar_styled.py
+++ b/docs/examples/widgets/progress_bar_styled.py
@@ -18,7 +18,7 @@ class StyledProgressBar(App[None]):
         yield Footer()
 
     def on_mount(self) -> None:
-        """Set up a timer to simulate progess happening."""
+        """Set up a timer to simulate progress happening."""
         self.progress_timer = self.set_interval(1 / 10, self.make_progress, pause=True)
 
     def make_progress(self) -> None:

--- a/docs/examples/widgets/progress_bar_styled_.py
+++ b/docs/examples/widgets/progress_bar_styled_.py
@@ -1,4 +1,5 @@
 from textual.app import App, ComposeResult
+from textual.clock import MockClock
 from textual.containers import Center, Middle
 from textual.timer import Timer
 from textual.widgets import Footer, ProgressBar
@@ -12,10 +13,10 @@ class StyledProgressBar(App[None]):
     """Timer to simulate progress happening."""
 
     def compose(self) -> ComposeResult:
-        self.time = 0
+        self.clock = MockClock()
         with Center():
             with Middle():
-                yield ProgressBar(_get_time=lambda: self.time)
+                yield ProgressBar(clock=self.clock)
         yield Footer()
 
     def on_mount(self) -> None:
@@ -30,17 +31,17 @@ class StyledProgressBar(App[None]):
         """Start the progress tracking."""
         self.query_one(ProgressBar).update(total=100)
         self.progress_timer.resume()
+        self.query_one(ProgressBar).refresh()
 
     def key_f(self) -> None:
         # Freeze time for the indeterminate progress bar.
-        self.time = 5
-        self.refresh()
+        self.clock.set_time(5.0)
 
     def key_t(self) -> None:
         # Freeze time to show always the same ETA.
-        self.time = 0
+        self.clock.set_time(0)
         self.query_one(ProgressBar).update(total=100, progress=0)
-        self.time = 3.9
+        self.clock.set_time(3.9)
         self.query_one(ProgressBar).update(progress=39)
 
     def key_u(self) -> None:

--- a/docs/examples/widgets/progress_bar_styled_.py
+++ b/docs/examples/widgets/progress_bar_styled_.py
@@ -12,13 +12,14 @@ class StyledProgressBar(App[None]):
     """Timer to simulate progress happening."""
 
     def compose(self) -> ComposeResult:
+        self.time = 0
         with Center():
             with Middle():
-                yield ProgressBar()
+                yield ProgressBar(_get_time=lambda: self.time)
         yield Footer()
 
     def on_mount(self) -> None:
-        """Set up a timer to simulate progess happening."""
+        """Set up a timer to simulate progress happening."""
         self.progress_timer = self.set_interval(1 / 10, self.make_progress, pause=True)
 
     def make_progress(self) -> None:
@@ -32,12 +33,15 @@ class StyledProgressBar(App[None]):
 
     def key_f(self) -> None:
         # Freeze time for the indeterminate progress bar.
-        self.query_one(ProgressBar).query_one("#bar")._get_elapsed_time = lambda: 5
+        self.time = 5
+        self.refresh()
 
     def key_t(self) -> None:
         # Freeze time to show always the same ETA.
-        self.query_one(ProgressBar).query_one("#eta")._get_elapsed_time = lambda: 3.9
-        self.query_one(ProgressBar).update(total=100, progress=39)
+        self.time = 0
+        self.query_one(ProgressBar).update(total=100, progress=0)
+        self.time = 3.9
+        self.query_one(ProgressBar).update(progress=39)
 
     def key_u(self) -> None:
         self.query_one(ProgressBar).update(total=100, progress=100)

--- a/src/textual/clock.py
+++ b/src/textual/clock.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from time import monotonic
+from typing import Callable
+
+import rich.repr
+
+
+@rich.repr.auto(angular=True)
+class Clock:
+    """An object to get relative time.
+
+    The `time` attribute of clock will return the time in seconds since the
+    Clock was created or reset.
+
+    """
+
+    def __init__(self, *, get_time: Callable[[], float] = monotonic) -> None:
+        """Create a clock.
+
+        Args:
+            get_time: A callable to get time in seconds.
+            start: Start the clock (time is 0 unless clock has been started).
+        """
+        self._get_time = get_time
+        self._start_time = self._get_time()
+
+    def __rich_repr__(self) -> rich.repr.Result:
+        yield self.time
+
+    def clone(self) -> Clock:
+        """Clone the Clock with an independent time."""
+        return Clock(get_time=self._get_time)
+
+    def reset(self) -> None:
+        """Reset the clock."""
+        self._start_time = self._get_time()
+
+    @property
+    def time(self) -> float:
+        """Time since creation or reset."""
+        return self._get_time() - self._start_time
+
+
+class MockClock(Clock):
+    """A mock clock object where the time may be explicitly set."""
+
+    def __init__(self, time: float = 0.0) -> None:
+        """Construct a mock clock."""
+        self._time = time
+        super().__init__(get_time=lambda: self._time)
+
+    def clone(self) -> MockClock:
+        """Clone the mocked clock (clone will return the same time as original)."""
+        clock = MockClock(self._time)
+        clock._get_time = self._get_time
+        clock._time = self._time
+        return clock
+
+    def reset(self) -> None:
+        """A null-op because it doesn't make sense to reset a mocked clock."""
+
+    def set_time(self, time: float) -> None:
+        """Set the time for the clock.
+
+        Args:
+            time: Time to set.
+        """
+        self._time = time
+
+    @property
+    def time(self) -> float:
+        """Time since creation or reset."""
+        return self._get_time()

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -474,13 +474,11 @@ class DOMNode(MessagePump):
         cls._merged_bindings = cls._merge_bindings()
         cls._css_type_names = frozenset(css_type_names)
         cls._computes = frozenset(
-            dict.fromkeys(
-                [
-                    name.lstrip("_")[8:]
-                    for name in dir(cls)
-                    if name.startswith(("_compute_", "compute_"))
-                ]
-            ).keys()
+            [
+                name.lstrip("_")[8:]
+                for name in dir(cls)
+                if name.startswith(("_compute_", "compute_"))
+            ]
         )
 
     def get_component_styles(self, name: str) -> RenderStyles:

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import bisect
+from math import ceil
 from operator import itemgetter
 from time import monotonic
 
@@ -112,4 +113,4 @@ class ETA:
         time_since_sample = time - recent_time
         remaining = 1.0 - (recent_progress + speed * time_since_sample)
         eta = max(0, remaining / speed)
-        return round(eta)
+        return ceil(eta)

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -64,12 +64,12 @@ class ETA:
             # Keep at least 10 samples
             return
         prune_time = self._samples[-1][0] - self.estimation_period
-        index = bisect.bisect_left(self._samples, prune_time)
+        index = bisect.bisect_left(self._samples, (prune_time, 0))
         del self._samples[:index]
 
     def _get_progress_at(self, time: float) -> tuple[float, float]:
         """Get the progress at a specific time."""
-        index = bisect.bisect_left(self._samples, time)
+        index = bisect.bisect_left(self._samples, (time, 0))
         if index >= len(self._samples):
             return self.last_sample
         if index == 0:

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import bisect
-from math import ceil
 from operator import itemgetter
 from time import monotonic
-from typing import Callable
 
 import rich.repr
 
@@ -11,47 +11,50 @@ import rich.repr
 class ETA:
     """Calculate speed and estimate time to arrival."""
 
-    def __init__(
-        self, estimation_period: float = 30, _get_time: Callable[[], float] = monotonic
-    ) -> None:
+    def __init__(self, estimation_period: float = 60) -> None:
         """Create an ETA.
 
         Args:
             estimation_period: Period in seconds, used to calculate speed. Defaults to 30.
-            _get_time: Optional replacement function to get current time.
         """
         self.estimation_period = estimation_period
-        self._get_time = _get_time
-        self._start_time = _get_time()
         self._samples: list[tuple[float, float]] = [(0.0, 0.0)]
+        self._add_count = 0
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "speed", self.speed
-        yield "eta", self.eta
+        yield "eta", self.get_eta(monotonic())
+
+    @property
+    def first_sample(self) -> tuple[float, float]:
+        """First sample, or `None` if no samples."""
+        assert self._samples, "Assumes samples not empty"
+        return self._samples[0]
+
+    @property
+    def last_sample(self) -> tuple[float, float]:
+        """Last sample, or `None` if no samples."""
+        assert self._samples, "Assumes samples not empty"
+        return self._samples[-1]
 
     def reset(self) -> None:
         """Start ETA calculations from current time."""
         del self._samples[:]
-        self._start_time = self._get_time()
 
-    @property
-    def _current_time(self) -> float:
-        """The time since the ETA was started."""
-        return self._get_time() - self._start_time
-
-    def add_sample(self, progress: float) -> None:
+    def add_sample(self, time: float, progress: float) -> None:
         """Add a new sample.
 
         Args:
+            time: Time when sample occurred.
             progress: Progress ratio (0 is start, 1 is complete).
         """
-        if self._samples and self._samples[-1][1] > progress:
+        if self._samples and self.last_sample[1] > progress:
             # If progress goes backwards, we need to reset calculations
             self.reset()
             return
-        current_time = self._current_time
-        self._samples.append((current_time, progress))
-        if not (len(self._samples) % 100):
+        self._samples.append((time, progress))
+        self._add_count += 1
+        if self._add_count % 100 == 0:
             # Prune periodically so we don't accumulate vast amounts of samples
             self._prune()
 
@@ -68,9 +71,10 @@ class ETA:
         """Get the progress at a specific time."""
         index = bisect.bisect_left(self._samples, time, key=itemgetter(0))
         if index >= len(self._samples):
-            return self._samples[-1]
+            return self.last_sample
         if index == 0:
-            return self._samples[0]
+            return self.first_sample
+        # Linearly interpolate progress between two samples
         time1, progress1 = self._samples[index]
         time2, progress2 = self._samples[index + 1]
         factor = (time - time1) / (time2 - time1)
@@ -85,7 +89,7 @@ class ETA:
             # Need at less 2 samples to calculate speed
             return None
 
-        recent_sample_time, progress2 = self._samples[-1]
+        recent_sample_time, progress2 = self.last_sample
         progress_start_time, progress1 = self._get_progress_at(
             recent_sample_time - self.estimation_period
         )
@@ -94,15 +98,18 @@ class ETA:
         speed = distance / time_delta if time_delta else 0
         return speed
 
-    @property
-    def eta(self) -> int | None:
-        """Estimated seconds until completion, or `None` if no estimate can be made."""
-        current_time = self._current_time
+    def get_eta(self, time: float) -> int | None:
+        """Estimated seconds until completion, or `None` if no estimate can be made.
+
+        Args:
+            time: Current time.
+        """
         speed = self.speed
         if not speed:
+            # Not enough samples to guess
             return None
-        recent_time, recent_progress = self._samples[-1]
-        time_since_sample = current_time - recent_time
+        recent_time, recent_progress = self.last_sample
+        time_since_sample = time - recent_time
         remaining = 1.0 - (recent_progress + speed * time_since_sample)
         eta = max(0, remaining / speed)
-        return ceil(eta)
+        return round(eta)

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import bisect
 from math import ceil
-from operator import itemgetter
 from time import monotonic
 
 import rich.repr
@@ -65,12 +64,12 @@ class ETA:
             # Keep at least 10 samples
             return
         prune_time = self._samples[-1][0] - self.estimation_period
-        index = bisect.bisect_left(self._samples, prune_time, key=itemgetter(0))
+        index = bisect.bisect_left(self._samples, prune_time)
         del self._samples[:index]
 
     def _get_progress_at(self, time: float) -> tuple[float, float]:
         """Get the progress at a specific time."""
-        index = bisect.bisect_left(self._samples, time, key=itemgetter(0))
+        index = bisect.bisect_left(self._samples, time)
         if index >= len(self._samples):
             return self.last_sample
         if index == 0:

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -31,13 +31,13 @@ class ETA:
 
     @property
     def first_sample(self) -> tuple[float, float]:
-        """First sample, or `None` if no samples."""
+        """First sample."""
         assert self._samples, "Assumes samples not empty"
         return self._samples[0]
 
     @property
     def last_sample(self) -> tuple[float, float]:
-        """Last sample, or `None` if no samples."""
+        """Last sample."""
         assert self._samples, "Assumes samples not empty"
         return self._samples[-1]
 

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -1,0 +1,96 @@
+import bisect
+from operator import itemgetter
+from time import monotonic
+
+
+class ETA:
+    """Calculate speed and estimate time to arrival."""
+
+    def __init__(self, estimation_period: float = 30) -> None:
+        """Create an ETA.
+
+        Args:
+            estimation_period: Period in seconds, used to calculate speed. Defaults to 30.
+        """
+        self.estimation_period = estimation_period
+        self._start_time = monotonic()
+        self._samples: list[tuple[float, float]] = [(0.0, 0.0)]
+
+    def reset(self) -> None:
+        """Start ETA calculations from current time."""
+        del self._samples[:]
+        self._start_time = monotonic()
+
+    @property
+    def _current_time(self) -> float:
+        return monotonic() - self._start_time
+
+    def add_sample(self, progress: float) -> None:
+        """Add a new sample.
+
+        Args:
+            progress: Progress ratio (0 is start, 1 is complete).
+        """
+        if self._samples and self._samples[-1][1] > progress:
+            # If progress goes backwards, we need to reset calculations
+            self.reset()
+            return
+        current_time = self._current_time
+        self._samples.append((current_time, progress))
+        if not (len(self._samples) % 100):
+            # Prune periodically so we don't accumulate vast amounts of samples
+            self._prune()
+
+    def _prune(self) -> None:
+        """Prune old samples."""
+        if len(self._samples) <= 10:
+            # Keep at least 10 samples
+            return
+        prune_time = self._samples[-1][0] - self.estimation_period
+        index = bisect.bisect_left(self._samples, prune_time, key=itemgetter(0))
+        del self._samples[:index]
+
+    def _get_progress_at(self, time: float) -> tuple[float, float]:
+        """Get the progress at a specific time."""
+        index = bisect.bisect_left(self._samples, time, key=itemgetter(0))
+        if index >= len(self._samples):
+            return self._samples[-1]
+        if index == 0:
+            return self._samples[0]
+        time1, progress1 = self._samples[index]
+        time2, progress2 = self._samples[index + 1]
+        factor = (time - time1) / (time2 - time1)
+        intermediate_progress = progress1 + (progress2 - progress1) * factor
+        return time, intermediate_progress
+
+    @property
+    def speed(self) -> float | None:
+        """The current speed, or `None` if it couldn't be calculated."""
+
+        if len(self._samples) <= 2:
+            # Need at less 2 samples to calculate speed
+            return None
+
+        recent_sample_time, progress2 = self._samples[-1]
+        progress_start_time, progress1 = self._get_progress_at(
+            recent_sample_time - self.estimation_period
+        )
+        time_delta = recent_sample_time - progress_start_time
+        distance = progress2 - progress1
+        speed = distance / time_delta
+        return speed
+
+    @property
+    def eta(self) -> float | None:
+        """Estimated seconds until completion, or `None` if no estimate can be made."""
+        current_time = self._current_time
+        if not self._samples:
+            return None
+        speed = self.speed
+        if not speed:
+            return None
+        recent_time, recent_progress = self._samples[-1]
+        time_since_sample = current_time - recent_time
+        remaining = 1.0 - (recent_progress + speed * time_since_sample)
+        eta = max(0, remaining / speed)
+        return eta

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -1,4 +1,5 @@
 import bisect
+from math import ceil
 from operator import itemgetter
 from time import monotonic
 
@@ -23,6 +24,7 @@ class ETA:
 
     @property
     def _current_time(self) -> float:
+        """The time since the ETA was started."""
         return monotonic() - self._start_time
 
     def add_sample(self, progress: float) -> None:
@@ -81,7 +83,7 @@ class ETA:
         return speed
 
     @property
-    def eta(self) -> float | None:
+    def eta(self) -> int | None:
         """Estimated seconds until completion, or `None` if no estimate can be made."""
         current_time = self._current_time
         if not self._samples:
@@ -93,4 +95,4 @@ class ETA:
         time_since_sample = current_time - recent_time
         remaining = 1.0 - (recent_progress + speed * time_since_sample)
         eta = max(0, remaining / speed)
-        return eta
+        return ceil(eta)

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -192,17 +192,6 @@ class ETAStatus(Label):
     """
     eta: reactive[float | None] = reactive[Optional[float]](None)
 
-    def __init__(
-        self,
-        name: str | None = None,
-        id: str | None = None,
-        classes: str | None = None,
-        disabled: bool = False,
-    ):
-        super().__init__(
-            "--:--:--", name=name, id=id, classes=classes, disabled=disabled
-        )
-
     def render(self) -> RenderResult:
         """Render the ETA display."""
         eta = self.eta
@@ -252,7 +241,7 @@ class ProgressBar(Widget, can_focus=False):
         print(progress_bar.percentage)  # 0.5
         ```
     """
-    _display_eta: reactive[float | None] = reactive[Optional[float]](None)
+    _display_eta: reactive[int | None] = reactive[Optional[int]](None)
 
     def __init__(
         self,
@@ -298,11 +287,7 @@ class ProgressBar(Widget, can_focus=False):
         self._eta = ETA()
 
     def on_mount(self) -> None:
-        def refresh_eta() -> None:
-            """Refresh eta display."""
-            self._display_eta = self._eta.eta
-
-        self.set_interval(1 / 2, refresh_eta)
+        self.set_interval(0.5, self.update)
 
     def compose(self) -> ComposeResult:
         if self.show_bar:
@@ -390,3 +375,5 @@ class ProgressBar(Widget, can_focus=False):
             self.progress += advance
             if self.progress is not None and self.total is not None:
                 self._eta.add_sample(self.progress / self.total)
+
+        self._display_eta = self._eta.eta

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -163,7 +163,7 @@ class ETAStatus(Label):
     }
     """
     eta: reactive[float | None] = reactive[Optional[float]](None)
-    """Estimated number of seconds till completion."""
+    """Estimated number of seconds till completion, or `None` if no estimate is available."""
 
     def render(self) -> RenderResult:
         """Render the ETA display."""
@@ -254,13 +254,13 @@ class ProgressBar(Widget, can_focus=False):
             disabled: Whether the widget is disabled or not.
             clock: An optional clock object (leave as default unless testing).
         """
+        self._clock = clock or Clock()
+        self._eta = ETA()
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
         self.total = total
         self.show_bar = show_bar
         self.show_percentage = show_percentage
         self.show_eta = show_eta
-        self._clock = clock or Clock()
-        self._eta = ETA()
 
     def on_mount(self) -> None:
         self.update()

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -333,7 +333,7 @@ class ProgressBar(Widget, can_focus=False):
         """
         current_time = self._clock.time
         if not isinstance(total, UnusedParameter):
-            if total != self.total:
+            if total is None or total != self.total:
                 self._eta.reset()
             self.total = total
 
@@ -350,4 +350,6 @@ class ProgressBar(Widget, can_focus=False):
             self.progress += advance
             add_sample()
 
-        self._display_eta = self._eta.get_eta(current_time)
+        self._display_eta = (
+            None if self.total is None else self._eta.get_eta(current_time)
+        )

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -292,6 +292,10 @@ class ProgressBar(Widget, can_focus=False):
             return 1.0
         return None
 
+    def _watch_progress(self, progress: float) -> None:
+        """Perform update when progress is modified."""
+        self.update(progress=progress)
+
     def advance(self, advance: float = 1) -> None:
         """Advance the progress of the progress bar by the given amount.
 

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -153,32 +153,12 @@ class PercentageStatus(Label):
     }
     """
 
-    _label_text: reactive[str] = reactive("", repaint=False)
-    """This is used as an auxiliary reactive to only refresh the label when needed."""
     _percentage: reactive[float | None] = reactive[Optional[float]](None)
     """The percentage of progress that has been completed."""
 
-    def __init__(
-        self,
-        name: str | None = None,
-        id: str | None = None,
-        classes: str | None = None,
-        disabled: bool = False,
-    ):
-        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
-        self._percentage = None
-        self._label_text = "--%"
-
-    def watch__percentage(self, percentage: float | None) -> None:
-        """Manage the text that shows the percentage of progress."""
-        if percentage is None:
-            self._label_text = "--%"
-        else:
-            self._label_text = f"{int(100 * percentage)}%"
-
-    def watch__label_text(self, label_text: str) -> None:
-        """If the label text changed, update the renderable (which also refreshes)."""
-        self.update(label_text)
+    def render(self) -> RenderResult:
+        percentage = self._percentage
+        return "--%" if percentage is None else f"{int(100 * percentage)}%"
 
 
 class ETAStatus(Label):
@@ -293,7 +273,7 @@ class ProgressBar(Widget, can_focus=False):
         if self.show_bar:
             yield Bar(id="bar").data_bind(_percentage=ProgressBar.percentage)
         if self.show_percentage:
-            PercentageStatus(id="percentage").data_bind(
+            yield PercentageStatus(id="percentage").data_bind(
                 _percentage=ProgressBar.percentage
             )
         if self.show_eta:

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -264,7 +264,7 @@ class ProgressBar(Widget, can_focus=False):
 
     def on_mount(self) -> None:
         self.update()
-        self.set_interval(0.5, self.update)
+        self.set_interval(1, self.update)
         self._clock.reset()
 
     def compose(self) -> ComposeResult:

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 from math import ceil
 from time import monotonic
-from typing import Callable, Optional
+from typing import Optional
 
 from rich.style import Style
 
 from .._types import UnusedParameter
 from ..app import ComposeResult, RenderResult
+from ..eta import ETA
 from ..geometry import clamp
 from ..reactive import reactive
 from ..renderables.bar import Bar as BarRenderable
-from ..timer import Timer
 from ..widget import Widget
 from ..widgets import Label
 
@@ -80,7 +80,7 @@ class Bar(Widget, can_focus=False):
         if percentage is not None:
             self.auto_refresh = None
         else:
-            self.auto_refresh = 1 / 15
+            self.auto_refresh = 1 / 5
 
     def render(self) -> RenderResult:
         """Render the bar with the correct portion filled."""
@@ -105,6 +105,8 @@ class Bar(Widget, can_focus=False):
         # Width used to enable the visual effect of the bar going into the corners.
         total_imaginary_width = width + highlighted_bar_width
 
+        start: float
+        end: float
         if self.app.animation_level == "none":
             start = 0
             end = width
@@ -188,15 +190,7 @@ class ETAStatus(Label):
         content-align-horizontal: right;
     }
     """
-
-    _label_text: reactive[str] = reactive("", repaint=False)
-    """This is used as an auxiliary reactive to only refresh the label when needed."""
-    _percentage: reactive[float | None] = reactive[Optional[float]](None)
-    """The percentage of progress that has been completed."""
-    _refresh_timer: Timer | None
-    """Timer to update ETA status even when progress stalls."""
-    _start_time: float | None
-    """The time when the widget started tracking progress."""
+    eta: reactive[float | None] = reactive[Optional[float]](None)
 
     def __init__(
         self,
@@ -205,62 +199,24 @@ class ETAStatus(Label):
         classes: str | None = None,
         disabled: bool = False,
     ):
-        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
-        self._percentage = None
-        self._label_text = "--:--:--"
-        self._start_time = None
-        self._refresh_timer = None
+        super().__init__(
+            "--:--:--", name=name, id=id, classes=classes, disabled=disabled
+        )
 
-    def on_mount(self) -> None:
-        """Periodically refresh the countdown so that the ETA is always up to date."""
-        self._refresh_timer = self.set_interval(1 / 2, self.update_eta, pause=True)
-
-    def watch__percentage(self, percentage: float | None) -> None:
-        if percentage is None:
-            self._label_text = "--:--:--"
+    def render(self) -> RenderResult:
+        """Render the ETA display."""
+        eta = self.eta
+        if eta is None:
+            return "--:--:--"
         else:
-            if self._refresh_timer is not None:
-                self._refresh_timer.reset()
-            self.update_eta()
-
-    def update_eta(self) -> None:
-        """Update the ETA display."""
-        percentage = self._percentage
-        delta = self._get_elapsed_time()
-        # We display --:--:-- if we haven't started, if we are done,
-        # or if we don't know when we started keeping track of time.
-        if not percentage or percentage >= 1 or not delta:
-            self._label_text = "--:--:--"
-            # If we are done, we can delete the timer that periodically refreshes
-            # the countdown display.
-            if percentage is not None and percentage >= 1:
-                self.auto_refresh = None
-        # Render a countdown timer with hh:mm:ss, unless it's a LONG time.
-        else:
-            left = ceil((delta / percentage) * (1 - percentage))
-            minutes, seconds = divmod(left, 60)
+            minutes, seconds = divmod(ceil(eta), 60)
             hours, minutes = divmod(minutes, 60)
             if hours > 999999:
-                self._label_text = "+999999h"
+                return "+999999h"
             elif hours > 99:
-                self._label_text = f"{hours}h"
+                return f"{hours}h"
             else:
-                self._label_text = f"{hours:02}:{minutes:02}:{seconds:02}"
-
-    def _get_elapsed_time(self) -> float:
-        """Get time to estimate time to progress completion.
-
-        Returns:
-            The time elapsed since the bar started being animated.
-        """
-        if self._start_time is None:
-            self._start_time = monotonic()
-            return 0
-        return monotonic() - self._start_time
-
-    def watch__label_text(self, label_text: str) -> None:
-        """If the ETA label changed, update the renderable (which also refreshes)."""
-        self.update(label_text)
+                return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
 class ProgressBar(Widget, can_focus=False):
@@ -296,6 +252,7 @@ class ProgressBar(Widget, can_focus=False):
         print(progress_bar.percentage)  # 0.5
         ```
     """
+    _display_eta: reactive[float | None] = reactive[Optional[float]](None)
 
     def __init__(
         self,
@@ -334,39 +291,28 @@ class ProgressBar(Widget, can_focus=False):
             disabled: Whether the widget is disabled or not.
         """
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
+        self.total = total
         self.show_bar = show_bar
         self.show_percentage = show_percentage
         self.show_eta = show_eta
+        self._eta = ETA()
 
-        self.total = total
+    def on_mount(self) -> None:
+        def refresh_eta() -> None:
+            """Refresh eta display."""
+            self._display_eta = self._eta.eta
+
+        self.set_interval(1 / 2, refresh_eta)
 
     def compose(self) -> ComposeResult:
-        # We create a closure so that we can determine what are the sub-widgets
-        # that are present and, therefore, will need to be notified about changes
-        # to the percentage.
-        def update_percentage(
-            widget: Bar | PercentageStatus | ETAStatus,
-        ) -> Callable[[float | None], None]:
-            """Closure to allow updating the percentage of a given widget."""
-
-            def updater(percentage: float | None) -> None:
-                """Update the percentage reactive of the enclosed widget."""
-                widget._percentage = percentage
-
-            return updater
-
         if self.show_bar:
-            bar = Bar(id="bar")
-            self.watch(self, "percentage", update_percentage(bar))
-            yield bar
+            yield Bar(id="bar").data_bind(_percentage=ProgressBar.percentage)
         if self.show_percentage:
-            percentage_status = PercentageStatus(id="percentage")
-            self.watch(self, "percentage", update_percentage(percentage_status))
-            yield percentage_status
+            PercentageStatus(id="percentage").data_bind(
+                _percentage=ProgressBar.percentage
+            )
         if self.show_eta:
-            eta_status = ETAStatus(id="eta")
-            self.watch(self, "percentage", update_percentage(eta_status))
-            yield eta_status
+            yield ETAStatus(id="eta").data_bind(eta=ProgressBar._display_eta)
 
     def _validate_progress(self, progress: float) -> float:
         """Clamp the progress between 0 and the maximum total."""
@@ -406,7 +352,7 @@ class ProgressBar(Widget, can_focus=False):
         Args:
             advance: Number of steps to advance progress by.
         """
-        self.progress += advance
+        self.update(advance=advance)
 
     def update(
         self,
@@ -431,8 +377,16 @@ class ProgressBar(Widget, can_focus=False):
             advance: Advance the progress by this number of steps.
         """
         if not isinstance(total, UnusedParameter):
+            if total != self.total:
+                self._eta.reset()
             self.total = total
-        if not isinstance(progress, UnusedParameter):
+
+        elif not isinstance(progress, UnusedParameter):
             self.progress = progress
-        if not isinstance(advance, UnusedParameter):
+            if self.progress is not None and self.total is not None:
+                self._eta.add_sample(self.progress / self.total)
+
+        elif not isinstance(advance, UnusedParameter):
             self.progress += advance
+            if self.progress is not None and self.total is not None:
+                self._eta.add_sample(self.progress / self.total)

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -56,7 +56,7 @@ class Bar(Widget, can_focus=False):
     }
     """
 
-    percentage: reactive[float | None] = reactive[float | None](None)
+    percentage: reactive[float | None] = reactive[Optional[float]](None)
     """The percentage of progress that has been completed."""
     _start_time: float | None
     """The time when the widget started tracking progress."""

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -106,7 +106,6 @@ class Bar(Widget, can_focus=False):
 
     def render_indeterminate(self) -> RenderResult:
         """Render a frame of the indeterminate progress bar animation."""
-        print(self._clock)
         width = self.size.width
         highlighted_bar_width = 0.25 * width
         # Width used to enable the visual effect of the bar going into the corners.
@@ -334,13 +333,17 @@ class ProgressBar(Widget, can_focus=False):
                 self._eta.reset()
             self.total = total
 
+        def add_sample() -> None:
+            """Add a new sample."""
+            if self.progress is not None and self.total:
+                self._eta.add_sample(current_time, self.progress / self.total)
+
         if not isinstance(progress, UnusedParameter):
             self.progress = progress
+            add_sample()
 
         if not isinstance(advance, UnusedParameter):
             self.progress += advance
-
-        if self.progress is not None and self.total:
-            self._eta.add_sample(current_time, self.progress / self.total)
+            add_sample()
 
         self._display_eta = self._eta.get_eta(current_time)

--- a/tests/snapshot_tests/snapshot_apps/recompose.py
+++ b/tests/snapshot_tests/snapshot_apps/recompose.py
@@ -29,7 +29,7 @@ class Progress(Horizontal):
     progress = reactive(0, recompose=True)
 
     def compose(self) -> ComposeResult:
-        bar = ProgressBar(100)
+        bar = ProgressBar(100, show_eta=False)
         bar.progress = self.progress
         yield bar
 

--- a/tests/snapshot_tests/snapshot_apps/tooltips.py
+++ b/tests/snapshot_tests/snapshot_apps/tooltips.py
@@ -4,7 +4,7 @@ from textual.widgets import ProgressBar
 
 class TooltipApp(App[None]):
     def compose(self) -> ComposeResult:
-        progress_bar = ProgressBar(100)
+        progress_bar = ProgressBar(100, show_eta=False)
         progress_bar.advance(10)
         progress_bar.tooltip = "Hello, Tooltip!"
         yield progress_bar

--- a/tests/test_eta.py
+++ b/tests/test_eta.py
@@ -1,0 +1,56 @@
+from textual.eta import ETA
+
+
+def test_basics() -> None:
+    eta = ETA()
+    eta.add_sample(1.0, 1.0)
+    assert eta.first_sample == (0, 0)
+    assert eta.last_sample == (1.0, 1.0)
+    assert len(eta._samples) == 2
+    repr(eta)
+
+
+def test_speed() -> None:
+    eta = ETA()
+    # One sample is not enough to determine speed
+    assert eta.speed is None
+    eta.add_sample(1.0, 0.5)
+    assert eta.speed == 0.5
+
+    # Check reset
+    eta.reset()
+    assert eta.speed is None
+    eta.add_sample(0.0, 0.0)
+    assert eta.speed is None
+    eta.add_sample(1.0, 0.5)
+    assert eta.speed == 0.5
+
+    # Check backwards
+    eta.add_sample(2.0, 0.0)
+    assert eta.speed is None
+    eta.add_sample(3.0, 1.0)
+    assert eta.speed == 1.0
+
+
+def test_get_progress_at() -> None:
+    eta = ETA()
+    eta.add_sample(1, 2)
+    # Check interpolation works
+    assert eta._get_progress_at(0) == (0, 0)
+    assert eta._get_progress_at(0.1) == (0.1, 0.2)
+    assert eta._get_progress_at(0.5) == (0.5, 1.0)
+
+
+def test_eta():
+    eta = ETA(estimation_period=2, extrapolate_period=5)
+    eta.add_sample(1, 0.1)
+    assert eta.speed == 0.1
+    assert eta.get_eta(1) == 9
+    assert eta.get_eta(2) == 8
+    assert eta.get_eta(3) == 7
+    assert eta.get_eta(4) == 6
+    assert eta.get_eta(5) == 5
+    # After 5 seconds (extrapolate_period), eta won't update
+    assert eta.get_eta(6) == 4
+    assert eta.get_eta(7) == 4
+    assert eta.get_eta(8) == 4

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -48,7 +48,6 @@ def test_progress_overflow():
     pb = ProgressBar(total=100)
 
     pb.advance(999_999)
-    assert pb.progress == 100
     assert pb.percentage == 1
 
     pb.update(total=50)
@@ -59,7 +58,6 @@ def test_progress_underflow():
     pb = ProgressBar(total=100)
 
     pb.advance(-999_999)
-    assert pb.progress == 0
     assert pb.percentage == 0
 
 

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -52,7 +52,6 @@ def test_progress_overflow():
     assert pb.percentage == 1
 
     pb.update(total=50)
-    assert pb.progress == 50
     assert pb.percentage == 1
 
 


### PR DESCRIPTION
Improved ETA for progress bar

- Reduces refreshes of the ProgressBar. Previously the widget would repaint every time `update` was called. Even if the output remained the same.
- Improved calculation of ETA based on recent samples. ETA is extrapolated based on this speed.
- Added a `Clock` object to return relative time, and allow for easier mocking. This is public, but as yet undocumented. This might become a public interface if we want devs to be able to swap out algorithms.

Closes https://github.com/Textualize/textual/issues/4054