### PR TITLE
prevent messages from constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.56.0] - Unreleased
+
+### Changed
+
+- self.prevent can be used in a widget constructor to prevent messages on mount https://github.com/Textualize/textual/pull/4392
+
 ## [0.55.1] - 2024-04-2
 
 ### Fixed

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -144,6 +144,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """
         self._next_callbacks: list[events.Callback] = []
         self._thread_id: int = threading.get_ident()
+        self._prevented_messages_on_mount = self._prevent_message_types_stack[-1]
 
     @property
     def _prevent_message_types_stack(self) -> list[set[type[Message]]]:
@@ -524,7 +525,11 @@ class MessagePump(metaclass=_MessagePumpMeta):
 
         try:
             await self._dispatch_message(events.Compose())
-            await self._dispatch_message(events.Mount())
+            if self._prevented_messages_on_mount:
+                with self.prevent(*self._prevented_messages_on_mount):
+                    await self._dispatch_message(events.Mount())
+            else:
+                await self._dispatch_message(events.Mount())
             self.check_idle()
             self._post_mount()
         except Exception as error:

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Iterable, TypeVar, Union
 
+import rich.repr
 from rich.console import RenderableType
 from rich.text import Text
 
@@ -256,6 +257,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
     exception.
     """
 
+    @rich.repr.auto
     class Changed(Message):
         """Posted when the select value was changed.
 
@@ -273,6 +275,10 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
             """The select widget."""
             self.value = value
             """The value of the Select when it changed."""
+
+        def __rich_repr__(self) -> rich.repr.Result:
+            yield self.select
+            yield self.value
 
         @property
         def control(self) -> Select[SelectType]:
@@ -407,7 +413,8 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         """Initialises the selected option for the `Select`."""
         if hint == self.BLANK and not self._allow_blank:
             hint = self._options[0][1]
-        self.value = hint
+        with self.prevent(Select.Changed):
+            self.value = hint
 
     def set_options(self, options: Iterable[tuple[RenderableType, SelectType]]) -> None:
         """Set the options for the Select.

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -413,8 +413,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         """Initialises the selected option for the `Select`."""
         if hint == self.BLANK and not self._allow_blank:
             hint = self._options[0][1]
-        with self.prevent(Select.Changed):
-            self.value = hint
+        self.value = hint
 
     def set_options(self, options: Iterable[tuple[RenderableType, SelectType]]) -> None:
         """Set the options for the Select.


### PR DESCRIPTION
https://github.com/Textualize/textual/issues/4391

Allows use of self.prevent to prevent messages from being sent on_mount

Original issue may be fixed with the following change to `compose`:

```python
from textual import on
from textual.app import App, ComposeResult
from textual.widgets import Header, Select

ITEMS = {"food": ["pizza", "burger", "salad"], "drink": ["water", "soda", "juice"]}


class SelectApp(App):
    CSS_PATH = "select.tcss"
    primary = "drink"
    secondary = "juice"

    def compose(self) -> ComposeResult:
        primary_items = [(item, item) for item in ITEMS]
        secondary_items = [(item, item) for item in ITEMS[self.primary]]
        yield Header()
        with self.prevent(Select.Changed): 
            yield Select(
                    primary_items,
                    value=self.primary,
                    prompt="Select Category",
                    id="primary",
                    classes="settings_option",
                    allow_blank=False,
                )
                yield Select(
                    secondary_items,
                    value=self.secondary,
                    prompt="Select Item",
                    id="secondary",
                    classes="settings_option",
                    allow_blank=False,
                )
        self.title = f"{self.primary=} {self.secondary=}"

    @on(Select.Changed)
    def select_changed(self, event: Select.Changed) -> None:
        if event.control.id == "primary":
            self.primary = event.value
            items = ITEMS[event.value]
            widget: Select = self.query_one("#secondary")
            widget.set_options((item, item) for item in items)
        if event.control.id == "secondary":
            self.secondary = event.value
        self.title = f"{self.primary=} {self.secondary=}"


if __name__ == "__main__":
    app = SelectApp()
    app.run()

```

