### PR TITLE
allow None in Screen callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues in Kitty terminal after exiting app https://github.com/Textualize/textual/issues/4779
 - Fixed exception when removing Selects https://github.com/Textualize/textual/pull/4786
 
+### Changed
+
+- Calling `Screen.dismiss` with no arguments, will invoke the screen callback with `None` (previously the callback wasn't invoke at all). https://github.com/Textualize/textual/pull/4795
+
 ## [0.73.0] - 2024-07-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Calling `Screen.dismiss` with no arguments, will invoke the screen callback with `None` (previously the callback wasn't invoke at all). https://github.com/Textualize/textual/pull/4795
+- Calling `Screen.dismiss` with no arguments will invoke the screen callback with `None` (previously the callback wasn't invoke at all). https://github.com/Textualize/textual/pull/4795
 
 ## [0.73.0] - 2024-07-18
 

--- a/docs/examples/guide/screens/modal03.py
+++ b/docs/examples/guide/screens/modal03.py
@@ -44,7 +44,7 @@ class ModalApp(App):
     def action_request_quit(self) -> None:
         """Action to display the quit dialog."""
 
-        def check_quit(quit: bool) -> None:
+        def check_quit(quit: bool | None) -> None:
             """Called when QuitScreen is dismissed."""
             if quit:
                 self.exit()

--- a/src/textual/_debug.py
+++ b/src/textual/_debug.py
@@ -1,5 +1,5 @@
 """
-Function related to debugging.
+Functions related to debugging.
 """
 
 from . import constants

--- a/src/textual/_debug.py
+++ b/src/textual/_debug.py
@@ -2,6 +2,8 @@
 Functions related to debugging.
 """
 
+from __future__ import annotations
+
 from . import constants
 
 
@@ -11,10 +13,11 @@ def get_caller_file_and_line() -> str | None:
     Returns:
         Path and file if `constants.DEBUG==True`
     """
-    import inspect
 
     if not constants.DEBUG:
         return None
+    import inspect
+
     try:
         current_frame = inspect.currentframe()
         caller_frame = inspect.getframeinfo(current_frame.f_back.f_back)

--- a/src/textual/_debug.py
+++ b/src/textual/_debug.py
@@ -1,0 +1,23 @@
+"""
+Function related to debugging.
+"""
+
+from . import constants
+
+
+def get_caller_file_and_line() -> str | None:
+    """Get the caller filename and line, if in debug mode, otherwise return `None`:
+
+    Returns:
+        Path and file if `constants.DEBUG==True`
+    """
+    import inspect
+
+    if not constants.DEBUG:
+        return None
+    try:
+        current_frame = inspect.currentframe()
+        caller_frame = inspect.getframeinfo(current_frame.f_back.f_back)
+        return f"{caller_frame.filename}:{caller_frame.lineno}"
+    except Exception:
+        return None

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3599,7 +3599,7 @@ class App(Generic[ReturnType], DOMNode):
     def action_command_palette(self) -> None:
         """Show the Textual command palette."""
         if self.use_command_palette and not CommandPalette.is_open(self):
-            self.push_screen(CommandPalette(), callback=self.call_next)
+            self.push_screen(CommandPalette())
 
     def _suspend_signal(self) -> None:
         """Signal that the application is being suspended."""

--- a/src/textual/await_complete.py
+++ b/src/textual/await_complete.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Awaitable, Generator
 import rich.repr
 from typing_extensions import Self
 
+from textual._inspection import get_caller_file_and_line
+
 from .message_pump import MessagePump
 
 if TYPE_CHECKING:
@@ -27,10 +29,12 @@ class AwaitComplete:
         self._awaitables = awaitables
         self._future: Future[Any] = gather(*awaitables)
         self._pre_await: CallbackType | None = pre_await
+        self._caller = get_caller_file_and_line()
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield self._awaitables
         yield "pre_await", self._pre_await, None
+        yield "caller", self._caller, None
 
     def set_pre_await_callback(self, pre_await: CallbackType | None) -> None:
         """Set a callback to run prior to awaiting.

--- a/src/textual/await_complete.py
+++ b/src/textual/await_complete.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Generator
 import rich.repr
 from typing_extensions import Self
 
-from textual._inspection import get_caller_file_and_line
-
+from ._debug import get_caller_file_and_line
 from .message_pump import MessagePump
 
 if TYPE_CHECKING:

--- a/src/textual/await_remove.py
+++ b/src/textual/await_remove.py
@@ -8,10 +8,14 @@ import asyncio
 from asyncio import Task, gather
 from typing import Generator
 
+import rich.repr
+
 from ._callback import invoke
+from ._debug import get_caller_file_and_line
 from ._types import CallbackType
 
 
+@rich.repr.auto
 class AwaitRemove:
     """An awaitable that waits for nodes to be removed."""
 
@@ -20,6 +24,12 @@ class AwaitRemove:
     ) -> None:
         self._tasks = tasks
         self._post_remove = post_remove
+        self._caller = get_caller_file_and_line()
+
+    def __rich_repr__(self) -> rich.repr.Result:
+        yield "tasks", self._tasks
+        yield "post_remove", self._post_remove
+        yield "caller", self._caller, None
 
     async def __call__(self) -> None:
         await self

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -39,7 +39,7 @@ from .message import Message
 from .reactive import var
 from .screen import Screen, SystemModalScreen
 from .timer import Timer
-from .types import CallbackType, IgnoreReturnCallbackType
+from .types import IgnoreReturnCallbackType
 from .widget import Widget
 from .widgets import Button, Input, LoadingIndicator, OptionList, Static
 from .widgets.option_list import Option
@@ -419,7 +419,7 @@ class CommandInput(Input):
     """
 
 
-class CommandPalette(SystemModalScreen[CallbackType]):
+class CommandPalette(SystemModalScreen):
     """The Textual command palette."""
 
     AUTO_FOCUS = "CommandInput"
@@ -1079,7 +1079,8 @@ class CommandPalette(SystemModalScreen[CallbackType]):
                 # decide what to do with it (hopefully it'll run it).
                 self._cancel_gather_commands()
                 self.app.post_message(CommandPalette.Closed(option_selected=True))
-                self.dismiss(self._selected_command.command)
+                self.dismiss()
+                self.app.call_later(self._selected_command.command)
 
     @on(OptionList.OptionHighlighted)
     def _stop_event_leak(self, event: OptionList.OptionHighlighted) -> None:

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -1080,7 +1080,7 @@ class CommandPalette(SystemModalScreen):
                 self._cancel_gather_commands()
                 self.app.post_message(CommandPalette.Closed(option_selected=True))
                 self.dismiss()
-                self.app.call_next(self._selected_command.command)
+                self.call_next(self._selected_command.command)
 
     @on(OptionList.OptionHighlighted)
     def _stop_event_leak(self, event: OptionList.OptionHighlighted) -> None:

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -1080,7 +1080,7 @@ class CommandPalette(SystemModalScreen):
                 self._cancel_gather_commands()
                 self.app.post_message(CommandPalette.Closed(option_selected=True))
                 self.dismiss()
-                self.app.call_later(self._selected_command.command)
+                self.app.call_next(self._selected_command.command)
 
     @on(OptionList.OptionHighlighted)
     def _stop_event_leak(self, event: OptionList.OptionHighlighted) -> None:

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -1080,7 +1080,7 @@ class CommandPalette(SystemModalScreen):
                 self._cancel_gather_commands()
                 self.app.post_message(CommandPalette.Closed(option_selected=True))
                 self.dismiss()
-                self.call_next(self._selected_command.command)
+                self.call_later(self._selected_command.command)
 
     @on(OptionList.OptionHighlighted)
     def _stop_event_leak(self, event: OptionList.OptionHighlighted) -> None:

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -618,11 +618,8 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Invoke pending callbacks in next callbacks queue."""
         callbacks = self._next_callbacks.copy()
         self._next_callbacks.clear()
-        from rich import print
 
-        print(callbacks)
         for callback in callbacks:
-            print(callback.callback)
             try:
                 with self.prevent(*callback._prevent):
                     await invoke(callback.callback)

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -446,6 +446,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
             *args: Positional arguments to pass to the callable.
             **kwargs: Keyword arguments to pass to the callable.
         """
+        assert callback is not None, "Callback must not be None"
         callback_message = events.Callback(callback=partial(callback, *args, **kwargs))
         callback_message._prevent.update(self._get_prevented_messages())
         self._next_callbacks.append(callback_message)
@@ -617,7 +618,11 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Invoke pending callbacks in next callbacks queue."""
         callbacks = self._next_callbacks.copy()
         self._next_callbacks.clear()
+        from rich import print
+
+        print(callbacks)
         for callback in callbacks:
+            print(callback.callback)
             try:
                 with self.prevent(*callback._prevent):
                     await invoke(callback.callback)

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -618,7 +618,6 @@ class MessagePump(metaclass=_MessagePumpMeta):
         """Invoke pending callbacks in next callbacks queue."""
         callbacks = self._next_callbacks.copy()
         self._next_callbacks.clear()
-
         for callback in callbacks:
             try:
                 with self.prevent(*callback._prevent):

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -106,7 +106,6 @@ class ResultCallback(Generic[ScreenResultType]):
         Note:
             If the requested or the callback are `None` this will be a no-op.
         """
-        print("callback", self.callback)
         if self.future is not None:
             self.future.set_result(result)
         if self.requester is not None and self.callback is not None:
@@ -1232,7 +1231,7 @@ class Screen(Generic[ScreenResultType], Widget):
     def dismiss(self, result: ScreenResultType | None = None) -> AwaitComplete:
         """Dismiss the screen, optionally with a result.
 
-        Additionally, any callback provided in [push_screen][textual.app.push_screen] will be invoked.
+        Any callback provided in [push_screen][textual.app.push_screen] will be invoked with the supplied result.
 
         Only the active screen may be dismissed. This method will produce a warning in the logs if
         called on an inactive screen (but otherwise have no effect).
@@ -1242,8 +1241,6 @@ class Screen(Generic[ScreenResultType], Widget):
             Textual will raise a [`ScreenError`][textual.app.ScreenError] if you await the return value from a
             message handler on the Screen being dismissed. If you want to dismiss the current screen, you can
             call `self.dismiss()` _without_ awaiting.
-
-        If `result` is not supplied, then the callback will be invoked with `None`.
 
         Args:
             result: The optional result to be passed to the result callback.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -68,7 +68,8 @@ ScreenResultType = TypeVar("ScreenResultType")
 """The result type of a screen."""
 
 ScreenResultCallbackType = Union[
-    Callable[[ScreenResultType], None], Callable[[ScreenResultType], Awaitable[None]]
+    Callable[[ScreenResultType | None], None],
+    Callable[[ScreenResultType | None], Awaitable[None]],
 ]
 """Type of a screen result callback function."""
 
@@ -1244,8 +1245,7 @@ class Screen(Generic[ScreenResultType], Widget):
             message handler on the Screen being dismissed. If you want to dismiss the current screen, you can
             call `self.dismiss()` _without_ awaiting.
 
-        If `result` is provided and a callback was set when the screen was [pushed][textual.app.App.push_screen], then
-        the callback will be invoked with `result`.
+        If `result` is not supplied, then the callback will be invoked with `None`.
 
         Args:
             result: The optional result to be passed to the result callback.
@@ -1255,8 +1255,10 @@ class Screen(Generic[ScreenResultType], Widget):
         if not self.is_active:
             self.log.warning("Can't dismiss inactive screen")
             return AwaitComplete()
-        if result is not self._NoResult and self._result_callbacks:
-            self._result_callbacks[-1](cast(ScreenResultType, result))
+        if self._result_callbacks:
+            self._result_callbacks[-1](
+                cast(ScreenResultType, None if result is self._NoResult else result)
+            )
         await_pop = self.app.pop_screen()
 
         def pre_await() -> None:

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -895,7 +895,7 @@ class Screen(Generic[ScreenResultType], Widget):
             future: A Future to hold the result.
         """
         self._result_callbacks.append(
-            ResultCallback[ScreenResultType | None](requester, callback, future)
+            ResultCallback[Optional[ScreenResultType]](requester, callback, future)
         )
 
     def _pop_result_callback(self) -> None:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -50,9 +50,9 @@ from ._animator import DEFAULT_EASING, Animatable, BoundAnimator, EasingFunction
 from ._arrange import DockArrangeResult, arrange
 from ._compose import compose
 from ._context import NoActiveAppError, active_app
+from ._debug import get_caller_file_and_line
 from ._dispatch_key import dispatch_key
 from ._easing import DEFAULT_SCROLL_EASING
-from ._inspection import get_caller_file_and_line
 from ._layout import Layout
 from ._segment_tools import align_lines
 from ._styles_cache import StylesCache

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -52,6 +52,7 @@ from ._compose import compose
 from ._context import NoActiveAppError, active_app
 from ._dispatch_key import dispatch_key
 from ._easing import DEFAULT_SCROLL_EASING
+from ._inspection import get_caller_file_and_line
 from ._layout import Layout
 from ._segment_tools import align_lines
 from ._styles_cache import StylesCache
@@ -114,6 +115,7 @@ _MOUSE_EVENTS_DISALLOW_IF_DISABLED = (events.MouseEvent, events.Enter, events.Le
 _MOUSE_EVENTS_ALLOW_IF_DISABLED = (events.MouseScrollDown, events.MouseScrollUp)
 
 
+@rich.repr.auto
 class AwaitMount:
     """An *optional* awaitable returned by [mount][textual.widget.Widget.mount] and [mount_all][textual.widget.Widget.mount_all].
 
@@ -126,6 +128,12 @@ class AwaitMount:
     def __init__(self, parent: Widget, widgets: Sequence[Widget]) -> None:
         self._parent = parent
         self._widgets = widgets
+        self._caller = get_caller_file_and_line()
+
+    def __rich_repr__(self) -> rich.repr.Result:
+        yield "parent", self._parent
+        yield "widgets", self._widgets
+        yield "caller", self._caller, None
 
     async def __call__(self) -> None:
         """Allows awaiting via a call operation."""

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -72,7 +72,7 @@ Button {
     def action_request_quit(self) -> None:
         """Action to display the quit dialog."""
 
-        def check_quit(quit: bool) -> None:
+        def check_quit(quit: bool | None) -> None:
             """Called when QuitScreen is dismissed."""
 
             if quit:

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from textual.app import App, ComposeResult
 from textual.containers import Grid
 from textual.screen import ModalScreen

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import sys
 import threading

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -326,6 +326,25 @@ async def test_dismiss_action():
         assert app.bingo
 
 
+async def test_dismiss_action_no_argument():
+    class ConfirmScreen(Screen[bool]):
+        BINDINGS = [("y", "dismiss", "Dismiss")]
+
+    class MyApp(App[None]):
+        bingo = False
+
+        def on_mount(self) -> None:
+            self.push_screen(ConfirmScreen(), callback=self.callback)
+
+        def callback(self, result: bool | None) -> None:
+            self.bingo = result
+
+    app = MyApp()
+    async with app.run_test() as pilot:
+        await pilot.press("y")
+        assert app.bingo is None
+
+
 async def test_switch_screen_no_op():
     """Regression test for https://github.com/Textualize/textual/issues/2650"""
 

--- a/tests/test_unmount.py
+++ b/tests/test_unmount.py
@@ -6,7 +6,7 @@ from textual.containers import Container
 from textual.screen import Screen
 
 
-async def test_unmount():
+async def test_unmount() -> None:
     """Test unmount events are received in reverse DOM order."""
     unmount_ids: list[str] = []
 


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/4790

Previously, calling `Screen.dismiss` with no arguments would not call the Screen callback. Now, it will call the callback with a `None` argument.

This feels like a more sensible default, as the dev can decide what to do with the screen result.