### PR TITLE
Clarify that `SelectionList` can use Rich Text

### DIFF
--- a/docs/widgets/selection_list.md
+++ b/docs/widgets/selection_list.md
@@ -30,8 +30,8 @@ my_selection_list: SelectionList[int] =  SelectionList(*selections)
 ## Examples
 
 A selection list is designed to be built up of single-line prompts (which
-can be [Rich renderables](../guide/widgets.md#rich-renderables)) and an
-associated unique value.
+can be [Rich `Text`](https://rich.readthedocs.io/en/stable/text.html)) and
+an associated unique value.
 
 ### Selections as tuples
 


### PR DESCRIPTION
Fixes the misleading text that prompted #4361.
