### PR TITLE
simplify test

### DIFF
--- a/tests/test_await_remove.py
+++ b/tests/test_await_remove.py
@@ -3,8 +3,8 @@ from textual.widgets import Label
 
 
 class SelfRemovingLabel(Label):
-    def on_mount(self) -> None:
-        self.set_timer(0.2, self.remove)
+    async def on_mount(self) -> None:
+        await self.remove()
 
 
 class RemoveOnTimerApp(App[None]):
@@ -17,6 +17,5 @@ async def test_multiple_simultaneous_removals():
     """Regression test for https://github.com/Textualize/textual/issues/2854."""
     # The app should run and finish without raising any errors.
     async with RemoveOnTimerApp().run_test() as pilot:
-        await pilot.pause(0.3)
         # Sanity check to ensure labels were removed.
         assert len(pilot.app.query(Label)) == 0


### PR DESCRIPTION
Fix https://github.com/Textualize/textual/issues/4822

Inserting constant pauses in tests seems to be a source of flakiness.

There are other examples of this, which we will fix later.