### PR TITLE
fix(inline driver): check padding when clearing output on quit

### DIFF
--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -306,7 +306,8 @@ class LinuxInlineDriver(Driver):
         self._disable_bracketed_paste()
         self.disable_input()
 
-        self.write("\x1b[2A\x1b[J")
+        back_lines = self._app.INLINE_PADDING + 1
+        self.write(f"\x1b[{back_lines}A\x1b[J")
 
         if self.attrs_before is not None:
             try:

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -306,7 +306,7 @@ class LinuxInlineDriver(Driver):
         self._disable_bracketed_paste()
         self.disable_input()
 
-        back_lines = self._app.INLINE_PADDING + 1
+        back_lines = max(self._app.INLINE_PADDING, 0) + 1
         self.write(f"\x1b[{back_lines}A\x1b[J")
 
         if self.attrs_before is not None:


### PR DESCRIPTION
Fixes #5017 by updating the `\x1b[2A` escape code to check the new `App.INLINE_PADDING`.

(Edit: I don't know why anyone would do this, but just in case I've now accounted for negative padding!)