### PR TITLE
Fix priority bindings not appearing in Footer when key clashes with a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix priority bindings not appearing in footer when key clashes with focused widget https://github.com/Textualize/textual/pull/4342
 
-### Changed
-
-- App.namespace_bindings renamed to App.active_bindings and now returns a list instead of a dict https://github.com/Textualize/textual/pull/4342
-
 ## [0.54.0] - 2024-03-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with flickering scrollbars https://github.com/Textualize/textual/pull/4315
 - Fixed issue where narrow TextArea would repeatedly wrap due to scrollbar appearing/disappearing https://github.com/Textualize/textual/pull/4334
 - Fix progress bar ETA not updating when setting `total` reactive https://github.com/Textualize/textual/pull/4316
+- Fix priority bindings not appearing in footer when key clashes with focused widget https://github.com/Textualize/textual/pull/4342
 
 ### Changed 
 
 - ProgressBar won't show ETA until there is at least one second of samples https://github.com/Textualize/textual/pull/4316
+- App.namespace_bindings renamed to App.active_bindings and now returns a list instead of a dict https://github.com/Textualize/textual/pull/4342
 
 ## [0.53.1] - 2023-03-18
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -846,7 +846,7 @@ class App(Generic[ReturnType], DOMNode):
         return focused
 
     @property
-    def namespace_bindings(self) -> dict[str, tuple[DOMNode, Binding]]:
+    def active_bindings(self) -> list[tuple[DOMNode, Binding]]:
         """Get currently active bindings.
 
         If no widget is focused, then app-level bindings are returned.
@@ -855,15 +855,15 @@ class App(Generic[ReturnType], DOMNode):
         This property may be used to inspect current bindings.
 
         Returns:
-            A mapping of keys onto pairs of nodes and bindings.
+            A list of tuples containing bindings that are currently active and the DOMNode the binding is associated with.
         """
 
-        namespace_binding_map: dict[str, tuple[DOMNode, Binding]] = {}
+        nodes_and_bindings: list[tuple[DOMNode, Binding]] = []
         for namespace, bindings in reversed(self._binding_chain):
-            for key, binding in bindings.keys.items():
-                namespace_binding_map[key] = (namespace, binding)
+            for binding in bindings.keys.values():
+                nodes_and_bindings.append((namespace, binding))
 
-        return namespace_binding_map
+        return nodes_and_bindings
 
     def _set_active(self) -> None:
         """Set this app to be the currently active app."""

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -103,9 +103,7 @@ class Footer(Widget):
         description_style = self.get_component_rich_style("footer--description")
 
         bindings = [
-            binding
-            for (_, binding) in self.app.namespace_bindings.values()
-            if binding.show
+            binding for (_, binding) in self.app.active_bindings if binding.show
         ]
 
         action_to_bindings = defaultdict(list)

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -103,7 +103,9 @@ class Footer(Widget):
         description_style = self.get_component_rich_style("footer--description")
 
         bindings = [
-            binding for (_, binding) in self.app.active_bindings if binding.show
+            binding
+            for (_, binding) in self.app.namespace_bindings.values()
+            if binding.show
         ]
 
         action_to_bindings = defaultdict(list)


### PR DESCRIPTION
… key on the focused widget

The `App.namespace_bindings` did not account for priority bindings, and so would override them if there was a clash (same keybinding) with another available binding in the focus chain.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
