### PR TITLE
test(bindings): add regression test for #4382

### DIFF
--- a/tests/snapshot_tests/snapshot_apps/bindings_screen_overrides_show.py
+++ b/tests/snapshot_tests/snapshot_apps/bindings_screen_overrides_show.py
@@ -1,0 +1,29 @@
+from textual.app import App, ComposeResult
+from textual.screen import Screen
+from textual.binding import Binding
+from textual.widgets import Footer
+
+
+class ShowBindingScreen(Screen):
+    BINDINGS = [
+        Binding("p", "app.pop_screen", "Binding shown"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Footer()
+
+
+class HideBindingApp(App):
+    """Regression test for https://github.com/Textualize/textual/issues/4382"""
+
+    BINDINGS = [
+        Binding("p", "app.pop_screen", "Binding hidden", show=False),
+    ]
+
+    def on_mount(self) -> None:
+        self.push_screen(ShowBindingScreen())
+
+
+if __name__ == "__main__":
+    app = HideBindingApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1294,3 +1294,8 @@ def test_grid_auto(snap_compare):
     """Test grid with keyline and auto-dimension."""
     # https://github.com/Textualize/textual/issues/4678
     assert snap_compare(SNAPSHOT_APPS_DIR / "grid_auto.py")
+
+
+def test_bindings_screen_overrides_show(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/4382"""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "bindings_screen_overrides_show.py")


### PR DESCRIPTION
This adds a regression test for #4382, where the visibility of bindings in the app should be overridden by bindings defined on a screen.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
