### PR TITLE
add ESCDELAY environment var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Textual will use the `ESCDELAY` env var when detecting escape keys
+- Textual will use the `ESCDELAY` env var when detecting escape keys https://github.com/Textualize/textual/pull/4848
 
 ## [0.75.1] - 2024-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Input cursor blink effect will now restart correctly when any action is performed on the input https://github.com/Textualize/textual/pull/4773
 
+### Added
+
+- Textual will use the `ESCDELAY` env var when detecting escape keys
+
 ## [0.75.1] - 2024-08-02
 
 ### Fixed

--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -113,7 +113,7 @@ class Parser(Generic[T]):
                 yield popleft()
 
     def parse(
-        self, on_token: Callable[[T], None]
+        self, token_callback: TokenCallback
     ) -> Generator[Read1 | Peek1, str, None]:
         """Implement to parse a stream of text.
 

--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -104,32 +104,3 @@ class Parser(Generic[T]):
         self, on_token: Callable[[T], None]
     ) -> Generator[Read1 | Peek1, str, None]:
         yield from ()
-
-
-if __name__ == "__main__":
-    data = "Where there is a Will there is a way!"
-
-    class TestParser(Parser[str]):
-        def parse(
-            self, on_token: Callable[[str], None]
-        ) -> Generator[Read1 | Peek1, str, None]:
-            while True:
-                try:
-                    data = yield self.read1(0.1)
-                except ParseTimeout:
-                    print("TIMEOUT")
-                    continue
-                if not data:
-                    break
-                on_token(data)
-
-    test_parser = TestParser()
-    from time import sleep
-
-    for n in range(0, len(data), 5):
-        test_parser.tick()
-        for token in test_parser.feed(data[n : n + 5]):
-            print(token)
-        sleep(0.1)
-    for token in test_parser.feed(""):
-        print(token)

--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -51,7 +51,7 @@ class Parser(Generic[T]):
 
     @property
     def is_eof(self) -> bool:
-        """Is the parser at the end of the fine (i.e. exhausted)?"""
+        """Is the parser at the end of the file (i.e. exhausted)?"""
         return self._eof
 
     def tick(self) -> Iterable[T]:

--- a/src/textual/_parser.py
+++ b/src/textual/_parser.py
@@ -118,7 +118,7 @@ class Parser(Generic[T]):
         """Implement to parse a stream of text.
 
         Args:
-            on_token: Callable to report a successful parsed data type.
+            token_callback: Callable to report a successful parsed data type.
 
         Yields:
             ParseAwaitable: One of `self.read1` or `self.peek1`

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -105,7 +105,9 @@ class XTermParser(Parser[Message]):
             return event
         return None
 
-    def parse(self, _on_token: TokenCallback) -> Generator[Read1 | Peek1, str, None]:
+    def parse(
+        self, token_callback: TokenCallback
+    ) -> Generator[Read1 | Peek1, str, None]:
         ESC = "\x1b"
         read1 = self.read1
         sequence_to_key_events = self._sequence_to_key_events
@@ -115,7 +117,7 @@ class XTermParser(Parser[Message]):
         def on_token(token: Message) -> None:
             """Hook to log events."""
             self.debug_log(str(token))
