### PR TITLE
Faster query_one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `DOMNode.check_consume_key` https://github.com/Textualize/textual/pull/4940
+- Added `DOMNode.query_exactly_one`
 
 ### Changed
 
 - KeyPanel will show multiple keys if bound to the same action https://github.com/Textualize/textual/pull/4940
+- `DOMNode.query_one` will not `raise TooManyMatches`
 
 ## [0.78.0] - 2024-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `DOMNode.check_consume_key` https://github.com/Textualize/textual/pull/4940
-- Added `DOMNode.query_exactly_one`
+- Added `DOMNode.query_exactly_one` https://github.com/Textualize/textual/pull/4950
+- Added `SelectorSet.is_simple` https://github.com/Textualize/textual/pull/4950
 
 ### Changed
 
 - KeyPanel will show multiple keys if bound to the same action https://github.com/Textualize/textual/pull/4940
-- `DOMNode.query_one` will not `raise TooManyMatches`
+- `DOMNode.query_one` will not `raise TooManyMatches` https://github.com/Textualize/textual/pull/4950
 
 ## [0.78.0] - 2024-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - KeyPanel will show multiple keys if bound to the same action https://github.com/Textualize/textual/pull/4940
-- `DOMNode.query_one` will not `raise TooManyMatches` https://github.com/Textualize/textual/pull/4950
+- Breaking change: `DOMNode.query_one` will not `raise TooManyMatches` https://github.com/Textualize/textual/pull/4950
 
 ## [0.78.0] - 2024-08-27
 

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -21,7 +21,6 @@ send_button = self.query_one("#send")
 
 This will retrieve a widget with an ID of `send`, if there is exactly one.
 If there are no matching widgets, Textual will raise a [NoMatches][textual.css.query.NoMatches] exception.
-If there is more than one match, Textual will raise a [TooManyMatches][textual.css.query.TooManyMatches] exception.
 
 You can also add a second parameter for the expected type, which will ensure that you get the type you are expecting.
 

--- a/src/textual/css/model.py
+++ b/src/textual/css/model.py
@@ -198,6 +198,12 @@ class SelectorSet:
         """Are there any pseudo selectors in the SelectorSet?"""
         return any(selector.pseudo_classes for selector in self.selectors)
 
+    @property
+    def is_simple(self) -> bool:
+        """Are all the selectors simple (i.e. only dependent on static DOM state)."""
+        simple_types = {SelectorType.ID, SelectorType.TYPE}
+        return all(selector.type in simple_types for selector in self.selectors)
+
     def __rich_repr__(self) -> rich.repr.Result:
         selectors = RuleSet._selector_to_css(self.selectors)
         yield selectors

--- a/src/textual/css/model.py
+++ b/src/textual/css/model.py
@@ -194,15 +194,14 @@ class SelectorSet:
         return RuleSet._selector_to_css(self.selectors)
 
     @property
-    def has_pseudo_selectors(self) -> bool:
-        """Are there any pseudo selectors in the SelectorSet?"""
-        return any(selector.pseudo_classes for selector in self.selectors)
-
-    @property
     def is_simple(self) -> bool:
         """Are all the selectors simple (i.e. only dependent on static DOM state)."""
         simple_types = {SelectorType.ID, SelectorType.TYPE}
-        return all(selector.type in simple_types for selector in self.selectors)
+        return all(
+            selector.type in simple_types
+            for selector in self.selectors
+            if not selector.pseudo_classes
+        )
 
     def __rich_repr__(self) -> rich.repr.Result:
         selectors = RuleSet._selector_to_css(self.selectors)

--- a/src/textual/css/model.py
+++ b/src/textual/css/model.py
@@ -198,9 +198,8 @@ class SelectorSet:
         """Are all the selectors simple (i.e. only dependent on static DOM state)."""
         simple_types = {SelectorType.ID, SelectorType.TYPE}
         return all(
-            selector.type in simple_types
+            (selector.type in simple_types and not selector.pseudo_classes)
             for selector in self.selectors
-            if not selector.pseudo_classes
         )
 
     def __rich_repr__(self) -> rich.repr.Result:

--- a/src/textual/css/model.py
+++ b/src/textual/css/model.py
@@ -193,6 +193,11 @@ class SelectorSet:
     def css(self) -> str:
         return RuleSet._selector_to_css(self.selectors)
 
+    @property
+    def has_pseudo_selectors(self) -> bool:
+        """Are there any pseudo selectors in the SelectorSet?"""
+        return any(selector.pseudo_classes for selector in self.selectors)
+
     def __rich_repr__(self) -> rich.repr.Result:
         selectors = RuleSet._selector_to_css(self.selectors)
         yield selectors

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -78,6 +78,10 @@ WalkMethod: TypeAlias = Literal["depth", "breadth"]
 ReactiveType = TypeVar("ReactiveType")
 
 
+QueryOneCacheKey: TypeAlias = "tuple[int, str, Type[Widget]]"
+"""The key used to cache query_one results."""
+
+
 class BadIdentifier(Exception):
     """Exception raised if you supply a `id` attribute or class name in the wrong format."""
 
