### PR TITLE
feat(events): add control property to Enter and Leave

### DIFF
--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -572,6 +572,11 @@ class Enter(Event, bubble=True, verbose=True):
         """The node directly under the mouse."""
         super().__init__()
 
+    @property
+    def control(self) -> DOMNode:
+        """Alias for the `node` under the mouse."""
+        return self.node
+
 
 class Leave(Event, bubble=True, verbose=True):
     """Sent when the mouse is moved away from a widget, or if a widget is
@@ -591,6 +596,11 @@ class Leave(Event, bubble=True, verbose=True):
         self.node = node
         """The node that was previously directly under the mouse."""
         super().__init__()
+
+    @property
+    def control(self) -> DOMNode:
+        """Alias for the `node` that was previously under the mouse."""
+        return self.node
 
 
 class Focus(Event, bubble=False):


### PR DESCRIPTION
Enable Enter and Leave events to be used with the on decorator by adding a control property.

Closes #5144.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
