### PR TITLE
Compute fast

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -163,6 +163,8 @@ class DOMNode(MessagePump):
 
     _decorated_handlers: dict[type[Message], list[tuple[Callable, str | None]]]
 
+    _computes: ClassVar[frozenset[str]]
+
     def __init__(
         self,
         *,
@@ -470,6 +472,15 @@ class DOMNode(MessagePump):
             css_type_names.add(base.__name__)
         cls._merged_bindings = cls._merge_bindings()
         cls._css_type_names = frozenset(css_type_names)
+        cls._computes = frozenset(
+            dict.fromkeys(
+                [
+                    name.lstrip("_")[8:]
+                    for name in dir(cls)
+                    if name.startswith(("_compute_", "compute_"))
+                ]
+            ).keys()
+        )
 
     def get_component_styles(self, name: str) -> RenderStyles:
         """Get a "component" styles object (must be defined in COMPONENT_CLASSES classvar).

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -163,6 +163,7 @@ class DOMNode(MessagePump):
 
     _decorated_handlers: dict[type[Message], list[tuple[Callable, str | None]]]
 
+    # Names of potential computed reactives
     _computes: ClassVar[frozenset[str]]
 
     def __init__(

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -341,7 +341,8 @@ class Reactive(Generic[ReactiveType]):
             obj: Reactable object.
         """
         _rich_traceback_guard = True
-        for compute in obj._reactives.keys():
+
+        for compute in obj._reactives.keys() & obj._computes:
             try:
                 compute_method = getattr(obj, f"compute_{compute}")
             except AttributeError:

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -341,7 +341,6 @@ class Reactive(Generic[ReactiveType]):
             obj: Reactable object.
         """
         _rich_traceback_guard = True
-
         for compute in obj._reactives.keys() & obj._computes:
             try:
                 compute_method = getattr(obj, f"compute_{compute}")


### PR DESCRIPTION
Noticed a quick optimization win. By recording the compute methods on class creation we can avoid work whenever a reactive is set.