### PR TITLE
Fixed a bug with flickering if scrollbar size is set to 0.

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1501,7 +1501,7 @@ class Widget(DOMNode):
         if not self.is_scrollable:
             return False, False
 
-        return (self.show_vertical_scrollbar, self.show_horizontal_scrollbar)
+        return (self.show_vertical_scrollbar and self.styles.scrollbar_size_vertival, self.show_horizontal_scrollbar and self.styles.scrollbar_size_horizontal)
 
     @property
     def scrollbars_space(self) -> tuple[int, int]:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1501,7 +1501,7 @@ class Widget(DOMNode):
         if not self.is_scrollable:
             return False, False
 
-        return (self.show_vertical_scrollbar and self.styles.scrollbar_size_vertival, self.show_horizontal_scrollbar and self.styles.scrollbar_size_horizontal)
+        return (self.show_vertical_scrollbar and self.styles.scrollbar_size_vertical, self.show_horizontal_scrollbar and self.styles.scrollbar_size_horizontal)
 
     @property
     def scrollbars_space(self) -> tuple[int, int]:


### PR DESCRIPTION
Basically in the textual website - https://textual.textualize.io/styles/scrollbar_size/ there is:
```
Tip
If you want to hide the scrollbar but still allow the container to scroll using the mousewheel or keyboard, you can set the scrollbar size to 0.
```
But when I tried it it would just flicker or not show up at all. Now if you want to hide a scrollbar you can use any of these:
```
scrollbar-size: 0 0;  # hide both scrollbars
scrollbar-size-horizontal: 0;  # hide horizontal scrollbar
scrollbar-size-vertical: 0;  # hide vertical scrollbar
```

It was a small change. Just a single line of code. I don't understand what exactly the change I made did but with trial and error I managed to fix it without knowing the internals of textual. I am pretty sure I didn't break anything since it is just a small change. I tested it with a small application and it worked so it should be good to go.
(If I did something wrong please tell me this is my first time contributing to a project. I am open to learn)