### PR TITLE
enforce mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `Footer` grid size https://github.com/Textualize/textual/pull/4545
 
+### Changed
+
+- Attempting to mount on a non-mounted widget now raises a MountError https://github.com/Textualize/textual/pull/4547
+
 ## [0.63.2] - 2024-05-23
 
 ### Fixed

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -770,6 +770,11 @@ class App(Generic[ReturnType], DOMNode):
         await self._animator.stop_animation(self, attribute, complete)
 
     @property
+    def is_dom_root(self) -> bool:
+        """Is this a root node (i.e. the App)?"""
+        return True
+
+    @property
     def debug(self) -> bool:
         """Is debug mode enabled?"""
         return "debug" in self.features

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -216,6 +216,11 @@ class MessagePump(metaclass=_MessagePumpMeta):
         return self._message_queue.qsize()
 
     @property
+    def is_dom_root(self):
+        """Is this a root node (i.e. the App)?"""
+        return False
+
+    @property
     def app(self) -> "App[object]":
         """
         Get the current app.
@@ -238,6 +243,16 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 node = node._parent
             active_app.set(node)
             return node
+
+    @property
+    def _is_linked_to_app(self) -> bool:
+        """Is this node linked to the app through the DOM?"""
+        node: MessagePump | None = self
+
+        while (node := node._parent) is not None:
+            if node.is_dom_root:
+                return True
+        return False
 
     @property
     def is_parent_active(self) -> bool:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -934,6 +934,8 @@ class Widget(DOMNode):
             Only one of ``before`` or ``after`` can be provided. If both are
             provided a ``MountError`` will be raised.
         """
+        if not self._is_linked_to_app:
+            raise MountError(f"Can't mount widget(s) before {self!r} is mounted")
         # Check for duplicate IDs in the incoming widgets
         ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
         unique_ids = set(ids_to_mount)
@@ -1121,9 +1123,9 @@ class Widget(DOMNode):
 
         Recomposing will remove children and call `self.compose` again to remount.
         """
-        if self._parent is not None:
-            async with self.batch():
-                await self.query("*").exclude(".-textual-system").remove()
+        async with self.batch():
+            await self.query("*").exclude(".-textual-system").remove()
+            if self._is_linked_to_app:
                 await self.mount_all(compose(self))
 
     def _post_register(self, app: App) -> None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1123,10 +1123,11 @@ class Widget(DOMNode):
 
         Recomposing will remove children and call `self.compose` again to remount.
         """
-        async with self.batch():
-            await self.query("*").exclude(".-textual-system").remove()
-            if self._is_linked_to_app:
-                await self.mount_all(compose(self))
+        if self._parent is not None:
+            async with self.batch():
+                await self.query("*").exclude(".-textual-system").remove()
+                if self._is_linked_to_app:
+                    await self.mount_all(compose(self))
 
     def _post_register(self, app: App) -> None:
         """Called when the instance is registered.

--- a/tests/test_widget_mounting.py
+++ b/tests/test_widget_mounting.py
@@ -114,3 +114,10 @@ async def test_mount_via_app() -> None:
         await pilot.app.mount_all(widgets)
         with pytest.raises(TooManyMatches):
             await pilot.app.mount(Static(), before="Static")
+
+
+def test_mount_error() -> None:
+    """Mounting a widget on an un-mounted widget should raise an error."""
+    with pytest.raises(MountError):
+        widget = Widget()
+        widget.mount(Static())


### PR DESCRIPTION
Raises a `MountError` if you try to mount a widget on to something that is not yet mounted.

Should catch misunderstandings about the DOM.

Fixed https://github.com/Textualize/textual/issues/4532