### PR TITLE
fix for publish when shutting down

### DIFF
--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -775,7 +775,7 @@ class Screen(Generic[ScreenResultType], Widget):
         finally:
             if self._bindings_updated:
                 self._bindings_updated = False
-                self.app.call_later(self.bindings_updated_signal.publish, self)
+                self.bindings_updated_signal.publish(self)
 
     def _compositor_refresh(self) -> None:
         """Perform a compositor refresh."""

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -108,7 +108,7 @@ class Signal(Generic[SignalT]):
 
         """
         # Don't publish if the DOM is not ready or shutting down
-        if not self._owner.is_attached or not self._owner.app._exit:
+        if not self._owner.is_attached or self._owner.app._exit:
             return
         for ancestor_node in self._owner.ancestors_with_self:
             if not ancestor_node.is_running:

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -108,7 +108,7 @@ class Signal(Generic[SignalT]):
 
         """
         # Don't publish if the DOM is not ready or shutting down
-        if not self._owner.is_attached:
+        if not self._owner.is_attached or not self._owner.app._exit:
             return
         for ancestor_node in self._owner.ancestors_with_self:
             if not ancestor_node.is_running:


### PR DESCRIPTION
Fix an issue with shutdown, in the Memray test suite.

This does appear to fix the following issue, but likely not the final fix for deadlocking.

https://github.com/Textualize/textual/issues/4699