### PR TITLE
fix: remove typo in docstring

### DIFF
--- a/examples/dictionary.py
+++ b/examples/dictionary.py
@@ -13,7 +13,7 @@ from textual.widgets import Input, Markdown
 
 
 class DictionaryApp(App):
-    """Searches ab dictionary API as-you-type."""
+    """Searches a dictionary API as-you-type."""
 
     CSS_PATH = "dictionary.tcss"
 


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
