### PR TITLE
Fix a broken link in the CSS types index

### DIFF
--- a/docs/css_types/index.md
+++ b/docs/css_types/index.md
@@ -8,5 +8,5 @@ The CSS types will be denoted by a keyword enclosed by angle brackets `<` and `>
 For example, the style [`align-horizontal`](../styles/align.md) references the CSS type [`<horizontal>`](./horizontal.md):
 
 --8<-- "docs/snippets/syntax_block_start.md"
-align-horizontal: <a href="./horizontal.md">&lt;horizontal&gt;</a>;
+align-horizontal: <a href="./horizontal/">&lt;horizontal&gt;</a>;
 --8<-- "docs/snippets/syntax_block_end.md"


### PR DESCRIPTION
Another borked link in the CSS docs. Checking with `rg "href.*md"` suggests this is the last instance of this sort of thing.