### PR TITLE
raise AttributeError

### DIFF
--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -104,7 +104,7 @@ def __getattr__(widget_class: str) -> type[Widget]:
         pass
 
     if widget_class not in __all__:
-        raise ImportError(f"Package 'textual.widgets' has no class '{widget_class}'")
+        raise AttributeError(f"Package 'textual.widgets' has no class '{widget_class}'")
 
     widget_module_path = f"._{camel_to_snake(widget_class)}"
     module = import_module(widget_module_path, package="textual.widgets")

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -586,7 +586,7 @@ def test_lazy_loading() -> None:
     """
 
     with pytest.raises(ImportError):
-        pass
+        from textual.widgets import Foo  # nopycln: import
 
     from textual import widgets
     from textual.widgets import Label

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -579,7 +579,17 @@ def test_bad_widget_name_raised() -> None:
 
 
 def test_lazy_loading() -> None:
+    """Regression test for https://github.com/Textualize/textual/issues/5077
+
+    Check that the lazy loading magic doesn't break attribute access.
+
+    """
+
+    with pytest.raises(ImportError):
+        pass
+
     from textual import widgets
+    from textual.widgets import Label
 
     assert not hasattr(widgets, "foo")
     assert not hasattr(widgets, "bar")

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -576,3 +576,11 @@ def test_bad_widget_name_raised() -> None:
 
         class lowercaseWidget(Widget):
             pass
+
+
+def test_lazy_loading() -> None:
+    from textual import widgets
+
+    assert not hasattr(widgets, "foo")
+    assert not hasattr(widgets, "bar")
+    assert hasattr(widgets, "Label")


### PR DESCRIPTION
The module level `getattr` was raising an ImportError when the module was not found. It should be an `AttributeError`, so it doesn't break attribute access. Python will also translate that in to an ImportError where appropriate.

Fixes https://github.com/Textualize/textual/issues/5077