### PR TITLE
docs: clarify unit of time

### DIFF
--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -191,7 +191,7 @@ class BoundAnimator:
             attribute: Name of the attribute to animate.
             value: The value to animate to.
             final_value: The final value of the animation. Defaults to `value` if not set.
-            duration: The duration of the animate.
+            duration: The duration (in seconds) of the animation.
             speed: The speed of the animation.
             delay: A delay (in seconds) before the animation starts.
             easing: An easing method.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -741,7 +741,7 @@ class App(Generic[ReturnType], DOMNode):
             attribute: Name of the attribute to animate.
             value: The value to animate to.
             final_value: The final value of the animation.
-            duration: The duration of the animate.
+            duration: The duration (in seconds) of the animation.
             speed: The speed of the animation.
             delay: A delay (in seconds) before the animation starts.
             easing: An easing method.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3387,7 +3387,7 @@ class App(Generic[ReturnType], DOMNode):
             message: The message for the notification.
             title: The title for the notification.
             severity: The severity of the notification.
-            timeout: The timeout for the notification.
+            timeout: The timeout (in seconds) for the notification.
 
         The `notify` method is used to create an application-wide
         notification, shown in a [`Toast`][textual.widgets._toast.Toast],

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -1152,7 +1152,7 @@ class RenderStyles(StylesBase):
             attribute: Name of the attribute to animate.
             value: The value to animate to.
             final_value: The final value of the animation. Defaults to `value` if not set.
-            duration: The duration of the animate.
+            duration: The duration (in seconds) of the animation.
             speed: The speed of the animation.
             delay: A delay (in seconds) before the animation starts.
             easing: An easing method.

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -350,7 +350,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Make a function call after a delay.
 
         Args:
-            delay: Time to wait before invoking callback.
+            delay: Time (in seconds) to wait before invoking callback.
             callback: Callback to call after time has expired.
             name: Name of the timer (for debug).
             pause: Start timer paused.
@@ -382,7 +382,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Call a function at periodic intervals.
 
         Args:
-            interval: Time between calls.
+            interval: Time (in seconds) between calls.
             callback: Function to call.
             name: Name of the timer object.
             repeat: Number of times to repeat the call or 0 for continuous.

--- a/src/textual/notifications.py
+++ b/src/textual/notifications.py
@@ -37,7 +37,7 @@ class Notification:
     """The severity level for the notification."""
 
     timeout: float = 5
-    """The timeout for the notification."""
+    """The timeout (in seconds) for the notification."""
 
     raised_at: float = field(default_factory=time)
     """The time when the notification was raised (in Unix time)."""

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1792,7 +1792,7 @@ class Widget(DOMNode):
             attribute: Name of the attribute to animate.
             value: The value to animate to.
             final_value: The final value of the animation. Defaults to `value` if not set.
-            duration: The duration of the animate.
+            duration: The duration (in seconds) of the animation.
             speed: The speed of the animation.
             delay: A delay (in seconds) before the animation starts.
             easing: An easing method.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3791,7 +3791,7 @@ class Widget(DOMNode):
             message: The message for the notification.
             title: The title for the notification.
             severity: The severity of the notification.
-            timeout: The timeout for the notification.
+            timeout: The timeout (in seconds) for the notification.
 
         See [`App.notify`][textual.app.App.notify] for the full
         documentation for this method.


### PR DESCRIPTION
Clarify the duration/delay time is in seconds in various places, but there may be others that I've missed.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
