### PR TITLE
docs: fix typos and spelling

### DIFF
--- a/docs/examples/guide/css/nesting02.tcss
+++ b/docs/examples/guide/css/nesting02.tcss
@@ -9,11 +9,11 @@
         padding: 1 2;
         margin: 1 2;
         text-align: center;
-        border: heavy $panel;    
+        border: heavy $panel;
 
         /* Style the Yes button */
         &.affirmative {
-            border: heavy $success;        
+            border: heavy $success;
         }
 
         /* Style the No button */

--- a/docs/examples/guide/reactivity/set_reactive01.py
+++ b/docs/examples/guide/reactivity/set_reactive01.py
@@ -49,7 +49,7 @@ class NameApp(App):
     CSS = """
     Screen {
         align: center middle;
-    }   
+    }
     """
     greeting_no: var[int] = var(0)
     BINDINGS = [("space", "greeting")]

--- a/docs/examples/guide/reactivity/set_reactive02.py
+++ b/docs/examples/guide/reactivity/set_reactive02.py
@@ -49,7 +49,7 @@ class NameApp(App):
     CSS = """
     Screen {
         align: center middle;
-    }   
+    }
     """
     greeting_no: var[int] = var(0)
     BINDINGS = [("space", "greeting")]

--- a/docs/examples/guide/screens/questions01.tcss
+++ b/docs/examples/guide/screens/questions01.tcss
@@ -1,17 +1,17 @@
 QuestionScreen {
     layout: grid;
-    grid-size: 2 2;                
+    grid-size: 2 2;
     align: center bottom;
 }
 
 QuestionScreen > Label {
-    margin: 1;       
+    margin: 1;
     text-align: center;
-    column-span: 2;    
+    column-span: 2;
     width: 1fr;
 }
 
 QuestionScreen Button {
-    margin: 2; 
-    width: 1fr;     
+    margin: 2;
+    width: 1fr;
 }

--- a/docs/examples/styles/hatch.tcss
+++ b/docs/examples/styles/hatch.tcss
@@ -1,7 +1,7 @@
 .hatch {
     height: 1fr;
     border: solid $secondary;
-  
+
     &.cross {
         hatch: cross $success;
     }

--- a/docs/examples/styles/keyline.tcss
+++ b/docs/examples/styles/keyline.tcss
@@ -5,16 +5,16 @@ Grid {
     keyline: heavy green;
 }
 Placeholder {
-    height: 1fr;      
+    height: 1fr;
 }
 .hidden {
     visibility: hidden;
-} 
+}
 #foo {
     column-span: 2;
 }
 #bar {
-    row-span: 2;        
+    row-span: 2;
 }
 #baz {
     column-span:3;

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -157,7 +157,7 @@ Textual uses the following scheme to map messages classes on to a Python method.
 
 Messages have a namespace if they are defined as a child class of a Widget.
 The namespace is the name of the parent class.
-For instance, the builtin `Input` class defines it's `Changed` message as follow:
+For instance, the builtin `Input` class defines its `Changed` message as follows:
 
 ```python
 class Input(Widget):

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -105,7 +105,7 @@ As mentioned earlier, widgets expand to fill the _width_ of their parent contain
 They do not, however, expand to fill the container's height.
 Thus, we need explicitly assign `height: 100%` to achieve this.
 
-A consequence of this "horizontal growth" behaviour is that if we remove the width restriction from the above example (by deleting `width: 1fr;`), each child widget will grow to fit the width of the screen,
+A consequence of this "horizontal growth" behavior is that if we remove the width restriction from the above example (by deleting `width: 1fr;`), each child widget will grow to fit the width of the screen,
 and only the first widget will be visible.
 The other two widgets in our layout are offscreen, to the right-hand side of the screen.
 In the case of `horizontal` layout, Textual will _not_ automatically add a scrollbar.

--- a/docs/guide/reactivity.md
+++ b/docs/guide/reactivity.md
@@ -200,7 +200,7 @@ The color is parsed in `on_input_submitted` and assigned to `self.color`. Becaus
 
 Textual only calls watch methods if the value of a reactive attribute _changes_.
 If the newly assigned value is the same as the previous value, the watch method is not called.
-You can override this behaviour by passing `always_update=True` to `reactive`.
+You can override this behavior by passing `always_update=True` to `reactive`.
 
 
 ### Dynamically watching reactive attributes

--- a/docs/styles/links/link_background_hover.md
+++ b/docs/styles/links/link_background_hover.md
@@ -20,7 +20,7 @@ If not provided, a Textual action link will have `link-background-hover` set to 
 
 ## Example
 
-The example below shows some links that have their background colour changed when the mouse moves over it and it shows that there is a default color for `link-background-hover`.
+The example below shows some links that have their background color changed when the mouse moves over it and it shows that there is a default color for `link-background-hover`.
 
 It also shows that `link-background-hover` does not affect hyperlinks.
 

--- a/docs/styles/links/link_color_hover.md
+++ b/docs/styles/links/link_color_hover.md
@@ -20,7 +20,7 @@ If not provided, a Textual action link will have `link-color-hover` set to `whit
 
 ## Example
 
