### PR TITLE
Ensure hover effect doesnt linger when mouse leaves Tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `TreeNodeSelected` messages are now posted before `TreeNodeExpanded` messages
 when an expandable node is selected https://github.com/Textualize/textual/pull/4753
 - `Markdown.LinkClicked.href` is now automatically unquoted https://github.com/Textualize/textual/pull/4749
+- The mouse cursor hover effect of `Tree` and `DirectoryTree` will no longer linger after the mouse leaves the widget https://github.com/Textualize/textual/pull/4766
 
 
 ## [0.72.0] - 2024-07-09

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -839,6 +839,10 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         else:
             self.hover_line = -1
 
+    def _on_leave(self, _: events.Leave) -> None:
+        # Ensure the hover effect doesn't linger after the mouse leaves.
+        self.hover_line = -1
+
     def _new_id(self) -> NodeID:
         """Create a new node ID.
 


### PR DESCRIPTION
When you interact with the tree using the mouse cursor and then move the mouse away, the hover effect remained.

This ensures the hover effect only applies when the mouse cursor is actually over the tree.

This was confusing as there was some extra highlighting taking place that was essentially meaningless.