### PR TITLE
Documentation updates

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1,7 +1,7 @@
 # Documentation Workflow
 
 * Ensure you're inside a *Python 3.10+* virtual environment
-* Run the live-reload server using `mkdocs serve` from the project root
+* Run the live-reload server using `mkdocs serve -f mkdocs-common.yml` from the project root
 * Create new pages by adding new directories and Markdown files inside `docs/*`
 
 ## Commands

--- a/docs/examples/guide/css/nesting01.py
+++ b/docs/examples/guide/css/nesting01.py
@@ -9,9 +9,10 @@ class NestingDemo(App):
     CSS_PATH = "nesting01.tcss"
 
     def compose(self) -> ComposeResult:
-        with Horizontal(id="questions"):
-            yield Static("Yes", classes="button affirmative")
-            yield Static("No", classes="button negative")
+        with Horizontal(id="status"):
+            yield Static("Builder", classes="box done")
+            yield Static("Test Runner", classes="box stopped")
+
 
 
 if __name__ == "__main__":

--- a/docs/examples/guide/css/nesting01.tcss
+++ b/docs/examples/guide/css/nesting01.tcss
@@ -1,11 +1,11 @@
 /* Style the container */
-#questions {
+#status {
     border: heavy $primary;
     align: center middle;
 }
 
-/* Style all buttons */
-#questions .button {
+/* Style all boxes */
+#status .box {
     width: 1fr;
     padding: 1 2;
     margin: 1 2;
@@ -13,12 +13,12 @@
     border: heavy $panel;
 }
 
-/* Style the Yes button */
-#questions .button.affirmative {
+/* Style the 'done' box */
+#status .box.done {
     border: heavy $success;
 }
 
-/* Style the No button */
-#questions .button.negative {
+/* Style the 'stopped' box */
+#status .box.stopped {
     border: heavy $error;
 }

--- a/docs/examples/guide/css/nesting02.py
+++ b/docs/examples/guide/css/nesting02.py
@@ -9,9 +9,9 @@ class NestingDemo(App):
     CSS_PATH = "nesting02.tcss"
 
     def compose(self) -> ComposeResult:
-        with Horizontal(id="questions"):
-            yield Static("Yes", classes="button affirmative")
-            yield Static("No", classes="button negative")
+        with Horizontal(id="status"):
+            yield Static("Builder", classes="box done")
+            yield Static("Test Runner", classes="box stopped")
 
 
 if __name__ == "__main__":

--- a/docs/examples/guide/css/nesting02.tcss
+++ b/docs/examples/guide/css/nesting02.tcss
@@ -1,23 +1,23 @@
 /* Style the container */
-#questions {
+#status {
     border: heavy $primary;
     align: center middle;
 
-    /* Style all buttons */
-    .button {
+    /* Style all boxes */
+    .box {
         width: 1fr;
         padding: 1 2;
         margin: 1 2;
         text-align: center;
         border: heavy $panel;    
 
-        /* Style the Yes button */
-        &.affirmative {
+        /* Style the 'done' box */
+        &.done {
             border: heavy $success;        
         }
 
-        /* Style the No button */
-        &.negative {
+        /* Style the 'stopped' box */
+        &.stopped {
             border: heavy $error;
         }
     }

--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -195,24 +195,24 @@ Let's look at the selectors supported by Textual CSS.
 
 ### Type selector
 
-The _type_ selector matches the name of the (Python) class. For example, the following widget can be matched with a `Button` selector:
+The _type_ selector matches the name of the (Python) class. For example, the following widget can be matched with a `BoxedText` selector:
 
 ```python
 from textual.widgets import Static
 
-class Button(Static):
+class BoxedText(Static):
     pass
 ```
 
 The following rule applies a border to this widget:
 
 ```css
-Button {
+BoxedText {
   border: solid blue;
 }
 ```
 
-The type selector will also match a widget's base classes. Consequently, a `Static` selector will also style the button because the `Button` Python class extends `Static`.
+The type selector will also match a widget's base classes. Consequently, a `Static` selector will also style the boxed text because the `BoxedText` Python class extends `Static`.
 
 ```css
 Static {
@@ -225,7 +225,7 @@ Static {
 
     The fact that the type selector matches base classes is a departure from browser CSS which doesn't have the same concept.
 
-You may have noticed that the `border` rule exists in both Static and Button. When this happens, Textual will use the most recently defined sub-class within a list of bases. So Button wins over Static, and Static wins over Widget (the base class of all widgets). Hence if both rules were in a stylesheet, the buttons would be "solid blue" and not "rounded white".
+You may have noticed that the `border` rule exists in both Static and BoxedText. When this happens, Textual will use the most recently defined sub-class within a list of bases. So BoxedText wins over Static, and Static wins over Widget (the base class of all widgets). Hence if both these rules were in a stylesheet, the boxed text would be "solid blue" and not "rounded white".
 
 ### ID selector
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -8,7 +8,8 @@ Report bugs via GitHub on the Textual [issues](https://github.com/Textualize/tex
 
 ## Help with using Textual
 
-You can seek help with using Textual [in the discussion area on GitHub](https://github.com/Textualize/textual/discussions).
+You can seek help with using Textual [on Discord's #help-wanted channel](https://discord.gg/jQeB3vB8) 
+or [in the discussion area on GitHub](https://github.com/Textualize/textual/discussions).
 
 ## Discord Server
 


### PR DESCRIPTION
Several small documentation updates:
* (close #4827) Fix CSS type selector example to use less confusing name than Button [which may be outdated now?]
*  Add direct link to #help-wanted channel.
* Update command for running live-reload server
* Rewrite Guide/Css/Nested CSS section.  The previous section was confusing about exactly how nesting selectors were joined, missed the common nesting operator usage  of "& Another Class {" found in the DEFAULT_CSS, and waffled on use of nested CSS.

This is enough to try to merge.

