### PR TITLE
fix(footer): exclude multi bindings for grid size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `Footer` grid size https://github.com/Textualize/textual/pull/4545
+
 ## [0.63.1] - 2024-05-22
 
 ### Fixed

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -23,36 +23,36 @@ class FooterKey(Widget):
     FooterKey {
         width: auto;
         height: 1;
-        background: $panel;        
-        color: $text-muted;        
-        .footer-key--key {     
-            color: $secondary;                   
+        background: $panel;
+        color: $text-muted;
+        .footer-key--key {
+            color: $secondary;
             background: $panel;
-            text-style: bold;                       
+            text-style: bold;
         }
 
         &:light .footer-key--key {
-            color: $primary; 
-        }        
+            color: $primary;
+        }
 
         &:hover {
             background: $panel-darken-2;
             color: $text;
-            .footer-key--key { 
-                background: $panel-darken-2;              
-            }            
+            .footer-key--key {
+                background: $panel-darken-2;
+            }
         }
 
-        &.-disabled {    
+        &.-disabled {
             text-style: dim;
             background: $panel;
             &:hover {
-                .footer-key--key {            
+                .footer-key--key {
                     background: $panel;
-                }    
-            }        
+                }
+            }
         }
-                   
+
     }
     """
 
@@ -110,7 +110,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
     DEFAULT_CSS = """
     Footer {
         layout: grid;
-        grid-columns: auto;        
+        grid-columns: auto;
         background: $panel;
         color: $text;
         dock: bottom;
@@ -118,7 +118,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
         scrollbar-size: 0 0;
         &.-compact {
             grid-gutter: 1;
-        }        
+        }
     }
     """
 

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -141,7 +141,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
         for binding, enabled in bindings:
             action_to_bindings[binding.action].append((binding, enabled))
 
-        self.styles.grid_size_columns = len(bindings)
+        self.styles.grid_size_columns = len(action_to_bindings)
         for multi_bindings in action_to_bindings.values():
             binding, enabled = multi_bindings[0]
             yield FooterKey(


### PR DESCRIPTION
Related to the fix for multiple bindings in #4543, I think the `Footer` grid size is wrong as it includes those multiple bindings?

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
