### PR TITLE
Don't sort "discover" items in the command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- "Discover" hits in the command palette are no longer sorted alphabetically https://github.com/Textualize/textual/pull/4720
+
 ## [0.72.0] - 2024-07-09
 
 ### Changed

--- a/docs/guide/command_palette.md
+++ b/docs/guide/command_palette.md
@@ -113,7 +113,6 @@ this is to aid in command discoverability.
 
 - `discover` accepts no parameters (instead of the search value)
 - `discover` yields instances of [`DiscoveryHit`][textual.command.DiscoveryHit] (instead of instances of [`Hit`][textual.command.Hit])
-- discovery hits are sorted in ascending alphabetical order because there is no matching and no match score is generated
 
 Instances of [`DiscoveryHit`][textual.command.DiscoveryHit] contain information about how the hit should be displayed, an optional help string, and a callback which will be run if the user selects that command.
 

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -865,7 +865,7 @@ class CommandPalette(SystemModalScreen[CallbackType]):
             clear_current: Should the current content of the list be cleared first?
         """
         # For the moment, this is a fairly naive approach to populating the
-        # command list with a sorted list of commands. Every time we add a
+        # command list with a list of commands. Every time we add a
         # new one we're nuking the list of options and populating them
         # again. If this turns out to not be a great approach, we may try
         # and get a lot smarter with this (ideally OptionList will grow a
@@ -876,7 +876,7 @@ class CommandPalette(SystemModalScreen[CallbackType]):
             if command_list.highlighted is not None and not clear_current
             else None
         )
-        command_list.clear_options().add_options(sorted(commands, reverse=True))
+        command_list.clear_options().add_options(commands)
         if highlighted is not None and highlighted.id:
             command_list.highlighted = command_list.get_option_index(highlighted.id)
         self._list_visible = bool(command_list.option_count)

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1188,7 +1188,7 @@ def test_example_color_command(snap_compare):
     """Test the color_command example."""
     assert snap_compare(
         EXAMPLES_DIR / "color_command.py",
-        press=["ctrl+backslash", "r", "e", "d", "down", "down", "enter"],
+        press=["ctrl+backslash", "r", "e", "d", "down", "enter"],
     )
 
 
@@ -1300,7 +1300,7 @@ def test_option_list_scrolling_with_multiline_options(snap_compare):
     # https://github.com/Textualize/textual/issues/4705
     assert snap_compare(WIDGET_EXAMPLES_DIR / "option_list_tables.py", press=["up"])
 
+
 def test_bindings_screen_overrides_show(snap_compare):
     """Regression test for https://github.com/Textualize/textual/issues/4382"""
     assert snap_compare(SNAPSHOT_APPS_DIR / "bindings_screen_overrides_show.py")
-


### PR DESCRIPTION
I think it's reasonable to give the user control over the order of items displayed in the command palette when it's first opened (I want to group related commands).

If they want to sort, they can easily call `sorted` themselves.

Closes https://github.com/Textualize/textual/issues/4705 (fixes the final bullet point - the other problems are already resolved as of `0.72.0`)