### PR TITLE
fix(footer): add space between binding key and description

### DIFF
--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -94,7 +94,10 @@ class FooterKey(Widget):
             )
         else:
             label_text = Text.assemble(
-                (f" {key_display} ", key_style), (description, description_style), " "
+                (f" {key_display} ", key_style),
+                " ",
+                (description, description_style),
+                " ",
             )
         label_text.stylize_before(self.rich_style)
         return label_text

--- a/tests/snapshot_tests/snapshot_apps/footer_spacing.py
+++ b/tests/snapshot_tests/snapshot_apps/footer_spacing.py
@@ -1,0 +1,19 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Footer
+
+
+class FooterApp(App):
+    CSS = """
+    Footer > FooterKey .footer-key--key{
+        background: red;
+    }
+    """
+    BINDINGS = [("q", "quit", "Quit the app")]
+
+    def compose(self) -> ComposeResult:
+        yield Footer()
+
+
+if __name__ == "__main__":
+    app = FooterApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1273,3 +1273,8 @@ def test_multi_keys(snap_compare):
 
 def test_data_table_in_tabs(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_tabs.py")
+
+
+def test_footer_space_between_key_and_description(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/4557"""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "footer_spacing.py")


### PR DESCRIPTION
Fixes #4557.

I figured this was a simple enough change to just make a PR and see this change was acceptable.

Here's some quick before and after screenshots. I purposely chose the ugliest example with the default footer styling, but for the most part an extra space isn't really too noticeable.

![image](https://github.com/Textualize/textual/assets/101601846/ff712050-e471-4b16-b097-43590bc6bc82)

![image](https://github.com/Textualize/textual/assets/101601846/21f13027-f948-4eef-9b11-f9f09ab5a7df)


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
