### PR TITLE
zero height renderables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- `get_content_height` will now return 0 if the renderable is Falsey
+
 ## [0.65.2] - 2023-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- `get_content_height` will now return 0 if the renderable is Falsey
+- `get_content_height` will now return 0 if the renderable is Falsey https://github.com/Textualize/textual/pull/4617
 
 ## [0.65.2] - 2023-06-06
 

--- a/examples/code_browser.tcss
+++ b/examples/code_browser.tcss
@@ -23,6 +23,7 @@ CodeBrowser.-show-tree #tree-view {
 #code-view {
     overflow: auto scroll;
     min-width: 100%;
+    hatch: right $primary;   
 }
 #code {
     width: auto;

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -118,7 +118,10 @@ class Timer:
             if timer._task is not None:
                 timer._active.set()
                 timer._task.cancel()
-                await timer._task
+                try:
+                    await timer._task
+                except CancelledError:
+                    pass
 
         await gather(*[stop_timer(timer) for timer in list(timers)])
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1345,13 +1345,17 @@ class Widget(DOMNode):
 
             renderable = self.render()
             if isinstance(renderable, Text):
-                height = len(
-                    renderable.wrap(
-                        self._console,
-                        width,
-                        no_wrap=renderable.no_wrap,
-                        tab_size=renderable.tab_size or 8,
+                height = (
+                    len(
+                        renderable.wrap(
+                            self._console,
+                            width,
+                            no_wrap=renderable.no_wrap,
+                            tab_size=renderable.tab_size or 8,
+                        )
                     )
+                    if renderable
+                    else 0
                 )
             else:
                 options = self._console.options.update_width(width).update(

--- a/src/textual/widgets/_label.py
+++ b/src/textual/widgets/_label.py
@@ -10,5 +10,6 @@ class Label(Static):
     Label {
         width: auto;
         height: auto;
+        min-height: 1;
     }
     """


### PR DESCRIPTION
Allow widgets to have 0 height, if the renderable is Falsey. This essentially hides widgets if they are empty.

The Label widget now has a `min-height` of 0, so as to maintain the previous behaviour.