### PR TITLE
fix(app): fix `inline_no_clear`

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2909,10 +2909,14 @@ class App(Generic[ReturnType], DOMNode):
                             self._driver.write(
                                 Control.move(-cursor_x, -cursor_y + 1).segment.text
                             )
-                            if inline_no_clear and not not self.app._exit_renderables:
+                            if inline_no_clear:
                                 console = Console()
-                                console.print(self.screen._compositor)
-                                console.print()
+                                try:
+                                    console.print(self.screen._compositor)
+                                except ScreenStackError:
+                                    pass
+                                else:
+                                    console.print()
 
                         driver.stop_application_mode()
             except Exception as error:


### PR DESCRIPTION
Fixes #5019. 

I'm afraid I don't fully understand commit 8c01ef7, but this change seems to fix the broken `inline_no_clear` without any regression related to issue #4882 which I believe this commit intended to fix.

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
