### PR TITLE
Fix sporadic NoMatches error reported from Header on app shutdown

### DIFF
--- a/src/textual/widgets/_header.py
+++ b/src/textual/widgets/_header.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from rich.text import Text
 
 from ..app import RenderResult
+from ..css.query import NoMatches
 from ..dom import NoScreen
 from ..events import Click, Mount
 from ..reactive import Reactive
@@ -216,13 +217,13 @@ class Header(Widget):
         async def set_title() -> None:
             try:
                 self.query_one(HeaderTitle).text = self.screen_title
-            except NoScreen:
+            except (NoScreen, NoMatches):
                 pass
 
         async def set_sub_title() -> None:
             try:
                 self.query_one(HeaderTitle).sub_text = self.screen_sub_title
-            except NoScreen:
+            except (NoScreen, NoMatches):
                 pass
 
         self.watch(self.app, "title", set_title)


### PR DESCRIPTION
During application shutdown, particularly when running via `App.run_test()`, it seems that the Header's watcher callback on `title` or `sub_title` is called while the Header's children, such as the `HeaderTitle`, are already unmounted. This results in a `NoMatches` error being raised.

We fix this by ignoring the `NoMatches` error, like we did with `NoScreen` in the recent "hardedning" commit 604b04db2.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
