### PR TITLE
check signal on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added support for Kitty's key protocol https://github.com/Textualize/textual/pull/4631
+- Added `App.CLOSE_TIMEOUT` https://github.com/Textualize/textual/pull/4635
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [0.67.0] - 2024-06-11
 
 ### Added
 
 - Added support for Kitty's key protocol https://github.com/Textualize/textual/pull/4631
+
+### Fixed
+
+- Fixed deadlock on shutdown https://github.com/Textualize/textual/pull/4635
 
 ## [0.66.0] - 2024-06-08
 
@@ -2102,6 +2106,7 @@ https://textual.textualize.io/blog/2022/11/08/version-040/#version-040
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
 
+[0.67.0]: https://github.com/Textualize/textual/compare/v0.66.0...v0.67.0
 [0.66.0]: https://github.com/Textualize/textual/compare/v0.65.2...v0.66.0
 [0.65.2]: https://github.com/Textualize/textual/compare/v0.65.1...v0.65.2
 [0.65.1]: https://github.com/Textualize/textual/compare/v0.65.0...v0.65.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "0.66.0"
+version = "0.67.0"
 homepage = "https://github.com/Textualize/textual"
 repository = "https://github.com/Textualize/textual"
 documentation = "https://textual.textualize.io/"

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3414,10 +3414,9 @@ class App(Generic[ReturnType], DOMNode):
                 except asyncio.TimeoutError:
                     # Likely a deadlock if we get here
                     # If not a deadlock, increase CLOSE_TIMEOUT, or set it to None
-                    if sys.__stderr__ is not None:
-                        sys.__stderr__.write(
-                            f"Timeout waiting for {close_children!r} to close; possible deadlock\n"
-                        )
+                    raise asyncio.TimeoutError(
+                        f"Timeout waiting for {close_children!r} to close; possible deadlock\n"
+                    ) from None
                 for child in children:
                     self._unregister(child)
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3414,9 +3414,10 @@ class App(Generic[ReturnType], DOMNode):
                 except asyncio.TimeoutError:
                     # Likely a deadlock if we get here
                     # If not a deadlock, increase CLOSE_TIMEOUT, or set it to None
-                    sys.__stderr__.write(
-                        f"Timeout waiting for {close_children!r} to close; possible deadlock\n"
-                    )
+                    if sys.__stderr__ is not None:
+                        sys.__stderr__.write(
+                            f"Timeout waiting for {close_children!r} to close; possible deadlock\n"
+                        )
                 for child in children:
                     self._unregister(child)
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3397,7 +3397,9 @@ class App(Generic[ReturnType], DOMNode):
         for children in reversed(node_children):
             # Closing children can be done asynchronously.
             close_messages = [
-                child._close_messages(wait=True) for child in children if child._running
+                child._close_messages(wait=True)
+                for child in children
+                if child._running and not child._closing
             ]
             # TODO: What if a message pump refuses to exit?
             if close_messages:

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from textual.app import App
+from textual.containers import Horizontal
+from textual.widgets import Footer, Tree
+
+
+class TreeApp(App[None]):
+    def compose(self):
+        yield Horizontal(Tree("Dune"))
+        yield Footer()
+
+
+def test_shutdown():
+    # regression test for https://github.com/Textualize/textual/issues/4634
+    # Testing that an app with the footer doesn't deadlock
+    app = TreeApp()
+
+    async def run_test():
+        async with app.run_test():
+            pass
+
+    asyncio.run(run_test())

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from textual.app import App
 from textual.containers import Horizontal
 from textual.widgets import Footer, Tree
@@ -11,13 +9,10 @@ class TreeApp(App[None]):
         yield Footer()
 
 
-def test_shutdown():
+async def test_shutdown():
     # regression test for https://github.com/Textualize/textual/issues/4634
     # Testing that an app with the footer doesn't deadlock
     app = TreeApp()
-
-    async def run_test():
-        async with app.run_test():
-            pass
-
-    asyncio.run(run_test())
+    print("Check for deadlock in test_shutdown.py")
+    async with app.run_test():
+        pass


### PR DESCRIPTION
Signals are proving problematic since they can be sent at arbitrary points.

This prevents publishing signals while the DOM is shutting down.

Fixes https://github.com/Textualize/textual/issues/4634