### PR TITLE
feat!: remove confusing app workers alias

### DIFF
--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -1025,7 +1025,7 @@ class CommandPalette(_SystemModalScreen[CallbackType]):
 
     def _cancel_gather_commands(self) -> None:
         """Cancel any operation that is gather commands."""
-        self.workers.cancel_group(self, self._GATHER_COMMANDS_GROUP)
+        self.app.workers.cancel_group(self, self._GATHER_COMMANDS_GROUP)
 
     @on(Input.Changed)
     def _input(self, event: Input.Changed) -> None:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -31,7 +31,6 @@ from rich.tree import Tree
 from ._context import NoActiveAppError, active_message_pump
 from ._node_list import NodeList
 from ._types import WatchCallbackType
-from ._worker_manager import WorkerManager
 from .binding import Binding, BindingType, _Bindings
 from .color import BLACK, WHITE, Color
 from .css._error_tools import friendly_list
@@ -386,11 +385,6 @@ class DOMNode(MessagePump):
             )
         self._auto_refresh = interval
 
-    @property
-    def workers(self) -> WorkerManager:
-        """The app's worker manager. Shortcut for `self.app.workers`."""
-        return self.app.workers
-
     def run_worker(
         self,
         work: WorkType[ResultType],
@@ -423,9 +417,9 @@ class DOMNode(MessagePump):
         # If we're running a worker from inside a secondary thread,
         # do so in a thread-safe way.
         if self.app._thread_id != threading.get_ident():
-            creator = partial(self.app.call_from_thread, self.workers._new_worker)
+            creator = partial(self.app.call_from_thread, self.app.workers._new_worker)
         else:
-            creator = self.workers._new_worker
+            creator = self.app.workers._new_worker
         worker: Worker[ResultType] = creator(
             work,
             self,

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3762,7 +3762,7 @@ class Widget(DOMNode):
         self.scroll_to_region(message.region, animate=True)
 
     def _on_unmount(self) -> None:
-        self.workers.cancel_node(self)
+        self.app.workers.cancel_node(self)
 
     def action_scroll_home(self) -> None:
         if not self._allow_scroll:

--- a/tests/command_palette/test_run_on_select.py
+++ b/tests/command_palette/test_run_on_select.py
@@ -37,7 +37,7 @@ async def test_with_run_on_select_on() -> None:
         assert isinstance(pilot.app, CommandPaletteRunOnSelectApp)
         pilot.app.action_command_palette()
         await pilot.press("0")
-        await pilot.app.screen.workers.wait_for_complete()
+        await pilot.app.workers.wait_for_complete()
         await pilot.press("down")
         await pilot.press("enter")
         assert pilot.app.selection is not None
@@ -57,7 +57,7 @@ async def test_with_run_on_select_off() -> None:
         assert isinstance(pilot.app, CommandPaletteDoNotRunOnSelectApp)
         pilot.app.action_command_palette()
         await pilot.press("0")
-        await pilot.app.screen.workers.wait_for_complete()
+        await pilot.app.workers.wait_for_complete()
         await pilot.press("down")
         await pilot.press("enter")
         assert pilot.app.selection is None

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -806,7 +806,7 @@ def test_command_palette(snap_compare) -> None:
         # await pilot.press("ctrl+backslash")
         pilot.app.screen.query_one(Input).cursor_blink = False
         await pilot.press("A")
-        await pilot.app.screen.workers.wait_for_complete()
+        await pilot.app.workers.wait_for_complete()
 
     assert snap_compare(SNAPSHOT_APPS_DIR / "command_palette.py", run_before=run_before)
 
@@ -814,7 +814,7 @@ def test_command_palette(snap_compare) -> None:
 def test_command_palette_discovery(snap_compare) -> None:
     async def run_before(pilot) -> None:
         pilot.app.screen.query_one(Input).cursor_blink = False
-        await pilot.app.screen.workers.wait_for_complete()
+        await pilot.app.workers.wait_for_complete()
 
     assert snap_compare(
         SNAPSHOT_APPS_DIR / "command_palette_discovery.py", run_before=run_before


### PR DESCRIPTION
Closes #3619. 

> I suggest we rename `DOMNode.workers` to `DOMNode.app_workers` and/or make it so that `DOMNode.workers` retrieves all workers started by/associated with the given widget.

There doesn't seem much benefit of just renaming this property if only a shortcut for `self.app.workers`?

This PR simply removes this confusing alias, but I'm happy to look into workers only tied to the given widget with a bit of guidance.

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
