### PR TITLE
Fix --help flag in docs

### DIFF
--- a/docs/guide/devtools.md
+++ b/docs/guide/devtools.md
@@ -95,7 +95,7 @@ You can serve multiple instances of your application at once!
 There are some additional switches for serving Textual apps. Run the following for a list:
 
 ```
-textual serve -h
+textual serve --help
 ```
 
 ## Live editing


### PR DESCRIPTION
Thank you for this project!

Just noticed that the docs mention `textual serve -h` as a way to list all options, but `-h` is the shorthand for `--host`.

This PR changes the flag to `--help`.