### PR TITLE
Fix styles not updating when a widget is blurred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed message handlers not working when message types are assigned as the value of class vars https://github.com/Textualize/textual/pull/3940
 - Fixed `CommandPalette` not focusing the input when opened when `App.AUTO_FOCUS` doesn't match the input https://github.com/Textualize/textual/pull/4763
 - `SelectionList.SelectionToggled` will now be sent for each option when a bulk toggle is performed (e.g. `toggle_all`). Previously no messages were sent at all. https://github.com/Textualize/textual/pull/4759
+- Fixed focus styles not being updated on blur https://github.com/Textualize/textual/pull/4771
 
 ### Changed
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -705,8 +705,8 @@ class Screen(Generic[ScreenResultType], Widget):
             # No focus, so blur currently focused widget if it exists
             if self.focused is not None:
                 self.focused.post_message(events.Blur())
-                self.focused = None
                 blurred = self.focused
+                self.focused = None
             self.log.debug("focus was removed")
         elif widget.focusable:
             if self.focused != widget:


### PR DESCRIPTION
When focus is removed, the widget that was blurred was not being recorded correctly.

As a result, the styling of the blurred widget wasn't being updated.
