### PR TITLE
ci: remove macos workaround for python versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,17 +21,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-
-        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        exclude:
-          - { python-version: "3.8", os: "macos-latest" }
-          - { python-version: "3.9", os: "macos-latest" }
-          - { python-version: "3.11", os: "macos-latest" }
-        include:
-          - { python-version: "3.8", os: "macos-13" }
-          - { python-version: "3.9", os: "macos-13" }
-          - { python-version: "3.11", os: "macos-13" }
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Remove the workaround in CI for `macos-latest` where the previously missing Python versions now seem to be supported.