### PR TITLE
fix: patch mixing width 100% with width auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix priority bindings not appearing in footer when key clashes with focused widget https://github.com/Textualize/textual/pull/4342
+- Patch for issues mixing `width: 100%` with `width: auto` https://github.com/Textualize/textual/issues/4360
 
 ### Changed
 

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -160,7 +160,8 @@ class Layout(ABC):
         if not widget._nodes:
             width = 0
         else:
-            arrangement = widget._arrange(Size(container.width, 0))
+            # Use a size of 0, 0 to ignore relative sizes, since those are flexible anyway
+            arrangement = widget._arrange(Size(0, 0))
             return arrangement.total_region.right
         return width
 

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -162,7 +162,8 @@ class Layout(ABC):
         else:
             # Use a size of 0, 0 to ignore relative sizes, since those are flexible anyway
             arrangement = widget._arrange(Size(0, 0))
-            return arrangement.total_region.right
+            width = arrangement.total_region.right
+
         return width
 
     def get_content_height(

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -239,6 +239,9 @@ class Button(Widget, can_focus=True):
     def post_render(self, renderable: RenderableType) -> ConsoleRenderable:
         return cast(ConsoleRenderable, renderable)
 
+    def get_content_width(self, container: Size, viewport: Size) -> int:
+        return len(self.label) + 2
+
     async def _on_click(self, event: events.Click) -> None:
         event.stop()
         self.press()

--- a/tests/snapshot_tests/snapshot_apps/width_100_percent.py
+++ b/tests/snapshot_tests/snapshot_apps/width_100_percent.py
@@ -1,0 +1,37 @@
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Label
+
+
+class Width100PCentApp(App[None]):
+
+    CSS = """
+    Vertical {
+        border: solid red;
+        width: auto;
+
+        Label {
+            border: solid green;
+        }
+
+        #first {
+            width: 100%;
+        }
+
+        #second {
+            width: auto;
+        }
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("I want to be 100% of my parent", id="first")
+            yield Label(
+                "I want my parent to be wide enough to wrap me and no more",
+                id="second",
+            )
+
+
+if __name__ == "__main__":
+    Width100PCentApp().run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -686,6 +686,7 @@ def test_markdown_component_classes_reloading(snap_compare, monkeypatch):
         run_before=run_before,
     )
 
+
 def test_markdown_space_squashing(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "markdown_whitespace.py")
 
@@ -1174,3 +1175,8 @@ def test_welcome(snap_compare):
 def test_button_with_console_markup(snap_compare):
     """Regression test for https://github.com/Textualize/textual/issues/4328"""
     assert snap_compare(SNAPSHOT_APPS_DIR / "button_markup.py")
+
+
+def test_width_100_percent_mixed_with_width_auto(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/4360"""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "width_100_percent.py")


### PR DESCRIPTION
Fixes #4360 by reverting the change in f094588. This change was intended to fix the issue with `Button` widths in #4024, but seems to have had wider unintended consequences. Instead this PR fixes the button width issue by adding a `get_content_width` override to button, which passes all tests.

There may be a wider issue with how relative sizes are handled in Textual, but this patch at least seems to provide a temporary fix.

This will also fix #4354 and other issues mentioned in #4360.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)