### PR TITLE
Ensure scrollbars get Show/Hide messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `OptionList.OptionHighlighted` leaking out of `Select` https://github.com/Textualize/textual/issues/4224
 - Fixed `Tab` enable/disable messages leaking into `TabbedContent` https://github.com/Textualize/textual/issues/4233
 - Fixed a style leak from `TabbedContent` https://github.com/Textualize/textual/issues/4232
+- Fixed active hidden scrollbars not releasing the mouse https://github.com/Textualize/textual/issues/4274
 
 ### Changed
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -762,26 +762,6 @@ class Screen(Generic[ScreenResultType], Widget):
         self._update_timer.pause()
         ResizeEvent = events.Resize
 
-        def _message_visibility(
-            widget: Widget, event: events.Show | events.Hide
-        ) -> None:
-            """Send a Show or Hide event to the given widget.
-
-            Args:
-                widget: The widget to send the event to.
-                event: The event to be sent.
-
-            Note:
-                This function ensures that any scrollbars attached to the
-                widget also get the messages; these are needed to help
-                update the grabbed status.
-            """
-            widget.post_message(event)
-            if widget.show_vertical_scrollbar:
-                widget.vertical_scrollbar.post_message(event)
-            if widget.show_horizontal_scrollbar:
-                widget.horizontal_scrollbar.post_message(event)
-
         try:
             if scroll:
                 exposed_widgets = self._compositor.reflow_visible(self, size)
@@ -812,7 +792,7 @@ class Screen(Generic[ScreenResultType], Widget):
                 Show = events.Show
 
                 for widget in hidden:
-                    _message_visibility(widget, Hide())
+                    widget.post_message(Hide())
 
                 # We want to send a resize event to widgets that were just added or change since last layout
                 send_resize = shown | resized
@@ -834,7 +814,7 @@ class Screen(Generic[ScreenResultType], Widget):
                         )
 
                 for widget in shown:
-                    _message_visibility(widget, Show())
+                    widget.post_message(Show())
 
         except Exception as error:
             self.app._handle_exception(error)

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -762,6 +762,26 @@ class Screen(Generic[ScreenResultType], Widget):
         self._update_timer.pause()
         ResizeEvent = events.Resize
 
+        def _message_visibility(
+            widget: Widget, event: events.Show | events.Hide
+        ) -> None:
+            """Send a Show or Hide event to the given widget.
+
+            Args:
+                widget: The widget to send the event to.
+                event: The event to be sent.
+
+            Note:
+                This function ensures that any scrollbars attached to the
+                widget also get the messages; these are needed to help
+                update the grabbed status.
+            """
+            widget.post_message(event)
+            if widget.show_vertical_scrollbar:
+                widget.vertical_scrollbar.post_message(event)
+            if widget.show_horizontal_scrollbar:
+                widget.horizontal_scrollbar.post_message(event)
+
         try:
             if scroll:
                 exposed_widgets = self._compositor.reflow_visible(self, size)
@@ -792,7 +812,7 @@ class Screen(Generic[ScreenResultType], Widget):
                 Show = events.Show
 
                 for widget in hidden:
-                    widget.post_message(Hide())
+                    _message_visibility(widget, Hide())
 
                 # We want to send a resize event to widgets that were just added or change since last layout
                 send_resize = shown | resized
@@ -814,7 +834,7 @@ class Screen(Generic[ScreenResultType], Widget):
                         )
 
                 for widget in shown:
-                    widget.post_message(Show())
+                    _message_visibility(widget, Show())
 
         except Exception as error:
             self.app._handle_exception(error)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3706,7 +3706,17 @@ class Widget(DOMNode):
             self.scroll_page_right()
             event.stop()
 
+    def _on_show(self, event: events.Show) -> None:
+        if self.show_horizontal_scrollbar:
+            self.horizontal_scrollbar.post_message(event)
+        if self.show_vertical_scrollbar:
+            self.vertical_scrollbar.post_message(event)
+
     def _on_hide(self, event: events.Hide) -> None:
+        if self.show_horizontal_scrollbar:
+            self.horizontal_scrollbar.post_message(event)
+        if self.show_vertical_scrollbar:
+            self.vertical_scrollbar.post_message(event)
         if self.has_focus:
             self.blur()
 


### PR DESCRIPTION
The idea here being that while scrollbars are attached to widgets, they exist outwith of the DOM, and so don't seem to take part in the usual flow of show/hide messaging. This change checks, when posting a show/hide message, if the widget receiving the message has scrollbars and if it does the message is also sent to them too.

Fixes #4274.
