### PR TITLE
Fix minor mistake in docs/styles/padding.md

### DIFF
--- a/docs/styles/padding.md
+++ b/docs/styles/padding.md
@@ -112,4 +112,4 @@ widget.styles.padding = (1, 2, 3, 4)
 ## See also
 
  - [`box-sizing`](./box_sizing.md) to specify how to account for padding in a widget's dimensions.
- - [`padding`](./margin.md) to add spacing around a widget.
+ - [`margin`](./margin.md) to add spacing around a widget.


### PR DESCRIPTION
It seems there is a little mistake in the document [here](https://textual.textualize.io/styles/padding/#see-also). The "padding" should be "margin". That link is correct though.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
