### PR TITLE
fix: make Document.end zero-indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `Integer` validator missing failure description when not a number https://github.com/Textualize/textual/issues/4413
 - Fixed a crash in `DataTable` if you clicked a link in the border https://github.com/Textualize/textual/issues/4410
+- Fixed an off-by-one error in the line number of the `Document.end` property https://github.com/Textualize/textual/issues/4426
 
 ### Added
 

--- a/src/textual/document/_document.py
+++ b/src/textual/document/_document.py
@@ -351,7 +351,7 @@ class Document(DocumentBase):
     def end(self) -> Location:
         """Returns the location of the end of the document."""
         last_line = self._lines[-1]
-        return (self.line_count, len(last_line))
+        return (self.line_count - 1, len(last_line))
 
     def get_index_from_location(self, location: Location) -> int:
         """Given a location, returns the index from the document's text.

--- a/tests/document/test_document.py
+++ b/tests/document/test_document.py
@@ -137,3 +137,16 @@ def test_location_from_index(text):
         len(lines) - 1,
         len(lines[-1]),
     )
+
+
+@pytest.mark.parametrize(
+    "text", [TEXT, TEXT_NEWLINE, TEXT_WINDOWS, TEXT_WINDOWS_NEWLINE]
+)
+def test_document_end(text):
+    """The location is always what we expect."""
+    document = Document(text)
+    expected_line_number = (
+        len(text.splitlines()) if text.endswith("\n") else len(text.splitlines()) - 1
+    )
+    expected_pos = 0 if text.endswith("\n") else (len(text.splitlines()[-1]))
+    assert document.end == (expected_line_number, expected_pos)


### PR DESCRIPTION
Fixes #4426

This changes `Document.end` to return a zero-indexed `Location`.

The only downstream dependency of this property in the Textual codebase is `TextArea.clear`, which is not impacted by this change (as tested in `tests/text_area/test_edit_via_api.py::test_clear`).

In the Changelog, I've marked this as a fix, although it's possible it's a breaking change for some app developers.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation (this behavior is not documented directly, so no changes were made)
- [x] Updated CHANGELOG.md (where appropriate)
