### PR TITLE
Input validators crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `tooltip` to Binding https://github.com/Textualize/textual/pull/4859
 
+### Fixed
+
+- Fix crash when `validate_on` value isn't a set https://github.com/Textualize/textual/pull/4868
+
 ## [0.76.0]
 
 ### Changed

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, Iterable, cast
+from typing import TYPE_CHECKING, ClassVar, Iterable
 
 from rich.cells import cell_len, get_character_cell_size
 from rich.console import Console, ConsoleOptions, RenderableType
@@ -301,7 +301,7 @@ class Input(Widget, can_focus=True):
             self.validators = list(validators)
 
         self.validate_on: set[str] = (
-            (_POSSIBLE_VALIDATE_ON_VALUES & cast("set[str]", validate_on))
+            (_POSSIBLE_VALIDATE_ON_VALUES & set(validate_on))
             if validate_on is not None
             else _POSSIBLE_VALIDATE_ON_VALUES
         )

--- a/tests/input/test_input_validation.py
+++ b/tests/input/test_input_validation.py
@@ -100,10 +100,11 @@ async def test_on_blur_triggers_validation():
     "validate_on",
     [
         set(),
+        [],
         {"blur"},
-        {"submitted"},
-        {"blur", "submitted"},
-        {"fried", "garbage"},
+        ["submitted"],
+        ["blur", "submitted"],
+        ["fried", "garbage"],
     ],
 )
 async def test_validation_on_changed_should_not_happen(validate_on):


### PR DESCRIPTION
Supplying a list to `Input.validate_on` causes a crash starting from `v0.76.0`.

```
|/textual/widgets/_input.py:304 in __init__
...
│   303 │   │   self.validate_on: set[str] = (                                               │
│ ❱ 304 │   │   │   (_POSSIBLE_VALIDATE_ON_VALUES & cast("set[str]", validate_on))           │
│   305 │   │   │   if validate_on is not None                                               │
│   306 │   │   │   else _POSSIBLE_VALIDATE_ON_VALUES                                        │
│   307 │   │   )

TypeError: RequestOptions() compose() method returned an invalid result; unsupported operand
type(s) for &: 'set' and 'list'
```
