### PR TITLE
watch with async

### DIFF
--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -192,10 +192,10 @@ class Header(Widget):
         return sub_title
 
     def _on_mount(self, _: Mount) -> None:
-        def set_title() -> None:
+        async def set_title() -> None:
             self.query_one(HeaderTitle).text = self.screen_title
 
-        def set_sub_title(sub_title: str) -> None:
+        async def set_sub_title() -> None:
             self.query_one(HeaderTitle).sub_text = self.screen_sub_title
 
         self.watch(self.app, "title", set_title)


### PR DESCRIPTION
A potential resolution for https://github.com/Textualize/textual/discussions/4268#discussioncomment-8823867

I wasn't able to reproduce this, but I think it was down to setting the title reactive from a task, when the widget wasn't fully mounted.

By making the watch method async, it should ensure that the title is updated after mount.