### PR TITLE
Change StringKey to simple strings.  Fix ordering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `events.Enter` and `events.Leave` events now bubble. https://github.com/Textualize/textual/pull/4818
 - Renamed `Widget.mouse_over` to `Widget.mouse_hover` https://github.com/Textualize/textual/pull/4818
 
+### Fixed
+
+- Fix crash when comparing `DataTable` `StringKey` objects https://github.com/Textualize/textual/pull/4820
+
 ## [0.74.0] - 2024-07-25
 
 ### Fixed

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -80,40 +80,26 @@ class DuplicateKey(Exception):
 class StringKey:
     """An object used as a key in a mapping.
 
-    It can optionally wrap a string,
-    and lookups into a map using the object behave the same as lookups using
-    the string itself."""
+    The object is either a string or, if none supplied, the string of the
+    id() of the StringKey object.
 
-    value: str | None
+    A StringKey can be compared with a plain str, meaning one can use
+    plain strings for lookups."""
 
     def __init__(self, value: str | None = None):
-        self.value = value
-
-    def __hash__(self):
         # If a string is supplied, we use the hash of the string. If no string was
         # supplied, we use the default hash to ensure uniqueness amongst instances.
-        return hash(self.value) if self.value is not None else id(self)
+        self.value = value if value is not None else str(id(self))
 
-    def __eq__(self, other: object) -> bool:
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other: str | StringKey) -> bool:
         # Strings will match Keys containing the same string value.
-        # Otherwise, you'll need to supply the exact same key object.
-        if isinstance(other, str):
-            return self.value == other
-        elif isinstance(other, StringKey):
-            if self.value is not None and other.value is not None:
-                return self.value == other.value
-            else:
-                return hash(self) == hash(other)
-        else:
-            return NotImplemented
+        return self.value == (other if isinstance(other, str) else other.value)
 
-    def __lt__(self, other):
-        if isinstance(other, str):
-            return self.value < other
-        elif isinstance(other, StringKey):
-            return self.value < other.value
-        else:
-            return NotImplemented
+    def __lt__(self, other: str | StringKey):
+        return self.value < (other if isinstance(other, str) else other.value)
 
     def __rich_repr__(self):
         yield "value", self.value

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -94,9 +94,11 @@ class StringKey:
     def __hash__(self):
         return hash(self.value)
 
-    def __eq__(self, other: str | StringKey) -> bool:
+    def __eq__(self, other: object) -> bool:
         # Strings will match Keys containing the same string value.
-        return self.value == (other if isinstance(other, str) else other.value)
+        if isinstance(other, (str, StringKey)):
+            return self.value == other
+        return NotImplemented
 
     def __lt__(self, other: str | StringKey):
         return self.value < (other if isinstance(other, str) else other.value)

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -21,6 +21,7 @@ from textual.widgets.data_table import (
     Row,
     RowDoesNotExist,
     RowKey,
+    StringKey
 )
 
 ROWS = [["0/0", "0/1"], ["1/0", "1/1"], ["2/0", "2/1"]]
@@ -1156,6 +1157,16 @@ def test_key_string_lookup():
     assert dictionary[RowKey("foo")] == "bar"
     assert dictionary["hello"] == "world"
     assert dictionary[RowKey("hello")] == "world"
+
+async def test_stringkey_comparison():
+    # StringKey is now exported.
+    id1 = StringKey()
+    id2 = StringKey()
+    name1 = StringKey("name1")
+    name2 = StringKey("name2")
+    assert name1 < name2 and name2 > name1
+    assert id1 != id2
+    junk = id1 < name1 and name2 < id2  # just see comparisons work
 
 
 async def test_scrolling_cursor_into_view():

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -21,7 +21,7 @@ from textual.widgets.data_table import (
     Row,
     RowDoesNotExist,
     RowKey,
-    StringKey
+    StringKey,
 )
 
 ROWS = [["0/0", "0/1"], ["1/0", "1/1"], ["2/0", "2/1"]]
@@ -1158,15 +1158,21 @@ def test_key_string_lookup():
     assert dictionary["hello"] == "world"
     assert dictionary[RowKey("hello")] == "world"
 
+
 async def test_stringkey_comparison():
-    # StringKey is now exported.
     id1 = StringKey()
     id2 = StringKey()
     name1 = StringKey("name1")
     name2 = StringKey("name2")
     assert name1 < name2 and name2 > name1
     assert id1 != id2
-    junk = id1 < name1 and name2 < id2  # just see comparisons work
+    _ = id1 < name1 and name2 < id2  # just see comparisons work
+
+
+async def test_stringkey_hash():
+    key = StringKey("hello")
+    assert hash(key) == hash("hello")
+    assert hash(key) == hash(StringKey("hello"))
 
 
 async def test_scrolling_cursor_into_view():


### PR DESCRIPTION
**Please review the following checklist.**

- [X] Docstrings on all new or modified functions / classes 
- [?] Updated documentation
- [n/a] Updated CHANGELOG.md (where appropriate)

DataTable's StringKey was recently exposed, meaning users could try to compare them.  Unfortunately, this was causing an a comparison between str and None:    `StringKey("a string") < StringKey()`.   To solve the problem and simplify the class, either a StringKey value is the supplied string or the string representation of its `id()`.

Test included, if you want to see it break before applying this change.