### PR TITLE
Account for scrollbar in DataTable page-up/down

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -2476,7 +2476,9 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         """Move the cursor one page down."""
         self._set_hover_cursor(False)
         if self.show_cursor and self.cursor_type in ("cell", "row"):
-            height = self.size.height - (self.header_height if self.show_header else 0)
+            height = self.scrollable_content_region.height - (
+                self.header_height if self.show_header else 0
+            )
 
             # Determine how many rows constitutes a "page"
             offset = 0
@@ -2498,7 +2500,9 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         """Move the cursor one page up."""
         self._set_hover_cursor(False)
         if self.show_cursor and self.cursor_type in ("cell", "row"):
-            height = self.size.height - (self.header_height if self.show_header else 0)
+            height = self.scrollable_content_region.height - (
+                self.header_height if self.show_header else 0
+            )
 
             # Determine how many rows constitutes a "page"
             offset = 0


### PR DESCRIPTION
If the content of a DataTable is wide enough to require a horizontal scrollbar, the page-up/down actions use the wrong height to figure out how far to move the cursor. At least this is what I think because it's inconsistent, e.g. the Tree widget does not behave like this.