### PR TITLE
Fix a typo in the docs for Underline.COMPONENT_CLASSES

### DIFF
--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -42,7 +42,7 @@ class Underline(Widget):
     """
     | Class | Description |
     | :- | :- |
-    | `underline-bar` | Style of the bar (may be used to change the color). |
+    | `underline--bar` | Style of the bar (may be used to change the color). |
     """
 
     highlight_start = reactive(0)


### PR DESCRIPTION
While this doesn't end up in the docs now, it could at some point in the future, so it's worth correcting.
