### PR TITLE
mutate reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `TextArea.line_number_start` reactive attribute https://github.com/Textualize/textual/pull/4471
+- Added `DOMNode.mutate_reactive`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `TextArea.line_number_start` reactive attribute https://github.com/Textualize/textual/pull/4471
-- Added `DOMNode.mutate_reactive`
+- Added `DOMNode.mutate_reactive` https://github.com/Textualize/textual/pull/4731
 
 ### Fixed
 

--- a/docs/examples/guide/reactivity/set_reactive03.py
+++ b/docs/examples/guide/reactivity/set_reactive03.py
@@ -1,0 +1,21 @@
+from textual.app import App, ComposeResult
+from textual.reactive import reactive
+from textual.widgets import Input, Label
+
+
+class MultiGreet(App):
+    names: reactive[list[str]] = reactive(list, recompose=True)  # (1)!
+
+    def compose(self) -> ComposeResult:
+        yield Input(placeholder="Give me a name")
+        for name in self.names:
+            yield Label(f"Hello, {name}")
+
+    def on_input_submitted(self, event: Input.Changed) -> None:
+        self.names.append(event.value)
+        self.mutate_reactive(MultiGreet.names)  # (2)!
+
+
+if __name__ == "__main__":
+    app = MultiGreet()
+    app.run()

--- a/docs/guide/reactivity.md
+++ b/docs/guide/reactivity.md
@@ -383,6 +383,13 @@ The following app contains a fix for this issue:
 
 The line `self.set_reactive(Greeter.greeting, greeting)` sets the `greeting` attribute but doesn't immediately invoke the watcher.
 
+## Mutable reactives
+
+Textual can detect when you set a reactive to a new value, but it can't detect when you _mutate_ a value.
+In practice, this means that Textual can detect changes to basic types (int, float, str, etc.), but not if you update a collection, such as a list or dict. 
+
+You can still use collections and other mutable objects in reactives, but you will need to call [`mutate_reactive`][textual.dom.DOMNode.mutate_reactive] after making changes for the reactive superpowers to work.
+
 ## Data binding
 
 Reactive attributes from one widget may be *bound* (connected) to another widget, so that changes to a single reactive will automatically update another widget (potentially more than one).