-            _on_token(token)
+            token_callback(token)
 
         def on_key_token(event: events.Key) -> None:
             """Token callback wrapper for handling keys.

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -185,9 +185,8 @@ class XTermParser(Parser[Message]):
 
             while True:
                 try:
-                    new_character = yield read1(
-                        None if self.windows else constants.ESCAPE_DELAY
-                    )
+                    timeout = None if self.windows else constants.ESCAPE_DELAY
+                    new_character = yield read1(timeout)
                 except ParseTimeout:
                     send_escape()
                     break

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -178,12 +178,16 @@ class XTermParser(Parser[events.Event]):
                 if not bracketed_paste:
                     peek_buffer = yield self.peek_buffer()
                     if peek_buffer:
+                        # Some characters already feed in to the parse
                         if peek_buffer[0] == ESC:
+                            # Next character is an escape, which means the previous escape
+                            # was a escape key (not introducing a sequence)
                             on_token(events.Key("escape", "\x1b"))
                             yield read1()
                     else:
                         if not more_data():
-                            self.debug_log("NO MORE DATA")
+                            # There is no input after ESCDELAY
+                            # The escape was (probably) a key
                             on_token(events.Key("escape", "\x1b"))
                             continue
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -39,11 +39,10 @@ SPECIAL_SEQUENCES = {BRACKETED_PASTE_START, BRACKETED_PASTE_END, FOCUSIN, FOCUSO
 _re_extended_key: Final = re.compile(r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])")
 
 
-
 class XTermParser(Parser[Message]):
     _re_sgr_mouse = re.compile(r"\x1b\[<(\d+);(\d+);(\d+)([Mm])")
 
-    def __init__(self, debug: bool = False) -> None:       
+    def __init__(self, debug: bool = False) -> None:
         self.last_x = 0
         self.last_y = 0
         self._debug_log_file = open("keys.log", "at") if debug else None
@@ -182,7 +181,7 @@ class XTermParser(Parser[Message]):
                 reissue_sequence_as_keys(sequence[1:])
 
             while True:
-                try:                   
+                try:
                     new_character = yield read1(constants.ESCAPE_DELAY)
                 except ParseTimeout:
                     send_escape()

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -106,7 +106,6 @@ class XTermParser(Parser[events.Event]):
     def parse(self, _on_token: TokenCallback) -> Generator[Read1 | Peek1, str, None]:
         ESC = "\x1b"
         read1 = self.read1
-        peek1 = self.peek1
         sequence_to_key_events = self._sequence_to_key_events
         paste_buffer: list[str] = []
         bracketed_paste = False

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -183,9 +183,6 @@ class XTermParser(Parser[events.Event]):
                 reissue_sequence_as_keys(sequence[1:])
 
             while True:
-                # If we run into another ESC at this point, then we've failed
-                # to find a match, and should issue everything we've seen within
-                # the suspected sequence as Key events instead.
                 try:
                     new_character = yield read1(
                         None if self.windows else constants.ESCAPE_DELAY

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -195,7 +195,7 @@ class XTermParser(Parser[events.Event]):
 
                 if new_character == ESC:
                     send_escape()
-                    if WINDOWS:
+                    if WINDOWS and len(sequence) == 1:
                         # In Windows two escapes are sent when pressing the escape key
                         send_escape()
                         break

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -297,7 +297,7 @@ class XTermParser(Parser[Message]):
             key_tokens.sort()
             key_tokens.append(key)
             yield events.Key(
-                f'{"+".join(key_tokens)}', sequence if len(sequence) == 1 else None
+                "+".join(key_tokens), sequence if len(sequence) == 1 else None
             )
             return
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import sys
 from typing import Any, Generator, Iterable
 
 from typing_extensions import Final
@@ -40,14 +39,11 @@ SPECIAL_SEQUENCES = {BRACKETED_PASTE_START, BRACKETED_PASTE_END, FOCUSIN, FOCUSO
 _re_extended_key: Final = re.compile(r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])")
 
 
-WINDOWS = sys.platform == "win32"
-
 
 class XTermParser(Parser[Message]):
     _re_sgr_mouse = re.compile(r"\x1b\[<(\d+);(\d+);(\d+)([Mm])")
 
-    def __init__(self, debug: bool = False, windows: bool = WINDOWS) -> None:
-        self.windows = windows
+    def __init__(self, debug: bool = False) -> None:       
         self.last_x = 0
         self.last_y = 0
         self._debug_log_file = open("keys.log", "at") if debug else None
@@ -186,9 +182,8 @@ class XTermParser(Parser[Message]):
                 reissue_sequence_as_keys(sequence[1:])
 
             while True:
-                try:
-                    timeout = None if self.windows else constants.ESCAPE_DELAY
-                    new_character = yield read1(timeout)
+                try:                   
+                    new_character = yield read1(constants.ESCAPE_DELAY)
                 except ParseTimeout:
                     send_escape()
                     break
@@ -198,9 +193,6 @@ class XTermParser(Parser[Message]):
 
                 if new_character == ESC:
                     send_escape()
-                    if self.windows and len(sequence) == 1:
-                        # In Windows two escapes are sent when pressing the escape key
-                        break
                     sequence = character
                     continue
                 else:

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -115,3 +115,6 @@ COLOR_SYSTEM: Final[str | None] = get_environ("TEXTUAL_COLOR_SYSTEM", "auto")
 
 TEXTUAL_ANIMATIONS: AnimationLevel = _get_textual_animations()
 """Determines whether animations run or not."""
+
+ESCAPE_DELAY: float = _get_environ_int("ESCDELAY", 100) / 1000.0
+"""The delay (in seconds) before reporting an escape key (not used if the extend key protocol is available)."""

--- a/src/textual/drivers/_input_reader_linux.py
+++ b/src/textual/drivers/_input_reader_linux.py
@@ -4,6 +4,8 @@ import sys
 from threading import Event
 from typing import Iterator
 
+from .. import constants
+
 
 class InputReader:
     """Read input from stdin."""
@@ -23,7 +25,7 @@ class InputReader:
     def more_data(self) -> bool:
         """Check if there is data pending."""
         EVENT_READ = selectors.EVENT_READ
-        for _key, events in self._selector.select(0.01):
+        for _key, events in self._selector.select(constants.ESCAPE_DELAY):
             if events & EVENT_READ:
                 return True
         return False

--- a/src/textual/drivers/_input_reader_linux.py
+++ b/src/textual/drivers/_input_reader_linux.py
@@ -4,8 +4,6 @@ import sys
 from threading import Event
 from typing import Iterator
 
-from .. import constants
-
 
 class InputReader:
     """Read input from stdin."""
@@ -21,14 +19,6 @@ class InputReader:
         self._selector = selectors.DefaultSelector()
         self._selector.register(self._fileno, selectors.EVENT_READ)
         self._exit_event = Event()
-
-    def more_data(self) -> bool:
-        """Check if there is data pending."""
-        EVENT_READ = selectors.EVENT_READ
-        for _key, events in self._selector.select(constants.ESCAPE_DELAY):
-            if events & EVENT_READ:
-                return True
-        return False
 
     def close(self) -> None:
         """Close the reader (will exit the iterator)."""

--- a/src/textual/drivers/_input_reader_windows.py
+++ b/src/textual/drivers/_input_reader_windows.py
@@ -17,10 +17,6 @@ class InputReader:
         self.timeout = timeout
         self._exit_event = Event()
 
-    def more_data(self) -> bool:
-        """Check if there is data pending."""
-        return True
-
     def close(self) -> None:
         """Close the reader (will exit the iterator)."""
         self._exit_event.set()

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import rich.repr
 
-from .. import constants, events
+from .. import events
 from .._loop import loop_last
 from .._parser import ParseError
 from .._xterm_parser import XTermParser
@@ -357,7 +357,7 @@ class LinuxDriver(Driver):
         """
         try:
             self.run_input_thread()
