### PR TITLE
micro ops

### DIFF
--- a/src/textual/_resolve.py
+++ b/src/textual/_resolve.py
@@ -104,8 +104,9 @@ def resolve_fraction_unit(
     Returns:
         The value of 1fr.
     """
+    F = Fraction
     if not remaining_space or not widget_styles:
-        return Fraction(1)
+        return F(1)
 
     initial_space = remaining_space
 
@@ -155,19 +156,19 @@ def resolve_fraction_unit(
 
     while remaining_fraction > 0:
         remaining_space_changed = False
-        resolve_fraction = Fraction(remaining_space, remaining_fraction)
+        resolve_fraction = F(remaining_space, remaining_fraction)
         for index, (scalar, min_value, max_value) in enumerate(resolve):
             value = resolved[index]
             if value is None:
                 resolved_scalar = scalar.resolve(size, viewport_size, resolve_fraction)
                 if min_value is not None and resolved_scalar < min_value:
                     remaining_space -= min_value
-                    remaining_fraction -= Fraction(scalar.value)
+                    remaining_fraction -= F(scalar.value)
                     resolved[index] = min_value
                     remaining_space_changed = True
                 elif max_value is not None and resolved_scalar > max_value:
                     remaining_space -= max_value
-                    remaining_fraction -= Fraction(scalar.value)
+                    remaining_fraction -= F(scalar.value)
                     resolved[index] = max_value
                     remaining_space_changed = True
 
@@ -219,8 +220,16 @@ def resolve_box_models(
             else widget._get_box_model(
                 size,
                 viewport_size,
-                max(fraction_zero, fraction_width - margin_width),
-                max(fraction_zero, fraction_height - margin_height),
+                (
+                    fraction_zero
+                    if (_width := fraction_width - margin_width) < 0
+                    else _width
+                ),
+                (
+                    fraction_zero
+                    if (_height := fraction_height - margin_height) < 0
+                    else _height
+                ),
             )
         )
         for (_dimension, widget, (margin_width, margin_height)) in zip(

--- a/src/textual/_resolve.py
+++ b/src/textual/_resolve.py
@@ -104,9 +104,9 @@ def resolve_fraction_unit(
     Returns:
         The value of 1fr.
     """
-    F = Fraction
+    _Fraction = Fraction
     if not remaining_space or not widget_styles:
-        return F(1)
+        return _Fraction(1)
 
     initial_space = remaining_space
 
@@ -156,19 +156,19 @@ def resolve_fraction_unit(
 
     while remaining_fraction > 0:
         remaining_space_changed = False
-        resolve_fraction = F(remaining_space, remaining_fraction)
+        resolve_fraction = _Fraction(remaining_space, remaining_fraction)
         for index, (scalar, min_value, max_value) in enumerate(resolve):
             value = resolved[index]
             if value is None:
                 resolved_scalar = scalar.resolve(size, viewport_size, resolve_fraction)
                 if min_value is not None and resolved_scalar < min_value:
                     remaining_space -= min_value
-                    remaining_fraction -= F(scalar.value)
+                    remaining_fraction -= _Fraction(scalar.value)
                     resolved[index] = min_value
                     remaining_space_changed = True
                 elif max_value is not None and resolved_scalar > max_value:
                     remaining_space -= max_value
-                    remaining_fraction -= F(scalar.value)
+                    remaining_fraction -= _Fraction(scalar.value)
                     resolved[index] = max_value
                     remaining_space_changed = True
 

--- a/src/textual/demo/widgets.py
+++ b/src/textual/demo/widgets.py
@@ -446,7 +446,7 @@ class WidgetsScreen(PageScreen):
     }
     """
 
-    BINDINGS = [("escape", "unfocus")]
+    BINDINGS = [("escape", "unfocus", "Unfocus any focused widget")]
 
     def compose(self) -> ComposeResult:
         with containers.VerticalScroll() as container:

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -182,7 +182,6 @@ class Layout(ABC):
         Returns:
             Content height (in lines).
         """
-
         if not widget._nodes:
             height = 0
         else:

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -182,6 +182,7 @@ class Layout(ABC):
         Returns:
             Content height (in lines).
         """
+
         if not widget._nodes:
             height = 0
         else:

--- a/src/textual/layouts/vertical.py
+++ b/src/textual/layouts/vertical.py
@@ -37,8 +37,10 @@ class VerticalLayout(Layout):
                 ),
                 sum(
                     [
-                        max(margin1[2], margin2[0])
-                        for margin1, margin2 in zip(box_margins, box_margins[1:])
+                        bottom if bottom > top else top
+                        for (_, _, bottom, _), (top, _, _, _) in zip(
+                            box_margins, box_margins[1:]
+                        )
                     ]
                 )
                 + (box_margins[0].top + box_margins[-1].bottom),
@@ -56,9 +58,14 @@ class VerticalLayout(Layout):
         )
 
         margins = [
-            max((box1.margin.bottom, box2.margin.top))
-            for box1, box2 in zip(box_models, box_models[1:])
+            (
+                margin_bottom
+                if (margin_bottom := margin1.bottom) > (margin_top := margin2.top)
+                else margin_top
+            )
+            for (_, _, margin1), (_, _, margin2) in zip(box_models, box_models[1:])
         ]
+
         if box_models:
             margins.append(box_models[-1].margin.bottom)
 
@@ -82,9 +89,9 @@ class VerticalLayout(Layout):
                 _WidgetPlacement(
                     _Region(
                         box_margin.left,
-                        int(y),
-                        int(content_width),
-                        int(next_y) - int(y),
+                        y.__int__(),
+                        content_width.__int__(),
+                        next_y.__int__() - y.__int__(),
                     ),
                     box_margin,
                     widget,


### PR DESCRIPTION
I few micro-optimizations for layout.

These do reduce readability, but this is critical code in vertical layouts.

This could be done to the horizontal layouts -- but it does tend to be the vertical layouts which have a tonne of widgets.

- Replace `max()` with equivalent ternary operator, sometimes with a walrus operator
- Replaced a few `int(fraction)` with `fraction.__init__()`
- Pulled Fraction in to local scope