@@ -218,7 +222,7 @@ class DOMNode(MessagePump):
             dict[str, tuple[MessagePump, Reactive | object]] | None
         ) = None
         self._pruning = False
-        self._query_one_cache: LRUCache[tuple[object, ...], DOMNode] = LRUCache(1024)
+        self._query_one_cache: LRUCache[QueryOneCacheKey, DOMNode] = LRUCache(1024)
 
         super().__init__()
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -29,12 +29,11 @@ from rich.style import Style
 from rich.text import Text
 from rich.tree import Tree
 
-from textual.cache import LRUCache
-
 from ._context import NoActiveAppError, active_message_pump
 from ._node_list import NodeList
 from ._types import WatchCallbackType
 from .binding import Binding, BindingsMap, BindingType
+from .cache import LRUCache
 from .color import BLACK, WHITE, Color
 from .css._error_tools import friendly_list
 from .css.constants import VALID_DISPLAY, VALID_VISIBILITY

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1410,9 +1410,7 @@ class DOMNode(MessagePump):
 
         selector_set = parse_selectors(query_selector)
 
-        children = walk_depth_first(self)
-        iter_children = iter(children)
-        for node in iter_children:
+        for node in walk_depth_first(self):
             if not match(selector_set, node):
                 continue
             if expect_type is not None and not isinstance(node, expect_type):
@@ -1475,6 +1473,8 @@ class DOMNode(MessagePump):
                 continue
             for later_node in iter_children:
                 if match(selector_set, later_node):
+                    if expect_type is not None and not isinstance(node, expect_type):
+                        continue
                     raise TooManyMatches(
                         "Call to query_one resulted in more than one matched node"
                     )

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -748,7 +748,7 @@ class DOMNode(MessagePump):
             ValueError: If the ID has already been set.
         """
         check_identifiers("id", new_id)
-        self._nodes.update()
+        self._nodes.updated()
         if self._id is not None:
             raise ValueError(
                 f"Node 'id' attribute may not be changed once set (current id={self._id!r})"

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -78,7 +78,7 @@ WalkMethod: TypeAlias = Literal["depth", "breadth"]
 ReactiveType = TypeVar("ReactiveType")
 
 
-QueryOneCacheKey: TypeAlias = "tuple[int, str, Type[Widget]]"
+QueryOneCacheKey: TypeAlias = "tuple[int, str, Type[Widget] | None]"
 """The key used to cache query_one results."""
 
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1421,7 +1421,7 @@ class DOMNode(MessagePump):
         else:
             cache_key = None
 
-        for node in walk_depth_first(self):
+        for node in walk_depth_first(self, with_root=False):
             if not match(selector_set, node):
                 continue
             if expect_type is not None and not isinstance(node, expect_type):
@@ -1485,7 +1485,7 @@ class DOMNode(MessagePump):
         else:
             cache_key = None
 
-        children = walk_depth_first(self)
+        children = walk_depth_first(self, with_root=False)
         iter_children = iter(children)
         for node in iter_children:
             if not match(selector_set, node):

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -810,10 +810,11 @@ class Widget(DOMNode):
         # We use Widget as a filter_type so that the inferred type of child is Widget.
         for child in walk_depth_first(self, filter_type=Widget):
             try:
-                if expect_type is None:
-                    return child.get_child_by_id(id)
-                else:
-                    return child.get_child_by_id(id, expect_type=expect_type)
+                if child._nodes:
+                    if expect_type is None:
+                        return child.get_child_by_id(id)
+                    else:
+                        return child.get_child_by_id(id, expect_type=expect_type)
             except NoMatches:
                 pass
             except WrongType as exc:
@@ -958,7 +959,7 @@ class Widget(DOMNode):
         # can be passed to query_one. So let's use that to get a widget to
         # work on.
         if isinstance(spot, str):
-            spot = self.query_one(spot, Widget)
+            spot = self.query_exactly_one(spot, Widget)
 
         # At this point we should have a widget, either because we got given
         # one, or because we pulled one out of the query. First off, does it

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -810,11 +810,10 @@ class Widget(DOMNode):
         # We use Widget as a filter_type so that the inferred type of child is Widget.
         for child in walk_depth_first(self, filter_type=Widget):
             try:
-                if child._nodes:
-                    if expect_type is None:
-                        return child.get_child_by_id(id)
-                    else:
-                        return child.get_child_by_id(id, expect_type=expect_type)
+                if expect_type is None:
+                    return child.get_child_by_id(id)
+                else:
+                    return child.get_child_by_id(id, expect_type=expect_type)
             except NoMatches:
                 pass
             except WrongType as exc:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -103,7 +103,7 @@ def test_query():
         assert app.query_one("#widget1") == widget1
         assert app.query_one("#widget1", Widget) == widget1
         with pytest.raises(TooManyMatches):
-            _ = app.query_one(Widget)
+            _ = app.query_exactly_one(Widget)
 
         assert app.query("Widget.float")[0] == sidebar
         assert app.query("Widget.float")[0:2] == [sidebar, tooltip]


### PR DESCRIPTION
A faster `query_one`.

- Exit when a match is found, without iterating the full DOM
- Caches simple queries (containing just IDs or types)
- Optimizes `get_widget_by_id` by going through `query_one`