-The example below shows some links that have their colour changed when the mouse moves over it.
+The example below shows some links that have their color changed when the mouse moves over it.
 It also shows that `link-color-hover` does not affect hyperlinks.
 
 === "Output"

--- a/docs/styles/links/link_style_hover.md
+++ b/docs/styles/links/link_style_hover.md
@@ -20,7 +20,7 @@ If not provided, a Textual action link will have `link-style-hover` set to `bold
 
 ## Example
 
-The example below shows some links that have their colour changed when the mouse moves over it.
+The example below shows some links that have their color changed when the mouse moves over it.
 It also shows that `link-style-hover` does not affect hyperlinks.
 
 === "Output"

--- a/docs/widgets/text_area.md
+++ b/docs/widgets/text_area.md
@@ -177,7 +177,7 @@ the cursor, selection, gutter, and more.
 
 #### Default theme
 
-The default `TextArea` theme is called `css`, which takes it's values entirely from CSS.
+The default `TextArea` theme is called `css`, which takes its values entirely from CSS.
 This means that the default appearance of the widget fits nicely into a standard Textual application,
 and looks right on both dark and light mode.
 

--- a/docs/widgets/text_area.md
+++ b/docs/widgets/text_area.md
@@ -292,7 +292,7 @@ This immediately updates the appearance of the `TextArea`:
 ```{.textual path="docs/examples/widgets/text_area_custom_theme.py" columns="42" lines="8"}
 ```
 
-### Tab and Escape behaviour
+### Tab and Escape behavior
 
 Pressing the ++tab++ key will shift focus to the next widget in your application by default.
 This matches how other widgets work in Textual.

--- a/examples/code_browser.tcss
+++ b/examples/code_browser.tcss
@@ -23,7 +23,7 @@ CodeBrowser.-show-tree #tree-view {
 #code-view {
     overflow: auto scroll;
     min-width: 100%;
-    hatch: right $primary;   
+    hatch: right $primary;
 }
 #code {
     width: auto;

--- a/examples/dictionary.tcss
+++ b/examples/dictionary.tcss
@@ -9,7 +9,7 @@ Input {
 
 #results {
     width: 100%;
-    height: auto;    
+    height: auto;
 }
 
 #results-container {

--- a/examples/merlin.py
+++ b/examples/merlin.py
@@ -49,8 +49,8 @@ class LabelSwitch(Widget):
     DEFAULT_CSS = """
     LabelSwitch Label {
         text-align: center;
-        width: 1fr;       
-        text-style: bold;         
+        width: 1fr;
+        text-style: bold;
     }
 
     LabelSwitch Label#label-5 {
@@ -101,7 +101,7 @@ class MerlinApp(App):
 
     CSS = """
     Screen {
-        align: center middle;   
+        align: center middle;
     }
 
     Screen.-win {
@@ -110,8 +110,8 @@ class MerlinApp(App):
 
     Screen.-win Timer {
         color: $success;
-    }    
-    
+    }
+
     Grid {
         width: auto;
         height: auto;

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -582,7 +582,7 @@ class Compositor:
 
             Args:
                 widget: The widget to add.
-                virtual_region: The Widget region relative to it's container.
+                virtual_region: The Widget region relative to its container.
                 region: The region the widget will occupy.
                 order: Painting order information.
                 layer_order: The order of the widget in its layer.

--- a/src/textual/_layout.py
+++ b/src/textual/_layout.py
@@ -20,7 +20,7 @@ ArrangeResult: TypeAlias = "list[WidgetPlacement]"
 @dataclass
 class DockArrangeResult:
     placements: list[WidgetPlacement]
-    """A `WidgetPlacement` for every widget to describe it's location on screen."""
+    """A `WidgetPlacement` for every widget to describe its location on screen."""
     widgets: set[Widget]
     """A set of widgets in the arrangement."""
     scroll_spacing: Spacing

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -290,7 +290,7 @@ class BoxProperty:
 
         Returns:
             A ``tuple[EdgeType, Style]`` containing the string type of the box and
-                it's style. Example types are "rounded", "solid", and "dashed".
+                its style. Example types are "rounded", "solid", and "dashed".
         """
         return obj.get_rule(self.name) or ("", self._default_color)  # type: ignore[return-value]
 

--- a/src/textual/document/_document_navigator.py
+++ b/src/textual/document/_document_navigator.py
@@ -21,7 +21,7 @@ class DocumentNavigator:
     may move your cursor to a position further along the current raw document line,
     rather than on to the next line in the raw document.
 
-    The DocumentNavigator class manages that behaviour.
+    The DocumentNavigator class manages that behavior.
 
     Given a cursor location in the unwrapped document, and a cursor movement action,
     this class can inform us of the destination the cursor will move to considering
@@ -49,9 +49,9 @@ class DocumentNavigator:
     document-space line. This is a codepoint index, rather than a visual offset.
     In "ABCDEF" with wrapping at width 3, there is a single wrap offset of 3.
 
-    "Smart home" refers to a modification of the "home" key behaviour. If smart home is
+    "Smart home" refers to a modification of the "home" key behavior. If smart home is
     enabled, the first non-whitespace character is considered to be the home location.
-    If the cursor is currently at this position, then the normal home behaviour applies.
+    If the cursor is currently at this position, then the normal home behavior applies.
     This is designed to make cursor movement more useful to end users.
     """
 
@@ -389,7 +389,7 @@ class DocumentNavigator:
 
         Args:
             location: The location to consider.
-            smart_home: Enable/disable 'smart home' behaviour.
+            smart_home: Enable/disable 'smart home' behavior.
 
         Returns:
             The home location, relative to the given location.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -639,7 +639,7 @@ class Widget(DOMNode):
         """Check if the widget is permitted to focus.
 
         The base class returns [`can_focus`][textual.widget.Widget.can_focus].
-        This method maybe overridden if additional logic is required.
+        This method may be overridden if additional logic is required.
 
         Returns:
             `True` if the widget may be focused, or `False` if it may not be focused.
@@ -650,7 +650,7 @@ class Widget(DOMNode):
         """Check if a widget's children may be focused.
 
         The base class returns [`can_focus_children`][textual.widget.Widget.can_focus_children].
-        This method maybe overridden if additional logic is required.
+        This method may be overridden if additional logic is required.
 
         Returns:
             `True` if the widget's children may be focused, or `False` if the widget's children may not be focused.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1813,7 +1813,7 @@ class Widget(DOMNode):
 
     @property
     def virtual_region(self) -> Region:
-        """The widget region relative to it's container (which may not be visible,
+        """The widget region relative to its container (which may not be visible,
         depending on scroll offset).
 
 
@@ -2845,7 +2845,7 @@ class Widget(DOMNode):
                     scrolled = True
 
             # Adjust the region by the amount we just scrolled it, and convert to
-            # it's parent's virtual coordinate system.
+            # its parent's virtual coordinate system.
 
             region = (
                 (

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -685,7 +685,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             cursor_type: The type of cursor to be used when navigating the data table
                 with the keyboard.
             cell_padding: The number of cells added on each side of each column. Setting
-                this value to zero will likely make your table very heard to read.
+                this value to zero will likely make your table very hard to read.
             name: The name of the widget.
             id: The ID of the widget in the DOM.
             classes: The CSS classes for the widget.

--- a/src/textual/widgets/_directory_tree.py
+++ b/src/textual/widgets/_directory_tree.py
@@ -336,7 +336,7 @@ class DirectoryTree(Tree[DirEntry]):
         await self.reload()
 
     def process_label(self, label: TextType) -> Text:
-        """Process a str or Text into a label. Maybe overridden in a subclass to modify how labels are rendered.
+        """Process a str or Text into a label. May be overridden in a subclass to modify how labels are rendered.
 
         Args:
             label: Label.

--- a/src/textual/widgets/_toggle_button.py
+++ b/src/textual/widgets/_toggle_button.py
@@ -73,7 +73,7 @@ class ToggleButton(Static, can_focus=True):
         text-style: underline;
     }
 
-    /* Base button colours (including in dark mode). */
+    /* Base button colors (including in dark mode). */
 
     ToggleButton > .toggle--button {
         color: $background;

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -706,7 +706,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
     def process_label(self, label: TextType) -> Text:
         """Process a `str` or `Text` value into a label.
 
-        Maybe overridden in a subclass to change how labels are rendered.
+        May be overridden in a subclass to change how labels are rendered.
 
         Args:
             label: Label.


### PR DESCRIPTION
Just a few typos/misspellings I've spotted in passing (and trailing whitespace in CSS examples).