### PR TITLE
reduce jank

### DIFF
--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -1211,7 +1211,6 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _on_screen_resume(self) -> None:
         """Screen has resumed."""
-
         if self.app.SUSPENDED_SCREEN_CLASS:
             self.remove_class(self.app.SUSPENDED_SCREEN_CLASS)
         self.stack_updates += 1

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -1205,11 +1205,13 @@ class Screen(Generic[ScreenResultType], Widget):
 
     def _screen_resized(self, size: Size):
         """Called by App when the screen is resized."""
-        self._compositor_refresh()
-        self._refresh_layout(size)
+        if self.stack_updates:
+            self._compositor_refresh()
+            self._refresh_layout(size)
 
     def _on_screen_resume(self) -> None:
         """Screen has resumed."""
+
         if self.app.SUSPENDED_SCREEN_CLASS:
             self.remove_class(self.app.SUSPENDED_SCREEN_CLASS)
         self.stack_updates += 1

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -259,6 +259,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
             await self.recompose()
 
     def on_mount(self) -> None:
+        self.call_next(self.bindings_changed, self.screen)
         self.screen.bindings_updated_signal.subscribe(self, self.bindings_changed)
 
     def on_unmount(self) -> None:


### PR DESCRIPTION
- Avoid a superfluous refresh when an app starts up. This will make apps with a lot of widgets display something faster. YMMV
- Refreshes the footer bindings early when switching screens, to avoid a frame of no bindings