### PR TITLE
Fix sorting in command palette search hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `RichLog` writing at wrong width when `write` occurs before width is known (e.g. in `compose` or `on_mount`) https://github.com/Textualize/textual/pull/4978
 - Fixed `RichLog.write` incorrectly shrinking width to `RichLog.min_width` when `shrink=True` (now shrinks to fit content area instead) https://github.com/Textualize/textual/pull/4978
 - Fixed flicker when setting `dark` reactive on startup https://github.com/Textualize/textual/pull/4989
+- Fixed command palette not sorting search results by their match score https://github.com/Textualize/textual/pull/4994
 
 ## [0.79.1] - 2024-08-31
 

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -892,10 +892,11 @@ class CommandPalette(SystemModalScreen):
             else None
         )
 
-        def sort_key(command: Command) -> tuple[float, str]:
+        def sort_key(command: Command) -> float:
+            # Only sort by score if it exists, otherwise do no sorting.
+            # This ensures we only sort Hits, and not DiscoveryHits.
             score = getattr(command.hit, "score", 0)
-            text = command.hit.text
-            return (-score, text or "")
+            return -score
 
         sorted_commands = sorted(commands, key=sort_key)
         command_list.clear_options().add_options(sorted_commands)

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -137,6 +137,16 @@ class DiscoveryHit:
         """The prompt to use when displaying the discovery hit in the command palette."""
         return self.display
 
+    @property
+    def score(self) -> float:
+        """A discovery hit always has a score of 0.
+
+        The order in which discovery hits are displayed is determined by the order
+        in which they are yielded by the Provider. It's up to the developer to yield
+        DiscoveryHits in the .
+        """
+        return 0.0
+
     def __lt__(self, other: object) -> bool:
         if isinstance(other, DiscoveryHit):
             assert self.text is not None
@@ -893,10 +903,7 @@ class CommandPalette(SystemModalScreen):
         )
 
         def sort_key(command: Command) -> float:
-            # Only sort by score if it exists, otherwise do no sorting.
-            # This ensures we only sort Hits, and not DiscoveryHits.
-            score = getattr(command.hit, "score", 0)
-            return -score
+            return -command.hit.score
 
         sorted_commands = sorted(commands, key=sort_key)
         command_list.clear_options().add_options(sorted_commands)

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_command_palette.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_command_palette.svg
@@ -19,138 +19,138 @@
         font-weight: 700;
     }
 
