### PR TITLE
docs: fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.54.0] - 2023-03-26
+## [0.54.0] - 2024-03-26
 
 ### Fixed
 
@@ -24,13 +24,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `Document.start` and `end` location properties for convenience https://github.com/Textualize/textual/pull/4267
 
-## [0.53.1] - 2023-03-18
+## [0.53.1] - 2024-03-18
 
 ### Fixed
 
 - Fixed issue with data binding https://github.com/Textualize/textual/pull/4308
 
-## [0.53.0] - 2023-03-18
+## [0.53.0] - 2024-03-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Exceptions inside `Widget.compose` or workers weren't bubbling up in tests https://github.com/Textualize/textual/issues/4282
+
+### Added
+
+- Added `Document.start` and `end` location properties for convenience https://github.com/Textualize/textual/pull/4267
+
 ## [0.54.0] - 2024-03-26
 
 ### Fixed
@@ -13,16 +23,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with flickering scrollbars https://github.com/Textualize/textual/pull/4315
 - Fixed issue where narrow TextArea would repeatedly wrap due to scrollbar appearing/disappearing https://github.com/Textualize/textual/pull/4334
 - Fix progress bar ETA not updating when setting `total` reactive https://github.com/Textualize/textual/pull/4316
-- Exceptions inside `Widget.compose` or workers weren't bubbling up in tests https://github.com/Textualize/textual/issues/4282
 
 ### Changed
 
 - ProgressBar won't show ETA until there is at least one second of samples https://github.com/Textualize/textual/pull/4316
 - `Input` waits until an edit has been made, after entry to the widget, before offering a suggestion https://github.com/Textualize/textual/pull/4335
-
-### Added
-
-- Added `Document.start` and `end` location properties for convenience https://github.com/Textualize/textual/pull/4267
 
 ## [0.53.1] - 2024-03-18
 


### PR DESCRIPTION
Spotted the wrong year in a few places in the changelog.

Also I think my addition to `Document` might have just missed being included the latest release - will check there aren't any others that have become out-of-sync.
