### PR TITLE
tweak key reporting

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -275,6 +275,7 @@ class XTermParser(Parser[Message]):
             key_tokens: list[str] = []
             if modifiers:
                 modifier_bits = int(modifiers) - 1
+                # Not convinced of the utility in reporting caps_lock and num_lock
                 MODIFIERS = (
                     "shift",
                     "alt",
@@ -282,12 +283,17 @@ class XTermParser(Parser[Message]):
                     "super",
                     "hyper",
                     "meta",
-                    "caps_lock",
-                    "num_lock",
+                    "",  # caps_lock
+                    "",  # num_lock
                 )
                 for bit, modifier in zip(range(8), MODIFIERS):
-                    if modifier_bits & (1 << bit):
+                    if modifier and modifier_bits & (1 << bit):
                         key_tokens.append(modifier)
+                if key_tokens:
+                    if key.isupper():
+                        key_tokens.append("shift")
+                        key = key.lower()
+
             key_tokens.sort()
             key_tokens.append(key)
             yield events.Key(


### PR DESCRIPTION
Some tweaks to how keys are reported (with the Kitty protocol).

- If "shift" is held with another modifier it is reported as "shift", rather than a capital letter. Previously if you press shift + ctrl + e, it is reported as `"ctrl+E"`. Now it is reported as `"ctrl+shft+e"`.

I think this makes sense, as a such a combination is unlikely to be a printable key

- Removed `caps_lock` and `num_lock` modifiers. This resulted in shift + key, and caps_lock + key being considered as different keys -- which I don't think makes sense. If this is ever a requirement, I think we should add booleans to the Key event.