### PR TITLE
Return correct bindings inside modal screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Return correct bindings inside modal screens
+
 ## [0.60.1] - 2024-05-15
 
 ### Fixed

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -868,7 +868,7 @@ class App(Generic[ReturnType], DOMNode):
         """
 
         bindings_map: dict[str, tuple[DOMNode, Binding]] = {}
-        for namespace, bindings in self._binding_chain:
+        for namespace, bindings in self._modal_binding_chain:
             for key, binding in bindings.keys.items():
                 if existing_key_and_binding := bindings_map.get(key):
                     _, existing_binding = existing_key_and_binding


### PR DESCRIPTION
- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

Fixes https://github.com/Textualize/textual/issues/4517

I'm not sure if the docstring for `App.namespace_bindings` should add detail on only returning bindings up to the next modal screen, but happy to amend if so!