### PR TITLE
tint fix

### DIFF
--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -399,6 +399,31 @@ class Color(NamedTuple):
             new_alpha,
         )
 
+    @lru_cache(maxsize=1024)
+    def tint(self, color: Color) -> Color:
+        """Apply a tint to a color.
+
+        Similar to blend, but combines color and alpha.
+
+        Args:
+            color: A color with alpha component.
+
+        Returns:
+            New color
+        """
+        r2, g2, b2, a2, ansi2 = color
+        if ansi2 is not None:
+            return color
+        r1, g1, b1, a1, ansi1 = self
+        if ansi1 is not None:
+            return color
+        return Color(
+            int(r1 + (r2 - r1) * a2),
+            int(g1 + (g2 - g1) * a2),
+            int(b1 + (b2 - b1) * a2),
+            a1,
+        )
+
     def __add__(self, other: object) -> Color:
         if isinstance(other, Color):
             return self.blend(other, other.a, 1.0)

--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -413,10 +413,10 @@ class Color(NamedTuple):
         """
         r2, g2, b2, a2, ansi2 = color
         if ansi2 is not None:
-            return color
+            return self
         r1, g1, b1, a1, ansi1 = self
         if ansi1 is not None:
-            return color
+            return self
         return Color(
             int(r1 + (r2 - r1) * a2),
             int(g1 + (g2 - g1) * a2),

--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -411,11 +411,12 @@ class Color(NamedTuple):
         Returns:
             New color
         """
-        r2, g2, b2, a2, ansi2 = color
-        if ansi2 is not None:
-            return self
+
         r1, g1, b1, a1, ansi1 = self
         if ansi1 is not None:
