### PR TITLE
chore(issue template): clarify textual command requires devtools

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,4 +17,6 @@ It will be helpful if you run the following command and paste the results:
 textual diagnose
 ```
 
+If you don't have the `textual` command on your path, you may have forgotten to install the `textual-dev` package.
+
 Feel free to add screenshots and / or videos. These can be very helpful!


### PR DESCRIPTION
The bug report issue template asks contributors to run the `textual diagnose` command. Unfortunately most bug reports don't provide this info and I've seen a few comments that this command doesn't work.

Clarifying that this command requires the devtools installed hopefully will help! 