### PR TITLE
Fix public exports of TabbedContent

### DIFF
--- a/src/textual/widgets/tabbed_content.py
+++ b/src/textual/widgets/tabbed_content.py
@@ -1,0 +1,6 @@
+from ._tabbed_content import ContentTab, ContentTabs
+
+__all__ = [
+    "ContentTab",
+    "ContentTabs",
+]


### PR DESCRIPTION
Ensures `ContentTab` and `ContentTabs` are exported, as they may be something the user wishes to interact with and right now there is no way to do so without going via a private module.