### PR TITLE
Fix wrong axis in HorizontalScroll docstring.

### DIFF
--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -106,7 +106,7 @@ class Horizontal(Widget, inherit_bindings=False):
 
 
 class HorizontalScroll(ScrollableContainer):
-    """A container with horizontal layout and an automatic scrollbar on the Y axis."""
+    """A container with horizontal layout and an automatic scrollbar on the X axis."""
 
     DEFAULT_CSS = """
     HorizontalScroll {


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
