### PR TITLE
limit scrolling by axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Add
 
-- Added `x_axis` and `y_axis` parameters to `Widget.scroll_to_region`
+- Added `x_axis` and `y_axis` parameters to `Widget.scroll_to_region` https://github.com/Textualize/textual/pull/5047
 
 ### Changed
 
-- Tree will no longer scroll the X axis when moving the cursor
+- Tree will no longer scroll the X axis when moving the cursor https://github.com/Textualize/textual/pull/5047
 
 ## [0.80.1] - 2024-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Add
+
+- Added `x_axis` and `y_axis` parameters to `Widget.scroll_to_region`
+
+### Changed
+
+- Tree will no longer scroll the X axis when moving the cursor
+
 ## [0.80.1] - 2024-09-24
 
 ### Fixed

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2874,6 +2874,8 @@ class Widget(DOMNode):
         force: bool = False,
         on_complete: CallbackType | None = None,
         level: AnimationLevel = "basic",
+        x_axis: bool = True,
+        y_axis: bool = True,
     ) -> Offset:
         """Scrolls a given region in to view, if required.
 
@@ -2892,6 +2894,8 @@ class Widget(DOMNode):
             force: Force scrolling even when prohibited by overflow styling.
             on_complete: A callable to invoke when the animation is finished.
             level: Minimum level required for the animation to take place (inclusive).
+            x_axis: Allow scrolling on X axis?
+            y_axis: Allow scrolling on Y axis?
 
         Returns:
             The distance that was scrolled.
@@ -2938,11 +2942,13 @@ class Widget(DOMNode):
             delta = Offset(delta.x, 0)
 
         if delta:
+            delta_x = delta.x if x_axis else 0
+            delta_y = delta.y if y_axis else 0
             if speed is None and duration is None:
                 duration = 0.2
             self.scroll_relative(
-                delta.x or None,
-                delta.y or None,
+                delta_x or None,
+                delta_y or None,
                 animate=animate,
                 speed=speed,
                 duration=duration,

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -1113,7 +1113,12 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         region = self._get_label_region(line)
         if region is not None:
             self.scroll_to_region(
-                region, animate=animate, force=True, center=self.center_scroll
+                region,
+                animate=animate,
+                force=True,
+                center=self.center_scroll,
+                origin_visible=False,
+                x_axis=False,  # Scrolling the X axis is quite jarring, and rarely necessary
             )
 
     def scroll_to_node(


### PR DESCRIPTION
Adds the ability to restrict scrolling by axis in `Widget.scroll_to_region`.

This was required to prevent the tree control from scrolling in the X direction when moving the cursor.