### PR TITLE
Refresh input when placeholder reactive is updated

### DIFF
--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -176,7 +176,7 @@ class Input(Widget, can_focus=True):
     input_scroll_offset = reactive(0)
     cursor_position = reactive(0)
     view_position = reactive(0)
-    placeholder = reactive("")
+    placeholder = reactive("", init=False)
     complete = reactive("")
     width = reactive(1)
     _cursor_visible = reactive(True)
@@ -393,6 +393,9 @@ class Input(Widget, can_focus=True):
             else:
                 self._cursor_visible = True
                 self._blink_timer.pause()
+
+    def _watch_placeholder(self) -> None:
+        self.refresh()
 
     @property
     def cursor_screen_offset(self) -> Offset:


### PR DESCRIPTION
More of a discussion - I'm not sure why this is required.

When I don't do this explicit refresh and the reactive is changed, the placeholder doesn't always refresh immediately.

If it's a reactive, shouldn't the widget be repainting without the need for this explicit refresh?