### PR TITLE
Binary encode

### DIFF
--- a/src/textual/_binary_encode.py
+++ b/src/textual/_binary_encode.py
@@ -231,38 +231,3 @@ def load(encoded: bytes) -> object:
         return decoder()
 
     return decode()
-
-
-if __name__ == "__main__":
-    tests = [
-        False,
-        True,
-        0,
-        1,
-        100,
-        "Hello",
-        b"World",
-        [],
-        [1, 2, 3],
-        ["hello", "world"],
-        ["hello", b"world"],
-        ("hello", "world"),
-        ("hello", b"world"),
-        {},
-        {"foo": "bar"},
-        {"foo": "bar", b"egg": b"baz"},
-        [{}],
-        [[1]],
-        [(1, 2), (3, 4)],
-    ]
-
-    from rich import print
-
-    for test in tests:
-        print("")
-        print(f"Encoding: \t{test!r}")
-        encoded = dump(test)
-        print(f"Encoded: \t{encoded!r}")
-        decoded = load(encoded)
-        print(f"Decoded: \t{decoded!r}")
-        assert test == decoded

--- a/src/textual/_binary_encode.py
+++ b/src/textual/_binary_encode.py
@@ -35,7 +35,7 @@ def dump(data: object) -> bytes:
         A byte string encoding the data.
     """
 
-    def encode_none(datum: None) -> bytes:
+    def encode_none(_datum: None) -> bytes:
         """
         Encodes a None value.
 
@@ -157,9 +157,10 @@ def dump(data: object) -> bytes:
             Encoded data bytes.
         """
         try:
-            return ENCODERS[type(datum)](datum)
+            decoder = ENCODERS[type(datum)]
         except KeyError:
             raise TypeError("Can't encode {datum!r}") from None
+        return decoder(datum)
 
     return encode(data)
 

--- a/src/textual/_binary_encode.py
+++ b/src/textual/_binary_encode.py
@@ -5,6 +5,7 @@ This is based on https://en.wikipedia.org/wiki/Bencode with some extensions.
 
 The following data types may be encoded:
 
+- None
 - int
 - bool
 - bytes
@@ -34,6 +35,18 @@ def dump(data: object) -> bytes:
         A byte string encoding the data.
     """
 
+    def encode_none(datum: None) -> bytes:
+        """
+        Encodes a None value.
+
+        Args:
+            datum: Always None.
+
+        Returns:
+            None encoded.
+        """
+        return b"N"
+
     def encode_bool(datum: bool) -> bytes:
         """
         Encode a boolean value.
@@ -44,7 +57,7 @@ def dump(data: object) -> bytes:
         Returns:
             The encoded bytes.
         """
-        return b"b%ie" % int(datum)
+        return b"T" if datum else b"F"
 
     def encode_int(datum: int) -> bytes:
         """
@@ -121,6 +134,7 @@ def dump(data: object) -> bytes:
         )
 
     ENCODERS: dict[type, Callable[[Any], Any]] = {
+        type(None): encode_none,
         bool: encode_bool,
         int: encode_int,
         bytes: encode_bytes,
@@ -221,17 +235,6 @@ def load(encoded: bytes) -> object:
             int_bytes += byte
         return int(int_bytes)
 
-    def decode_bool() -> bool:
-        """Decode a bool from the encoded data.
-
-        Returns:
-            A bool.
-        """
-        int_bytes = b""
-        while (byte := get_byte()) != b"e":
-            int_bytes += byte
-        return int(int_bytes) == 1
-
     def decode_bytes(size_bytes: bytes) -> bytes:
         """Decode a bytes string from the encoded data.
 
@@ -297,11 +300,13 @@ def load(encoded: bytes) -> object:
 
     DECODERS = {
         b"i": decode_int,
-        b"b": decode_bool,
         b"s": decode_string,
         b"l": decode_list,
         b"t": decode_tuple,
         b"d": decode_dict,
+        b"T": lambda: True,
+        b"F": lambda: False,
+        b"N": lambda: None,
     }
 
     def decode() -> object:

