### PR TITLE
Add `TextArea.matching_bracket_location` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `TextArea.line_number_start` reactive attribute https://github.com/Textualize/textual/pull/4471
+- Added `TextArea.line_number_start` reactive attribute https://github.com/Textualize/textual/pull/4471
+- Added `TextArea.matching_bracket_location` property https://github.com/Textualize/textual/pull/4764
 - Added `DOMNode.mutate_reactive` https://github.com/Textualize/textual/pull/4731
 - Added "quality" parameter to `textual.color.Gradient` https://github.com/Textualize/textual/pull/4739
 - Added `textual.color.Gradient.get_rich_color` https://github.com/Textualize/textual/pull/4739

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -645,6 +645,7 @@ TextArea {
         match_location = None
         bracket_stack: list[str] = []
         if bracket in _OPENING_BRACKETS:
+            # Search forwards for a closing bracket
             for candidate, candidate_location in self._yield_character_locations(
                 search_from
             ):
@@ -660,6 +661,7 @@ TextArea {
                             match_location = candidate_location
                             break
         elif bracket in _CLOSING_BRACKETS:
+            # Search backwards for an opening bracket
             for (
                 candidate,
                 candidate_location,
@@ -1252,6 +1254,11 @@ TextArea {
         """The text between the start and end points of the current selection."""
         start, end = self.selection
         return self.get_text_range(start, end)
+
+    @property
+    def matching_bracket_location(self) -> Location | None:
+        """The location of the matching bracket, if there is one."""
+        return self._matching_bracket_location
 
     def get_text_range(self, start: Location, end: Location) -> str:
         """Get the text between a start and end location.


### PR DESCRIPTION
This exists as a private attribute but it can be useful when interacting with the text area, so it adds a public property for accessing it.