### PR TITLE
run commands regardless of the bindings checking order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed issues in Kitty terminal after exiting app https://github.com/Textualize/textual/issues/4779
+- Fixed `Footer` items not being clickable when their `priority` is set to `True`
 
 ## [0.73.0] - 2024-07-18
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3048,7 +3048,7 @@ class App(Generic[ReturnType], DOMNode):
             else self.screen._modal_binding_chain
         ):
             binding = bindings.keys.get(key)
-            if binding is not None and binding.priority == priority:
+            if binding is not None:
                 if await self.run_action(binding.action, namespace):
                     return True
         return False


### PR DESCRIPTION
Currently, when a `Binding` is marked with `priority=True`, it isn't clickable with the mouse because `_check_bindings` will only run un-prioritized bindings. This removes the check and runs actions regardless of their priority status. I'm not sure why this check was there to begin with honestly, so hopefully I'm not breaking anything else.

- [x] Updated CHANGELOG.md (where appropriate)
