### PR TITLE
Fix `TextArea` holding on to focus when hidden while doing a mouse selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `OptionList.OptionHighlighted` leaking out of `Select` https://github.com/Textualize/textual/issues/4224
 - Fixed `Tab` enable/disable messages leaking into `TabbedContent` https://github.com/Textualize/textual/issues/4233
 - Fixed a style leak from `TabbedContent` https://github.com/Textualize/textual/issues/4232
+- Fixed the mouse not being released when hiding a `TextArea` while mouse selection is happening https://github.com/Textualize/textual/issues/4292
 
 ### Changed
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1498,12 +1498,20 @@ TextArea {
             selection_start, _ = self.selection
             self.selection = Selection(selection_start, target)
 
-    async def _on_mouse_up(self, event: events.MouseUp) -> None:
+    def _end_mouse_selection(self) -> None:
         """Finalize the selection that has been made using the mouse."""
         self._selecting = False
         self.release_mouse()
         self.record_cursor_width()
         self._restart_blink()
+
+    async def _on_mouse_up(self, event: events.MouseUp) -> None:
+        """Finalize the selection that has been made using the mouse."""
+        self._end_mouse_selection()
+
+    async def _on_hide(self, event: events.Hide) -> None:
+        """Finalize the selection that has been made using the mouse when thew widget is hidden."""
+        self._end_mouse_selection()
 
     async def _on_paste(self, event: events.Paste) -> None:
         """When a paste occurs, insert the text from the paste event into the document."""


### PR DESCRIPTION
Discovered by @TomJGooding and similar to #4274 -- if a `TextArea` was in a mouse selection state and the `TextArea` was hidden, the selection didn't get ended and so the mouse remained captured by the (now hidden) `TextArea`.

Fixes #4292.