-        except BaseException as error:
+        except BaseException:
             import rich.traceback
 
             self._app.call_later(
@@ -373,16 +373,9 @@ class LinuxDriver(Driver):
         fileno = self.fileno
         EVENT_READ = selectors.EVENT_READ
 
-        def more_data() -> bool:
-            """Check if there is more data to parse."""
-
-            for _key, selector_events in selector.select(constants.ESCAPE_DELAY):
-                if selector_events & EVENT_READ:
-                    return True
-            return False
-
-        parser = XTermParser(more_data, self._debug)
+        parser = XTermParser(self._debug)
         feed = parser.feed
+        tick = parser.tick
 
         utf8_decoder = getincrementaldecoder("utf-8")().decode
         decode = utf8_decoder
@@ -407,6 +400,8 @@ class LinuxDriver(Driver):
                         break
                     for event in feed(unicode_data):
                         self.process_event(event)
+            for event in tick():
+                self.process_event(event)
 
         try:
             while not self.exit_event.is_set():

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -245,11 +245,9 @@ class LinuxDriver(Driver):
 
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
-
         self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
-        self.write(
-            "\x1b[1;u"
-        )  # Disambiguate escape codes https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
+        # Disambiguate escape codes https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
+        self.write("\x1b[1;u")
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread)
         send_size_event()

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -410,7 +410,6 @@ class LinuxDriver(Driver):
         try:
             while not self.exit_event.is_set():
                 process_selector_events(selector.select(0.1))
-
             process_selector_events(selector.select(0.1), final=True)
 
         finally:

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import rich.repr
 
-from .. import events
+from .. import constants, events
 from .._loop import loop_last
 from .._parser import ParseError
 from .._xterm_parser import XTermParser
@@ -376,7 +376,7 @@ class LinuxDriver(Driver):
         def more_data() -> bool:
             """Check if there is more data to parse."""
 
-            for _key, selector_events in selector.select(0.1):
+            for _key, selector_events in selector.select(constants.ESCAPE_DELAY):
                 if selector_events & EVENT_READ:
                     return True
             return False

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -245,7 +245,11 @@ class LinuxDriver(Driver):
 
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
+
         self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+        self.write(
+            "\x1b[1;u"
+        )  # Disambiguate escape codes https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread)
         send_size_event()

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import rich.repr
 
-from .. import events
+from .. import constants, events
 from .._xterm_parser import XTermParser
 from ..driver import Driver
 from ..geometry import Size
@@ -127,7 +127,7 @@ class LinuxInlineDriver(Driver):
         def more_data() -> bool:
             """Check if there is more data to parse."""
 
-            for _key, events in selector.select(0.1):
+            for _key, events in selector.select(constants.ESCAPE_DELAY):
                 if events & EVENT_READ:
                     return True
             return False

--- a/src/textual/drivers/web_driver.py
+++ b/src/textual/drivers/web_driver.py
@@ -163,7 +163,7 @@ class WebDriver(Driver):
     def run_input_thread(self) -> None:
         """Wait for input and dispatch events."""
         input_reader = self._input_reader
