### PR TITLE
Fix `TextArea` display corruption/crash after undo of reverse-selected replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a crash in `TextArea` when undoing an edit to a selection the selection was made backwards https://github.com/Textualize/textual/issues/4301
 
 ## [0.53.1] - 2023-03-18
 

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1396,7 +1396,7 @@ TextArea {
             # `insert` is not None because event.character cannot be
             # None because we've checked that it's printable.
             assert insert is not None
-            start, end = self.selection
+            start, end = sorted(self.selection)
             self._replace_via_keyboard(insert, start, end)
 
     def _find_columns_to_next_tab_stop(self) -> int:

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1396,7 +1396,7 @@ TextArea {
             # `insert` is not None because event.character cannot be
             # None because we've checked that it's printable.
             assert insert is not None
-            start, end = sorted(self.selection)
+            start, end = self.selection
             self._replace_via_keyboard(insert, start, end)
 
     def _find_columns_to_next_tab_stop(self) -> int:

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1291,7 +1291,7 @@ TextArea {
             return
 
         old_gutter_width = self.gutter_width
-        minimum_from = edits[-1].from_location
+        minimum_from = edits[-1].top
         maximum_old_end = (0, 0)
         maximum_new_end = (0, 0)
         for edit in reversed(edits):
@@ -1304,7 +1304,7 @@ TextArea {
             if end_location > maximum_old_end:
                 maximum_old_end = end_location
             if edit.to_location > maximum_new_end:
-                maximum_new_end = edit.to_location
+                maximum_new_end = edit.bottom
 
         new_gutter_width = self.gutter_width
         if old_gutter_width != new_gutter_width:

--- a/tests/text_area/test_issue_4301.py
+++ b/tests/text_area/test_issue_4301.py
@@ -1,12 +1,13 @@
+from itertools import product
+
+import pytest
+
 from textual.app import App, ComposeResult
 from textual.widgets import TextArea
 from textual.widgets.text_area import Selection
 
 TEST_TEXT = "\n".join(f"01234567890 - {n}" for n in range(10))
-TEST_SELECTION = Selection((2, 5), (0, 5))
 TEST_SELECTED_TEXT = "567890 - 0\n01234567890 - 1\n01234"
-TEST_REPLACEMENT = "A"
-TEST_RESULT_TEXT = TEST_TEXT.replace(TEST_SELECTED_TEXT, TEST_REPLACEMENT)
 
 
 class TextAreaApp(App[None]):
@@ -15,14 +16,23 @@ class TextAreaApp(App[None]):
         yield TextArea(TEST_TEXT)
 
 
-async def test_issue_4301_reproduction() -> None:
+@pytest.mark.parametrize(
+    "selection, edit",
+    product(
+        [Selection((0, 5), (2, 5)), Selection((2, 5), (0, 5))],
+        ["A", "delete", "backspace"],
+    ),
+)
+async def test_issue_4301_reproduction(selection: Selection, edit: str) -> None:
+    """Test https://github.com/Textualize/textual/issues/4301"""
 
     async with (app := TextAreaApp()).run_test() as pilot:
         assert app.query_one(TextArea).text == TEST_TEXT
-        app.query_one(TextArea).selection = TEST_SELECTION
+        app.query_one(TextArea).selection = selection
         assert app.query_one(TextArea).selected_text == TEST_SELECTED_TEXT
-        await pilot.press("A")
-        assert app.query_one(TextArea).text == TEST_RESULT_TEXT
+        await pilot.press(edit)
         await pilot.press("ctrl+z")
         assert app.query_one(TextArea).text == TEST_TEXT
+        # Note that the real test here is that the following code doesn't
+        # result in a crash; everything above should really be a given.
         await pilot.press(*(["down"] * 10))

--- a/tests/text_area/test_issue_4301.py
+++ b/tests/text_area/test_issue_4301.py
@@ -1,0 +1,28 @@
+from textual.app import App, ComposeResult
+from textual.widgets import TextArea
+from textual.widgets.text_area import Selection
+
+TEST_TEXT = "\n".join(f"01234567890 - {n}" for n in range(10))
+TEST_SELECTION = Selection((2, 5), (0, 5))
+TEST_SELECTED_TEXT = "567890 - 0\n01234567890 - 1\n01234"
+TEST_REPLACEMENT = "A"
+TEST_RESULT_TEXT = TEST_TEXT.replace(TEST_SELECTED_TEXT, TEST_REPLACEMENT)
+
+
+class TextAreaApp(App[None]):
+
+    def compose(self) -> ComposeResult:
+        yield TextArea(TEST_TEXT)
+
+
+async def test_issue_4301_reproduction() -> None:
+
+    async with (app := TextAreaApp()).run_test() as pilot:
+        assert app.query_one(TextArea).text == TEST_TEXT
+        app.query_one(TextArea).selection = TEST_SELECTION
+        assert app.query_one(TextArea).selected_text == TEST_SELECTED_TEXT
+        await pilot.press("A")
+        assert app.query_one(TextArea).text == TEST_RESULT_TEXT
+        await pilot.press("ctrl+z")
+        assert app.query_one(TextArea).text == TEST_TEXT
+        await pilot.press(*(["down"] * 10))


### PR DESCRIPTION
Fix for #4301
