### PR TITLE
Demo fixes

### DIFF
--- a/src/textual/demo/__main__.py
+++ b/src/textual/demo/__main__.py
@@ -1,4 +1,4 @@
-from textual.demo2.demo_app import DemoApp
+from textual.demo.demo_app import DemoApp
 
 if __name__ == "__main__":
     app = DemoApp()

--- a/src/textual/demo/projects.py
+++ b/src/textual/demo/projects.py
@@ -211,7 +211,8 @@ class ProjectsScreen(PageScreen):
     """
 
     def compose(self) -> ComposeResult:
-        with VerticalScroll():
+        with VerticalScroll() as container:
+            container.can_focus = False
             with Center():
                 yield Markdown(PROJECTS_MD)
             with ItemGrid(min_column_width=40):

--- a/src/textual/demo/widgets.py
+++ b/src/textual/demo/widgets.py
@@ -449,7 +449,8 @@ class WidgetsScreen(PageScreen):
     BINDINGS = [("escape", "unfocus")]
 
     def compose(self) -> ComposeResult:
-        with containers.VerticalScroll():
+        with containers.VerticalScroll() as container:
+            container.can_focus = False
             yield Markdown(WIDGETS_MD, classes="column")
             yield Buttons()
             yield Checkboxes()


### PR DESCRIPTION
The demo app wasn't working when run inside the repo.

I've also updated the VerticalScrolls to `can_focus=False` because it's very confusing to tab through widgets and have focus "disappear" when the container gets focus.