-        parser = XTermParser(input_reader.more_data, debug=self._debug)
+        parser = XTermParser(debug=self._debug)
         utf8_decoder = getincrementaldecoder("utf-8")().decode
         decode = utf8_decoder
         # The server sends us a stream of bytes, which contains the equivalent of stdin, plus

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -226,7 +226,7 @@ class EventMonitor(threading.Thread):
 
     def run(self) -> None:
         exit_requested = self.exit_event.is_set
-        parser = XTermParser(lambda: False)
+        parser = XTermParser()
 
         try:
             read_count = wintypes.DWORD(0)

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -9,10 +9,10 @@ from ctypes import Structure, Union, byref, wintypes
 from ctypes.wintypes import BOOL, CHAR, DWORD, HANDLE, SHORT, UINT, WCHAR, WORD
 from typing import IO, TYPE_CHECKING, Callable, List, Optional
 
+from .. import constants
 from .._xterm_parser import XTermParser
 from ..events import Event, Resize
 from ..geometry import Size
-from .. import constants
 
 if TYPE_CHECKING:
     from ..app import App
@@ -244,8 +244,8 @@ class EventMonitor(threading.Thread):
             append_key = keys.append
 
             while not exit_requested():
-               
-                for event in parser.tick():                  
+
+                for event in parser.tick():
                     self.process_event(event)
 
                 # Wait for new events

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -12,6 +12,7 @@ from typing import IO, TYPE_CHECKING, Callable, List, Optional
 from .._xterm_parser import XTermParser
 from ..events import Event, Resize
 from ..geometry import Size
+from .. import constants
 
 if TYPE_CHECKING:
     from ..app import App
@@ -226,7 +227,7 @@ class EventMonitor(threading.Thread):
 
     def run(self) -> None:
         exit_requested = self.exit_event.is_set
-        parser = XTermParser()
+        parser = XTermParser(debug=constants.DEBUG)
 
         try:
             read_count = wintypes.DWORD(0)
@@ -243,8 +244,12 @@ class EventMonitor(threading.Thread):
             append_key = keys.append
 
             while not exit_requested():
+               
+                for event in parser.tick():                  
+                    self.process_event(event)
+
                 # Wait for new events
-                if wait_for_handles([hIn], 200) is None:
+                if wait_for_handles([hIn], 100) is None:
                     # No new events
                     continue
 

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -174,11 +174,21 @@ def test_single_escape(parser):
     assert [event.key for event in events] == ["escape"]
 
 
-@windows_only
 def test_double_escape(parser):
     """Windows Terminal writes double ESC when the user presses the Escape key once."""
+    parser.windows = False
     events = list(parser.feed("\x1b\x1b"))
     events.extend(parser.feed(""))
+    print(events)
+    assert [event.key for event in events] == ["escape", "escape"]
+
+
+def test_windows_double_escape(parser):
+    """Windows Terminal writes double ESC when the user presses the Escape key once."""
+    parser.windows = True
+    events = list(parser.feed("\x1b\x1b"))
+    events.extend(parser.feed(""))
+    print(events)
     assert [event.key for event in events] == ["escape"]
 
 

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -33,7 +33,7 @@ def chunks(data, size):
 
 @pytest.fixture
 def parser():
-    return XTermParser(more_data=lambda: False)
+    return XTermParser()
 
 
 @pytest.mark.parametrize("chunk_size", [2, 3, 4, 5, 6])
@@ -132,7 +132,7 @@ def test_unknown_sequence_followed_by_known_sequence(parser, chunk_size):
     sequence = unknown_sequence + known_sequence
 
     events = []
-    parser.more_data = lambda: True
+
     for chunk in chunks(sequence, chunk_size):
         events.append(parser.feed(chunk))
 

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -1,5 +1,4 @@
 import itertools
-import sys
 
 import pytest
 
@@ -14,8 +13,6 @@ from textual.events import (
     Paste,
 )
 from textual.messages import TerminalSupportsSynchronizedOutput
-
-windows_only = pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
 
 
 def chunks(data, size):

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -172,21 +172,11 @@ def test_single_escape(parser):
 
 
 def test_double_escape(parser):
-    """Windows Terminal writes double ESC when the user presses the Escape key once."""
-    parser.windows = False
+    """Test double escape."""
     events = list(parser.feed("\x1b\x1b"))
     events.extend(parser.feed(""))
     print(events)
     assert [event.key for event in events] == ["escape", "escape"]
-
-
-def test_windows_double_escape(parser):
-    """Windows Terminal writes double ESC when the user presses the Escape key once."""
-    parser.windows = True
-    events = list(parser.feed("\x1b\x1b"))
-    events.extend(parser.feed(""))
-    print(events)
-    assert [event.key for event in events] == ["escape"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/4816

The `ESCDELAY` env var is the number of milliseconds before registering an escape key. This is borrowed from curses, so may be set in some environments already,

When looking in to this, I discovered that we weren't actually using any delay to detect escape keys. The mechanism to do that had been broken for a while.