### PR TITLE
Quality of life: Expand the hover/click area for the tree nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `home` and `end` now works horizontally instead of vertically in DataTable https://github.com/Textualize/textual/pull/4633
+- `Tree` and `DirectoryTree` nodes now have a bigger click target, spanning the full line https://github.com/Textualize/textual/pull/4636
 
 ### Fixed
 

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -1089,6 +1089,8 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
             else:
                 line_style = base_style
 
+            line_style += Style(meta={"line": y})
+
             guides = Text(style=line_style)
             guides_append = guides.append
 
@@ -1124,7 +1126,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
                 )
 
             label = self.render_label(line.path[-1], line_style, label_style).copy()
-            label.stylize(Style(meta={"node": line.node._id, "line": y}))
+            label.stylize(Style(meta={"node": line.node._id}))
             guides.append(label)
 
             segments = list(guides.render(self.app.console))


### PR DESCRIPTION
A quick quality of life change.

If you had nodes with small names, e.g. `.`, they could be quite hard to click on.

This change expands the range which hover/click affects a node. This brings it in line with how the tree works in VSCode/PyCharm.

https://github.com/Textualize/textual/assets/5740731/60df511d-924c-4f4a-a60f-54c44d25f6be

