### PR TITLE
fix setting total by attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed a crash in `TextArea` when undoing an edit to a selection the selection was made backwards https://github.com/Textualize/textual/issues/4301
+- Fix progress bar ETA not updating when setting `total` reactive https://github.com/Textualize/textual/pull/4316
+- ProgressBar won't show ETA until there is at least one second of samples https://github.com/Textualize/textual/pull/4316
 
 ## [0.53.1] - 2023-03-18
 

--- a/src/textual/eta.py
+++ b/src/textual/eta.py
@@ -97,6 +97,9 @@ class ETA:
         progress_start_time, progress1 = self._get_progress_at(
             recent_sample_time - self.estimation_period
         )
+        if recent_sample_time - progress_start_time < 1:
+            # Require at least a second span to calculate speed.
+            return None
         time_delta = recent_sample_time - progress_start_time
         distance = progress2 - progress1
         speed = distance / time_delta if time_delta else 0

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -296,6 +296,10 @@ class ProgressBar(Widget, can_focus=False):
         """Perform update when progress is modified."""
         self.update(progress=progress)
 
+    def _watch_total(self, total: float) -> None:
+        """Update when the total is modified."""
+        self.update(total=total)
+
     def advance(self, advance: float = 1) -> None:
         """Advance the progress of the progress bar by the given amount.
 


### PR DESCRIPTION
Fixes ETA not updating when setting the total via an attribute.

Don't return speed if there is <1 second of samples. This hides the flicker of ETA updates when there aren't many samples.