### PR TITLE
Tests re-raise exceptions that happen inside `Widget.compose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a crash in `TextArea` when undoing an edit to a selection the selection was made backwards https://github.com/Textualize/textual/issues/4301
 - Fixed issue with flickering scrollbars https://github.com/Textualize/textual/pull/4315
 - Fix progress bar ETA not updating when setting `total` reactive https://github.com/Textualize/textual/pull/4316
+- Exceptions inside `Widget.compose` weren't bubbling up in tests https://github.com/Textualize/textual/issues/4282
 
 ### Changed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a crash in `TextArea` when undoing an edit to a selection the selection was made backwards https://github.com/Textualize/textual/issues/4301
 - Fixed issue with flickering scrollbars https://github.com/Textualize/textual/pull/4315
 - Fix progress bar ETA not updating when setting `total` reactive https://github.com/Textualize/textual/pull/4316
-- Exceptions inside `Widget.compose` weren't bubbling up in tests https://github.com/Textualize/textual/issues/4282
+- Exceptions inside `Widget.compose` or workers weren't bubbling up in tests https://github.com/Textualize/textual/issues/4282
 
 ### Changed 
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3618,10 +3618,8 @@ class Widget(DOMNode):
             raise TypeError(
                 f"{self!r} compose() method returned an invalid result; {error}"
             ) from error
-        except Exception:
-            from rich.traceback import Traceback
-
-            self.app.panic(Traceback())
+        except Exception as error:
+            self.app._handle_exception(error)
         else:
             self._extend_compose(widgets)
             await self.mount_composed_widgets(widgets)

--- a/src/textual/worker.py
+++ b/src/textual/worker.py
@@ -375,7 +375,7 @@ class Worker(Generic[ResultType]):
 
             app.log.worker(Traceback())
             if self.exit_on_error:
-                app._fatal_error()
+                app._handle_exception(error)
         else:
             self.state = WorkerState.SUCCESS
             app.log.worker(self)

--- a/src/textual/worker.py
+++ b/src/textual/worker.py
@@ -375,7 +375,8 @@ class Worker(Generic[ResultType]):
 
             app.log.worker(Traceback())
             if self.exit_on_error:
-                app._handle_exception(error)
+                worker_failed = WorkerFailed(self._error)
+                app._handle_exception(worker_failed)
         else:
             self.state = WorkerState.SUCCESS
             app.log.worker(self)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -9,6 +9,7 @@ from textual.containers import Center, Middle
 from textual.pilot import OutOfBounds
 from textual.screen import Screen
 from textual.widgets import Button, Label
+from textual.worker import WorkerFailed
 
 KEY_CHARACTERS_TO_TEST = "akTW03" + punctuation
 """Test some "simple" characters (letters + digits) and all punctuation."""
@@ -110,9 +111,10 @@ async def test_pilot_exception_catching_worker():
         async def crash(self) -> None:
             1 / 0
 
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(WorkerFailed) as exc:
         async with SimpleAppThatCrashes().run_test():
             pass
+        assert exc.type is ZeroDivisionError
 
 
 async def test_pilot_click_screen():

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -2,7 +2,7 @@ from string import punctuation
 
 import pytest
 
-from textual import events
+from textual import events, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Middle
@@ -71,7 +71,7 @@ async def test_pilot_exception_catching_app_compose():
             pass
 
 
-async def test_pilot_exception_cathing_widget_compose():
+async def test_pilot_exception_catching_widget_compose():
     class SomeScreen(Screen[None]):
         def compose(self) -> ComposeResult:
             1 / 0
@@ -99,6 +99,20 @@ async def test_pilot_exception_catching_action():
     with pytest.raises(ZeroDivisionError):
         async with FailingApp().run_test() as pilot:
             await pilot.press("b")
+
+
+async def test_pilot_exception_catching_worker():
+    class SimpleAppThatCrashes(App[None]):
+        def on_mount(self) -> None:
+            self.crash()
+
+        @work(name="crash")
+        async def crash(self) -> None:
+            1 / 0
+
+    with pytest.raises(ZeroDivisionError):
+        async with SimpleAppThatCrashes().run_test():
+            pass
 
 
 async def test_pilot_click_screen():

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -7,6 +7,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Middle
 from textual.pilot import OutOfBounds
+from textual.screen import Screen
 from textual.widgets import Button, Label
 
 KEY_CHARACTERS_TO_TEST = "akTW03" + punctuation
@@ -56,7 +57,7 @@ async def test_pilot_press_ascii_chars():
             assert keys_pressed[-1] == char
 
 
-async def test_pilot_exception_catching_compose():
+async def test_pilot_exception_catching_app_compose():
     """Ensuring that test frameworks are aware of exceptions
     inside compose methods when running via Pilot run_test()."""
 
@@ -64,6 +65,21 @@ async def test_pilot_exception_catching_compose():
         def compose(self) -> ComposeResult:
             1 / 0
             yield Label("Beep")
+
+    with pytest.raises(ZeroDivisionError):
+        async with FailingApp().run_test():
+            pass
+
+
+async def test_pilot_exception_cathing_widget_compose():
+    class SomeScreen(Screen[None]):
+        def compose(self) -> ComposeResult:
+            1 / 0
+            yield Label("Beep")
+
+    class FailingApp(App[None]):
+        def on_mount(self) -> None:
+            self.push_screen(SomeScreen())
 
     with pytest.raises(ZeroDivisionError):
         async with FailingApp().run_test():

--- a/tests/workers/test_worker.py
+++ b/tests/workers/test_worker.py
@@ -113,10 +113,10 @@ async def test_run_error() -> None:
         pass
 
     app = ErrorApp()
-    async with app.run_test():
-        worker: Worker[str] = Worker(app, run_error)
-        worker._start(app)
-        with pytest.raises(WorkerFailed):
+    with pytest.raises(WorkerFailed):
+        async with app.run_test():
+            worker: Worker[str] = Worker(app, run_error)
+            worker._start(app)
             await worker.wait()
 
 
@@ -218,12 +218,12 @@ async def test_self_referential_deadlock():
         await get_current_worker().wait()
 
     app = App()
-    async with app.run_test():
-        worker = Worker(app, self_referential_work)
-        worker._start(app)
-        with pytest.raises(WorkerFailed) as exc:
+    with pytest.raises(WorkerFailed) as exc:
+        async with app.run_test():
+            worker = Worker(app, self_referential_work)
+            worker._start(app)
             await worker.wait()
-            assert exc.type is DeadlockError
+        assert exc.type is DeadlockError
 
 
 async def test_wait_without_start():


### PR DESCRIPTION
This will fix #4282.

The fix was to simply leverage the machinery introduced in #2754; for some reason, exceptions caught inside `Widget.compose` or workers were directly being sent to `App.panic` instead of using `App._handle_exception`.