### PR TITLE
Pseudo update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `background-tint` CSS rule https://github.com/Textualize/textual/pull/5117
-- Added first-of-type, last-of-type, odd, and even pseudo classes https://github.com/Textualize/textual/pull/5139
+- Added `:first-of-type`, `:last-of-type`, `:odd`, and `:even` pseudo classes https://github.com/Textualize/textual/pull/5139
 
 ## [0.83.0] - 2024-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `background-tint` CSS rule https://github.com/Textualize/textual/pull/5117
+- Added first-of-type, last-of-type, odd, and even pseudo classes https://github.com/Textualize/textual/pull/5139
 
 ## [0.83.0] - 2024-10-10
 

--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -330,10 +330,14 @@ Here are some other pseudo classes:
 - `:dark` Matches widgets in dark mode (where `App.dark == True`).
 - `:disabled` Matches widgets which are in a disabled state.
 - `:enabled` Matches widgets which are in an enabled state.
+- `:even` Matches a widget at an evenly numbered position within its siblings.
+- `:first-of-type` Matches a widget that is the first of its type amongst its siblings.
 - `:focus-within` Matches widgets with a focused child widget.
 - `:focus` Matches widgets which have input focus.
 - `:inline` Matches widgets when the app is running in inline mode.
+- `:last-of-type` Matches a widget that is the last of its type amongst its siblings.
 - `:light` Matches widgets in dark mode (where `App.dark == False`).
+- `:odd` Matches a widget at an oddly numbered position within its siblings.
 
 ## Combinators
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3153,7 +3153,8 @@ class App(Generic[ReturnType], DOMNode):
                 self._register_child(parent, widget, before, after)
                 if widget._nodes:
                     self._register(widget, *widget._nodes, cache=cache)
-                apply_stylesheet(widget, cache=cache)
+        for widget in widget_list:
+            apply_stylesheet(widget, cache=cache)
 
         if not self._running:
             # If the app is not running, prevent awaiting of the widget tasks

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3143,6 +3143,8 @@ class App(Generic[ReturnType], DOMNode):
             widget_list = widgets
 
         apply_stylesheet = self.stylesheet.apply
+        new_widgets: list[DOMNode] = []
+        add_new_widget = new_widgets.append
         for widget in widget_list:
             widget._closing = False
             widget._closed = False
@@ -3150,10 +3152,11 @@ class App(Generic[ReturnType], DOMNode):
             if not isinstance(widget, Widget):
                 raise AppError(f"Can't register {widget!r}; expected a Widget instance")
             if widget not in self._registry:
+                add_new_widget(widget)
                 self._register_child(parent, widget, before, after)
                 if widget._nodes:
                     self._register(widget, *widget._nodes, cache=cache)
-        for widget in widget_list:
+        for widget in new_widgets:
             apply_stylesheet(widget, cache=cache)
 
         if not self._running:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3143,7 +3143,7 @@ class App(Generic[ReturnType], DOMNode):
             widget_list = widgets
 
         apply_stylesheet = self.stylesheet.apply
-        new_widgets: list[DOMNode] = []
+        new_widgets: list[Widget] = []
         add_new_widget = new_widgets.append
         for widget in widget_list:
             widget._closing = False

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -487,6 +487,16 @@ class App(Generic[ReturnType], DOMNode):
     INLINE_PADDING: ClassVar[int] = 1
     """Number of blank lines above an inline app."""
 
+    PSEUDO_CLASSES: ClassVar[dict[str, Callable[[App], bool]]] = {
+        "focus": lambda app: app.app_focus,
+        "blur": lambda app: not app.app_focus,
+        "dark": lambda app: app.dark,
+        "light": lambda app: not app.dark,
+        "inline": lambda app: app.is_inline,
+        "ansi": lambda app: app.ansi_color,
+        "nocolor": lambda app: app.no_color,
+    }  # type: ignore[assignment]
+
     title: Reactive[str] = Reactive("", compute=False)
     """The title of the app, displayed in the header."""
     sub_title: Reactive[str] = Reactive("", compute=False)
@@ -891,21 +901,6 @@ class App(Generic[ReturnType], DOMNode):
         finally:
             active_message_pump.reset(message_pump_reset_token)
             active_app.reset(app_reset_token)
