### PR TITLE
Fix `cursor_blink` reactive not affecting the blink effect when set after mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix crash when `validate_on` value isn't a set https://github.com/Textualize/textual/pull/4868
+- Fix `Input.cursor_blink` having no effect on the blink cycle after mounting https://github.com/Textualize/textual/pull/4869
 
 ## [0.76.0]
 

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -583,7 +583,7 @@ class Input(Widget, can_focus=True):
     def _pause_blink_cycle(self) -> None:
         """Hide the blinking cursor and pause the blink cycle."""
         self._cursor_visible = False
-        if self.cursor_blink and self._blink_timer:
+        if self._blink_timer:
             self._blink_timer.pause()
 
     def insert_text_at_cursor(self, text: str) -> None:


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
