### PR TITLE
Reorder reactive comparison to short-circuit uncomparable types

### DIFF
--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -287,7 +287,7 @@ class Reactive(Generic[ReactiveType]):
         if callable(public_validate_function):
             value = public_validate_function(value)
         # If the value has changed, or this is the first time setting the value
-        if current_value != value or self._always_update:
+        if self._always_update or current_value != value:
             # Store the internal value
             setattr(obj, self.internal_name, value)
 


### PR DESCRIPTION
If `always_update`, dont attempt to compare new vs old.  Useful for types with cannot be compared or have otherwise complicated comparison logic that the user has indicated is unnecessary for the `reactive` instance