### PR TITLE
fix(list view): fix bugs with initial index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `ListView` bugs with the initial index https://github.com/Textualize/textual/pull/4452
+
 ## [0.58.0] - 2024-04-25
 
 ### Fixed

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -119,9 +119,10 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
         )
         # Set the index to the given initial index, or the first available index after.
         self._index = _widget_navigation.find_next_enabled(
-            self._nodes,
-            anchor=initial_index - 1 if initial_index is not None else None,
+            children,
+            anchor=initial_index if initial_index is not None else None,
             direction=1,
+            with_anchor=True,
         )
 
     def _on_mount(self, _: Mount) -> None:

--- a/tests/listview/test_listview_initial_index.py
+++ b/tests/listview/test_listview_initial_index.py
@@ -1,0 +1,42 @@
+import pytest
+
+from textual.app import App, ComposeResult
+from textual.widgets import Label, ListItem, ListView
+
+
+@pytest.mark.parametrize(
+    "initial_index,expected_index",
+    [
+        (0, 1),
+        (1, 1),
+        (2, 4),
+        (3, 4),
+        (4, 4),
+        (5, 5),
+        (6, 7),
+        (7, 7),
+        (8, 1),
+    ],
+)
+async def test_listview_initial_index(initial_index, expected_index) -> None:
+    """Regression test for https://github.com/Textualize/textual/issues/4449"""
+
+    class ListViewDisabledItemsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield ListView(
+                ListItem(Label("0"), disabled=True),
+                ListItem(Label("1")),
+                ListItem(Label("2"), disabled=True),
+                ListItem(Label("3"), disabled=True),
+                ListItem(Label("4")),
+                ListItem(Label("5")),
+                ListItem(Label("6"), disabled=True),
+                ListItem(Label("7")),
+                ListItem(Label("8"), disabled=True),
+                initial_index=initial_index,
+            )
+
+    app = ListViewDisabledItemsApp()
+    async with app.run_test() as pilot:
+        list_view = pilot.app.query_one(ListView)
+        assert list_view._index == expected_index

--- a/tests/listview/test_listview_navigation.py
+++ b/tests/listview/test_listview_navigation.py
@@ -35,7 +35,6 @@ async def test_keyboard_navigation_with_disabled_items() -> None:
             await pilot.press("up")
 
     assert app.highlighted == [
-        None,
         "1",
         "4",
         "5",


### PR DESCRIPTION
Fixes #4449.

There's currently a problem with how the `ListView._index` is set in `__init__`:

https://github.com/Textualize/textual/blob/a5cab15cc10143fb49771231c35cbe5665083f9c/src/textual/widgets/_list_view.py#L120-L125

The `self._nodes` aren't actually available yet, which means this will always just return  `initial_index - 1` (the anchor).  This causes the off-by-one error in the original issue, but also means there's no actual checking for the next enabled item!

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
