### PR TITLE
Message signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - When displaying a message using `App.exit()`, the console no longer highlights things such as numbers.
 
+### Added
+
+- Added `message_signal` to MessagePump, to listen to events sent to another widget. https://github.com/Textualize/textual/pull/4487
+
 ## [0.58.1] - 2024-05-01
 
 ### Fixed

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -147,6 +147,11 @@ class MessagePump(metaclass=_MessagePumpMeta):
         self._thread_id: int = threading.get_ident()
         self._prevented_messages_on_mount = self._prevent_message_types_stack[-1]
         self.message_signal: Signal[Message] = Signal(self, "messages")
+        """Subscribe to this signal to be notified of all messages sent to this widget.
+        
+        This is a fairly low-level mechanism, and shouldn't replace regular message handling.
+        
+        """
 
     @property
     def _prevent_message_types_stack(self) -> list[set[type[Message]]]:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -42,6 +42,7 @@ from .errors import DuplicateKeyHandlers
 from .events import Event
 from .message import Message
 from .reactive import Reactive, TooManyComputesError
+from .signal import Signal
 from .timer import Timer, TimerCallback
 
 if TYPE_CHECKING:
@@ -145,6 +146,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
         self._next_callbacks: list[events.Callback] = []
         self._thread_id: int = threading.get_ident()
         self._prevented_messages_on_mount = self._prevent_message_types_stack[-1]
+        self.message_signal: Signal[Message] = Signal(self, "messages")
 
     @property
     def _prevent_message_types_stack(self) -> list[set[type[Message]]]:
@@ -582,6 +584,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 self.app._handle_exception(error)
                 break
             finally:
+                self.message_signal.publish(message)
                 self._message_queue.task_done()
 
                 current_time = time()

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -17,7 +17,6 @@ import rich.repr
 from textual import log
 
 if TYPE_CHECKING:
-    from .dom import DOMNode
     from .message_pump import MessagePump
 
 SignalT = TypeVar("SignalT")
@@ -73,7 +72,7 @@ class Signal(Generic[SignalT]):
         if callback not in callbacks:
             callbacks.append(callback)
 
-    def unsubscribe(self, node: DOMNode) -> None:
+    def unsubscribe(self, node: MessagePump) -> None:
         """Unsubscribe a node from this signal.
 
         Args:

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -18,6 +18,7 @@ from textual import log
 
 if TYPE_CHECKING:
     from .dom import DOMNode
+    from .message_pump import MessagePump
 
 SignalT = TypeVar("SignalT")
 
@@ -34,7 +35,7 @@ class SignalError(Exception):
 class Signal(Generic[SignalT]):
     """A signal that a widget may subscribe to, in order to invoke callbacks when an associated event occurs."""
 
-    def __init__(self, owner: DOMNode, name: str) -> None:
+    def __init__(self, owner: MessagePump, name: str) -> None:
         """Initialize a signal.
 
         Args:
@@ -43,16 +44,16 @@ class Signal(Generic[SignalT]):
         """
         self._owner = owner
         self._name = name
-        self._subscriptions: WeakKeyDictionary[DOMNode, list[SignalCallbackType]] = (
-            WeakKeyDictionary()
-        )
+        self._subscriptions: WeakKeyDictionary[
+            MessagePump, list[SignalCallbackType]
+        ] = WeakKeyDictionary()
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "owner", self._owner
         yield "name", self._name
         yield "subscriptions", list(self._subscriptions.keys())
 
-    def subscribe(self, node: DOMNode, callback: SignalCallbackType) -> None:
+    def subscribe(self, node: MessagePump, callback: SignalCallbackType) -> None:
         """Subscribe a node to this signal.
 
         When the signal is published, the callback will be invoked.


### PR DESCRIPTION
Adds a mechanism to listen to events from any widget.

All widgets now have a `message_signal` which you can subscribe to, in order to be notified about messages sent to that widget. Note that it will publish all events, so you will likely need to check the message type with isinstance.

Here's an example:

```python
from textual.app import App, ComposeResult
from textual.widgets import Label
from textual import events

class SApp(App):
    def compose(self) -> ComposeResult:
        yield Label("Hello, World")

    def on_mount(self):
        def listen_messages(message):
            if isinstance(message, events.MouseDown):
                self.notify(str(message))
        self.screen.message_signal.subscribe(self, listen_messages)


app = SApp()
app.run()
```



Fixes https://github.com/Textualize/textual/issues/4485
