### PR TITLE
await screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Breaking change: `App.push_screen` now returns an Awaitable rather than a screen. https://github.com/Textualize/textual/pull/4672
+- Breaking change: `Screen.dismiss` now returns an Awaitable rather than a bool. https://github.com/Textualize/textual/pull/4672
+
+
 ## [0.70.0] - 2024-06-19
 
 ### Fixed

--- a/src/textual/_worker_manager.py
+++ b/src/textual/_worker_manager.py
@@ -175,5 +175,7 @@ class WorkerManager:
         Args:
             workers: An iterable of workers or None to wait for all workers in the manager.
         """
-
-        await asyncio.gather(*[worker.wait() for worker in (workers or self)])
+        try:
+            await asyncio.gather(*[worker.wait() for worker in (workers or self)])
+        except asyncio.CancelledError:
+            pass

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1938,7 +1938,8 @@ class App(Generic[ReturnType], DOMNode):
         stack = self._screen_stacks[mode]
         del self._screen_stacks[mode]
 
-        async def remove_screens():
+        async def remove_screens() -> None:
+            """Remove screens."""
             for screen in reversed(stack):
                 await self._replace_screen(screen)
 
@@ -2173,6 +2174,7 @@ class App(Generic[ReturnType], DOMNode):
             )
 
         async def do_switch() -> None:
+            """Task to perform switch."""
             next_screen, await_mount = self._get_screen(screen)
             if screen is self.screen or next_screen is self.screen:
                 self.log.system(f"Screen {screen} is already current.")
@@ -2264,6 +2266,7 @@ class App(Generic[ReturnType], DOMNode):
             )
 
         async def do_pop() -> None:
+            """Task to pop the screen."""
             previous_screen = await self._replace_screen(screen_stack.pop())
             previous_screen._pop_result_callback()
             self.screen.post_message(events.ScreenResume())
@@ -2370,7 +2373,6 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             error: An exception instance.
         """
-        self.log.error(error)
         self._return_code = 1
         # If we're running via pilot and this is the first exception encountered,
         # take note of it so that we can re-raise for test frameworks later.

--- a/src/textual/await_complete.py
+++ b/src/textual/await_complete.py
@@ -4,6 +4,9 @@ from asyncio import Future, gather
 from typing import Any, Awaitable, Generator
 
 import rich.repr
+from typing_extensions import Self
+
+from .message_pump import MessagePump
 
 
 @rich.repr.auto(angular=True)
@@ -17,6 +20,15 @@ class AwaitComplete:
             awaitables: One or more awaitables to run concurrently.
         """
         self._future: Future[Any] = gather(*awaitables)
+
+    def call_next(self, node: MessagePump) -> Self:
+        """Await after the next message.
+
+        Args:
+            node: The node which created the object.
+        """
+        node.call_next(self)
+        return self
 
     async def __call__(self) -> Any:
         return await self

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -493,7 +493,10 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 running_widget = None
 
             if running_widget is None or running_widget is not self:
-                await self._task
+                try:
+                    await self._task
+                except CancelledError:
+                    pass
 
     def _start_messages(self) -> None:
         """Start messages task."""

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -676,7 +676,7 @@ class Widget(DOMNode):
             loading_indicator = self.get_loading_widget()
             loading_indicator.add_class(LOADING_INDICATOR_CLASS)
             await_mount = self.mount(loading_indicator)
-            return AwaitComplete(remove_indicator, await_mount)
+            return AwaitComplete(remove_indicator, await_mount).call_next(self)
         else:
             return remove_indicator
 

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -170,7 +170,7 @@ class DirectoryTree(Tree[DirEntry]):
             node.data.loaded = True
             self._load_queue.put_nowait(node)
 
-        return AwaitComplete(self, self._load_queue.join())
+        return AwaitComplete(self._load_queue.join())
 
     def reload(self) -> AwaitComplete:
         """Reload the `DirectoryTree` contents.

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -170,7 +170,7 @@ class DirectoryTree(Tree[DirEntry]):
             node.data.loaded = True
             self._load_queue.put_nowait(node)
 
-        return AwaitComplete(self._load_queue.join())
+        return AwaitComplete(self, self._load_queue.join())
 
     def reload(self) -> AwaitComplete:
         """Reload the `DirectoryTree` contents.

--- a/tests/css/test_screen_css.py
+++ b/tests/css/test_screen_css.py
@@ -210,7 +210,7 @@ async def test_screen_css_switch_screen_type_by_name():
     class MyApp(SwitchBaseApp):
         SCREENS = {"screenwithcss": ScreenWithCSS}
 
-        def key_p(self):
+        async def key_p(self):
             self.switch_screen("screenwithcss")
 
         def key_o(self):

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -5,7 +5,7 @@ import threading
 import pytest
 
 from textual import work
-from textual.app import App, ComposeResult, ScreenStackError
+from textual.app import App, ComposeResult, ScreenError, ScreenStackError
 from textual.events import MouseMove
 from textual.geometry import Offset
 from textual.screen import Screen
@@ -110,7 +110,7 @@ async def test_screens():
     # Check screen stack is empty
     assert app.screen_stack == []
     # Push a screen
-    app.push_screen("screen1")
+    await app.push_screen("screen1")
     # Check it is on the stack
     assert app.screen_stack == [screen1]
     # Check it is current
@@ -119,21 +119,21 @@ async def test_screens():
     assert app.children == (screen1,)
 
     # Switch to another screen
-    app.switch_screen("screen2")
+    await app.switch_screen("screen2")
     # Check it has changed the stack and that it is current
     assert app.screen_stack == [screen2]
     assert app.screen is screen2
     assert app.children == (screen2,)
 
     # Push another screen
-    app.push_screen("screen3")
+    await app.push_screen("screen3")
     assert app.screen_stack == [screen2, screen3]
     assert app.screen is screen3
     # Only the current screen is in children
     assert app.children == (screen3,)
 
     # Pop a screen
-    assert app.pop_screen() is screen3
+    await app.pop_screen()
     assert app.screen is screen2
     assert app.screen_stack == [screen2]
 
@@ -293,14 +293,16 @@ async def test_auto_focus_skips_non_focusable_widgets():
 async def test_dismiss_non_top_screen():
     class MyApp(App[None]):
         async def key_p(self) -> None:
-            self.bottom, top = Screen(), Screen()
+            self.bottom = Screen()
+            top = Screen()
             await self.push_screen(self.bottom)
             await self.push_screen(top)
 
     app = MyApp()
     async with app.run_test() as pilot:
         await pilot.press("p")
-        assert not app.bottom.dismiss()
+        with pytest.raises(ScreenError):
+            await app.bottom.dismiss()
 
 
 async def test_dismiss_action():


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/4668

The problem was that removing screens was concurrent, which could cause issues if you do it fast. This change prevents overlapping of these tasks.