### PR TITLE
Squish whitespace in `Markdown`

### DIFF
--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path, PurePath
 from typing import Callable, Iterable, Optional
 
@@ -146,10 +147,14 @@ class MarkdownBlock(Static):
         self._token = token
         style_stack: list[Style] = [Style()]
         content = Text()
+        repeating_whitespace = re.compile(r"[ \t]+")  # Space or tabs get reduced.
         if token.children:
             for child in token.children:
                 if child.type == "text":
-                    content.append(child.content, style_stack[-1])
+                    content.append(
+                        re.sub(repeating_whitespace, " ", child.content),
+                        style_stack[-1],
+                    )
                 if child.type == "hardbreak":
                     content.append("\n")
                 if child.type == "softbreak":

--- a/tests/snapshot_tests/snapshot_apps/markdown_whitespace.py
+++ b/tests/snapshot_tests/snapshot_apps/markdown_whitespace.py
@@ -1,0 +1,49 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Markdown
+
+MARKDOWN = (
+    """\
+X X
+
+X  X
+
+X\tX
+
+X\t\tX
+""",
+    """\
+X \tX
+
+X \t \tX
+""",
+    """\
+[X X  X\tX\t\tX \t \tX](https://example.com/)
+
+_X X  X\tX\t\tX \t \tX_
+
+**X X  X\tX\t\tX \t \tX**
+
+~~X X  X\tX\t\tX \t \tX~~
+"""
+)
+
+class MarkdownSpaceApp(App[None]):
+
+    CSS = """
+    Screen {
+        layout: horizontal;
+    }
+    Markdown {
+        margin-left: 0;
+        border-left: solid red;
+        width: 1fr;
+        height: 1fr;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        for document in MARKDOWN:
+            yield Markdown(document)
+
+if __name__ == "__main__":
+    MarkdownSpaceApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -686,6 +686,9 @@ def test_markdown_component_classes_reloading(snap_compare, monkeypatch):
         run_before=run_before,
     )
 
+def test_markdown_space_squashing(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "markdown_whitespace.py")
+
 
 def test_layer_fix(snap_compare):
     # Check https://github.com/Textualize/textual/issues/1358


### PR DESCRIPTION
Collapse whitespace within the text of a markdown document when displaying it with `Markdown`. With this change multiple concurrent instances of space and tab are collapsed down to a single space.

Implements #4321.