### PR TITLE
fix(option list): fix scrolling with multiline options

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -20,7 +20,7 @@ from ..scroll_view import ScrollView
 from ..strip import Strip
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing_extensions import Self, TypeAlias
 
 
 class DuplicateID(Exception):

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -357,10 +357,10 @@ class OptionList(ScrollView, can_focus=True):
                     )
                 )
 
+                self._spans.append(OptionLineSpan(len(self._lines), height))
                 self._lines.extend(
                     (option_index, y_offset) for y_offset in range(height)
                 )
-                self._spans.append(OptionLineSpan(option_index, height))
                 option_index += 1
             else:
                 self._lines.append(OptionLineSpan(-1, 0))

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1294,3 +1294,8 @@ def test_grid_auto(snap_compare):
     """Test grid with keyline and auto-dimension."""
     # https://github.com/Textualize/textual/issues/4678
     assert snap_compare(SNAPSHOT_APPS_DIR / "grid_auto.py")
+
+
+def test_option_list_scrolling_with_multiline_options(snap_compare):
+    # https://github.com/Textualize/textual/issues/4705
+    assert snap_compare(WIDGET_EXAMPLES_DIR / "option_list_tables.py", press=["up"])


### PR DESCRIPTION
The recent changes to the `OptionList` widget unfortunately have broken scrolling where options span multiple lines.

For example, try scrolling the [option of tables example in the docs](https://textual.textualize.io/widgets/option_list/#options-as-rich-renderables) using the up/down keys. This is also the cause of the `CommandPalette` issues described in #4705.

The `OptionList` had quite a overhaul with the recent update, so I'm creating this PR as only a draft for now. If I have understood the changes correctly, I'm not sure the "line position for the start of the option" is correctly tracked here?

https://github.com/Textualize/textual/blob/37f0f26f1c9380a9fe45866dd383005686df7839/src/textual/widgets/_option_list.py#L363-L364

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
