### PR TITLE
Enable unsetting active tab pane / tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - When the terminal window loses focus, the currently-focused widget will also lose focus.
   - When the terminal window regains focus, the previously-focused widget will regain focus.
 - TextArea binding for <kbd>ctrl</kbd>+<kbd>k</kbd> will now delete the line if the line is empty https://github.com/Textualize/textual/issues/4277
+- The active tab (in `Tabs`) / tab pane (in `TabbedContent`) can now be unset https://github.com/Textualize/textual/issues/4241
 
 ## [0.52.1] - 2024-02-20
 

--- a/docs/widgets/tabbed_content.md
+++ b/docs/widgets/tabbed_content.md
@@ -127,6 +127,7 @@ For example, to create a `TabbedContent` that has red and green labels:
 
 ## Messages
 
+- [TabbedContent.Cleared][textual.widgets.TabbedContent.Cleared]
 - [TabbedContent.TabActivated][textual.widgets.TabbedContent.TabActivated]
 
 ## Bindings

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -455,8 +455,6 @@ class TabbedContent(Widget):
 
         async def _remove_content() -> None:
             await gather(*removal_awaitables)
-            if self.tab_count == 0:
-                self.post_message(self.Cleared(self).set_sender(self))
 
         return AwaitComplete(_remove_content())
 
@@ -474,7 +472,6 @@ class TabbedContent(Widget):
 
         async def _clear_content() -> None:
             await await_clear
-            self.post_message(self.Cleared(self).set_sender(self))
 
         return AwaitComplete(_clear_content())
 

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -285,7 +285,8 @@ class Tabs(Widget, can_focus=True):
     class Cleared(Message):
         """Sent when there are no active tabs.
 
-        This can occur when Tabs are cleared, or if all tabs are hidden.
+        This can occur when Tabs are cleared, if all tabs are hidden, or if the
+        currently active tab is unset.
         """
 
         def __init__(self, tabs: Tabs) -> None:
@@ -527,9 +528,10 @@ class Tabs(Widget, can_focus=True):
         async def do_remove() -> None:
             """Perform the remove after refresh so the underline bar gets new positions."""
             await remove_await
-            if next_tab is None:
+            if next_tab is None or (removing_active_tab and next_tab.id is None):
                 self.active = ""
             elif removing_active_tab:
+                assert next_tab.id is not None
                 self.active = next_tab.id
                 next_tab.add_class("-active")
 
@@ -575,12 +577,12 @@ class Tabs(Widget, can_focus=True):
 
     def watch_active(self, previously_active: str, active: str) -> None:
         """Handle a change to the active tab."""
+        self.query("#tabs-list > Tab.-active").remove_class("-active")
         if active:
             try:
                 active_tab = self.query_one(f"#tabs-list > #{active}", Tab)
             except NoMatches:
                 return
-            self.query("#tabs-list > Tab.-active").remove_class("-active")
             active_tab.add_class("-active")
             self._highlight_active(animate=previously_active != "")
             self._scroll_active_tab()
@@ -699,16 +701,20 @@ class Tabs(Widget, can_focus=True):
         self._move_tab(-1)
 
     def _move_tab(self, direction: int) -> None:
-        """Activate the next tab.
+        """Activate the next enabled tab in the given direction.
+
+        Tab selection wraps around. If no tab is currently active, the "next"
+        tab is set to be the first and the "previous" tab is the last one.
 
         Args:
             direction: +1 for the next tab, -1 for the previous.
         """
         active_tab = self.active_tab
-        if active_tab is None:
-            return
         tabs = self._potentially_active_tabs
         if not tabs:
+            return
+        if not active_tab:
+            self.active = tabs[0 if direction == 1 else -1].id or ""
             return
         tab_count = len(tabs)
         new_tab_index = (tabs.index(active_tab) + direction) % tab_count

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -316,15 +316,8 @@ async def test_change_active_from_code():
         assert tabs.active_tab.id == "tab-2"
         assert tabs.active == tabs.active_tab.id
 
-        # TODO: This one is questionable. It seems Tabs has been designed so
-        # that you can set the active tab to an empty string, and it remains
-        # so, and just removes the underline; no other changes. So active
-        # will be an empty string while active_tab will be a tab. This feels
-        # like an oversight. Need to investigate and possibly modify this
-        # behaviour unless there's a good reason for this.
         tabs.active = ""
-        assert tabs.active_tab is not None
-        assert tabs.active_tab.id == "tab-2"
+        assert tabs.active_tab is None
 
 
 async def test_navigate_tabs_with_keyboard():


### PR DESCRIPTION
Goes over `TabbedContent` and `Tabs` and allows unsetting their respective tab pane/tab.
Although we currently don't know if it makes a lot of sense (Will did mention a custom widget/renderable/thingy situation where it could make sense to have no active tab) we won't prevent the programmers to make use of this flexibility in their apps.

Went through both widgets to make sure the `Cleared` messages are sent in the correct places and not in duplicate.

Also made a small change so that if there's no active tab, then pressing right/left will respectively activate the first or last tab.

Fixed the documentation as reported in #4241.

Fixes #4241.