### PR TITLE
Fix off-by-2 calculation in horizontal scrolling of Tree & DirectoryTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with `Tabs` where disabled tabs could still be activated by clicking the underline https://github.com/Textualize/textual/issues/4701
 - Fixed scroll_visible with margin https://github.com/Textualize/textual/pull/4719
 - Fixed programmatically disabling button stuck in hover state https://github.com/Textualize/textual/pull/4724
-- Fixed `Tree` and `DirectoryTree` horizontal scrolling off-by-2
+- Fixed `Tree` and `DirectoryTree` horizontal scrolling off-by-2 https://github.com/Textualize/textual/pull/4744
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with `Tabs` where disabled tabs could still be activated by clicking the underline https://github.com/Textualize/textual/issues/4701
 - Fixed scroll_visible with margin https://github.com/Textualize/textual/pull/4719
 - Fixed programmatically disabling button stuck in hover state https://github.com/Textualize/textual/pull/4724
+- Fixed `Tree` and `DirectoryTree` horizontal scrolling off-by-2
 
 ### Changed
 

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -70,13 +70,13 @@ class _TreeLine(Generic[TreeDataType]):
             Width in cells.
         """
         if show_root:
-            return 2 + (max(0, len(self.path) - 1)) * guide_depth
+            width = (max(0, len(self.path) - 1)) * guide_depth
         else:
-            guides = 2
+            width = 0
             if len(self.path) > 1:
-                guides += (len(self.path) - 1) * guide_depth
+                width += (len(self.path) - 1) * guide_depth
 
-        return guides
+        return width
 
 
 class TreeNodes(ImmutableSequenceView["TreeNode[TreeDataType]"]):


### PR DESCRIPTION
Fixes #4741.

I think the addition of the two was something to account for the emojis in the directory tree - however, it broke tree scrolling.

Also, it seems it caused an additional 2 blank cells on the right side of the tree widget.

I've tested the fix here with Tree and DirectoryTree, with show_root=True and show_root=False.

It's a visual thing, but not sure it warrants a new snapshot test.