### PR TITLE
fix(text area): end mouse selection only if currently selecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `TextArea` to end mouse selection only if currently selecting https://github.com/Textualize/textual/pull/4436
+
 ## [0.57.1] - 2024-04-20
 
 ### Fixed

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1520,11 +1520,13 @@ TextArea {
 
     async def _on_mouse_up(self, event: events.MouseUp) -> None:
         """Finalize the selection that has been made using the mouse."""
-        self._end_mouse_selection()
+        if self._selecting:
+            self._end_mouse_selection()
 
     async def _on_hide(self, event: events.Hide) -> None:
-        """Finalize the selection that has been made using the mouse when thew widget is hidden."""
-        self._end_mouse_selection()
+        """Finalize the selection that has been made using the mouse when the widget is hidden."""
+        if self._selecting:
+            self._end_mouse_selection()
 
     async def _on_paste(self, event: events.Paste) -> None:
         """When a paste occurs, insert the text from the paste event into the document."""

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1513,20 +1513,19 @@ TextArea {
 
     def _end_mouse_selection(self) -> None:
         """Finalize the selection that has been made using the mouse."""
-        self._selecting = False
-        self.release_mouse()
-        self.record_cursor_width()
-        self._restart_blink()
+        if self._selecting:
+            self._selecting = False
+            self.release_mouse()
+            self.record_cursor_width()
+            self._restart_blink()
 
     async def _on_mouse_up(self, event: events.MouseUp) -> None:
         """Finalize the selection that has been made using the mouse."""
-        if self._selecting:
-            self._end_mouse_selection()
+        self._end_mouse_selection()
 
     async def _on_hide(self, event: events.Hide) -> None:
         """Finalize the selection that has been made using the mouse when the widget is hidden."""
-        if self._selecting:
-            self._end_mouse_selection()
+        self._end_mouse_selection()
 
     async def _on_paste(self, event: events.Paste) -> None:
         """When a paste occurs, insert the text from the paste event into the document."""


### PR DESCRIPTION
The `TextArea` should only invoke the `_end_mouse_selection` method if we're actually currently selecting with the mouse.

This will fix #4434 where currently the cursor blink is restarted after the `TextArea` is hidden in the `TabbedContent`.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
