### PR TITLE
Remove `-screen-suspended` class

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -487,6 +487,9 @@ class App(Generic[ReturnType], DOMNode):
     INLINE_PADDING: ClassVar[int] = 1
     """Number of blank lines above an inline app."""
 
+    SUSPENDED_SCREEN_CLASS: ClassVar[str] = ""
+    """Class to apply to suspended screens, or empty string for no class."""
+
     _PSEUDO_CLASSES: ClassVar[dict[str, Callable[[App], bool]]] = {
         "focus": lambda app: app.app_focus,
         "blur": lambda app: not app.app_focus,

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -1210,6 +1210,8 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _on_screen_resume(self) -> None:
         """Screen has resumed."""
+        if self.app.SUSPENDED_SCREEN_CLASS:
+            self.remove_class(self.app.SUSPENDED_SCREEN_CLASS)
         self.stack_updates += 1
         self.app._refresh_notifications()
         size = self.app.size
@@ -1229,6 +1231,8 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _on_screen_suspend(self) -> None:
         """Screen has suspended."""
+        if self.app.SUSPENDED_SCREEN_CLASS:
+            self.add_class(self.app.SUSPENDED_SCREEN_CLASS)
         self.app._set_mouse_over(None)
         self._clear_tooltip()
         self.stack_updates += 1

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -1210,7 +1210,6 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _on_screen_resume(self) -> None:
         """Screen has resumed."""
-        self.remove_class("-screen-suspended")
         self.stack_updates += 1
         self.app._refresh_notifications()
         size = self.app.size
@@ -1230,7 +1229,6 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _on_screen_suspend(self) -> None:
         """Screen has suspended."""
-        self.add_class("-screen-suspended")
         self.app._set_mouse_over(None)
         self._clear_tooltip()
         self.stack_updates += 1

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1960,6 +1960,7 @@ def test_ansi_command_palette(snap_compare):
     """Test command palette on top of ANSI colors."""
 
     class CommandPaletteApp(App[None]):
+        SUSPENDED_SCREEN_CLASS = "-screen-suspended"
         CSS = """
         Label {
             width: 1fr;


### PR DESCRIPTION
Screens would get a `-screen-suspended` class when suspended. This caused the stylesheet to be re-applied to everything.

Ultimately this causes a delay proportional to the volume of CSS used.

Since we've never advertised or made use of this feature, I think it makes sense to remove it.  

I tested this with `textual colors` which was noticeably slow when summoning the command palette. With this fix, it is snappy again.

Fixes https://github.com/Textualize/textual/issues/5143