### PR TITLE
Tidy up the `Event`-related documentation

### DIFF
--- a/docs/events/app_blur.md
+++ b/docs/events/app_blur.md
@@ -1,0 +1,20 @@
+# AppBlur
+
+The `AppBlur` event is sent to the application when the terminal window
+loses focus.
+
+!!! note
+    Only available when running under textual-web or within terminals that
+    support `FocusIn` reporting.
+
+## Attributes
+
+_No other attributes_
+
+## Code
+
+::: textual.events.AppBlur
+
+## See also
+
+- [AppFocus](app_focus.md)

--- a/docs/events/app_blur.md
+++ b/docs/events/app_blur.md
@@ -1,19 +1,10 @@
-# AppBlur
-
-The `AppBlur` event is sent to the application when the terminal window
-loses focus.
-
-!!! note
-    Only available when running under textual-web or within terminals that
-    support `FocusIn` reporting.
-
-## Attributes
-
-_No other attributes_
-
-## Code
+---
+title: AppBlur
+---
 
 ::: textual.events.AppBlur
+    options:
+      heading_level: 1
 
 ## See also
 

--- a/docs/events/app_focus.md
+++ b/docs/events/app_focus.md
@@ -1,19 +1,10 @@
-# AppFocus
-
-The `AppFocus` event is sent to the application when the terminal window
-gains focus.
-
-!!! note
-    Only available when running under textual-web or within terminals that
-    support `FocusOut` reporting.
-
-## Attributes
-
-_No other attributes_
-
-## Code
+---
+title: AppFocus
+---
 
 ::: textual.events.AppFocus
+    options:
+      heading_level: 1
 
 ## See also
 

--- a/docs/events/app_focus.md
+++ b/docs/events/app_focus.md
@@ -1,0 +1,20 @@
+# AppFocus
+
+The `AppFocus` event is sent to the application when the terminal window
+gains focus.
+
+!!! note
+    Only available when running under textual-web or within terminals that
+    support `FocusOut` reporting.
+
+## Attributes
+
+_No other attributes_
+
+## Code
+
+::: textual.events.AppFocus
+
+## See also
+
+- [AppBlur](app_blur.md)

--- a/docs/events/blur.md
+++ b/docs/events/blur.md
@@ -1,14 +1,10 @@
-# Blur
-
-The `Blur` event is sent to a widget when it loses focus.
-
-## Attributes
-
-_No other attributes_
-
-## Code
+---
+title: Blur
+---
 
 ::: textual.events.Blur
+    options:
+      heading_level: 1
 
 ## See also
 

--- a/docs/events/blur.md
+++ b/docs/events/blur.md
@@ -1,7 +1,3 @@
----
-title: Blur
----
-
 ::: textual.events.Blur
     options:
       heading_level: 1

--- a/docs/events/blur.md
+++ b/docs/events/blur.md
@@ -2,9 +2,6 @@
 
 The `Blur` event is sent to a widget when it loses focus.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/click.md
+++ b/docs/events/click.md
@@ -2,9 +2,6 @@
 
 The `Click` event is sent to a widget when the user clicks a mouse button.
 
-- [x] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 | attribute  | type | purpose                                   |

--- a/docs/events/click.md
+++ b/docs/events/click.md
@@ -6,6 +6,8 @@ See [MouseEvent][textual.events.MouseEvent] for the full list of properties and 
 
 ## See also
 
+- [Enter](enter.md)
+- [Leave](leave.md)
 - [MouseDown](mouse_down.md)
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)

--- a/docs/events/click.md
+++ b/docs/events/click.md
@@ -1,22 +1,14 @@
-# Click
-
-The `Click` event is sent to a widget when the user clicks a mouse button.
-
-## Attributes
-
-| attribute  | type | purpose                                   |
-|------------|------|-------------------------------------------|
-| `x`        | int  | Mouse x coordinate, relative to Widget    |
-| `y`        | int  | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | int  | Change in x since last mouse event        |
-| `delta_y`  | int  | Change in y since last mouse event        |
-| `button`   | int  | Index of mouse button                     |
-| `shift`    | bool | Shift key pressed if True                 |
-| `meta`     | bool | Meta key pressed if True                  |
-| `ctrl`     | bool | Ctrl key pressed if True                  |
-| `screen_x` | int  | Mouse x coordinate relative to the screen |
-| `screen_y` | int  | Mouse y coordinate relative to the screen |
-
-## Code
-
 ::: textual.events.Click
