### PR TITLE
disable key disambiguate

### DIFF
--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -247,7 +247,9 @@ class LinuxDriver(Driver):
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
         self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
         # Disambiguate escape codes https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
-        self.write("\x1b[1;u")
+        # self.write(
+        #     "\x1b[1;u"
+        # )  # Causes https://github.com/Textualize/textual/issues/4870 on iTerm
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread)
         send_size_event()


### PR DESCRIPTION
This seems to break output on some terminals.

Going to disable for now, and come back to it later.

https://github.com/Textualize/textual/issues/4870