--- a/docs/guide/reactivity.md
+++ b/docs/guide/reactivity.md
@@ -390,6 +390,24 @@ In practice, this means that Textual can detect changes to basic types (int, flo
 
 You can still use collections and other mutable objects in reactives, but you will need to call [`mutate_reactive`][textual.dom.DOMNode.mutate_reactive] after making changes for the reactive superpowers to work.
 
+Here's an example, that uses a reactive list:
+
+=== "set_reactive03.py"
+
+    ```python hl_lines="16"
+    --8<-- "docs/examples/guide/reactivity/set_reactive03.py"
+    ```
+
+    1. Creates a reactive list of strings.
+    2. Explicitly mutate the reactive list.
+
+=== "Output"
+
+    ```{.textual path="docs/examples/guide/reactivity/set_reactive03.py" press="W,i,l,l,enter"}
+    ```
+
+Note the call to `mutate_reactive`. Without it, the display would not update when a new name is appended to the list.
+
 ## Data binding
 
 Reactive attributes from one widget may be *bound* (connected) to another widget, so that changes to a single reactive will automatically update another widget (potentially more than one).

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -258,7 +258,7 @@ class DOMNode(MessagePump):
 
         internal_name = f"_reactive_{reactive.name}"
         value = getattr(self, internal_name)
-        reactive._set(self, value)
+        reactive._set(self, value, always=True)
 
     def data_bind(
         self,

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -237,6 +237,19 @@ class DOMNode(MessagePump):
             )
         setattr(self, f"_reactive_{reactive.name}", value)
 
+    def mutate_reactive(self, reactive: Reactive[ReactiveType]) -> None:
+        """Force an update to a mutable reactive.
+
+        This will invoke any associated watchers.
+
+        Args:
+            reactive (_type_): _description_
+        """
+
+        internal_name = f"_reactive_{reactive.name}"
+        value = getattr(self, internal_name)
+        reactive._set(self, value)
+
     def data_bind(
         self,
         *reactives: Reactive[Any],

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -247,7 +247,7 @@ class DOMNode(MessagePump):
             ```
 
         Textual will automatically detect when a reactive is set to a new value, but it is unable
-        to detect if a value is _mutated_ (such as updating a list, dict, or attribute of an).
+        to detect if a value is _mutated_ (such as updating a list, dict, or attribute of an object).
         If you do wish to use a collection or other mutable object in a reactive, then you can call
         this method after your reactive is updated. This will ensure that all the reactive _superpowers_
         work.

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -221,7 +221,7 @@ class DOMNode(MessagePump):
             ```
 
         Args:
-            name: Name of reactive attribute.
+            reactive: A reactive property (use the class scope syntax, i.e. `MyClass.my_reactive`).
             value: New value of reactive.
 
         Raises:
@@ -240,10 +240,20 @@ class DOMNode(MessagePump):
     def mutate_reactive(self, reactive: Reactive[ReactiveType]) -> None:
         """Force an update to a mutable reactive.
 
-        This will invoke any associated watchers.
+        Example:
+            ```python
+            self.reactive_name_list.append("Jessica")
+            self.mutate_reactive(MyClass.reactive_name_list)
+            ```
+
+        Textual will automatically detect when a reactive is set to a new value, but it is unable
+        to detect if a value is _mutated_ (such as updating a list, dict, or attribute of an).
+        If you do wish to use a collection or other mutable object in a reactive, then you can call
+        this method after your reactive is updated. This will ensure that all the reactive _superpowers_
+        work.
 
         Args:
-            reactive (_type_): _description_
+            reactive: A reactive property (use the class scope syntax, i.e. `MyClass.my_reactive`).
         """
 
         internal_name = f"_reactive_{reactive.name}"

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -298,8 +298,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
             `True` if the message will be sent, or `False` if it is disabled.
         """
 
-        enabled = type(message) not in self._disabled_messages
-        return enabled
+        return type(message) not in self._disabled_messages
 
     def disable_messages(self, *messages: type[Message]) -> None:
         """Disable message types from being processed."""

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -287,7 +287,7 @@ class Reactive(Generic[ReactiveType]):
         if callable(public_validate_function):
             value = public_validate_function(value)
         # If the value has changed, or this is the first time setting the value
-        if always or current_value != value or self._always_update:
+        if always or self._always_update or current_value != value:
             # Store the internal value
             setattr(obj, self.internal_name, value)
 

--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -262,7 +262,7 @@ class Reactive(Generic[ReactiveType]):
         else:
             return getattr(obj, internal_name)
 
-    def __set__(self, obj: Reactable, value: ReactiveType) -> None:
+    def _set(self, obj: Reactable, value: ReactiveType, always: bool = False) -> None:
         _rich_traceback_omit = True
 
         if not hasattr(obj, "_id"):
@@ -287,7 +287,7 @@ class Reactive(Generic[ReactiveType]):
         if callable(public_validate_function):
             value = public_validate_function(value)
         # If the value has changed, or this is the first time setting the value
-        if current_value != value or self._always_update:
+        if always or current_value != value or self._always_update:
             # Store the internal value
             setattr(obj, self.internal_name, value)
 
@@ -307,6 +307,11 @@ class Reactive(Generic[ReactiveType]):
                     layout=self._layout,
                     recompose=self._recompose,
                 )
+
+    def __set__(self, obj: Reactable, value: ReactiveType) -> None:
+        _rich_traceback_omit = True
+
+        self._set(obj, value)
 
     @classmethod
     def _check_watchers(cls, obj: Reactable, name: str, old_value: Any) -> None:


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/3245

- Added a `mutate_reactive` method to explicitly invoke watchers etc. Required for mutable objects / containers in reactives.
- Some micro-optimizations involved in posting messages.