+    options:
+      heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
+
+## See also
+
+- [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
+- [MouseMove](mouse_move.md)
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollUp](mouse_scroll_up.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/descendant_blur.md
+++ b/docs/events/descendant_blur.md
@@ -2,9 +2,6 @@
 
 The `DescendantBlur` event is sent to a widget when one of its children loses focus.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/descendant_blur.md
+++ b/docs/events/descendant_blur.md
@@ -4,7 +4,10 @@ The `DescendantBlur` event is sent to a widget when one of its children loses fo
 
 ## Attributes
 
-_No other attributes_
+| Attribute | Type                              | Purpose                                            |
+|-----------|-----------------------------------|----------------------------------------------------|
+| `widget`  | [`Widget`][textual.widget.Widget] | The widget that was blurred                        |
+| `control` | [`Widget`][textual.widget.Widget] | The widget that was blurred (an alias of `widget`) |
 
 ## Code
 

--- a/docs/events/descendant_blur.md
+++ b/docs/events/descendant_blur.md
@@ -1,20 +1,15 @@
-# DescendantBlur
-
-The `DescendantBlur` event is sent to a widget when one of its children loses focus.
-
-## Attributes
-
-| Attribute | Type                              | Purpose                                            |
-|-----------|-----------------------------------|----------------------------------------------------|
-| `widget`  | [`Widget`][textual.widget.Widget] | The widget that was blurred                        |
-| `control` | [`Widget`][textual.widget.Widget] | The widget that was blurred (an alias of `widget`) |
-
-## Code
+---
+title: DescendantBlur
+---
 
 ::: textual.events.DescendantBlur
+    options:
+      heading_level: 1
 
 ## See also
 
+- [AppBlur](app_blur.md)
+- [AppFocus](app_focus.md)
 - [Blur](blur.md)
 - [DescendantFocus](descendant_focus.md)
 - [Focus](focus.md)

--- a/docs/events/descendant_focus.md
+++ b/docs/events/descendant_focus.md
@@ -4,7 +4,10 @@ The `DescendantFocus` event is sent to a widget when one of its descendants rece
 
 ## Attributes
 
-_No other attributes_
+| Attribute | Type                              | Purpose                                            |
+|-----------|-----------------------------------|----------------------------------------------------|
+| `widget`  | [`Widget`][textual.widget.Widget] | The widget that was focused                        |
+| `control` | [`Widget`][textual.widget.Widget] | The widget that was focused (an alias of `widget`) |
 
 ## Code
 

--- a/docs/events/descendant_focus.md
+++ b/docs/events/descendant_focus.md
@@ -2,9 +2,6 @@
 
 The `DescendantFocus` event is sent to a widget when one of its descendants receives focus.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/descendant_focus.md
+++ b/docs/events/descendant_focus.md
@@ -1,20 +1,15 @@
-# DescendantFocus
-
-The `DescendantFocus` event is sent to a widget when one of its descendants receives focus.
-
-## Attributes
-
-| Attribute | Type                              | Purpose                                            |
-|-----------|-----------------------------------|----------------------------------------------------|
-| `widget`  | [`Widget`][textual.widget.Widget] | The widget that was focused                        |
-| `control` | [`Widget`][textual.widget.Widget] | The widget that was focused (an alias of `widget`) |
-
-## Code
+---
+title: DescendantFocus
+---
 
 ::: textual.events.DescendantFocus
+    options:
+      heading_level: 1
 
 ## See also
 
+- [AppBlur](app_blur.md)
+- [AppFocus](app_focus.md)
 - [Blur](blur.md)
 - [DescendantBlur](descendant_blur.md)
 - [Focus](focus.md)

--- a/docs/events/enter.md
+++ b/docs/events/enter.md
@@ -1,11 +1,12 @@
-# Enter
-
-The `Enter` event is sent to a widget when the mouse pointer first moves over a widget.
-
-## Attributes
-
-_No other attributes_
-
-## Code
-
 ::: textual.events.Enter
+    options:
+      heading_level: 1
+
+## See also
+
+- [Click](click.md)
+- [MouseDown](mouse_down.md)
+- [MouseMove](mouse_move.md)
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollUp](mouse_scroll_up.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/enter.md
+++ b/docs/events/enter.md
@@ -2,9 +2,6 @@
 
 The `Enter` event is sent to a widget when the mouse pointer first moves over a widget.
 
-- [ ] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/enter.md
+++ b/docs/events/enter.md
@@ -5,6 +5,7 @@
 ## See also
 
 - [Click](click.md)
+- [Leave](leave.md)
 - [MouseDown](mouse_down.md)
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)

--- a/docs/events/focus.md
+++ b/docs/events/focus.md
@@ -2,9 +2,6 @@
 
 The `Focus` event is sent to a widget when it receives input focus.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/focus.md
+++ b/docs/events/focus.md
@@ -1,17 +1,11 @@
-# Focus
-
-The `Focus` event is sent to a widget when it receives input focus.
-
-## Attributes
-
-_No other attributes_
-
-## Code
-
 ::: textual.events.Focus
+    options:
+      heading_level: 1
 
 ## See also
 
+- [AppBlur](app_blur.md)
+- [AppFocus](app_focus.md)
 - [Blur](blur.md)
 - [DescendantBlur](descendant_blur.md)
 - [DescendantFocus](descendant_focus.md)

--- a/docs/events/hide.md
+++ b/docs/events/hide.md
@@ -1,11 +1,3 @@
-# Hide
-
-The `Hide` event is sent to a widget when it is hidden from view.
-
-## Attributes
-
-_No additional attributes_
-
-## Code
-
 ::: textual.events.Hide
+    options:
+      heading_level: 1

--- a/docs/events/hide.md
+++ b/docs/events/hide.md
@@ -2,9 +2,6 @@
 
 The `Hide` event is sent to a widget when it is hidden from view.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No additional attributes_

--- a/docs/events/key.md
+++ b/docs/events/key.md
@@ -1,15 +1,3 @@
-# Key
-
-The `Key` event is sent to a widget when the user presses a key on the keyboard.
-
-## Attributes
-
-| Attribute   | Type            | Purpose                                                                 |
-|-------------|-----------------|-------------------------------------------------------------------------|
-| `key`       | `str`           | Name of the key that was pressed.                                       |
-| `character` | `str` or `None` | The printable character that was pressed, or `None` it isn't printable. |
-| `aliases`   | `list[str]`     | The aliases do for the key, including the key itself.                   |
-
-## Code
-
 ::: textual.events.Key
+    options:
+      heading_level: 1

--- a/docs/events/key.md
+++ b/docs/events/key.md
@@ -2,9 +2,6 @@
 
 The `Key` event is sent to a widget when the user presses a key on the keyboard.
 
-- [x] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 | attribute | type        | purpose                                                     |

--- a/docs/events/key.md
+++ b/docs/events/key.md
@@ -4,10 +4,11 @@ The `Key` event is sent to a widget when the user presses a key on the keyboard.
 
 ## Attributes
 
