### PR TITLE
constrain both axis

### DIFF
--- a/src/textual/css/_styles_builder.py
+++ b/src/textual/css/_styles_builder.py
@@ -1047,6 +1047,40 @@ class StylesBuilder:
             self.styles._rules[name] = value  # type: ignore
 
     def process_constrain(self, name: str, tokens: list[Token]) -> None:
+        if len(tokens) == 1:
+            try:
+                value = self._process_enum(name, tokens, VALID_CONSTRAIN)
+            except StyleValueError:
+                self.error(
+                    name,
+                    tokens[0],
+                    string_enum_help_text(name, VALID_CONSTRAIN, context="css"),
+                )
+            else:
+                self.styles._rules["constrain_x"] = value  # type: ignore
+                self.styles._rules["constrain_y"] = value  # type: ignore
+        elif len(tokens) == 2:
+            constrain_x, constrain_y = self._process_enum_multiple(
+                name, tokens, VALID_CONSTRAIN, 2
+            )
+            self.styles._rules["constrain_x"] = constrain_x  # type: ignore
+            self.styles._rules["constrain_y"] = constrain_y  # type: ignore
+        else:
+            self.error(name, tokens[0], "one or two values here")
+
+    def process_constrain_x(self, name: str, tokens: list[Token]) -> None:
+        try:
+            value = self._process_enum(name, tokens, VALID_CONSTRAIN)
+        except StyleValueError:
+            self.error(
+                name,
+                tokens[0],
+                string_enum_help_text(name, VALID_CONSTRAIN, context="css"),
+            )
+        else:
+            self.styles._rules[name] = value  # type: ignore
+
+    def process_constrain_y(self, name: str, tokens: list[Token]) -> None:
         try:
             value = self._process_enum(name, tokens, VALID_CONSTRAIN)
         except StyleValueError:

--- a/src/textual/css/constants.py
+++ b/src/textual/css/constants.py
@@ -74,7 +74,7 @@ VALID_PSEUDO_CLASSES: Final = {
     "nocolor",
 }
 VALID_OVERLAY: Final = {"none", "screen"}
-VALID_CONSTRAIN: Final = {"x", "y", "both", "inflect", "none"}
+VALID_CONSTRAIN: Final = {"inflect", "limit", "none"}
 VALID_KEYLINE: Final = {"none", "thin", "heavy", "double"}
 VALID_HATCH: Final = {"left", "right", "cross", "vertical", "horizontal"}
 HATCHES: Final = {

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -190,7 +190,8 @@ class RulesMap(TypedDict, total=False):
     hatch: tuple[str, Color] | Literal["none"]
 
     overlay: Overlay
-    constrain: Constrain
+    constrain_x: Constrain
+    constrain_y: Constrain
 
 
 RULE_NAMES = list(RulesMap.__annotations__.keys())
@@ -450,7 +451,8 @@ class StylesBase:
     overlay = StringEnumProperty(
         VALID_OVERLAY, "none", layout=True, refresh_parent=True
     )
-    constrain = StringEnumProperty(VALID_CONSTRAIN, "none")
+    constrain_x = StringEnumProperty(VALID_CONSTRAIN, "none")
+    constrain_y = StringEnumProperty(VALID_CONSTRAIN, "none")
 
     def __textual_animation__(
         self,
@@ -1172,8 +1174,18 @@ class Styles(StylesBase):
             append_declaration("subtitle-text-style", str(self.border_subtitle_style))
         if "overlay" in rules:
             append_declaration("overlay", str(self.overlay))
-        if "constrain" in rules:
-            append_declaration("constrain", str(self.constrain))
+        if "constrain_x" in rules and "constrain_y" in rules:
+            if self.constrain_x == self.constrain_y:
+                append_declaration("constrain", self.constrain_x)
+            else:
+                append_declaration(
+                    "constrain", f"{self.constrain_x} {self.constrain_y}"
+                )
+        elif "constrain_x" in rules:
+            append_declaration("constrain-x", self.constrain_x)
+        elif "constrain_y" in rules:
+            append_declaration("constrain-y", self.constrain_y)
+
         if "keyline" in rules:
             keyline_type, keyline_color = self.keyline
             if keyline_type != "none":

--- a/src/textual/css/types.py
+++ b/src/textual/css/types.py
@@ -36,7 +36,7 @@ BoxSizing = Literal["border-box", "content-box"]
 Overflow = Literal["scroll", "hidden", "auto"]
 EdgeStyle = Tuple[EdgeType, Color]
 TextAlign = Literal["left", "start", "center", "right", "end", "justify"]
-Constrain = Literal["none", "x", "y", "both"]
+Constrain = Literal["none", "inflect", "limit"]
 Overlay = Literal["none", "screen"]
 
 Specificity3 = Tuple[int, int, int]

--- a/src/textual/widgets/_tooltip.py
+++ b/src/textual/widgets/_tooltip.py
@@ -8,13 +8,15 @@ class Tooltip(Static, inherit_css=False):
     Tooltip {
         layer: _tooltips;
         margin: 1 2;
+
         padding: 1 2;
         background: $background;
         width: auto;
         height: auto;
-        constrain: inflect;
+        constrain: limit inflect;
         max-width: 40;
         display: none;
+        offset-x: -50%;
     }
     """
     DEFAULT_CLASSES = "-textual-system"


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5007

This builds on the undocumented `constrain` rule. It can now accept two values for X and Y axis.

"inflect" will mirror the widget about the axis.
"inside" will prevent the widget from moving outside of the container.

Setting the tooltip's constrain to "inside inflect" seems to give a more typical tooltip behavor.

Also adds support for relative offsets. By setting the Tooltips x-offset to "-50%", it can be displayed centered underneath the cursor.
