### PR TITLE
signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added `immediate` switch to `Signal.publish`
+
 ## [0.63.3] - 2024-05-24
 
 ### Fixed

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1505,7 +1505,7 @@ class DOMNode(MessagePump):
         See [actions](/guide/actions#dynamic-actions) for how to use this method.
 
         """
-        self.call_later(self.screen.refresh_bindings)
+        self.screen.refresh_bindings()
 
     async def action_toggle(self, attribute_name: str) -> None:
         """Toggle an attribute on the node.

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -245,7 +245,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
             return node
 
     @property
-    def _is_linked_to_app(self) -> bool:
+    def is_attached(self) -> bool:
         """Is this node linked to the app through the DOM?"""
         node: MessagePump | None = self
 
@@ -274,19 +274,6 @@ class MessagePump(metaclass=_MessagePumpMeta):
             A logger.
         """
         return self.app._logger
-
-    @property
-    def is_attached(self) -> bool:
-        """Is the node attached to the app via the DOM?"""
-        from .app import App
-
-        node = self
-
-        while not isinstance(node, App):
-            if node._parent is None:
-                return False
-            node = node._parent
-        return True
 
     def _attach(self, parent: MessagePump) -> None:
         """Set the parent, and therefore attach this node to the tree.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -739,7 +739,9 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _on_mount(self, event: events.Mount) -> None:
         """Set up the tooltip-clearing signal when we mount."""
-        self.screen_layout_refresh_signal.subscribe(self, self._maybe_clear_tooltip)
+        self.screen_layout_refresh_signal.subscribe(
+            self, self._maybe_clear_tooltip, immediate=True
+        )
 
     async def _on_idle(self, event: events.Idle) -> None:
         # Check for any widgets marked as 'dirty' (needs a repaint)

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -65,11 +65,18 @@ class Signal(Generic[SignalT]):
         Args:
             node: Node to subscribe.
             callback: A callback function which takes a single argument and returns anything (return type ignored).
-            immediate: Invoke the callback immediately on publish if `True`, otherwise post it to the DOM node.
+            immediate: Invoke the callback immediately on publish if `True`, otherwise post it to the DOM node to be
+                called once existing messages have been processed.
 
         Raises:
             SignalError: Raised when subscribing a non-mounted widget.
         """
+
+        if not node.is_running:
+            raise SignalError(
+                f"Node must be running to subscribe to a signal (has {node} been mounted)?"
+            )
+
         if immediate:
 
             def signal_callback(data: object):
@@ -82,10 +89,6 @@ class Signal(Generic[SignalT]):
                 """Post the callback to the node, to call at the next opertunity."""
                 node.call_next(callback, data)
 
-        if not node.is_running:
-            raise SignalError(
-                f"Node must be running to subscribe to a signal (has {node} been mounted)?"
-            )
         callbacks = self._subscriptions.setdefault(node, [])
         callbacks.append(signal_callback)
 

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -52,7 +52,12 @@ class Signal(Generic[SignalT]):
         yield "name", self._name
         yield "subscriptions", list(self._subscriptions.keys())
 
-    def subscribe(self, node: MessagePump, callback: SignalCallbackType) -> None:
+    def subscribe(
+        self,
+        node: MessagePump,
+        callback: SignalCallbackType,
+        immediate: bool = False,
+    ) -> None:
         """Subscribe a node to this signal.
 
         When the signal is published, the callback will be invoked.
@@ -60,17 +65,29 @@ class Signal(Generic[SignalT]):
         Args:
             node: Node to subscribe.
             callback: A callback function which takes a single argument and returns anything (return type ignored).
+            immediate: Invoke the callback immediately on publish if `True`, otherwise post it to the DOM node.
 
         Raises:
             SignalError: Raised when subscribing a non-mounted widget.
         """
+        if immediate:
+
+            def signal_callback(data: object):
+                """Invoke the callback immediately."""
+                callback(data)
+
+        else:
+
+            def signal_callback(data: object):
+                """Post the callback to the node, to call at the next opertunity."""
+                node.call_next(callback, data)
+
         if not node.is_running:
             raise SignalError(
                 f"Node must be running to subscribe to a signal (has {node} been mounted)?"
             )
         callbacks = self._subscriptions.setdefault(node, [])
-        if callback not in callbacks:
-            callbacks.append(callback)
+        callbacks.append(signal_callback)
 
     def unsubscribe(self, node: MessagePump) -> None:
         """Unsubscribe a node from this signal.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -934,7 +934,7 @@ class Widget(DOMNode):
             Only one of ``before`` or ``after`` can be provided. If both are
             provided a ``MountError`` will be raised.
         """
-        if not self._is_linked_to_app:
+        if not self.is_attached:
             raise MountError(f"Can't mount widget(s) before {self!r} is mounted")
         # Check for duplicate IDs in the incoming widgets
         ids_to_mount = [widget.id for widget in widgets if widget.id is not None]
@@ -1126,7 +1126,7 @@ class Widget(DOMNode):
         if self._parent is not None:
             async with self.batch():
                 await self.query("*").exclude(".-textual-system").remove()
-                if self._is_linked_to_app:
+                if self.is_attached:
                     await self.mount_all(compose(self))
 
     def _post_register(self, app: App) -> None:

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 import rich.repr
 from rich.text import Text
@@ -10,6 +11,9 @@ from ..binding import Binding
 from ..containers import ScrollableContainer
 from ..reactive import reactive
 from ..widget import Widget
+
+if TYPE_CHECKING:
+    from ..screen import Screen
 
 
 @rich.repr.auto
@@ -157,9 +161,9 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
             )
 
     def on_mount(self) -> None:
-        def bindings_changed(screen) -> None:
+        async def bindings_changed(screen: Screen) -> None:
             if screen is self.screen:
-                self.call_next(self.recompose)
+                await self.recompose()
 
         self.screen.bindings_updated_signal.subscribe(self, bindings_changed)
 

--- a/tests/test_suspend.py
+++ b/tests/test_suspend.py
@@ -48,8 +48,8 @@ async def test_suspend_supported(capfd: pytest.CaptureFixture[str]) -> None:
             calls.add("resume signal")
 
         def on_mount(self) -> None:
-            self.app_suspend_signal.subscribe(self, self.on_suspend)
-            self.app_resume_signal.subscribe(self, self.on_resume)
+            self.app_suspend_signal.subscribe(self, self.on_suspend, immediate=True)
+            self.app_resume_signal.subscribe(self, self.on_resume, immediate=True)
 
     async with SuspendApp(driver_class=HeadlessSuspendDriver).run_test(
         headless=False


### PR DESCRIPTION
Refactor of signals.

Signals were originally added for the process suspend feature, where the callback needs to be immediate. It has since been expanded to notify DOM nodes about bindings, where the callback could benefit from being run in the node's context.

This adds an `immediate` flag which toggles between the two requirements.