-| attribute | type        | purpose                                                     |
-| --------- | ----------- | ----------------------------------------------------------- |
-| `key`     | str         | Name of the key that was pressed.                           |
-| `char`    | str or None | The character that was pressed, or None it isn't printable. |
+| Attribute   | Type            | Purpose                                                                 |
+|-------------|-----------------|-------------------------------------------------------------------------|
+| `key`       | `str`           | Name of the key that was pressed.                                       |
+| `character` | `str` or `None` | The printable character that was pressed, or `None` it isn't printable. |
+| `aliases`   | `list[str]`     | The aliases do for the key, including the key itself.                   |
 
 ## Code
 

--- a/docs/events/leave.md
+++ b/docs/events/leave.md
@@ -2,9 +2,6 @@
 
 The `Leave` event is sent to a widget when the mouse pointer moves off a widget.
 
-- [ ] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/leave.md
+++ b/docs/events/leave.md
@@ -1,11 +1,13 @@
-# Leave
-
-The `Leave` event is sent to a widget when the mouse pointer moves off a widget.
-
-## Attributes
-
-_No other attributes_
-
-## Code
-
 ::: textual.events.Leave
+    options:
+      heading_level: 1
+
+## See also
+
+- [Click](click.md)
+- [Enter](enter.md)
+- [MouseDown](mouse_down.md)
+- [MouseMove](mouse_move.md)
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollUp](mouse_scroll_up.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/load.md
+++ b/docs/events/load.md
@@ -1,13 +1,3 @@
-# Load
-
-The `Load` event is sent to the app prior to switching the terminal to application mode.
-
-The load event is typically used to do any setup actions required by the app that don't change the display.
-
-## Attributes
-
-_No additional attributes_
-
-## Code
-
 ::: textual.events.Load
+    options:
+      heading_level: 1

--- a/docs/events/load.md
+++ b/docs/events/load.md
@@ -4,9 +4,6 @@ The `Load` event is sent to the app prior to switching the terminal to applicati
 
 The load event is typically used to do any setup actions required by the app that don't change the display.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No additional attributes_

--- a/docs/events/mount.md
+++ b/docs/events/mount.md
@@ -1,13 +1,3 @@
-# Mount
-
-The `Mount` event is sent to a widget and Application when it is first mounted.
-
-The mount event is typically used to set the initial state of a widget or to add new children widgets.
-
-## Attributes
-
-_No additional attributes_
-
-## Code
-
 ::: textual.events.Mount
+    options:
+      heading_level: 1

--- a/docs/events/mount.md
+++ b/docs/events/mount.md
@@ -4,9 +4,6 @@ The `Mount` event is sent to a widget and Application when it is first mounted.
 
 The mount event is typically used to set the initial state of a widget or to add new children widgets.
 
-- [ ] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 _No additional attributes_

--- a/docs/events/mouse_capture.md
+++ b/docs/events/mouse_capture.md
@@ -11,3 +11,7 @@ The `MouseCapture` event is sent to a widget when it is capturing mouse events f
 ## Code
 
 ::: textual.events.MouseCapture
+
+## See also
+
+- [MouseRelease](mouse_release.md)

--- a/docs/events/mouse_capture.md
+++ b/docs/events/mouse_capture.md
@@ -1,16 +1,6 @@
-# MouseCapture
-
-The `MouseCapture` event is sent to a widget when it is capturing mouse events from outside of its borders on the screen.
-
-## Attributes
-
-| Attribute        | Type                                | Purpose                                       |
-|------------------|-------------------------------------|-----------------------------------------------|
-| `mouse_position` | [`Offset`][textual.geometry.Offset] | Mouse coordinates when the mouse was captured |
-
-## Code
-
 ::: textual.events.MouseCapture
+    options:
+      heading_level: 1
 
 ## See also
 

--- a/docs/events/mouse_capture.md
+++ b/docs/events/mouse_capture.md
@@ -2,9 +2,6 @@
 
 The `MouseCapture` event is sent to a widget when it is capturing mouse events from outside of its borders on the screen.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 | attribute        | type   | purpose                                       |

--- a/docs/events/mouse_capture.md
+++ b/docs/events/mouse_capture.md
@@ -4,9 +4,9 @@ The `MouseCapture` event is sent to a widget when it is capturing mouse events f
 
 ## Attributes
 
-| attribute        | type   | purpose                                       |
-| ---------------- | ------ | --------------------------------------------- |
-| `mouse_position` | Offset | Mouse coordinates when the mouse was captured |
+| Attribute        | Type                                | Purpose                                       |
+|------------------|-------------------------------------|-----------------------------------------------|
+| `mouse_position` | [`Offset`][textual.geometry.Offset] | Mouse coordinates when the mouse was captured |
 
 ## Code
 

--- a/docs/events/mouse_capture.md
+++ b/docs/events/mouse_capture.md
@@ -1,3 +1,7 @@
+---
+title: MouseCapture
+---
+
 ::: textual.events.MouseCapture
     options:
       heading_level: 1

--- a/docs/events/mouse_down.md
+++ b/docs/events/mouse_down.md
@@ -1,23 +1,20 @@
-# MouseDown
-
-The `MouseDown` event is sent to a widget when a mouse button is pressed.
-
-## Attributes
-
-| Attribute  | Type                        | Purpose                                   |
-|------------|-----------------------------|-------------------------------------------|
-| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
-| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | `int`                       | Change in x since last mouse event        |
-| `delta_y`  | `int`                       | Change in y since last mouse event        |
-| `button`   | `int`                       | Index of mouse button                     |
-| `shift`    | `bool`                      | Shift key pressed if True                 |
-| `meta`     | `bool`                      | Meta key pressed if True                  |
-| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
-| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
-| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
-| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
-
-## Code
+---
+title: MouseDown
+---
 
 ::: textual.events.MouseDown
+    options:
+      heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
+
+## See also
+
+- [Click](click.md)
+- [Enter](enter.md)
+- [Leave](leave.md)
+- [MouseEvent][textual.events.MouseEvent]
+- [MouseMove](mouse_move.md)
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollUp](mouse_scroll_up.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/mouse_down.md
+++ b/docs/events/mouse_down.md
@@ -2,9 +2,6 @@
 
 The `MouseDown` event is sent to a widget when a mouse button is pressed.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 | attribute  | type | purpose                                   |

--- a/docs/events/mouse_down.md
+++ b/docs/events/mouse_down.md
@@ -4,18 +4,19 @@ The `MouseDown` event is sent to a widget when a mouse button is pressed.
 
 ## Attributes
 
-| attribute  | type | purpose                                   |
-| ---------- | ---- | ----------------------------------------- |
-| `x`        | int  | Mouse x coordinate, relative to Widget    |
-| `y`        | int  | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | int  | Change in x since last mouse event        |
-| `delta_y`  | int  | Change in y since last mouse event        |
-| `button`   | int  | Index of mouse button                     |
-| `shift`    | bool | Shift key pressed if True                 |
-| `meta`     | bool | Meta key pressed if True                  |
-| `ctrl`     | bool | Ctrl key pressed if True                  |
-| `screen_x` | int  | Mouse x coordinate relative to the screen |
-| `screen_y` | int  | Mouse y coordinate relative to the screen |
+| Attribute  | Type                        | Purpose                                   |
+|------------|-----------------------------|-------------------------------------------|
+| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
+| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
+| `delta_x`  | `int`                       | Change in x since last mouse event        |
+| `delta_y`  | `int`                       | Change in y since last mouse event        |
+| `button`   | `int`                       | Index of mouse button                     |
+| `shift`    | `bool`                      | Shift key pressed if True                 |
+| `meta`     | `bool`                      | Meta key pressed if True                  |
+| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
+| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
+| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
+| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
 
 ## Code
 

--- a/docs/events/mouse_move.md
+++ b/docs/events/mouse_move.md
@@ -2,9 +2,6 @@
 
 The `MouseMove` event is sent to a widget when the mouse pointer is moved over a widget.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 | attribute  | type | purpose                                   |

--- a/docs/events/mouse_move.md
+++ b/docs/events/mouse_move.md
@@ -4,18 +4,19 @@ The `MouseMove` event is sent to a widget when the mouse pointer is moved over a
 
 ## Attributes
 
-| attribute  | type | purpose                                   |
-|------------|------|-------------------------------------------|
-| `x`        | int  | Mouse x coordinate, relative to Widget    |
-| `y`        | int  | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | int  | Change in x since last mouse event        |
-| `delta_y`  | int  | Change in y since last mouse event        |
-| `button`   | int  | Index of mouse button                     |
-| `shift`    | bool | Shift key pressed if True                 |
-| `meta`     | bool | Meta key pressed if True                  |
-| `ctrl`     | bool | Ctrl key pressed if True                  |
-| `screen_x` | int  | Mouse x coordinate relative to the screen |
-| `screen_y` | int  | Mouse y coordinate relative to the screen |
+| Attribute  | Type                        | Purpose                                   |
+|------------|-----------------------------|-------------------------------------------|
+| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
+| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
+| `delta_x`  | `int`                       | Change in x since last mouse event        |
+| `delta_y`  | `int`                       | Change in y since last mouse event        |
+| `button`   | `int`                       | Index of mouse button                     |
+| `shift`    | `bool`                      | Shift key pressed if True                 |
+| `meta`     | `bool`                      | Meta key pressed if True                  |
+| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
+| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
+| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
+| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
 
 ## Code
 

--- a/docs/events/mouse_move.md
+++ b/docs/events/mouse_move.md
@@ -1,23 +1,20 @@
-# MouseMove
-
-The `MouseMove` event is sent to a widget when the mouse pointer is moved over a widget.
-
-## Attributes
-
-| Attribute  | Type                        | Purpose                                   |
-|------------|-----------------------------|-------------------------------------------|
-| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
-| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | `int`                       | Change in x since last mouse event        |
-| `delta_y`  | `int`                       | Change in y since last mouse event        |
-| `button`   | `int`                       | Index of mouse button                     |
-| `shift`    | `bool`                      | Shift key pressed if True                 |
-| `meta`     | `bool`                      | Meta key pressed if True                  |
-| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
-| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
-| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
-| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
-
-## Code
+---
+title: MouseMove
+---
 
 ::: textual.events.MouseMove
+    options:
+      heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
+
+## See also
+
+- [Click](click.md)
+- [Enter](enter.md)
+- [Leave](leave.md)
+- [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollUp](mouse_scroll_up.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/mouse_release.md
+++ b/docs/events/mouse_release.md
@@ -1,16 +1,10 @@
-# MouseRelease
-
-The `MouseRelease` event is sent to a widget when it is no longer receiving mouse events outside of its borders.
-
-## Attributes
-
-| Attribute        | Type                                | Purpose                                       |
-|------------------|-------------------------------------|-----------------------------------------------|
-| `mouse_position` | [`Offset`][textual.geometry.Offset] | Mouse coordinates when the mouse was released |
-
-## Code
+---
+title: MouseRelease
+---
 
 ::: textual.events.MouseRelease
+    options:
+      heading_level: 1
 
 ## See also
 

--- a/docs/events/mouse_release.md
+++ b/docs/events/mouse_release.md
@@ -4,9 +4,9 @@ The `MouseRelease` event is sent to a widget when it is no longer receiving mous
 
 ## Attributes
 
-| attribute        | type   | purpose                                       |
-|------------------|--------|-----------------------------------------------|
-| `mouse_position` | Offset | Mouse coordinates when the mouse was released |
+| Attribute        | Type                                | Purpose                                       |
+|------------------|-------------------------------------|-----------------------------------------------|
+| `mouse_position` | [`Offset`][textual.geometry.Offset] | Mouse coordinates when the mouse was released |
 
 ## Code
 

--- a/docs/events/mouse_release.md
+++ b/docs/events/mouse_release.md
@@ -11,3 +11,7 @@ The `MouseRelease` event is sent to a widget when it is no longer receiving mous
 ## Code
 
 ::: textual.events.MouseRelease
+
+## See also
+
+- [MouseCapture](mouse_capture.md)

--- a/docs/events/mouse_release.md
+++ b/docs/events/mouse_release.md
@@ -2,9 +2,6 @@
 
 The `MouseRelease` event is sent to a widget when it is no longer receiving mouse events outside of its borders.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 | attribute        | type   | purpose                                       |

--- a/docs/events/mouse_scroll_down.md
+++ b/docs/events/mouse_scroll_down.md
@@ -1,23 +1,20 @@
-# MouseScrollDown
-
-The `MouseScrollDown` event is sent to a widget when the scroll wheel (or trackpad equivalent) is moved _down_.
-
-## Attributes
-
-| Attribute  | Type                        | Purpose                                   |
-|------------|-----------------------------|-------------------------------------------|
-| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
-| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | `int`                       | Change in x since last mouse event        |
-| `delta_y`  | `int`                       | Change in y since last mouse event        |
-| `button`   | `int`                       | Index of mouse button                     |
-| `shift`    | `bool`                      | Shift key pressed if True                 |
-| `meta`     | `bool`                      | Meta key pressed if True                  |
-| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
-| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
-| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
-| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
-
-## Code
+---
+title: MouseScrollDown
+---
 
 ::: textual.events.MouseScrollDown
+    options:
+      heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
+
+## See also
+
+- [Click](click.md)
+- [Enter](enter.md)
+- [Leave](leave.md)
+- [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
+- [MouseMove](mouse_move.md)
+- [MouseScrollUp](mouse_scroll_up.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/mouse_scroll_down.md
+++ b/docs/events/mouse_scroll_down.md
@@ -4,10 +4,19 @@ The `MouseScrollDown` event is sent to a widget when the scroll wheel (or trackp
 
 ## Attributes
 
-| attribute | type | purpose                                |
-|-----------|------|----------------------------------------|
-| `x`       | int  | Mouse x coordinate, relative to Widget |
-| `y`       | int  | Mouse y coordinate, relative to Widget |
+| Attribute  | Type                        | Purpose                                   |
+|------------|-----------------------------|-------------------------------------------|
+| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
+| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
+| `delta_x`  | `int`                       | Change in x since last mouse event        |
+| `delta_y`  | `int`                       | Change in y since last mouse event        |
+| `button`   | `int`                       | Index of mouse button                     |
+| `shift`    | `bool`                      | Shift key pressed if True                 |
+| `meta`     | `bool`                      | Meta key pressed if True                  |
+| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
+| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
+| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
+| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
 
 ## Code
 

--- a/docs/events/mouse_scroll_down.md
+++ b/docs/events/mouse_scroll_down.md
@@ -2,9 +2,6 @@
 
 The `MouseScrollDown` event is sent to a widget when the scroll wheel (or trackpad equivalent) is moved _down_.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 | attribute | type | purpose                                |

--- a/docs/events/mouse_scroll_up.md
+++ b/docs/events/mouse_scroll_up.md
@@ -4,10 +4,19 @@ The `MouseScrollUp` event is sent to a widget when the scroll wheel (or trackpad
 
 ## Attributes
 
-| attribute | type | purpose                                |
-|-----------|------|----------------------------------------|
-| `x`       | int  | Mouse x coordinate, relative to Widget |
-| `y`       | int  | Mouse y coordinate, relative to Widget |
+| Attribute  | Type                        | Purpose                                   |
+|------------|-----------------------------|-------------------------------------------|
+| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
+| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
+| `delta_x`  | `int`                       | Change in x since last mouse event        |
+| `delta_y`  | `int`                       | Change in y since last mouse event        |
+| `button`   | `int`                       | Index of mouse button                     |
+| `shift`    | `bool`                      | Shift key pressed if True                 |
+| `meta`     | `bool`                      | Meta key pressed if True                  |
+| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
+| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
+| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
+| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
 
 ## Code
 

--- a/docs/events/mouse_scroll_up.md
+++ b/docs/events/mouse_scroll_up.md
@@ -1,23 +1,20 @@
-# MouseScrollUp
-
-The `MouseScrollUp` event is sent to a widget when the scroll wheel (or trackpad equivalent) is moved _up_.
-
-## Attributes
-
-| Attribute  | Type                        | Purpose                                   |
-|------------|-----------------------------|-------------------------------------------|
-| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
-| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | `int`                       | Change in x since last mouse event        |
-| `delta_y`  | `int`                       | Change in y since last mouse event        |
-| `button`   | `int`                       | Index of mouse button                     |
-| `shift`    | `bool`                      | Shift key pressed if True                 |
-| `meta`     | `bool`                      | Meta key pressed if True                  |
-| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
-| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
-| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
-| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
-
-## Code
+---
+title: MouseScrollUp
+---
 
 ::: textual.events.MouseScrollUp
+    options:
+      heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
+
+## See also
+
+- [Click](click.md)
+- [Enter](enter.md)
+- [Leave](leave.md)
+- [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
+- [MouseMove](mouse_move.md)
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseUp](mouse_up.md)

--- a/docs/events/mouse_scroll_up.md
+++ b/docs/events/mouse_scroll_up.md
@@ -2,9 +2,6 @@
 
 The `MouseScrollUp` event is sent to a widget when the scroll wheel (or trackpad equivalent) is moved _up_.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 | attribute | type | purpose                                |

--- a/docs/events/mouse_up.md
+++ b/docs/events/mouse_up.md
@@ -4,18 +4,19 @@ The `MouseUp` event is sent to a widget when the user releases a mouse button.
 
 ## Attributes
 
-| attribute  | type | purpose                                   |
-|------------|------|-------------------------------------------|
-| `x`        | int  | Mouse x coordinate, relative to Widget    |
-| `y`        | int  | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | int  | Change in x since last mouse event        |
-| `delta_y`  | int  | Change in y since last mouse event        |
-| `button`   | int  | Index of mouse button                     |
-| `shift`    | bool | Shift key pressed if True                 |
-| `meta`     | bool | Meta key pressed if True                  |
-| `ctrl`     | bool | Ctrl key pressed if True                  |
-| `screen_x` | int  | Mouse x coordinate relative to the screen |
-| `screen_y` | int  | Mouse y coordinate relative to the screen |
+| Attribute  | Type                        | Purpose                                   |
+|------------|-----------------------------|-------------------------------------------|
+| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
+| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
+| `delta_x`  | `int`                       | Change in x since last mouse event        |
+| `delta_y`  | `int`                       | Change in y since last mouse event        |
+| `button`   | `int`                       | Index of mouse button                     |
+| `shift`    | `bool`                      | Shift key pressed if True                 |
+| `meta`     | `bool`                      | Meta key pressed if True                  |
+| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
+| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
+| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
+| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
 
 ## Code
 

--- a/docs/events/mouse_up.md
+++ b/docs/events/mouse_up.md
@@ -1,23 +1,20 @@
-# MouseUp
-
-The `MouseUp` event is sent to a widget when the user releases a mouse button.
-
-## Attributes
-
-| Attribute  | Type                        | Purpose                                   |
-|------------|-----------------------------|-------------------------------------------|
-| `x`        | `int`                       | Mouse x coordinate, relative to Widget    |
-| `y`        | `int`                       | Mouse y coordinate, relative to Widget    |
-| `delta_x`  | `int`                       | Change in x since last mouse event        |
-| `delta_y`  | `int`                       | Change in y since last mouse event        |
-| `button`   | `int`                       | Index of mouse button                     |
-| `shift`    | `bool`                      | Shift key pressed if True                 |
-| `meta`     | `bool`                      | Meta key pressed if True                  |
-| `ctrl`     | `bool`                      | Ctrl key pressed if True                  |
-| `screen_x` | `int`                       | Mouse x coordinate relative to the screen |
-| `screen_y` | `int`                       | Mouse y coordinate relative to the screen |
-| `style`    | [`Style`][rich.style.Style] | The Rich Style under the mouse cursor     |
-
-## Code
+---
+title: MouseUp
+---
 
 ::: textual.events.MouseUp
+    options:
+      heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
+
+## See also
+
+- [Click](click.md)
+- [Enter](enter.md)
+- [Leave](leave.md)
+- [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
+- [MouseMove](mouse_move.md)
+- [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollUp](mouse_scroll_up.md)

--- a/docs/events/mouse_up.md
+++ b/docs/events/mouse_up.md
@@ -2,9 +2,6 @@
 
 The `MouseUp` event is sent to a widget when the user releases a mouse button.
 
-- [x] Bubbles
-- [x] Verbose
-
 ## Attributes
 
 | attribute  | type | purpose                                   |

--- a/docs/events/paste.md
+++ b/docs/events/paste.md
@@ -2,9 +2,6 @@
 
 The `Paste` event is sent to a widget when the user pastes text.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 | attribute | type | purpose                  |

--- a/docs/events/paste.md
+++ b/docs/events/paste.md
@@ -4,9 +4,9 @@ The `Paste` event is sent to a widget when the user pastes text.
 
 ## Attributes
 
-| attribute | type | purpose                  |
-|-----------|------|--------------------------|
-| `text`    | str  | The text that was pasted |
+| Attribute | Type  | Purpose                  |
+|-----------|-------|--------------------------|
+| `text`    | `str` | The text that was pasted |
 
 ## Code
 

--- a/docs/events/paste.md
+++ b/docs/events/paste.md
@@ -1,13 +1,3 @@
-# Paste
-
-The `Paste` event is sent to a widget when the user pastes text.
-
-## Attributes
-
-| Attribute | Type  | Purpose                  |
-|-----------|-------|--------------------------|
-| `text`    | `str` | The text that was pasted |
-
-## Code
-
 ::: textual.events.Paste
+    options:
+      heading_level: 1

--- a/docs/events/print.md
+++ b/docs/events/print.md
@@ -1,0 +1,14 @@
+# Print
+
+The `Print` event is sent to a widget that is capturing prints.
+
+## Attributes
+
+| Attribute | Type   | Purpose                                             |
+|-----------|--------|-----------------------------------------------------|
+| `text`    | `str`  | The text that was printed.                          |
+| `stderr`  | `bool` | `True` if printed to `stderr`, `False` if `stdout`. |
+
+## Code
+
+::: textual.events.Print

--- a/docs/events/print.md
+++ b/docs/events/print.md
@@ -1,14 +1,3 @@
-# Print
-
-The `Print` event is sent to a widget that is capturing prints.
-
-## Attributes
-
-| Attribute | Type   | Purpose                                             |
-|-----------|--------|-----------------------------------------------------|
-| `text`    | `str`  | The text that was printed.                          |
-| `stderr`  | `bool` | `True` if printed to `stderr`, `False` if `stdout`. |
-
-## Code
-
 ::: textual.events.Print
+    options:
+      heading_level: 1

--- a/docs/events/resize.md
+++ b/docs/events/resize.md
@@ -1,15 +1,3 @@
-# Resize
-
-The `Resize` event is sent to a widget when its size changes and when it is first made visible.
-
-## Attributes
-
-| Attribute        | Type                            | Purpose                                          |
-|------------------|---------------------------------|--------------------------------------------------|
-| `size`           | [`Size`][textual.geometry.Size] | The new size of the Widget                       |
-| `virtual_size`   | [`Size`][textual.geometry.Size] | The virtual size (scrollable area) of the Widget |
-| `container_size` | [`Size`][textual.geometry.Size] | The size of the container (parent widget)        |
-
-## Code
-
 ::: textual.events.Resize
+    options:
+      heading_level: 1

--- a/docs/events/resize.md
+++ b/docs/events/resize.md
@@ -4,11 +4,11 @@ The `Resize` event is sent to a widget when its size changes and when it is firs
 
 ## Attributes
 
-| attribute        | type | purpose                                          |
-|------------------|------|--------------------------------------------------|
-| `size`           | Size | The new size of the Widget                       |
-| `virtual_size`   | Size | The virtual size (scrollable area) of the Widget |
-| `container_size` | Size | The size of the container (parent widget)        |
+| Attribute        | Type                            | Purpose                                          |
+|------------------|---------------------------------|--------------------------------------------------|
+| `size`           | [`Size`][textual.geometry.Size] | The new size of the Widget                       |
+| `virtual_size`   | [`Size`][textual.geometry.Size] | The virtual size (scrollable area) of the Widget |
+| `container_size` | [`Size`][textual.geometry.Size] | The size of the container (parent widget)        |
 
 ## Code
 

--- a/docs/events/resize.md
+++ b/docs/events/resize.md
@@ -2,9 +2,6 @@
 
 The `Resize` event is sent to a widget when its size changes and when it is first made visible.
 
-- [x] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 | attribute        | type | purpose                                          |

--- a/docs/events/screen_resume.md
+++ b/docs/events/screen_resume.md
@@ -1,11 +1,7 @@
-# ScreenResume
-
-The `ScreenResume` event is sent to a **Screen** when it becomes current.
-
-## Attributes
-
-_No other attributes_
-
-## Code
+---
+title: ScreenResume
+---
 
 ::: textual.events.ScreenResume
+    options:
+      heading_level: 1

--- a/docs/events/screen_resume.md
+++ b/docs/events/screen_resume.md
@@ -2,9 +2,6 @@
 
 The `ScreenResume` event is sent to a **Screen** when it becomes current.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/screen_suspend.md
+++ b/docs/events/screen_suspend.md
@@ -1,11 +1,7 @@
-# ScreenSuspend
-
-The `ScreenSuspend` event is sent to a **Screen** when it is replaced by another screen.
-
-## Attributes
-
-_No other attributes_
-
-## Code
+---
+title: ScreenSuspend
+---
 
 ::: textual.events.ScreenSuspend
+    options:
+      heading_level: 1

--- a/docs/events/screen_suspend.md
+++ b/docs/events/screen_suspend.md
@@ -2,9 +2,6 @@
 
 The `ScreenSuspend` event is sent to a **Screen** when it is replaced by another screen.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No other attributes_

--- a/docs/events/show.md
+++ b/docs/events/show.md
@@ -1,11 +1,3 @@
-# Show
-
-The `Show` event is sent to a widget when it becomes visible.
-
-## Attributes
-
-_No additional attributes_
-
-## Code
-
 ::: textual.events.Show
+    options:
+      heading_level: 1

--- a/docs/events/show.md
+++ b/docs/events/show.md
@@ -2,9 +2,6 @@
 
 The `Show` event is sent to a widget when it becomes visible.
 
-- [ ] Bubbles
-- [ ] Verbose
-
 ## Attributes
 
 _No additional attributes_

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -44,6 +44,7 @@ nav:
       - Events:
           - "events/index.md"
           - "events/blur.md"
+          - "events/click.md"
           - "events/descendant_blur.md"
           - "events/descendant_focus.md"
           - "events/enter.md"
@@ -54,7 +55,6 @@ nav:
           - "events/load.md"
           - "events/mount.md"
           - "events/mouse_capture.md"
-          - "events/click.md"
           - "events/mouse_down.md"
           - "events/mouse_move.md"
           - "events/mouse_release.md"

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -62,6 +62,7 @@ nav:
           - "events/mouse_scroll_up.md"
           - "events/mouse_up.md"
           - "events/paste.md"
+          - "events/print.md"
           - "events/resize.md"
           - "events/screen_resume.md"
           - "events/screen_suspend.md"

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -43,6 +43,8 @@ nav:
           - "css_types/vertical.md"
       - Events:
           - "events/index.md"
+          - "events/app_blur.md"
+          - "events/app_focus.md"
           - "events/blur.md"
           - "events/click.md"
           - "events/descendant_blur.md"

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -333,15 +333,25 @@ class MouseEvent(InputEvent, bubble=True):
     ) -> None:
         super().__init__()
         self.x = x
+        """The relative x coordinate."""
         self.y = y
+        """The relative y coordinate."""
         self.delta_x = delta_x
+        """Change in x since the last message."""
         self.delta_y = delta_y
+        """Change in y since the last message."""
         self.button = button
+        """Indexed of the pressed button."""
         self.shift = shift
+        """`True` if the shift key is pressed."""
         self.meta = meta
+        """`True` if the meta key is pressed."""
         self.ctrl = ctrl
+        """`True` if the ctrl key is pressed."""
         self.screen_x = x if screen_x is None else screen_x
+        """The absolute x coordinate."""
         self.screen_y = y if screen_y is None else screen_y
+        """The absolute y coordinate."""
         self._style = style or Style()
 
     @classmethod

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -213,6 +213,7 @@ class MouseRelease(Event, bubble=False):
     def __init__(self, mouse_position: Offset) -> None:
         super().__init__()
         self.mouse_position = mouse_position
+        """The position of the mouse when released."""
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield None, self.mouse_position

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -110,8 +110,11 @@ class Resize(Event, bubble=False):
         container_size: Size | None = None,
     ) -> None:
         self.size = size
+        """The new size of the Widget."""
         self.virtual_size = virtual_size
+        """The virtual size (scrollable size) of the Widget."""
         self.container_size = size if container_size is None else container_size
+        """The size of the Widget's container widget."""
         super().__init__()
 
     def can_replace(self, message: "Message") -> bool:

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -660,21 +660,26 @@ class ScreenSuspend(Event, bubble=False):
 
 @rich.repr.auto
 class Print(Event, bubble=False):
-    """Sent to a widget that is capturing prints.
+    """Sent to a widget that is capturing [`print`][print].
 
     - [ ] Bubbles
     - [ ] Verbose
 
     Args:
         text: Text that was printed.
-        stderr: True if the print was to stderr, or False for stdout.
+        stderr: `True` if the print was to stderr, or `False` for stdout.
 
+    Note:
+        Python's [`print`][print] output can be captured with
+        [`App.begin_capture_print`][textual.app.App.begin_capture_print].
     """
 
     def __init__(self, text: str, stderr: bool = False) -> None:
         super().__init__()
         self.text = text
+        """The text that was printed."""
         self.stderr = stderr
+        """`True` if the print was to stderr, or `False` for stdout."""
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield self.text

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -396,20 +396,12 @@ class MouseEvent(InputEvent, bubble=True):
 
     @property
     def screen_offset(self) -> Offset:
-        """Mouse coordinate relative to the screen.
-
-        Returns:
-            Mouse coordinate.
-        """
+        """Mouse coordinate relative to the screen."""
         return Offset(self.screen_x, self.screen_y)
 
     @property
     def delta(self) -> Offset:
-        """Mouse coordinate delta (change since last event).
-
-        Returns:
-            Mouse coordinate.
-        """
+        """Mouse coordinate delta (change since last event)."""
         return Offset(self.delta_x, self.delta_y)
 
     @property

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -193,6 +193,7 @@ class MouseCapture(Event, bubble=False):
     def __init__(self, mouse_position: Offset) -> None:
         super().__init__()
         self.mouse_position = mouse_position
+        """The position of the mouse when captured."""
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield None, self.mouse_position

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -574,11 +574,12 @@ class AppFocus(Event, bubble=False):
 class AppBlur(Event, bubble=False):
     """Sent when the app loses focus.
 
-    Only available when running within a terminal that supports `FocusOut`,
-    or when running via textual-web.
-
     - [ ] Bubbles
     - [ ] Verbose
+
+    Note:
+        Only available when running within a terminal that supports
+        `FocusOut`, or when running via textual-web.
     """
 
 

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -563,16 +563,17 @@ class Blur(Event, bubble=False):
 class AppFocus(Event, bubble=False):
     """Sent when the app has focus.
 
-    Only available when running within a terminal that supports `FocusIn`,
-    or when running via textual-web.
-
     - [ ] Bubbles
     - [ ] Verbose
+
+    Note:
+        Only available when running within a terminal that supports
+        `FocusIn`, or when running via textual-web.
     """
 
 
 class AppBlur(Event, bubble=False):
-    """Sent when the app loses focus.
+    """Sent when the app gains focus.
 
     - [ ] Bubbles
     - [ ] Verbose

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -636,6 +636,7 @@ class Paste(Event, bubble=True):
     def __init__(self, text: str) -> None:
         super().__init__()
         self.text = text
+        """The text that was pasted."""
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "text", self.text

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -233,8 +233,6 @@ class Key(InputEvent):
     Args:
         key: The key that was pressed.
         character: A printable character or ``None`` if it is not printable.
-    Attributes:
-        aliases: The aliases for the key, including the key itself.
     """
 
     __slots__ = ["key", "character", "aliases"]
@@ -242,10 +240,13 @@ class Key(InputEvent):
     def __init__(self, key: str, character: str | None) -> None:
         super().__init__()
         self.key = key
+        """The key that was pressed."""
         self.character = (
             (key if len(key) == 1 else None) if character is None else character
         )
+        """A printable character or ``None`` if it is not printable."""
         self.aliases: list[str] = _get_key_aliases(key)
+        """The aliases for the key, including the key itself."""
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "key", self.key
@@ -269,7 +270,7 @@ class Key(InputEvent):
         """Check if the key is printable (produces a unicode character).
 
         Returns:
-            True if the key is printable.
+            `True` if the key is printable.
         """
         return False if self.character is None else self.character.isprintable()
 

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -581,7 +581,7 @@ class AppFocus(Event, bubble=False):
 
 
 class AppBlur(Event, bubble=False):
-    """Sent when the app gains focus.
+    """Sent when the app loses focus.
 
     - [ ] Bubbles
     - [ ] Verbose


### PR DESCRIPTION
A PR that wanders through the `Event`-related docs and tidies up some issues. Main changes are:

- Removes almost all of the in-md-file documentation for all documented events and instead relies on their docstrings.
- Adds missing docstrings where appropriate.
- Adds more see-also goodness where noticed and appropriate.
- Adds `Print` to the documented events.
- Adds `AppBlur` and `AppFocus` to the list of events now that they're more widely-used.

Fixes #4174.