### PR TITLE
improve simulate key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed issues in Kitty terminal after exiting app https://github.com/Textualize/textual/issues/4779
 - Fixed exception when removing Selects https://github.com/Textualize/textual/pull/4786
+- Fixed issue with non-clickable Footer keys https://github.com/Textualize/textual/pull/4798
 
 ## [0.73.0] - 2024-07-18
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3029,7 +3029,14 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             key: Key to simulate. May also be the name of a key, e.g. "space".
         """
-        self.call_later(self._check_bindings, key)
+        event = events.Key(key, None)
+        self.post_message(event)
+
+        # async def dispatch_simulated_key() -> None:
+        #     if not (await self._check_bindings(event.key, priority=True)):
+        #         await dispatch_key(self, event)
+
+        # self.call_later(dispatch_simulated_key)
 
     async def _check_bindings(self, key: str, priority: bool = False) -> bool:
         """Handle a key press.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3029,14 +3029,7 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             key: Key to simulate. May also be the name of a key, e.g. "space".
         """
-        event = events.Key(key, None)
-        self.post_message(event)
-
-        # async def dispatch_simulated_key() -> None:
-        #     if not (await self._check_bindings(event.key, priority=True)):
-        #         await dispatch_key(self, event)
-
-        # self.call_later(dispatch_simulated_key)
+        self.post_message(events.Key(key, None))
 
     async def _check_bindings(self, key: str, priority: bool = False) -> bool:
         """Handle a key press.

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -342,6 +342,7 @@ class Pilot(Generic[ReturnType]):
             # E.g., the click event is preceded by MouseDown/MouseUp to emulate how
             # the driver works and emits a click event.
             widget_at, _ = app.get_widget_at(*offset)
+            print(widget_at)
             event = mouse_event_cls(**message_arguments)
             # Bypass event processing in App.on_event. Because App.on_event
             # is responsible for updating App.mouse_position, and because

--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -342,7 +342,6 @@ class Pilot(Generic[ReturnType]):
             # E.g., the click event is preceded by MouseDown/MouseUp to emulate how
             # the driver works and emits a click event.
             widget_at, _ = app.get_widget_at(*offset)
-            print(widget_at)
             event = mouse_event_cls(**message_arguments)
             # Bypass event processing in App.on_event. Because App.on_event
             # is responsible for updating App.mouse_position, and because

--- a/tests/footer/test_footer.py
+++ b/tests/footer/test_footer.py
@@ -1,0 +1,58 @@
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widget import Widget
+from textual.widgets import Button, Footer
+
+
+async def test_footer_bindings() -> None:
+    app_binding_count = 0
+
+    class TestWidget(Widget, can_focus=True):
+        BINDINGS = [
+            Binding("b", "widget_binding", "Overridden Binding"),
+        ]
+
+        DEFAULT_CSS = """
+        TestWidget {
+            border: tall $background;
+            width: 50%;
+            height: 50%;
+            content-align: center middle;
+
+            &:focus {
+                border: tall $accent;
+            }
+        }
+        """
+
+        def action_widget_binding(self) -> None:
+            assert False, "should never be called since there is a priority binding"
+
+    class PriorityBindingApp(App):
+        BINDINGS = [
+            Binding("b", "app_binding", "Priority Binding", priority=True),
+        ]
+
+        CSS = """
+        Screen {
+            align: center middle;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            yield TestWidget()
+            yield Button("Move Focus")
+            yield Footer()
+
+        def action_app_binding(self) -> None:
+            nonlocal app_binding_count
+            app_binding_count += 1
+
+    app = PriorityBindingApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app_binding_count == 0
+        await pilot.click("Footer", offset=(1, 0))
+        assert app_binding_count == 1
+        await pilot.click("Footer")
+        assert app_binding_count == 2


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/4794

The culprit was `App.simulate_key` which circumvented some logic re priority bindings.