### PR TITLE
fix: disable kitty keyboard before leaving alt screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed issues in Kitty terminal after exiting app https://github.com/Textualize/textual/issues/4779
+
 ## [0.73.0] - 2024-07-18
 
 ### Added

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -336,13 +336,13 @@ class LinuxDriver(Driver):
             except termios.error:
                 pass
 
+        # Disable the Kitty keyboard protocol. This must be done before leaving
+        # the alt screen. https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+        self.write("\x1b[<u")
         # Alt screen false, show cursor
         self.write("\x1b[?1049l")
         self.write("\x1b[?25h")
         self.write("\x1b[?1004l")  # Disable FocusIn/FocusOut.
-        self.write(
-            "\x1b[<u"
-        )  # Disable https://sw.kovidgoyal.net/kitty/keyboard-protocol/
         self.flush()
 
     def close(self) -> None:


### PR DESCRIPTION
Fixes #4779.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
