### PR TITLE
Fix `Markdown.goto_anchor` not scrolling the heading into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Dependency issue
 
-## [0.60.0] - 2024-05-14 
+## [0.60.0] - 2024-05-14
 
 ### Fixed
 
@@ -206,7 +206,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `Size.with_width` and `Size.with_height` https://github.com/Textualize/textual/pull/4393
-  
+
 ### Fixed
 
 - Fixed issue with inline mode and multiple screens https://github.com/Textualize/textual/pull/4393
@@ -221,7 +221,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed mouse escape sequences being generated with `mouse=False` 
+- Fixed mouse escape sequences being generated with `mouse=False`
 
 ## [0.55.0] - 2024-04-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `Markdown.goto_anchor` no longer scrolling the heading into view.
+
 ## [0.63.6] - 2024-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed `Markdown.goto_anchor` no longer scrolling the heading into view.
+- Fixed `Markdown.goto_anchor` no longer scrolling the heading into view https://github.com/Textualize/textual/pull/4583
 
 ## [0.63.6] - 2024-05-29
 

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -232,7 +232,7 @@ class MarkdownHeader(MarkdownBlock):
     MarkdownHeader {
         color: $text;
         margin: 2 0 1 0;
-       
+
     }
     """
 
@@ -243,7 +243,7 @@ class MarkdownH1(MarkdownHeader):
     DEFAULT_CSS = """
 
     MarkdownH1 {
-        content-align: center middle;             
+        content-align: center middle;
         text-style: bold;
         color: $success;
         &:light {color: $primary;}
@@ -260,7 +260,7 @@ class MarkdownH2(MarkdownHeader):
         text-style: underline;
         color: $success;
          &:light {color: $primary;}
-      
+
     }
     """
 
@@ -270,7 +270,7 @@ class MarkdownH3(MarkdownHeader):
 
     DEFAULT_CSS = """
     MarkdownH3 {
-       
+
         text-style: bold;
         color: $success;
         &:light {color: $primary;}
@@ -300,7 +300,7 @@ class MarkdownH5(MarkdownHeader):
         text-style: bold;
         color: $text;
         margin: 1 0;
-       
+
     }
     """
 
@@ -493,8 +493,8 @@ class MarkdownTable(MarkdownBlock):
 
     DEFAULT_CSS = """
     MarkdownTable {
-        width: 100%;     
-        background: $panel;        
+        width: 100%;
+        background: $panel;
     }
     """
 
@@ -597,11 +597,11 @@ class MarkdownFence(MarkdownBlock):
         margin: 1 0;
         overflow: auto;
         width: 100%;
-        height: auto;       
+        height: auto;
         max-height: 20;
         color: rgb(210,210,210);
 
-        
+
     }
 
     MarkdownFence > * {

--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -839,7 +839,7 @@ class Markdown(Widget):
         unique = TrackedSlugs()
         for _, title, header_id in self._table_of_contents:
             if unique.slug(title) == anchor:
-                self.parent.scroll_to_widget(self.query_one(f"#{header_id}"), top=True)
+                self.query_one(f"#{header_id}").scroll_visible(top=True)
                 return True
         return False
 


### PR DESCRIPTION
`Markdown.goto_anchor` used to scroll the heading into view, there is code in there to do this. As was pointed out on Discord today, it no longer does. This PR changes how the request to scroll is done and now does the scrolling again.

Useful code to test before and after:

```python
from textual.app import App, ComposeResult
from textual.widgets import Markdown

class MarkdownGotoApp(App[None]):

    def compose(self) -> ComposeResult:
        yield Markdown(
            "\n\n".join(
                f"# Heading {n}\n\n" +
                ("XXXXX " * 1000)
                for n in range(100)
            )
        )

    def on_mount(self) -> None:
        if self.query_one(Markdown).goto_anchor("heading-50"):
            self.notify("Markdown thinks we found and went to the anchor")
        else:
            self.notify("The anchor could not be found", severity="error")


if __name__ == "__main__":
    MarkdownGotoApp().run()
```