### PR TITLE
fix(selection list): update indexes after option removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `SelectionList` issues after removing an option https://github.com/Textualize/textual/pull/4464
+
 ## [0.58.0] - 2024-04-25
 
 ### Fixed

--- a/src/textual/widgets/_selection_list.py
+++ b/src/textual/widgets/_selection_list.py
@@ -646,6 +646,11 @@ class SelectionList(Generic[SelectionType], OptionList):
         option = self.get_option_at_index(index)
         self._deselect(option.value)
         del self._values[option.value]
+        # Decrement index of options after the one we just removed.
+        self._values = {
+            option_value: option_index - 1 if option_index > index else option_index
+            for option_value, option_index in self._values.items()
+        }
         return super()._remove_option(index)
 
     def add_options(

--- a/tests/selection_list/test_selection_list_create.py
+++ b/tests/selection_list/test_selection_list_create.py
@@ -114,3 +114,10 @@ async def test_options_are_available_soon() -> None:
     selection = Selection("", 0, id="some_id")
     selection_list = SelectionList[int](selection)
     assert selection_list.get_option("some_id") is selection
+
+
+async def test_removing_option_updates_indexes() -> None:
+    async with SelectionListApp().run_test() as pilot:
+        selections = pilot.app.query_one(SelectionList)
+        selections.remove_option_at_index(0)
+        assert list(selections._values.values())[0] == 0

--- a/tests/selection_list/test_selection_list_create.py
+++ b/tests/selection_list/test_selection_list_create.py
@@ -119,5 +119,7 @@ async def test_options_are_available_soon() -> None:
 async def test_removing_option_updates_indexes() -> None:
     async with SelectionListApp().run_test() as pilot:
         selections = pilot.app.query_one(SelectionList)
+        assert selections._values == {n: n for n in range(5)}
+
         selections.remove_option_at_index(0)
-        assert list(selections._values.values())[0] == 0
+        assert selections._values == {n + 1: n for n in range(4)}


### PR DESCRIPTION
Fixes #4462.

I've added a basic test that the index is updated, but I'm not sure if you need a regression test that actually replicates the issue above?

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
