### PR TITLE
Implement Widget.render_delta_lines

### DIFF
--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -899,12 +899,18 @@ class Compositor:
         return self._cuts
 
     def _get_renders(
-        self, crop: Region | None = None
+        self,
+        crop: Region | None = None,
+        allow_delta_updates: bool = False,
     ) -> Iterable[tuple[Region, Region, list[Strip]]]:
         """Get rendered widgets (lists of segments) in the composition.
 
         Args:
             crop: Region to crop to, or `None` for entire screen.
+            allow_delta_updates: Whether we can issue partial updates for widgets or
+                not. If `True`, widgets with `_enable_delta_updates` will produce only
+                updates for lines inside `crop` that have changed. If `False`, each
+                widget produces the full render for the region inside `crop`.
 
         Returns:
             An iterable of <region>, <clip region>, and <strips>
@@ -935,17 +941,16 @@ class Compositor:
 
         for widget, region, clip in widget_regions:
             if contains_region(clip, region):
-                yield region, clip, widget.render_lines(
-                    _Region(0, 0, region.width, region.height)
-                )
+                region_to_render = _Region(0, 0, region.width, region.height)
             else:
                 new_x, new_y, new_width, new_height = intersection(region, clip)
-                if new_width and new_height:
-                    yield region, clip, widget.render_lines(
-                        _Region(
-                            new_x - region.x, new_y - region.y, new_width, new_height
-                        )
-                    )
+                region_to_render = _Region(
+                    new_x - region.x, new_y - region.y, new_width, new_height
+                )
+            if allow_delta_updates and widget._enable_delta_updates:
+                yield from widget.render_delta_lines(region, clip, region_to_render)
+            else:
+                yield region, clip, widget.render_lines(region_to_render)
 
     def render_update(
         self, full: bool = False, screen_stack: list[Screen] | None = None
@@ -995,7 +1000,7 @@ class Compositor:
             is_rendered_line = {y for y, _, _ in spans}.__contains__
         else:
             return None
-        chops = self._render_chops(crop, is_rendered_line)
+        chops = self._render_chops(crop, is_rendered_line, allow_delta_updates=True)
         chop_ends = [cut_set[1:] for cut_set in self.cuts]
         return ChopsUpdate(chops, spans, chop_ends)
 
@@ -1013,12 +1018,17 @@ class Compositor:
         self,
         crop: Region,
         is_rendered_line: Callable[[int], bool],
+        allow_delta_updates: bool = False,
     ) -> Sequence[Mapping[int, Strip | None]]:
         """Render update 'chops'.
 
         Args:
             crop: Region to crop to.
             is_rendered_line: Callable to check if line should be rendered.
+            allow_delta_updates: Whether we can issue partial updates for widgets or
+                not. If `True`, widgets with `_enable_delta_updates` will produce only
+                updates for lines inside `crop` that have changed. If `False`, each
+                widget produces the full render for the region inside `crop`.
 
         Returns:
             Chops structure.
@@ -1031,7 +1041,7 @@ class Compositor:
         cut_strips: Iterable[Strip]
 
         # Go through all the renders in reverse order and fill buckets with no render
-        renders = self._get_renders(crop)
+        renders = self._get_renders(crop, allow_delta_updates=allow_delta_updates)
         intersection = Region.intersection
 
         for region, clip, strips in renders:

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -234,6 +234,7 @@ class ScrollBar(Widget):
         self.grabbed_position: float = 0
         super().__init__(name=name)
         self.auto_links = False
+        self._enable_delta_updates = False
 
     window_virtual_size: Reactive[int] = Reactive(100)
     window_size: Reactive[int] = Reactive(0)
@@ -366,6 +367,7 @@ class ScrollBarCorner(Widget):
 
     def __init__(self, name: str | None = None):
         super().__init__(name=name)
+        self._enable_delta_updates = False
 
     def render(self) -> RenderableType:
         assert self.parent is not None

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -1008,6 +1008,15 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
                 self.cursor_line = -1
         self.refresh()
 
+    def render_delta_lines(
+        self,
+        region: Region,
+        clip: Region,
+        region_to_render: Region,
+    ) -> tuple[Region, Region, list[Strip]]:
+        self._pseudo_class_state = self.get_pseudo_class_state()
+        return super().render_delta_lines(region, clip, region_to_render)
+
     def render_lines(self, crop: Region) -> list[Strip]:
         self._pseudo_class_state = self.get_pseudo_class_state()
         return super().render_lines(crop)


### PR DESCRIPTION
The method `Widget.render_delta_lines` provides a mechanism for a widget to render itself and only issue strips that correspond to lines that actually changed.

The code in this draft isn't as polished as it should be but provides a fairly decent proof of concept for this feature.
At the moment, the PR shows that _all_ widgets have opted into this system and scrollbars have explicitly opted out.
In the future, this feature will probably only be used by _some_ widgets (and not all) but I did this to test it better.

It is easy to see that this code already skips updating large chunks of apps.
To check this, you can do something as simple as adding a `print` inside the method `Widget.render_delta_lines`:

```py
...
if matches_cache:
    print(f"Skipped printing {len(new_strips)}.")
    y_offset += len(new_strips)
    continue
```

---


Currently there is at least one bug with the implementation.
You can trigger this bug if you have an app with a single `Input` widget.
Follow these steps to trigger the bug:

 1. run the app
 2. click the input to focus it
 3. click outside of the terminal so that focus goes out of the app
 4. click back in the terminal _**but not**_ on the input directly

After the cursor blinks once, the top and bottom strips of the input will look weird, just like in this recording:

https://github.com/Textualize/textual/assets/5621605/66135a74-c242-4762-bc9d-ef215a95b339

You can use this app to trigger the bug:

```py
from textual.app import App, ComposeResult
from textual.app import App, ComposeResult
from textual.widgets import Input


class MyApp(App[None]):
    """Textual app to compute and visually display diffs."""

    AUTO_FOCUS = None

    def compose(self) -> ComposeResult:
        yield Input()


if __name__ == "__main__":
    MyApp().run()
```