### PR TITLE
fix(tabs): disabled tab not activated by clicking underline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.72.0] - 2024-07-09
+## Unreleased
 
 ### Fixed
 
 - Fixed issue with `Tabs` where disabled tabs could still be activated by clicking the underline https://github.com/Textualize/textual/issues/4701
+
+## [0.72.0] - 2024-07-09
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed issue with `Tabs` where a disabled tab could still be activated by clicking the underline https://github.com/Textualize/textual/issues/4701
+
 ## [0.71.0] - 2024-06-29
 
 ### Changed

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -673,7 +673,7 @@ class Tabs(Widget, can_focus=True):
         offset = event.offset + (0, -1)
         self.focus()
         for tab in self.query(Tab):
-            if offset in tab.region:
+            if offset in tab.region and not tab.disabled:
                 self._activate_tab(tab)
                 break
 

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -491,3 +491,22 @@ async def test_mouse_navigation_messages():
             "on_tabs_tab_activated",
             "on_tabs_tab_activated",
         ]
+
+
+async def test_disabled_tab_is_not_activated_by_clicking_underline():
+    """Regression test for https://github.com/Textualize/textual/issues/4701"""
+
+    class DisabledTabApp(App):
+        def compose(self) -> ComposeResult:
+            yield Tabs(
+                Tab("Enabled", id="enabled"),
+                Tab("Disabled", id="disabled", disabled=True),
+            )
+
+    app = DisabledTabApp()
+    async with app.run_test() as pilot:
+        # Click the underline beneath the disabled tab
+        await pilot.click(Tabs, offset=(14, 2))
+        tabs = pilot.app.query_one(Tabs)
+        assert tabs.active_tab is not None
+        assert tabs.active_tab.id == "enabled"


### PR DESCRIPTION
Fixes #4701.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