+            return self
+        r2, g2, b2, a2, ansi2 = color
+        if ansi2 is not None:
             return self
         return Color(
             int(r1 + (r2 - r1) * a2),

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1026,11 +1026,11 @@ class DOMNode(MessagePump):
             has_rule = styles.has_rule
             opacity *= styles.opacity
             if has_rule("background"):
-                text_background = (
-                    background + styles.background + styles.background_tint
+                text_background = background + styles.background.tint(
+                    styles.background_tint
                 )
                 background += (
-                    styles.background + styles.background_tint
+                    styles.background.tint(styles.background_tint)
                 ).multiply_alpha(opacity)
             else:
                 text_background = background
@@ -1119,7 +1119,7 @@ class DOMNode(MessagePump):
         for node in reversed(self.ancestors_with_self):
             styles = node.styles
             base_background = background
-            background += styles.background + styles.background_tint
+            background += styles.background.tint(styles.background_tint)
         return (base_background, background)
 
     @property
@@ -1135,7 +1135,7 @@ class DOMNode(MessagePump):
             styles = node.styles
             base_background = background
             opacity *= styles.opacity
-            background += (styles.background + styles.background_tint).multiply_alpha(
+            background += styles.background.tint(styles.background_tint).multiply_alpha(
                 opacity
             )
         return (base_background, background)
@@ -1152,7 +1152,7 @@ class DOMNode(MessagePump):
         for node in reversed(self.ancestors_with_self):
             styles = node.styles
             base_background = background
-            background += styles.background + styles.background_tint
+            background += styles.background.tint(styles.background_tint)
             if styles.has_rule("color"):
                 base_color = color
                 if styles.auto_color:

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_background_tint.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_background_tint.svg
@@ -19,134 +19,134 @@
         font-weight: 700;
     }
 
-    .terminal-2147534319-matrix {
+    .terminal-3859065499-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-2147534319-title {
+    .terminal-3859065499-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-2147534319-r1 { fill: #e2e3e3 }
-.terminal-2147534319-r2 { fill: #c5c8c6 }
-.terminal-2147534319-r3 { fill: #ebebec }
-.terminal-2147534319-r4 { fill: #f3f3f4 }
-.terminal-2147534319-r5 { fill: #fcfcfc }
+    .terminal-3859065499-r1 { fill: #e4e4ee }
+.terminal-3859065499-r2 { fill: #c5c8c6 }
+.terminal-3859065499-r3 { fill: #e4e2ec }
+.terminal-3859065499-r4 { fill: #e4e0ea }
+.terminal-3859065499-r5 { fill: #e4dde8 }
     </style>
 
     <defs>
-    <clipPath id="terminal-2147534319-clip-terminal">
+    <clipPath id="terminal-3859065499-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-2147534319-line-0">
+    <clipPath id="terminal-3859065499-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-1">
+<clipPath id="terminal-3859065499-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-2">
+<clipPath id="terminal-3859065499-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-3">
+<clipPath id="terminal-3859065499-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-4">
+<clipPath id="terminal-3859065499-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-5">
+<clipPath id="terminal-3859065499-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-6">
+<clipPath id="terminal-3859065499-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-7">
+<clipPath id="terminal-3859065499-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-8">
+<clipPath id="terminal-3859065499-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-9">
+<clipPath id="terminal-3859065499-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-10">
+<clipPath id="terminal-3859065499-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-11">
+<clipPath id="terminal-3859065499-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-12">
+<clipPath id="terminal-3859065499-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-13">
+<clipPath id="terminal-3859065499-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-14">
+<clipPath id="terminal-3859065499-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-15">
+<clipPath id="terminal-3859065499-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-16">
+<clipPath id="terminal-3859065499-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-17">
+<clipPath id="terminal-3859065499-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-18">
+<clipPath id="terminal-3859065499-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-19">
+<clipPath id="terminal-3859065499-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-20">
+<clipPath id="terminal-3859065499-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-21">
+<clipPath id="terminal-3859065499-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2147534319-line-22">
+<clipPath id="terminal-3859065499-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-2147534319-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">BackgroundTintApp</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3859065499-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">BackgroundTintApp</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-2147534319-clip-terminal)">
-    <rect fill="#24292f" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#24292f" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#66696d" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#66696d" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#66696d" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#66696d" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#66696d" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#66696d" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#a8aaac" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#a8aaac" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#a8aaac" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#a8aaac" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#a8aaac" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#a8aaac" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ededed" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ededed" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ededed" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ededed" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ededed" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ededed" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-2147534319-matrix">
-    <text class="terminal-2147534319-r1" x="0" y="20" textLength="976" clip-path="url(#terminal-2147534319-line-0)">0%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2147534319-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2147534319-line-0)">
-</text><text class="terminal-2147534319-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2147534319-line-1)">
-</text><text class="terminal-2147534319-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2147534319-line-2)">
-</text><text class="terminal-2147534319-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2147534319-line-3)">
-</text><text class="terminal-2147534319-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2147534319-line-4)">
-</text><text class="terminal-2147534319-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2147534319-line-5)">
-</text><text class="terminal-2147534319-r3" x="0" y="166.4" textLength="976" clip-path="url(#terminal-2147534319-line-6)">33%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2147534319-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2147534319-line-6)">
-</text><text class="terminal-2147534319-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2147534319-line-7)">
-</text><text class="terminal-2147534319-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2147534319-line-8)">
-</text><text class="terminal-2147534319-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2147534319-line-9)">
-</text><text class="terminal-2147534319-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2147534319-line-10)">
-</text><text class="terminal-2147534319-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2147534319-line-11)">
-</text><text class="terminal-2147534319-r4" x="0" y="312.8" textLength="976" clip-path="url(#terminal-2147534319-line-12)">66%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2147534319-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2147534319-line-12)">
-</text><text class="terminal-2147534319-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2147534319-line-13)">
-</text><text class="terminal-2147534319-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2147534319-line-14)">
-</text><text class="terminal-2147534319-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2147534319-line-15)">
-</text><text class="terminal-2147534319-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2147534319-line-16)">
-</text><text class="terminal-2147534319-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2147534319-line-17)">
-</text><text class="terminal-2147534319-r5" x="0" y="459.2" textLength="976" clip-path="url(#terminal-2147534319-line-18)">100%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2147534319-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2147534319-line-18)">
-</text><text class="terminal-2147534319-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2147534319-line-19)">
-</text><text class="terminal-2147534319-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2147534319-line-20)">
-</text><text class="terminal-2147534319-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2147534319-line-21)">
-</text><text class="terminal-2147534319-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2147534319-line-22)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3859065499-clip-terminal)">
+    <rect fill="#333383" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#333383" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#333383" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#333383" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#333383" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#333383" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#332272" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#332272" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#332272" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#332272" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#332272" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#332272" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#331161" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#331161" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#331161" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#331161" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#331161" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#331161" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#330050" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#330050" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#330050" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#330050" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#330050" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#330050" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-3859065499-matrix">
+    <text class="terminal-3859065499-r1" x="0" y="20" textLength="976" clip-path="url(#terminal-3859065499-line-0)">0%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3859065499-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3859065499-line-0)">
+</text><text class="terminal-3859065499-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3859065499-line-1)">
+</text><text class="terminal-3859065499-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3859065499-line-2)">
+</text><text class="terminal-3859065499-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3859065499-line-3)">
+</text><text class="terminal-3859065499-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3859065499-line-4)">
+</text><text class="terminal-3859065499-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3859065499-line-5)">
+</text><text class="terminal-3859065499-r3" x="0" y="166.4" textLength="976" clip-path="url(#terminal-3859065499-line-6)">33%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3859065499-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3859065499-line-6)">
+</text><text class="terminal-3859065499-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3859065499-line-7)">
+</text><text class="terminal-3859065499-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3859065499-line-8)">
+</text><text class="terminal-3859065499-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3859065499-line-9)">
+</text><text class="terminal-3859065499-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3859065499-line-10)">
+</text><text class="terminal-3859065499-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3859065499-line-11)">
+</text><text class="terminal-3859065499-r4" x="0" y="312.8" textLength="976" clip-path="url(#terminal-3859065499-line-12)">66%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3859065499-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3859065499-line-12)">
+</text><text class="terminal-3859065499-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3859065499-line-13)">
+</text><text class="terminal-3859065499-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3859065499-line-14)">
+</text><text class="terminal-3859065499-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3859065499-line-15)">
+</text><text class="terminal-3859065499-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3859065499-line-16)">
+</text><text class="terminal-3859065499-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3859065499-line-17)">
+</text><text class="terminal-3859065499-r5" x="0" y="459.2" textLength="976" clip-path="url(#terminal-3859065499-line-18)">100%&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3859065499-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3859065499-line-18)">
+</text><text class="terminal-3859065499-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3859065499-line-19)">
+</text><text class="terminal-3859065499-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3859065499-line-20)">
+</text><text class="terminal-3859065499-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3859065499-line-21)">
+</text><text class="terminal-3859065499-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3859065499-line-22)">
 </text>
     </g>
     </g>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -2314,15 +2314,27 @@ def test_maximize_allow(snap_compare):
 
 
 def test_background_tint(snap_compare):
+    """Test background tint with alpha."""
+
+    # The screen background is dark blue
+    # The vertical is 20% white
+    # With no background tint, the verticals will be a light blue
+    # With a 100% tint, the vertical should be 20% red plus the blue (i.e. purple)
+
+    # tl;dr you should see 4 bars, blue at the top, purple at the bottom, and two shades in betweenm
+
     class BackgroundTintApp(App):
         CSS = """
-        Vertical {
-            background: $panel;
+        Screen {
+            background: rgb(0,0,100)
         }
-        #tint1 { background-tint: $foreground 0%; }
-        #tint2 { background-tint: $foreground 33%; }
-        #tint3 { background-tint: $foreground 66%; }
-        #tint4 { background-tint: $foreground 100% }
+        Vertical {
+            background: rgba(255,255,255,0.2);
+        }
+        #tint1 { background-tint: rgb(255,0,0) 0%; }
+        #tint2 { background-tint: rgb(255,0,0) 33%; }
+        #tint3 { background-tint: rgb(255,0,0) 66%; }
+        #tint4 { background-tint: rgb(255,0,0) 100% }
         """
 
         def compose(self) -> ComposeResult:

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -2321,7 +2321,7 @@ def test_background_tint(snap_compare):
     # With no background tint, the verticals will be a light blue
     # With a 100% tint, the vertical should be 20% red plus the blue (i.e. purple)
 
-    # tl;dr you should see 4 bars, blue at the top, purple at the bottom, and two shades in betweenm
+    # tl;dr you should see 4 bars, blue at the top, purple at the bottom, and two shades in between
 
     class BackgroundTintApp(App):
         CSS = """

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -265,3 +265,27 @@ def test_is_transparent():
     assert not Color(20, 20, 30, a=0.01).is_transparent
     assert not Color(20, 20, 30, a=1).is_transparent
     assert not Color(20, 20, 30, 0, ansi=1).is_transparent
+
+
+@pytest.mark.parametrize(
+    "base,tint,expected",
+    [
+        (
+            Color(0, 0, 0),
+            Color(10, 20, 30),
+            Color(10, 20, 30),
+        ),
+        (
+            Color(0, 0, 0, 0.5),
+            Color(255, 255, 255, 0.5),
+            Color(127, 127, 127, 0.5),
+        ),
+        (
+            Color(100, 0, 0, 0.2),
+            Color(0, 100, 0, 0.5),
+            Color(50, 50, 0, 0.2),
+        ),
+    ],
+)
+def test_tint(base: Color, tint: Color, expected: Color) -> None:
+    assert base.tint(tint) == expected


### PR DESCRIPTION
A change to background tint, which preserves the initial alpha.

> I think if you apply a background tint >0% on a widget that has any transparency in it’s background color, the effect is unexpected (edited) 
> The effect seems like it’s removing the transparency component of the color completely and not applying the tint at all
> MyWidget {
>   background: red 10%;
>  background-tint: blue 1%;
> }
> The result widget looks like red 100%

With this change, the background will be red with a (small) tint of blue, with 10% alpha