### PR TITLE
Let mouse scroll events pass through disabled widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a style leak from `TabbedContent` https://github.com/Textualize/textual/issues/4232
 - Fixed active hidden scrollbars not releasing the mouse https://github.com/Textualize/textual/issues/4274
 - Fixed the mouse not being released when hiding a `TextArea` while mouse selection is happening https://github.com/Textualize/textual/issues/4292
+- Fix mouse scrolling not working when mouse cursor is over a disabled child widget https://github.com/Textualize/textual/issues/4242
 
 ### Changed
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3567,8 +3567,12 @@ class Widget(DOMNode):
         message_type = type(message)
         if self._is_prevented(message_type):
             return False
-        # Otherwise, if this is a mouse event, the widget receiving the
-        # event must not be disabled at this moment.
+        # Mouse scroll events should always go through, this allows mouse
+        # wheel scrolling to pass through disabled widgets.
+        if isinstance(message, (events.MouseScrollDown, events.MouseScrollUp)):
+            return True
+        # Otherwise, if this is any other mouse event, the widget receiving
+        # the event must not be disabled at this moment.
         return (
             not self._self_or_ancestors_disabled
             if isinstance(message, (events.MouseEvent, events.Enter, events.Leave))


### PR DESCRIPTION
All mouse events are stopped when they hit a disabled widget; this is mostly correct, except for mouse scroll events (scroll wheel, trackpad swipes, etc). This PR ensures that those particular events always pass through.

Fixes #4242.
