### PR TITLE
Fix deadlock between node removal and closing the app

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3412,6 +3412,12 @@ class App(Generic[ReturnType], DOMNode):
                 finished_event: Event to set when complete.
             """
             try:
+                if not self._running:
+                    # It does not make sense to remove nodes if we are
+                    # closing the whole application. This also prevents
+                    # a deadlock on `self._dom_lock`, which
+                    # `self._prune_nodes` would try to acquire.
+                    return
                 await self._prune_nodes(widgets)
             finally:
                 finished_event.set()


### PR DESCRIPTION
There is a deadlock issue on `App._dom_lock`, where `_close_all` holds the lock and waits for the task associated with a message pump, but that task may be executing a "called-next" `_prune_nodes` call driven by an `AwaitRemove` which was triggered, for example, by the `Footer.recompose` call from handling the `bindings_updated` signal. This deadlock leads to a `TimeoutError` on app close.

We fix this by omitting the call to `_prune_nodes` in the `AwaitRemove` task if the whole application is already closing; it does not make sense to remove individual nodes in this case anyway.

Fixes #4677


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
