### PR TITLE
Adjust Log.highlighter type to allow for custom highlighters.

### DIFF
--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -4,7 +4,7 @@ import re
 from typing import TYPE_CHECKING, Iterable, Optional, Sequence
 
 from rich.cells import cell_len
-from rich.highlighter import ReprHighlighter
+from rich.highlighter import Highlighter, ReprHighlighter
 from rich.segment import Segment
 from rich.style import Style
 from rich.text import Text
@@ -70,7 +70,7 @@ class Log(ScrollView, can_focus=True):
         self._width = 0
         self._updates = 0
         self._render_line_cache: LRUCache[int, Strip] = LRUCache(1024)
-        self.highlighter = ReprHighlighter()
+        self.highlighter: Highlighter = ReprHighlighter()
         """The Rich Highlighter object to use, if `highlight=True`"""
 
     @property


### PR DESCRIPTION
This is the exact same as #4247 but for Log instead of RichLog: without an explicit type, tools like mypy assume Log.highlighter must be a ReprHighlighter instead of a Highlighter.

Checklist: not worth it.