### PR TITLE
Support zero-indexed line numbers in TextArea

### DIFF
--- a/docs/widgets/text_area.md
+++ b/docs/widgets/text_area.md
@@ -353,6 +353,8 @@ the `show_line_numbers` attribute to `True` or `False`.
 
 Setting this attribute will immediately repaint the `TextArea` to reflect the new value.
 
+You can also change the start line number (the topmost line number in the gutter) by setting the `line_number_start` reactive attribute.
+
 ### Extending `TextArea`
 
 Sometimes, you may wish to subclass `TextArea` to add some extra functionality.
@@ -506,6 +508,7 @@ A detailed view of these classes is out of scope, but do note that a lot of the 
 | `theme`                | `str`                    | `"css"`       | The theme to use.                                                |
 | `selection`            | `Selection`              | `Selection()` | The current selection.                                           |
 | `show_line_numbers`    | `bool`                   | `False`       | Show or hide line numbers.                                       |
+| `line_number_start`    | `int`                    | `1`           | The start line number in the gutter.                            |
 | `indent_width`         | `int`                    | `4`           | The number of spaces to indent and width of tabs.                |
 | `match_cursor_bracket` | `bool`                   | `True`        | Enable/disable highlighting matching brackets under cursor.      |
 | `cursor_blink`         | `bool`                   | `True`        | Enable/disable blinking of the cursor when the widget has focus. |

--- a/tests/snapshot_tests/snapshot_apps/text_area_line_number_start.py
+++ b/tests/snapshot_tests/snapshot_apps/text_area_line_number_start.py
@@ -1,0 +1,25 @@
+from textual.app import App, ComposeResult
+from textual.widgets import TextArea
+
+TEXT = """\
+Foo
+Bar
+Baz
+"""
+
+
+class LineNumbersReactive(App[None]):
+    START_LINE_NUMBER = 9999
+
+    def compose(self) -> ComposeResult:
+        yield TextArea(
+            TEXT,
+            soft_wrap=True,
+            show_line_numbers=True,
+            line_number_start=self.START_LINE_NUMBER,
+        )
+
+
+app = LineNumbersReactive()
+if __name__ == "__main__":
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1000,6 +1000,12 @@ def test_text_area_wrapping_and_folding(snap_compare):
     )
 
 
+def test_text_area_line_number_start(snap_compare):
+    assert snap_compare(
+        SNAPSHOT_APPS_DIR / "text_area_line_number_start.py", terminal_size=(32, 8)
+    )
+
+
 def test_digits(snap_compare) -> None:
     assert snap_compare(SNAPSHOT_APPS_DIR / "digits.py")
 


### PR DESCRIPTION
Possible alternatives:

- Add this as a keyword argument - IMO this use-case will not be common enough to deserve it's own typed keyword argument being there until the end of  time
- Make the ``show_line_numbers`` kw accept an ``int`` (with ``-1`` signifying ``False``) - won't add another kw but will terribly hurt readability
- Split up the source code in such a way it won't require overriding the entire ``render_line`` method  to do this in one's own project - not worth it, will probably end up being very invasive, while this approach is fairly elegant

Something I still consider adding:

typing this class variable as ``: Literal[0, 1]`` to increase clarity of what it's use case really is