### PR TITLE
fix(datatable): prevent crash with border link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## Fixed
+
+- Fixed a crash in `DataTable` if you clicked a link in the border https://github.com/Textualize/textual/issues/4410
+
 ## [0.56.4] - 2024-04-09
 
 ### Fixed

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -2441,7 +2441,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
     async def _on_click(self, event: events.Click) -> None:
         self._set_hover_cursor(True)
         meta = event.style.meta
-        if not meta:
+        if not "row" in meta or not "column" in meta:
             return
 
         row_index = meta["row"]

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -6,7 +6,7 @@ from rich.text import Text
 
 from textual._wait import wait_for_idle
 from textual.actions import SkipAction
-from textual.app import App, RenderableType
+from textual.app import App, ComposeResult, RenderableType
 from textual.coordinate import Coordinate
 from textual.geometry import Offset
 from textual.message import Message
@@ -1420,3 +1420,31 @@ async def test_move_cursor_respects_animate_parameter():
         await pilot.press("s")
 
     assert scrolls == [True, False]
+
+
+async def test_clicking_border_link_doesnt_crash():
+    """Regression test for https://github.com/Textualize/textual/issues/4410"""
+
+    class DataTableWithBorderLinkApp(App):
+        CSS = """
+        DataTable {
+            border: solid red;
+        }
+        """
+        link_clicked = False
+
+        def compose(self) -> ComposeResult:
+            yield DataTable()
+
+        def on_mount(self) -> None:
+            table = self.query_one(DataTable)
+            table.border_title = "[@click=test_link]Border Link[/]"
+
+        def action_test_link(self) -> None:
+            self.link_clicked = True
+
+    app = DataTableWithBorderLinkApp()
+    async with app.run_test() as pilot:
+        # Test clicking the link in the border doesn't crash with KeyError: 'row'
+        await pilot.click(DataTable, offset=(5, 0))
+        assert app.link_clicked is True


### PR DESCRIPTION
Fixes #4410.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
