### PR TITLE
Prevent rich console from highlighting patterns in exit messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- When displaying a message using `App.exit()`, the console no longer highlights things such as numbers.
+
 ## [0.58.0] - 2024-04-25
 
 ### Fixed

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -453,7 +453,7 @@ class App(Generic[ReturnType], DOMNode):
             soft_wrap=False,
         )
         self._workers = WorkerManager(self)
-        self.error_console = Console(markup=False, stderr=True)
+        self.error_console = Console(markup=False, highlight=False, stderr=True)
         self.driver_class = driver_class or self.get_driver_class()
         self._screen_stacks: dict[str, list[Screen[Any]]] = {"_default": []}
         """A stack of screens per mode."""


### PR DESCRIPTION
When someone uses the `exit()` method with the `message` parameter inside an `App` subclass, certain patterns, such as numbers, will be highlighted. This PR fixes this issue

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