-
-    def get_pseudo_classes(self) -> Iterable[str]:
-        """Pseudo classes for a widget.
-
-        Returns:
-            Names of the pseudo classes.
-        """
-        yield "focus" if self.app_focus else "blur"
-        yield "dark" if self.dark else "light"
-        if self.is_inline:
-            yield "inline"
-        if self.ansi_color:
-            yield "ansi"
-        if self.no_color:
-            yield "nocolor"
 
     def _watch_ansi_color(self, ansi_color: bool) -> None:
         """Enable or disable the truecolor filter when the reactive changes"""

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -487,7 +487,7 @@ class App(Generic[ReturnType], DOMNode):
     INLINE_PADDING: ClassVar[int] = 1
     """Number of blank lines above an inline app."""
 
-    PSEUDO_CLASSES: ClassVar[dict[str, Callable[[App], bool]]] = {
+    _PSEUDO_CLASSES: ClassVar[dict[str, Callable[[App], bool]]] = {
         "focus": lambda app: app.app_focus,
         "blur": lambda app: not app.app_focus,
         "dark": lambda app: app.dark,

--- a/src/textual/css/constants.py
+++ b/src/textual/css/constants.py
@@ -72,6 +72,10 @@ VALID_PSEUDO_CLASSES: Final = {
     "inline",
     "light",
     "nocolor",
+    "first-of-type",
+    "last-of-type",
+    "odd",
+    "even",
 }
 VALID_OVERLAY: Final = {"none", "screen"}
 VALID_CONSTRAIN: Final = {"inflect", "inside", "none"}

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -432,6 +432,16 @@ class Stylesheet:
             if _check_selectors(selector_set.selectors, css_path_nodes):
                 yield selector_set.specificity
 
+    # pseudo classes which iterate over many nodes
+    # these have the potential to be slow, and shouldn't be used in a cache key
+    EXPENSIVE_PSEUDO_CLASSES = {
+        "first-of-type",
+        "last-of_type",
+        "odd",
+        "even",
+        "focus-within",
+    }
+
     def apply(
         self,
         node: DOMNode,
@@ -468,13 +478,18 @@ class Stylesheet:
         }
         rules = list(filter(limit_rules.__contains__, reversed(self.rules)))
 
-        node._has_hover_style = any("hover" in rule.pseudo_classes for rule in rules)
-        node._has_focus_within = any(
-            "focus-within" in rule.pseudo_classes for rule in rules
-        )
+        all_pseudo_classes = set()
+        for rule in rules:
+            all_pseudo_classes |= rule.pseudo_classes
 
-        cache_key: tuple | None
-        if cache is not None:
+        node._has_hover_style = "hover" in all_pseudo_classes
+        node._has_focus_within = "focus-within" in all_pseudo_classes
+
+        cache_key: tuple | None = None
+
+        if cache is not None and all_pseudo_classes.isdisjoint(
+            self.EXPENSIVE_PSEUDO_CLASSES
+        ):
             cache_key = (
                 node._parent,
                 (
@@ -483,7 +498,7 @@ class Stylesheet:
                     else (node._id if f"#{node._id}" in rules_map else None)
                 ),
                 node.classes,
-                node.pseudo_classes,
+                node._pseudo_classes_cache_key,
                 node._css_type_name,
             )
             cached_result: RulesMap | None = cache.get(cache_key)
@@ -491,8 +506,6 @@ class Stylesheet:
                 self.replace_rules(node, cached_result, animate=animate)
                 self._process_component_classes(node)
                 return
-        else:
-            cache_key = None
 
         _check_rule = self._check_rule
         css_path_nodes = node.css_path_nodes
@@ -561,8 +574,7 @@ class Stylesheet:
                         rule_value = getattr(_DEFAULT_STYLES, initial_rule_name)
                     node_rules[initial_rule_name] = rule_value  # type: ignore[literal-required]
 
-            if cache is not None:
-                assert cache_key is not None
+            if cache_key is not None:
                 cache[cache_key] = node_rules
             self.replace_rules(node, node_rules, animate=animate)
         self._process_component_classes(node)

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -439,7 +439,6 @@ class Stylesheet:
         "last-of_type",
         "odd",
         "even",
-        "focus-within",
     }
 
     def apply(
@@ -484,6 +483,9 @@ class Stylesheet:
 
         node._has_hover_style = "hover" in all_pseudo_classes
         node._has_focus_within = "focus-within" in all_pseudo_classes
+        node._has_order_style = not all_pseudo_classes.isdisjoint(
+            {"first-of-type", "last-of-type", "odd", "even"}
+        )
 
         cache_key: tuple | None = None
 

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -476,11 +476,7 @@ class Stylesheet:
             for rule in rules_map[name]
         }
         rules = list(filter(limit_rules.__contains__, reversed(self.rules)))
-
-        all_pseudo_classes = set()
-        for rule in rules:
-            all_pseudo_classes |= rule.pseudo_classes
-
+        all_pseudo_classes = set().union(*[rule.pseudo_classes for rule in rules])
         node._has_hover_style = "hover" in all_pseudo_classes
         node._has_focus_within = "focus-within" in all_pseudo_classes
         node._has_order_style = not all_pseudo_classes.isdisjoint(

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1681,9 +1681,14 @@ class DOMNode(MessagePump):
         Returns:
             `True` if all pseudo class names are present.
         """
-        PSEUDO_CLASSES = self._PSEUDO_CLASSES
+        get_pseudo_class_callable = self._PSEUDO_CLASSES.get
+
+        def missing_pseudo_class(node: DOMNode) -> bool:
+            """Callable when a pseudo class is missing."""
+            return False
+
         return all(
-            (name in PSEUDO_CLASSES and PSEUDO_CLASSES[name](self))
+            get_pseudo_class_callable(name, missing_pseudo_class)(self)
             for name in class_names
         )
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1687,15 +1687,6 @@ class DOMNode(MessagePump):
             for name in class_names
         )
 
-    _CACHEABLE_PSEUDO_CLASSES = [
-        "hover",
-        "focus",
-        "can-focus",
-        "disabled",
-        "dark",
-        "focus-within",
-    ]
-
     @property
     def _pseudo_classes_cache_key(self) -> tuple[int, ...]:
         """A cache key used when updating a number of nodes from the stylesheet."""

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -180,7 +180,8 @@ class DOMNode(MessagePump):
     # Names of potential computed reactives
     _computes: ClassVar[frozenset[str]]
 
-    PSEUDO_CLASSES: ClassVar[dict[str, Callable[[object], bool]]] = {}
+    _PSEUDO_CLASSES: ClassVar[dict[str, Callable[[object], bool]]] = {}
+    """Pseudo class checks."""
 
     def __init__(
         self,
@@ -1239,7 +1240,7 @@ class DOMNode(MessagePump):
 
         return {
             name
-            for name, check_class in self.PSEUDO_CLASSES.items()
+            for name, check_class in self._PSEUDO_CLASSES.items()
             if check_class(self)
         }
 
@@ -1665,7 +1666,7 @@ class DOMNode(MessagePump):
         Returns:
             `True` if the DOM node has the pseudo class, `False` if not.
         """
-        return class_name in self.PSEUDO_CLASSES and self.PSEUDO_CLASSES[class_name](
+        return class_name in self._PSEUDO_CLASSES and self._PSEUDO_CLASSES[class_name](
             self
         )
 
@@ -1678,7 +1679,7 @@ class DOMNode(MessagePump):
         Returns:
             `True` if all pseudo class names are present.
         """
-        PSEUDO_CLASSES = self.PSEUDO_CLASSES
+        PSEUDO_CLASSES = self._PSEUDO_CLASSES
         return all(
             (name in PSEUDO_CLASSES and PSEUDO_CLASSES[name](self))
             for name in class_names

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1685,6 +1685,20 @@ class DOMNode(MessagePump):
             for name in class_names
         )
 
+    _CACHEABLE_PSEUDO_CLASSES = [
+        "hover",
+        "focus",
+        "can-focus",
+        "disabled",
+        "dark",
+        "focus-within",
+    ]
+
+    @property
+    def _pseudo_classes_cache_key(self) -> tuple[int, ...]:
+        """A cache key used when updating a number of nodes from the stylesheet."""
+        return ()
+
     def refresh(
         self, *, repaint: bool = True, layout: bool = False, recompose: bool = False
     ) -> Self:

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1668,9 +1668,10 @@ class DOMNode(MessagePump):
         Returns:
             `True` if the DOM node has the pseudo class, `False` if not.
         """
-        return class_name in self._PSEUDO_CLASSES and self._PSEUDO_CLASSES[class_name](
-            self
-        )
+        try:
+            return self._PSEUDO_CLASSES[class_name](self)
+        except KeyError:
+            return False
 
     def has_pseudo_classes(self, class_names: set[str]) -> bool:
         """Check the node has all the given pseudo classes.

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -220,6 +220,8 @@ class DOMNode(MessagePump):
         )
         self._has_hover_style: bool = False
         self._has_focus_within: bool = False
+        self._has_order_style: bool = False
+        """The node has an ordered dependent pseudo-style (`:odd`, `:even`, `:first-of-type`, `:last-of-type`)"""
         self._reactive_connect: (
             dict[str, tuple[MessagePump, Reactive[object] | object]] | None
         ) = None

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1681,16 +1681,11 @@ class DOMNode(MessagePump):
         Returns:
             `True` if all pseudo class names are present.
         """
-        get_pseudo_class_callable = self._PSEUDO_CLASSES.get
-
-        def missing_pseudo_class(node: DOMNode) -> bool:
-            """Callable when a pseudo class is missing."""
+        PSEUDO_CLASSES = self._PSEUDO_CLASSES
+        try:
+            return all(PSEUDO_CLASSES[name](self) for name in class_names)
+        except KeyError:
             return False
-
-        return all(
-            get_pseudo_class_callable(name, missing_pseudo_class)(self)
-            for name in class_names
-        )
 
     @property
     def _pseudo_classes_cache_key(self) -> tuple[int, ...]:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -367,7 +367,7 @@ class Widget(DOMNode):
     # Default sort order, incremented by constructor
     _sort_order: ClassVar[int] = 0
 
-    PSEUDO_CLASSES: ClassVar[dict[str, Callable[[Widget], bool]]] = {
+    _PSEUDO_CLASSES: ClassVar[dict[str, Callable[[Widget], bool]]] = {
         "hover": lambda widget: widget.mouse_hover,
         "focus": lambda widget: widget.has_focus,
         "blur": lambda widget: not widget.has_focus,

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -793,7 +793,7 @@ class Widget(DOMNode):
         if parent._nodes._updates == self._odd[0]:
             return self._odd[1]
         try:
-            is_odd = parent.children.index(self) % 2 == 0
+            is_odd = parent._nodes.index(self) % 2 == 0
             self._odd = (parent._nodes._updates, is_odd)
             return is_odd
         except ValueError:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -3357,6 +3357,15 @@ class Widget(DOMNode):
         )
         return pseudo_classes
 
+    @property
+    def _pseudo_classes_cache_key(self) -> tuple[int, ...]:
+        """A cache key that changes when the pseudo-classes change."""
+        return (
+            self.mouse_hover,
+            self.has_focus,
+            self.is_disabled,
+        )
+
     def _get_rich_justify(self) -> JustifyMethod | None:
         """Get the justify method that may be passed to a Rich renderable."""
         text_justify: JustifyMethod | None = None

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -777,7 +777,7 @@ class Widget(DOMNode):
         if parent._nodes._updates == self._last_of_type[0]:
             return self._last_of_type[1]
         widget_type = type(self)
-        for node in reversed(parent.children):
+        for node in reversed(parent._nodes):
             if isinstance(node, widget_type):
                 self._last_of_type = (parent._nodes._updates, node is self)
                 return self._last_of_type[1]
@@ -1166,8 +1166,16 @@ class Widget(DOMNode):
             parent, *widgets, before=insert_before, after=insert_after
         )
 
+        def update_styles(children: Iterable[DOMNode]) -> None:
+            """Update order related CSS"""
+            for child in children:
+                if child._has_order_style:
+                    child._update_styles()
+
+        self.call_later(update_styles, list(self.children))
         await_mount = AwaitMount(self, mounted)
         self.call_next(await_mount)
+
         return await_mount
 
     def mount_all(

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_pseudo_classes.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_pseudo_classes.svg
@@ -1,0 +1,153 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3002484098-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3002484098-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3002484098-r1 { fill: #ff0000 }
+.terminal-3002484098-r2 { fill: #c5c8c6 }
+.terminal-3002484098-r3 { fill: #e2e5e3 }
+.terminal-3002484098-r4 { fill: #e5e2e3 }
+.terminal-3002484098-r5 { fill: #008000 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3002484098-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-3002484098-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3002484098-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3002484098-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">PSApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3002484098-clip-terminal)">
+    <rect fill="#273e2e" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="12.2" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="85.4" y="25.9" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="12.2" y="50.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="73.2" y="99.1" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="196.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="73.2" y="196.7" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="294.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="73.2" y="294.3" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="391.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="73.2" y="391.9" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#273e2e" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="12.2" y="513.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="73.2" y="513.9" width="890.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="963.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="12.2" y="538.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="963.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#3d242a" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-3002484098-matrix">
+    <text class="terminal-3002484098-r1" x="0" y="20" textLength="976" clip-path="url(#terminal-3002484098-line-0)">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓</text><text class="terminal-3002484098-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3002484098-line-0)">
+</text><text class="terminal-3002484098-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-1)">┃</text><text class="terminal-3002484098-r3" x="12.2" y="44.4" textLength="73.2" clip-path="url(#terminal-3002484098-line-1)">Item&#160;1</text><text class="terminal-3002484098-r1" x="963.8" y="44.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-1)">┃</text><text class="terminal-3002484098-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-1)">
+</text><text class="terminal-3002484098-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-2)">┃</text><text class="terminal-3002484098-r1" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-2)">┃</text><text class="terminal-3002484098-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-2)">
+</text><text class="terminal-3002484098-r1" x="0" y="93.2" textLength="976" clip-path="url(#terminal-3002484098-line-3)">┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</text><text class="terminal-3002484098-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3002484098-line-3)">
+</text><text class="terminal-3002484098-r4" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-3002484098-line-4)">Item&#160;2</text><text class="terminal-3002484098-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3002484098-line-4)">
+</text><text class="terminal-3002484098-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3002484098-line-5)">
+</text><text class="terminal-3002484098-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-6)">
+</text><text class="terminal-3002484098-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-7)">
+</text><text class="terminal-3002484098-r3" x="0" y="215.2" textLength="73.2" clip-path="url(#terminal-3002484098-line-8)">Item&#160;3</text><text class="terminal-3002484098-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3002484098-line-8)">
+</text><text class="terminal-3002484098-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3002484098-line-9)">
+</text><text class="terminal-3002484098-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3002484098-line-10)">
+</text><text class="terminal-3002484098-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-11)">
+</text><text class="terminal-3002484098-r4" x="0" y="312.8" textLength="73.2" clip-path="url(#terminal-3002484098-line-12)">Item&#160;4</text><text class="terminal-3002484098-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-12)">
+</text><text class="terminal-3002484098-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3002484098-line-13)">
+</text><text class="terminal-3002484098-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3002484098-line-14)">
+</text><text class="terminal-3002484098-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3002484098-line-15)">
+</text><text class="terminal-3002484098-r3" x="0" y="410.4" textLength="73.2" clip-path="url(#terminal-3002484098-line-16)">Item&#160;5</text><text class="terminal-3002484098-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-16)">
+</text><text class="terminal-3002484098-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-17)">
+</text><text class="terminal-3002484098-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3002484098-line-18)">
+</text><text class="terminal-3002484098-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3002484098-line-19)">
+</text><text class="terminal-3002484098-r5" x="0" y="508" textLength="976" clip-path="url(#terminal-3002484098-line-20)">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓</text><text class="terminal-3002484098-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3002484098-line-20)">
+</text><text class="terminal-3002484098-r5" x="0" y="532.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-21)">┃</text><text class="terminal-3002484098-r4" x="12.2" y="532.4" textLength="61" clip-path="url(#terminal-3002484098-line-21)">HELLO</text><text class="terminal-3002484098-r5" x="963.8" y="532.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-21)">┃</text><text class="terminal-3002484098-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3002484098-line-21)">
+</text><text class="terminal-3002484098-r5" x="0" y="556.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-22)">┃</text><text class="terminal-3002484098-r5" x="963.8" y="556.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-22)">┃</text><text class="terminal-3002484098-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3002484098-line-22)">
+</text><text class="terminal-3002484098-r5" x="0" y="581.2" textLength="976" clip-path="url(#terminal-3002484098-line-23)">┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -2374,3 +2374,34 @@ def test_fr_and_margin(snap_compare):
                 yield Label("A margin of 4, should be 4 cells around the text")
 
     assert snap_compare(FRApp())
+
+
+def test_pseudo_classes(snap_compare):
+    """Test pseudo classes added in https://github.com/Textualize/textual/pull/5139
+
+    You should see 6 bars, with alternating green and red backgrounds.
+
+    The first bar should have a red border.
+
+    The last bar should have a green border.
+
+    """
+
+    class PSApp(App):
+        CSS = """
+        Label { width: 1fr; height: 1fr; }
+        Label:first-of-type { border:heavy red; }
+        Label:last-of-type { border:heavy green; }
+        Label:odd {background: $success 20%; }
+        Label:even {background: $error 20%; }
+        """
+
+        def compose(self) -> ComposeResult:
+            for item_number in range(5):
+                yield Label(f"Item {item_number+1}")
+
+        def on_mount(self) -> None:
+            # Mounting a new widget should updated previous widgets, as the last of type has changed
+            self.mount(Label("HELLO"))
+
+    assert snap_compare(PSApp())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -37,6 +37,9 @@ async def test_hover_update_styles():
             "can-focus",
             "dark",
             "enabled",
+            "first-of-type",
+            "last-of-type",
+            "odd",
         }
 
         # Take note of the initial background colour
@@ -50,6 +53,9 @@ async def test_hover_update_styles():
             "dark",
             "enabled",
             "hover",
+            "first-of-type",
+            "last-of-type",
+            "odd",
         }
         assert button.styles.background != initial_background
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,7 +39,7 @@ async def test_hover_update_styles():
             "enabled",
             "first-of-type",
             "last-of-type",
-            "odd",
+            "even",
         }
 
         # Take note of the initial background colour
@@ -55,7 +55,7 @@ async def test_hover_update_styles():
             "hover",
             "first-of-type",
             "last-of-type",
-            "odd",
+            "even",
         }
         assert button.styles.background != initial_background
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -594,3 +594,38 @@ def test_lazy_loading() -> None:
     assert not hasattr(widgets, "foo")
     assert not hasattr(widgets, "bar")
     assert hasattr(widgets, "Label")
+
+
+async def test_of_type() -> None:
+    class MyApp(App):
+        def compose(self) -> ComposeResult:
+            for ordinal in range(5):
+                yield Label(f"Item {ordinal}")
+
+    app = MyApp()
+    async with app.run_test():
+        labels = list(app.query(Label))
+        assert labels[0].first_of_type
+        assert not labels[0].last_of_type
+        assert labels[0].is_odd
+        assert not labels[0].is_even
+
+        assert not labels[1].first_of_type
+        assert not labels[1].last_of_type
+        assert not labels[1].is_odd
+        assert labels[1].is_even
+
+        assert not labels[2].first_of_type
+        assert not labels[2].last_of_type
+        assert labels[2].is_odd
+        assert not labels[2].is_even
+
+        assert not labels[3].first_of_type
+        assert not labels[3].last_of_type
+        assert not labels[3].is_odd
+        assert labels[3].is_even
+
+        assert not labels[4].first_of_type
+        assert labels[4].last_of_type
+        assert labels[4].is_odd
+        assert not labels[4].is_even


### PR DESCRIPTION
Improves the mechanism to expose pseudo classes.

Previously a widget would return all its pseudo classes, even if Textual just needed to know if a single one was present. This made it expensive, and there was a reluctance to add more pseudo classes. This new mechanism can check for the presence of pseudo classes without generating all of them. It's faster, and we can add new ones without slowing down.

- Added `first-of-type`, `last-of-type`, `odd`, and `even` pseudo classes.
- Optimizations to caching stylesheet.apply