### PR TITLE
Allow more easily customisable scrollbar glyphs

### DIFF
--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -70,11 +70,11 @@ class ScrollTo(ScrollMessage, verbose=True):
 
 
 class ScrollBarRender:
-    _vertical_bars: ClassVar[list[str]] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", " "]
+    VERTICAL_BARS: ClassVar[list[str]] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", " "]
     """Glyphs used for vertical scrollbar ends, for smoother display."""
-    _horizontal_bars: ClassVar[list[str]] = ["▉", "▊", "▋", "▌", "▍", "▎", "▏", " "]
+    HORIZONTAL_BARS: ClassVar[list[str]] = ["▉", "▊", "▋", "▌", "▍", "▎", "▏", " "]
     """Glyphs used for horizontal scrollbar ends, for smoother display."""
-    _blank_glyph: ClassVar[str] = " "
+    BLANK_GLYPH: ClassVar[str] = " "
     """Glyph used for the main body of the scrollbar"""
 
     def __init__(
@@ -106,9 +106,9 @@ class ScrollBarRender:
         bar_color: Color = Color.parse("bright_magenta"),
     ) -> Segments:
         if vertical:
-            bars = cls._vertical_bars
+            bars = cls.VERTICAL_BARS
         else:
-            bars = cls._horizontal_bars
+            bars = cls.HORIZONTAL_BARS
 
         back = back_color
         bar = bar_color
@@ -119,7 +119,7 @@ class ScrollBarRender:
 
         _Segment = Segment
         _Style = Style
-        blank = cls._blank_glyph * width_thickness
+        blank = cls.BLANK_GLYPH * width_thickness
 
         foreground_meta = {"@mouse.down": "grab"}
         if window_size and size and virtual_size and size != virtual_size:

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -70,6 +70,13 @@ class ScrollTo(ScrollMessage, verbose=True):
 
 
 class ScrollBarRender:
+    _vertical_bars: ClassVar[list[str]] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", " "]
+    """Glyphs used for vertical scrollbar ends, for smoother display."""
+    _horizontal_bars: ClassVar[list[str]] = ["▉", "▊", "▋", "▌", "▍", "▎", "▏", " "]
+    """Glyphs used for horizontal scrollbar ends, for smoother display."""
+    _blank_glyph: ClassVar[str] = " "
+    """Glyph used for the main body of the scrollbar"""
+
     def __init__(
         self,
         virtual_size: int = 100,
@@ -99,9 +106,9 @@ class ScrollBarRender:
         bar_color: Color = Color.parse("bright_magenta"),
     ) -> Segments:
         if vertical:
-            bars = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", " "]
+            bars = cls._vertical_bars
         else:
-            bars = ["▉", "▊", "▋", "▌", "▍", "▎", "▏", " "]
+            bars = cls._horizontal_bars
 
         back = back_color
         bar = bar_color
@@ -112,7 +119,7 @@ class ScrollBarRender:
 
         _Segment = Segment
         _Style = Style
-        blank = " " * width_thickness
+        blank = cls._blank_glyph * width_thickness
 
         foreground_meta = {"@mouse.down": "grab"}
         if window_size and size and virtual_size and size != virtual_size:


### PR DESCRIPTION
- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation (not needed I think?)
- [x] Updated CHANGELOG.md (not needed, I don't think it warrants a changelog?)

Closes #4500

This allows a user to easily customise scrollbar display. For example, when using the Consolas font, scrollbars display poorly:
![cmd_NfNfGUSQfX](https://github.com/Textualize/textual/assets/3398021/03cfb020-96cd-42d6-b152-b1abac5e7fbf)

By reducing the characters to those supported, the display is more consistent:
```python
ScrollBarRender._vertical_bars = ["▄", "█", " "]
```
![cmd_4MxcLegZxq](https://github.com/Textualize/textual/assets/3398021/5c2109c7-673b-4aa7-8cd5-1fbd55324528)

By using some lightly shaded characters, the scrollbars gain some flair:
```python
ScrollBarRender._vertical_bars = ["░", "▒", "▓", " "]
```
![cmd_1HZHPAXOts](https://github.com/Textualize/textual/assets/3398021/8aee9251-21b6-455c-a2c4-e9476f805d77)

The blank glyph can also be replaced:
```python
ScrollBarRender._vertical_bars = ["░", "▓", " "]
ScrollBarRender._blank_glyph = "▒"
```
![cmd_HieEhLsuqH](https://github.com/Textualize/textual/assets/3398021/35520356-4e89-4a97-b8ad-9bc169b8980d)

This is easier than replacing the entire `ScrollBarRender.render_bar` function.
