### PR TITLE
SelectionList events changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Tree` and `DirectoryTree` horizontal scrolling off-by-2 https://github.com/Textualize/textual/pull/4744
 - Fixed text-opacity in component styles https://github.com/Textualize/textual/pull/4747
 - Ensure `Tree.select_node` sends `NodeSelected` message https://github.com/Textualize/textual/pull/4753
+- `SelectionList.SelectionToggled` will now be sent for each option when a bulk toggle is performed (e.g. `toggle_all`). Previously no messages were sent at all. https://github.com/Textualize/textual/pull/4759
 
 ### Changed
 

--- a/tests/selection_list/test_selection_messages.py
+++ b/tests/selection_list/test_selection_messages.py
@@ -101,6 +101,16 @@ async def test_toggle_all() -> None:
         await pilot.pause()
         assert pilot.app.messages == [
             ("SelectionHighlighted", 0),
+            ("SelectionToggled", 0),
+            ("SelectionToggled", 1),
+            ("SelectionToggled", 2),
+            ("SelectionToggled", 3),
+            ("SelectionToggled", 4),
+            ("SelectionToggled", 5),
+            ("SelectionToggled", 6),
+            ("SelectionToggled", 7),
+            ("SelectionToggled", 8),
+            ("SelectionToggled", 9),
             ("SelectedChanged", None),
         ]
 


### PR DESCRIPTION
Ensures "Toggled" events are sent when bulk toggling via the API occurs.

Also explicitly defines semantics of "toggled" vs "changed" in the docstrings.

Toggled events only fire when the value is explicitly toggled via user interaction or a toggle method. Setting a value programmatically to a value that happens to be the opposite of the current value is not considered a "toggle", although it is considered a "change".
