### PR TITLE
Fix Cursor Drag on Programmatic Edit

### DIFF
--- a/src/textual/document/_edit.py
+++ b/src/textual/document/_edit.py
@@ -81,8 +81,16 @@ class Edit:
         )
 
         row_offset = new_edit_to_row - edit_bottom_row
-        target_selection_start_row = selection_start_row + row_offset
-        target_selection_end_row = selection_end_row + row_offset
+        target_selection_start_row = (
+            selection_start_row + row_offset
+            if edit_bottom_row <= selection_start_row
+            else selection_start_row
+        )
+        target_selection_end_row = (
+            selection_end_row + row_offset
+            if edit_bottom_row <= selection_end_row
+            else selection_end_row
+        )
 
         if self.maintain_selection_offset:
             self._updated_selection = Selection(

--- a/tests/text_area/test_edit_via_api.py
+++ b/tests/text_area/test_edit_via_api.py
@@ -106,6 +106,27 @@ async def test_insert_character_near_cursor_maintain_selection_offset(
         assert text_area.selection == Selection.cursor(cursor_destination)
 
 
+@pytest.mark.parametrize(
+    "cursor_location,insert_location,cursor_destination",
+    [
+        ((1, 0), (0, 0), (2, 0)),  # API insert before cursor row
+        ((0, 0), (0, 0), (1, 0)),  # API insert right at cursor row
+        ((0, 0), (1, 0), (0, 0)),  # API insert after cursor row
+    ],
+)
+async def test_insert_newline_around_cursor_maintain_selection_offset(
+    cursor_location,
+    insert_location,
+    cursor_destination
+):
+    app = TextAreaApp()
+    async with app.run_test():
+        text_area = app.query_one(TextArea)
+        text_area.move_cursor(cursor_location)
+        text_area.insert("X\n", location=insert_location)
+        assert text_area.selection == Selection.cursor(cursor_destination)
+
+
 async def test_insert_newlines_start():
     app = TextAreaApp()
     async with app.run_test():


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

Hey folks! :wave: 

Thank you all for your amazing work. :hearts: 

I am building a collaborative text editor by combining Y-CRDTs via [ypy](https://github.com/y-crdt/ypy)/[pycrdt](https://github.com/jupyter-server/pycrdt) with the `TextArea` widget. You did an awesome job on this and @darrenburns I enjoyed reading your [blog post about it](https://textual.textualize.io/blog/2023/09/18/things-i-learned-while-building-textuals-textarea/). :sparkles: 
The process of putting the pieces together was pretty smooth.

The only issue I faced until now was that my cursor gets dragged away by inserts *after* my cursor position:

[![cursor-drag](https://asciinema.org/a/658434.svg)](https://asciinema.org/a/658434)

With this PR, I added the conditions to only apply the row offset when the insert happens before the cursor location:

[![no-cursor-drag](https://asciinema.org/a/658435.svg)](https://asciinema.org/a/658435)

A new test comes with it.

<details>
<summary>:snake: This is the Python script I used for testing.</summary>

```python
import anyio

from textual.app import App
from textual.widgets import TextArea, Label


TEXT = [
    "I must not fear.\n",
    "Fear is the mind-killer.\n",
    "Fear is the little-death that brings total obliteration.\n",
    "I will face my fear.\n",
    "\n",
]


class TestApp(App):
   def __init__(self):
       super().__init__()
       self.textarea = TextArea()
       self.textarea.show_line_numbers = True
       self.textarea.cursor_blink = False
       self.label = Label()

   def compose(self):
       yield self.textarea
       yield self.label


async def auto_insert(textarea, label):
    try:
        i = 0
        while True:
            textarea.insert(TEXT[i % 5], (i, 0))
            label.update(f"{i=}, {textarea.cursor_location=}")
            await anyio.sleep(1)
            i += 1
    except anyio.get_cancelled_exc_class():
        return


async def main():
    app = TestApp()
    textarea = app.textarea
    label = app.label
    async with anyio.create_task_group() as tg:
        tg.start_soon(auto_insert, textarea, label)
        await app.run_async()


if __name__ == "__main__":
    try:
        anyio.run(main)
    except KeyboardInterrupt:
        print("exiting gracefully")
```
</details>

What are your thoughts?

