### PR TITLE
default screen method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.61.0] - Unreleased
+
+### Added
+
+- Added App.get_default_screen
+
 ## [0.60.1] - 2024-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added App.get_default_screen
+- Added `App.get_default_screen` https://github.com/Textualize/textual/pull/4520
 
 ## [0.60.1] - 2024-05-15
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -888,7 +888,7 @@ class App(Generic[ReturnType], DOMNode):
         Implement this method if you would like to use a custom Screen as the default screen.
 
         Returns:
-            A screen subclass.
+            A screen instance.
         """
         return Screen(id="_default")
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -879,6 +879,19 @@ class App(Generic[ReturnType], DOMNode):
 
         return bindings_map
 
+    def get_default_screen(self) -> Screen:
+        """Get the default screen.
+
+        This is called when the App is first composed. The returned screen instance
+        will be the first screen on the stack.
+
+        Implement this method if you would like to use a custom Screen as the default screen.
+
+        Returns:
+            A screen subclass.
+        """
+        return Screen(id="_default")
+
     def _set_active(self) -> None:
         """Set this app to be the currently active app."""
         active_app.set(self)
@@ -2973,7 +2986,7 @@ class App(Generic[ReturnType], DOMNode):
         # Handle input events that haven't been forwarded
         # If the event has been forwarded it may have bubbled up back to the App
         if isinstance(event, events.Compose):
-            screen: Screen[Any] = Screen(id=f"_default")
+            screen: Screen[Any] = self.get_default_screen()
             self._register(self, screen)
             self._screen_stack.append(screen)
             screen.post_message(events.ScreenResume())

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -496,3 +496,20 @@ async def test_push_screen_wait_for_dismiss_no_worker() -> None:
     with pytest.raises(NoActiveWorker):
         async with app.run_test() as pilot:
             await pilot.press("x", "y")
+
+
+async def test_default_custom_screen() -> None:
+    """Test we can override the default screen."""
+
+    class CustomScreen(Screen):
+        pass
+
+    class CustomScreenApp(App):
+        def get_default_screen(self) -> Screen:
+            return CustomScreen()
+
+    app = CustomScreenApp()
+    async with app.run_test():
+        assert len(app.screen_stack) == 1
+        assert isinstance(app.screen_stack[0], CustomScreen)
+        assert app.screen is app.screen_stack[0]


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/4519

Allows the app to customize the default screen.

This is preferable over pushing a custom screen on mount, so you aren't left with a empty screen on the stack.