--- a/src/textual/_binary_encode.py
+++ b/src/textual/_binary_encode.py
@@ -162,6 +162,8 @@ def load(encoded: bytes) -> object:
     Returns:
         Decoded data.
     """
+    if not isinstance(encoded, bytes):
+        raise TypeError("must be bytes")
     max_position = len(encoded)
     position = 0
 

--- a/src/textual/_binary_encode.py
+++ b/src/textual/_binary_encode.py
@@ -1,0 +1,203 @@
+"""
+An encoding / decoding format suitable for serializing data structures to binary.
+
+This is based on https://en.wikipedia.org/wiki/Bencode with some extensions.
+
+The following data types may be encoded:
+
+- int
+- bool
+- bytes
+- str
+- list
+- tuple
+- dict
+
+"""
+
+from __future__ import annotations
+
+
+class DecodeError(Exception):
+    """A problem decoding data."""
+
+
+def dump(data: object) -> bytes:
+    """Encodes a data structure in to bytes.
+
+    Args:
+        data: Data structure
+
+    Returns:
+        A byte string encoding the data.
+    """
+
+    def encode(datum: object) -> bytes:
+        """Recursively encode data.
+
+        Args:
+            datum: Data suitable for encoding.
+
+        Raises:
+            TypeError: If `datum` is not one of the supported types.
+
+        Returns:
+            Encoded data bytes.
+        """
+        if isinstance(datum, bool):
+            return b"b%ie" % int(datum)
+        if isinstance(datum, int):
+            return b"i%ie" % datum
+        if isinstance(datum, bytes):
+            return b"%i:%s" % (len(datum), datum)
+        if isinstance(datum, str):
+            return b"s%i:%s" % (len(datum), datum.encode("utf-8"))
+        if isinstance(datum, list):
+            return b"l%se" % b"".join(encode(element) for element in datum)
+        if isinstance(datum, tuple):
+            return b"t%se" % b"".join(encode(element) for element in datum)
+        if isinstance(datum, dict):
+            return b"d%se" % b"".join(
+                b"%s%s" % (encode(key), encode(value)) for key, value in datum.items()
+            )
+
+        raise TypeError("Can't encode {datum!r}")
+
+    return encode(data)
+
+
+def load(encoded: bytes) -> object:
+    """Load an encoded data structure from bytes.
+
+    Args:
+        encoded: Encoded data in bytes.
+
+    Raises:
+        DecodeError: If an error was encountered decoding the string.
+
+    Returns:
+        Decoded data.
+    """
+    position = 0
+
+    max_position = len(encoded)
+
+    def get_byte() -> bytes:
+        nonlocal position
+        if position >= max_position:
+            raise DecodeError(f"Failed to decode {encoded!r}")
+        character = encoded[position : position + 1]
+        position += 1
+        return character
+
+    def peek_byte() -> bytes:
+        return encoded[position : position + 1]
+
+    def get_bytes(size: int) -> bytes:
+        nonlocal position
+        bytes_data = encoded[position : position + size]
+        position += size
+        return bytes_data
+
+    def decode_int():
+        int_bytes = b""
+        while (byte := get_byte()) != b"e":
+            int_bytes += byte
+        return int(int_bytes)
+
+    def decode_bool() -> bool:
+        int_bytes = b""
+        while (byte := get_byte()) != b"e":
+            int_bytes += byte
+        return int(int_bytes) == 1
+
+    def decode_bytes(size_bytes: bytes) -> bytes:
+        while (byte := get_byte()) != b":":
+            size_bytes += byte
+        bytes_string = get_bytes(int(size_bytes))
+        return bytes_string
+
+    def decode_string() -> str:
+        size_bytes = b""
+        while (byte := get_byte()) != b":":
+            size_bytes += byte
+        bytes_string = get_bytes(int(size_bytes))
+        decoded_string = bytes_string.decode("utf-8", errors="replace")
+        return decoded_string
+
+    def decode_list() -> list[object]:
+        elements: list[object] = []
+        add_element = elements.append
+        while peek_byte() != b"e":
+            add_element(decode())
+        get_byte()
+        return elements
+
+    def decode_tuple() -> tuple[object, ...]:
+        elements: list[object] = []
+        add_element = elements.append
+        while peek_byte() != b"e":
+            add_element(decode())
+        get_byte()
+        return tuple(elements)
+
+    def decode_dict() -> dict[object, object]:
+        elements: dict[object, object] = {}
+        add_element = elements.__setitem__
+        while peek_byte() != b"e":
+            add_element(decode(), decode())
+        get_byte()
+        return elements
+
+    DECODERS = {
+        b"i": decode_int,
+        b"b": decode_bool,
+        b"s": decode_string,
+        b"l": decode_list,
+        b"t": decode_tuple,
+        b"d": decode_dict,
+    }
+
+    def decode() -> object:
+        """Decode bytes."""
+        decoder = DECODERS.get(initial := get_byte(), None)
+        if decoder is None:
+            return decode_bytes(initial)
+        return decoder()
+
+    return decode()
+
+
+if __name__ == "__main__":
+    tests = [
+        False,
+        True,
+        0,
+        1,
+        100,
+        "Hello",
+        b"World",
+        [],
+        [1, 2, 3],
+        ["hello", "world"],
+        ["hello", b"world"],
+        ("hello", "world"),
+        ("hello", b"world"),
+        {},
+        {"foo": "bar"},
+        {"foo": "bar", b"egg": b"baz"},
+        [{}],
+        [[1]],
+        [(1, 2), (3, 4)],
+    ]
+
+    from rich import print
+
+    for test in tests:
+        print("")
+        print(f"Encoding: \t{test!r}")
+        encoded = dump(test)
+        print(f"Encoded: \t{encoded!r}")
+        decoded = load(encoded)
+        print(f"Decoded: \t{decoded!r}")
+        assert test == decoded

--- a/tests/test_binary_encode.py
+++ b/tests/test_binary_encode.py
@@ -44,6 +44,7 @@ def test_round_trip(data: object) -> None:
 @pytest.mark.parametrize(
     "data",
     [
+        b"",
         b"100:hello",
         b"i",
         b"i1",
@@ -55,3 +56,10 @@ def test_round_trip(data: object) -> None:
 def test_bad_encoding(data: bytes) -> None:
     with pytest.raises(DecodeError):
         load(data)
+
+
+def test_load_wrong_type():
+    with pytest.raises(TypeError):
+        load(None)
+    with pytest.raises(TypeError):
+        load("foo")

--- a/tests/test_binary_encode.py
+++ b/tests/test_binary_encode.py
@@ -8,6 +8,8 @@ from textual._binary_encode import DecodeError, dump, load
     [
         False,
         True,
+        -10,
+        -1,
         0,
         1,
         100,

--- a/tests/test_binary_encode.py
+++ b/tests/test_binary_encode.py
@@ -49,6 +49,7 @@ def test_round_trip(data: object) -> None:
         b"i1",
         b"i10",
         b"li1e",
+        b"x100",
     ],
 )
 def test_bad_encoding(data: bytes) -> None:

--- a/tests/test_binary_encode.py
+++ b/tests/test_binary_encode.py
@@ -1,0 +1,54 @@
+import pytest
+
+from textual._binary_encode import DecodeError, dump, load
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        False,
+        True,
+        0,
+        1,
+        100,
+        "",
+        "Hello",
+        b"World",
+        b"",
+        [],
+        (),
+        [1, 2, 3],
+        ["hello", "world"],
+        ["hello", b"world"],
+        ("hello", "world"),
+        ("hello", b"world"),
+        {},
+        {"foo": "bar"},
+        {"foo": "bar", b"egg": b"baz"},
+        {"foo": "bar", b"egg": b"baz", "list_of_things": [1, 2, 3, "Paul", "Jessica"]},
+        [{}],
+        [[1]],
+        [(1, 2), (3, 4)],
+    ],
+)
+def test_round_trip(data: object) -> None:
+    """Test the data may be encoded then decoded"""
+    encoded = dump(data)
+    assert isinstance(encoded, bytes)
+    decoded = load(encoded)
+    assert data == decoded
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"100:hello",
+        b"i",
+        b"i1",
+        b"i10",
+        b"li1e",
+    ],
+)
+def test_bad_encoding(data: bytes) -> None:
+    with pytest.raises(DecodeError):
+        load(data)

--- a/tests/test_binary_encode.py
+++ b/tests/test_binary_encode.py
@@ -60,6 +60,20 @@ def test_bad_encoding(data: bytes) -> None:
         load(data)
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        set(),
+        float,
+        ...,
+        [float],
+    ],
+)
+def test_dump_invalid_type(data):
+    with pytest.raises(TypeError):
+        dump(data)
+
+
 def test_load_wrong_type():
     with pytest.raises(TypeError):
         load(None)

--- a/tests/test_binary_encode.py
+++ b/tests/test_binary_encode.py
@@ -6,6 +6,7 @@ from textual._binary_encode import DecodeError, dump, load
 @pytest.mark.parametrize(
     "data",
     [
+        None,
         False,
         True,
         -10,
@@ -19,6 +20,7 @@ from textual._binary_encode import DecodeError, dump, load
         b"",
         [],
         (),
+        [None],
         [1, 2, 3],
         ["hello", "world"],
         ["hello", b"world"],


### PR DESCRIPTION
A codec based on [Bencode](https://en.wikipedia.org/wiki/Bencode). 

This can encode Python objects into binary.

Currently floats aren't supported, but they could be.

@darrenburns This should replace msgpack in textual-serve/web.