-    .terminal-3691012651-matrix {
+    .terminal-3948438059-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3691012651-title {
+    .terminal-3948438059-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3691012651-r1 { fill: #646464 }
-.terminal-3691012651-r2 { fill: #c5c8c6 }
-.terminal-3691012651-r3 { fill: #004578 }
-.terminal-3691012651-r4 { fill: #dfe1e2 }
-.terminal-3691012651-r5 { fill: #00ff00 }
-.terminal-3691012651-r6 { fill: #000000 }
-.terminal-3691012651-r7 { fill: #1e1e1e }
-.terminal-3691012651-r8 { fill: #dfe1e2;font-weight: bold }
-.terminal-3691012651-r9 { fill: #fea62b;font-weight: bold }
+    .terminal-3948438059-r1 { fill: #646464 }
+.terminal-3948438059-r2 { fill: #c5c8c6 }
+.terminal-3948438059-r3 { fill: #004578 }
+.terminal-3948438059-r4 { fill: #dfe1e2 }
+.terminal-3948438059-r5 { fill: #00ff00 }
+.terminal-3948438059-r6 { fill: #000000 }
+.terminal-3948438059-r7 { fill: #1e1e1e }
+.terminal-3948438059-r8 { fill: #dfe1e2;font-weight: bold }
+.terminal-3948438059-r9 { fill: #fea62b;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-3691012651-clip-terminal">
+    <clipPath id="terminal-3948438059-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-3691012651-line-0">
+    <clipPath id="terminal-3948438059-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-1">
+<clipPath id="terminal-3948438059-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-2">
+<clipPath id="terminal-3948438059-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-3">
+<clipPath id="terminal-3948438059-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-4">
+<clipPath id="terminal-3948438059-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-5">
+<clipPath id="terminal-3948438059-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-6">
+<clipPath id="terminal-3948438059-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-7">
+<clipPath id="terminal-3948438059-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-8">
+<clipPath id="terminal-3948438059-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-9">
+<clipPath id="terminal-3948438059-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-10">
+<clipPath id="terminal-3948438059-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-11">
+<clipPath id="terminal-3948438059-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-12">
+<clipPath id="terminal-3948438059-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-13">
+<clipPath id="terminal-3948438059-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-14">
+<clipPath id="terminal-3948438059-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-15">
+<clipPath id="terminal-3948438059-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-16">
+<clipPath id="terminal-3948438059-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-17">
+<clipPath id="terminal-3948438059-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-18">
+<clipPath id="terminal-3948438059-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-19">
+<clipPath id="terminal-3948438059-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-20">
+<clipPath id="terminal-3948438059-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-21">
+<clipPath id="terminal-3948438059-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3691012651-line-22">
+<clipPath id="terminal-3948438059-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3691012651-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">CommandPaletteApp</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3948438059-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">CommandPaletteApp</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3691012651-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3948438059-clip-terminal)">
     <rect fill="#161616" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="12.2" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="48.8" y="99.1" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="48.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="61" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e1e1e1" x="73.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="85.4" y="123.5" width="866.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="951.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="48.8" y="147.9" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="196.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="196.7" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="221.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="221.1" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="245.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="245.5" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="269.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="269.9" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="294.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="294.3" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="318.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="318.7" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="343.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="343.1" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="367.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="367.5" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="391.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="391.9" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="416.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="122" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="134.2" y="416.3" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0e1c26" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#161616" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-3691012651-matrix">
-    <text class="terminal-3691012651-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3691012651-line-0)">
-</text><text class="terminal-3691012651-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-1)">
-</text><text class="terminal-3691012651-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-2)">
-</text><text class="terminal-3691012651-r3" x="0" y="93.2" textLength="976" clip-path="url(#terminal-3691012651-line-3)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-3691012651-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3691012651-line-3)">
-</text><text class="terminal-3691012651-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3691012651-line-4)">
-</text><text class="terminal-3691012651-r6" x="24.4" y="142" textLength="12.2" clip-path="url(#terminal-3691012651-line-5)">🔎</text><text class="terminal-3691012651-r4" x="61" y="142" textLength="12.2" clip-path="url(#terminal-3691012651-line-5)">A</text><text class="terminal-3691012651-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3691012651-line-5)">
-</text><text class="terminal-3691012651-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-6)">
-</text><text class="terminal-3691012651-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-7)">
-</text><text class="terminal-3691012651-r8" x="0" y="215.2" textLength="122" clip-path="url(#terminal-3691012651-line-8)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="215.2" textLength="12.2" clip-path="url(#terminal-3691012651-line-8)">a</text><text class="terminal-3691012651-r8" x="134.2" y="215.2" textLength="841.8" clip-path="url(#terminal-3691012651-line-8)">&#160;test&#160;of&#160;this&#160;code&#160;0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3691012651-line-8)">
-</text><text class="terminal-3691012651-r8" x="0" y="239.6" textLength="122" clip-path="url(#terminal-3691012651-line-9)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="239.6" textLength="12.2" clip-path="url(#terminal-3691012651-line-9)">a</text><text class="terminal-3691012651-r8" x="134.2" y="239.6" textLength="841.8" clip-path="url(#terminal-3691012651-line-9)">&#160;test&#160;of&#160;this&#160;code&#160;1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3691012651-line-9)">
-</text><text class="terminal-3691012651-r8" x="0" y="264" textLength="122" clip-path="url(#terminal-3691012651-line-10)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="264" textLength="12.2" clip-path="url(#terminal-3691012651-line-10)">a</text><text class="terminal-3691012651-r8" x="134.2" y="264" textLength="841.8" clip-path="url(#terminal-3691012651-line-10)">&#160;test&#160;of&#160;this&#160;code&#160;2&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3691012651-line-10)">
-</text><text class="terminal-3691012651-r8" x="0" y="288.4" textLength="122" clip-path="url(#terminal-3691012651-line-11)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="288.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-11)">a</text><text class="terminal-3691012651-r8" x="134.2" y="288.4" textLength="841.8" clip-path="url(#terminal-3691012651-line-11)">&#160;test&#160;of&#160;this&#160;code&#160;3&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-11)">
-</text><text class="terminal-3691012651-r8" x="0" y="312.8" textLength="122" clip-path="url(#terminal-3691012651-line-12)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="312.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-12)">a</text><text class="terminal-3691012651-r8" x="134.2" y="312.8" textLength="841.8" clip-path="url(#terminal-3691012651-line-12)">&#160;test&#160;of&#160;this&#160;code&#160;4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-12)">
-</text><text class="terminal-3691012651-r8" x="0" y="337.2" textLength="122" clip-path="url(#terminal-3691012651-line-13)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="337.2" textLength="12.2" clip-path="url(#terminal-3691012651-line-13)">a</text><text class="terminal-3691012651-r8" x="134.2" y="337.2" textLength="841.8" clip-path="url(#terminal-3691012651-line-13)">&#160;test&#160;of&#160;this&#160;code&#160;5&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3691012651-line-13)">
-</text><text class="terminal-3691012651-r8" x="0" y="361.6" textLength="122" clip-path="url(#terminal-3691012651-line-14)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="361.6" textLength="12.2" clip-path="url(#terminal-3691012651-line-14)">a</text><text class="terminal-3691012651-r8" x="134.2" y="361.6" textLength="841.8" clip-path="url(#terminal-3691012651-line-14)">&#160;test&#160;of&#160;this&#160;code&#160;6&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3691012651-line-14)">
-</text><text class="terminal-3691012651-r8" x="0" y="386" textLength="122" clip-path="url(#terminal-3691012651-line-15)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="386" textLength="12.2" clip-path="url(#terminal-3691012651-line-15)">a</text><text class="terminal-3691012651-r8" x="134.2" y="386" textLength="841.8" clip-path="url(#terminal-3691012651-line-15)">&#160;test&#160;of&#160;this&#160;code&#160;7&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3691012651-line-15)">
-</text><text class="terminal-3691012651-r8" x="0" y="410.4" textLength="122" clip-path="url(#terminal-3691012651-line-16)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="410.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-16)">a</text><text class="terminal-3691012651-r8" x="134.2" y="410.4" textLength="841.8" clip-path="url(#terminal-3691012651-line-16)">&#160;test&#160;of&#160;this&#160;code&#160;8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-16)">
-</text><text class="terminal-3691012651-r8" x="0" y="434.8" textLength="122" clip-path="url(#terminal-3691012651-line-17)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3691012651-r9" x="122" y="434.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-17)">a</text><text class="terminal-3691012651-r8" x="134.2" y="434.8" textLength="841.8" clip-path="url(#terminal-3691012651-line-17)">&#160;test&#160;of&#160;this&#160;code&#160;9&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3691012651-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-17)">
-</text><text class="terminal-3691012651-r3" x="0" y="459.2" textLength="976" clip-path="url(#terminal-3691012651-line-18)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-3691012651-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3691012651-line-18)">
-</text><text class="terminal-3691012651-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3691012651-line-19)">
-</text><text class="terminal-3691012651-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3691012651-line-20)">
-</text><text class="terminal-3691012651-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3691012651-line-21)">
-</text><text class="terminal-3691012651-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3691012651-line-22)">
+    <g class="terminal-3948438059-matrix">
+    <text class="terminal-3948438059-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3948438059-line-0)">
+</text><text class="terminal-3948438059-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-1)">
+</text><text class="terminal-3948438059-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-2)">
+</text><text class="terminal-3948438059-r3" x="0" y="93.2" textLength="976" clip-path="url(#terminal-3948438059-line-3)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-3948438059-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3948438059-line-3)">
+</text><text class="terminal-3948438059-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3948438059-line-4)">
+</text><text class="terminal-3948438059-r6" x="24.4" y="142" textLength="12.2" clip-path="url(#terminal-3948438059-line-5)">🔎</text><text class="terminal-3948438059-r4" x="61" y="142" textLength="12.2" clip-path="url(#terminal-3948438059-line-5)">A</text><text class="terminal-3948438059-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3948438059-line-5)">
+</text><text class="terminal-3948438059-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-6)">
+</text><text class="terminal-3948438059-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-7)">
+</text><text class="terminal-3948438059-r8" x="0" y="215.2" textLength="122" clip-path="url(#terminal-3948438059-line-8)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="215.2" textLength="12.2" clip-path="url(#terminal-3948438059-line-8)">a</text><text class="terminal-3948438059-r8" x="134.2" y="215.2" textLength="841.8" clip-path="url(#terminal-3948438059-line-8)">&#160;test&#160;of&#160;this&#160;code&#160;9&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3948438059-line-8)">
+</text><text class="terminal-3948438059-r8" x="0" y="239.6" textLength="122" clip-path="url(#terminal-3948438059-line-9)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="239.6" textLength="12.2" clip-path="url(#terminal-3948438059-line-9)">a</text><text class="terminal-3948438059-r8" x="134.2" y="239.6" textLength="841.8" clip-path="url(#terminal-3948438059-line-9)">&#160;test&#160;of&#160;this&#160;code&#160;8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3948438059-line-9)">
+</text><text class="terminal-3948438059-r8" x="0" y="264" textLength="122" clip-path="url(#terminal-3948438059-line-10)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="264" textLength="12.2" clip-path="url(#terminal-3948438059-line-10)">a</text><text class="terminal-3948438059-r8" x="134.2" y="264" textLength="841.8" clip-path="url(#terminal-3948438059-line-10)">&#160;test&#160;of&#160;this&#160;code&#160;7&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3948438059-line-10)">
+</text><text class="terminal-3948438059-r8" x="0" y="288.4" textLength="122" clip-path="url(#terminal-3948438059-line-11)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="288.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-11)">a</text><text class="terminal-3948438059-r8" x="134.2" y="288.4" textLength="841.8" clip-path="url(#terminal-3948438059-line-11)">&#160;test&#160;of&#160;this&#160;code&#160;6&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-11)">
+</text><text class="terminal-3948438059-r8" x="0" y="312.8" textLength="122" clip-path="url(#terminal-3948438059-line-12)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="312.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-12)">a</text><text class="terminal-3948438059-r8" x="134.2" y="312.8" textLength="841.8" clip-path="url(#terminal-3948438059-line-12)">&#160;test&#160;of&#160;this&#160;code&#160;5&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-12)">
+</text><text class="terminal-3948438059-r8" x="0" y="337.2" textLength="122" clip-path="url(#terminal-3948438059-line-13)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="337.2" textLength="12.2" clip-path="url(#terminal-3948438059-line-13)">a</text><text class="terminal-3948438059-r8" x="134.2" y="337.2" textLength="841.8" clip-path="url(#terminal-3948438059-line-13)">&#160;test&#160;of&#160;this&#160;code&#160;4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3948438059-line-13)">
+</text><text class="terminal-3948438059-r8" x="0" y="361.6" textLength="122" clip-path="url(#terminal-3948438059-line-14)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="361.6" textLength="12.2" clip-path="url(#terminal-3948438059-line-14)">a</text><text class="terminal-3948438059-r8" x="134.2" y="361.6" textLength="841.8" clip-path="url(#terminal-3948438059-line-14)">&#160;test&#160;of&#160;this&#160;code&#160;3&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3948438059-line-14)">
+</text><text class="terminal-3948438059-r8" x="0" y="386" textLength="122" clip-path="url(#terminal-3948438059-line-15)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="386" textLength="12.2" clip-path="url(#terminal-3948438059-line-15)">a</text><text class="terminal-3948438059-r8" x="134.2" y="386" textLength="841.8" clip-path="url(#terminal-3948438059-line-15)">&#160;test&#160;of&#160;this&#160;code&#160;2&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3948438059-line-15)">
+</text><text class="terminal-3948438059-r8" x="0" y="410.4" textLength="122" clip-path="url(#terminal-3948438059-line-16)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="410.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-16)">a</text><text class="terminal-3948438059-r8" x="134.2" y="410.4" textLength="841.8" clip-path="url(#terminal-3948438059-line-16)">&#160;test&#160;of&#160;this&#160;code&#160;1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-16)">
+</text><text class="terminal-3948438059-r8" x="0" y="434.8" textLength="122" clip-path="url(#terminal-3948438059-line-17)">&#160;&#160;This&#160;is&#160;</text><text class="terminal-3948438059-r9" x="122" y="434.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-17)">a</text><text class="terminal-3948438059-r8" x="134.2" y="434.8" textLength="841.8" clip-path="url(#terminal-3948438059-line-17)">&#160;test&#160;of&#160;this&#160;code&#160;0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3948438059-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-17)">
+</text><text class="terminal-3948438059-r3" x="0" y="459.2" textLength="976" clip-path="url(#terminal-3948438059-line-18)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-3948438059-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3948438059-line-18)">
+</text><text class="terminal-3948438059-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3948438059-line-19)">
+</text><text class="terminal-3948438059-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3948438059-line-20)">
+</text><text class="terminal-3948438059-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3948438059-line-21)">
+</text><text class="terminal-3948438059-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3948438059-line-22)">
 </text>
     </g>
     </g>


### PR DESCRIPTION
Fixes #4927.

This will only sort _search_ hits by their match score, and do no sorting for discovery hits.

Discovery hits are left unsorted as we decided to leave that up to the end user - they may wish the most frequent commands to appear at the top for example.