### PR TITLE
feat(widget): add scrollable_size property

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1636,6 +1636,15 @@ class Widget(DOMNode):
         return self.content_region.size
 
     @property
+    def scrollable_size(self) -> Size:
+        """The size of the scrollable content.
+
+        Returns:
+            Scrollable content size.
+        """
+        return self.scrollable_content_region.size
+
+    @property
     def outer_size(self) -> Size:
         """The size of the widget (including padding and border).
 


### PR DESCRIPTION
Closes #2175. 

`self.scrollable_content_region.size` is bit verbose!

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
