### PR TITLE
query errors

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -40,9 +40,10 @@ from textual.css.constants import VALID_DISPLAY, VALID_VISIBILITY
 from textual.css.errors import DeclarationError, StyleValueError
 from textual.css.match import match
 from textual.css.parse import parse_declarations, parse_selectors
-from textual.css.query import NoMatches, TooManyMatches
+from textual.css.query import InvalidQueryFormat, NoMatches, TooManyMatches
 from textual.css.styles import RenderStyles, Styles
 from textual.css.tokenize import IDENTIFIER
+from textual.css.tokenizer import TokenError
 from textual.message_pump import MessagePump
 from textual.reactive import Reactive, ReactiveError, _Mutated, _watch
 from textual.timer import Timer
@@ -1441,7 +1442,12 @@ class DOMNode(MessagePump):
         else:
             query_selector = selector.__name__
 
-        selector_set = parse_selectors(query_selector)
+        try:
+            selector_set = parse_selectors(query_selector)
+        except TokenError:
+            raise InvalidQueryFormat(
+                f"Unable to parse {query_selector!r} as a query; check for syntax errors"
+            ) from None
 
         if all(selectors.is_simple for selectors in selector_set):
             cache_key = (self._nodes._updates, query_selector, expect_type)
@@ -1505,7 +1511,12 @@ class DOMNode(MessagePump):
         else:
             query_selector = selector.__name__
 
-        selector_set = parse_selectors(query_selector)
+        try:
+            selector_set = parse_selectors(query_selector)
+        except TokenError:
+            raise InvalidQueryFormat(
+                f"Unable to parse {query_selector!r} as a query; check for syntax errors"
+            ) from None
 
         if all(selectors.is_simple for selectors in selector_set):
             cache_key = (self._nodes._updates, query_selector, expect_type)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -14,6 +14,22 @@ from textual.widget import Widget
 from textual.widgets import Input, Label
 
 
+def test_query_errors():
+    app = App()
+
+    with pytest.raises(InvalidQueryFormat):
+        app.query_one("foo_bar")
+
+    with pytest.raises(InvalidQueryFormat):
+        app.query("foo_bar")
+
+    with pytest.raises(InvalidQueryFormat):
+        app.query("1")
+
+    with pytest.raises(InvalidQueryFormat):
+        app.query_one("1")
+
+
 def test_query():
     class View(Widget):
         pass


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5179

Doesn't confuse a selector parse error as a CSS error.

<img width="948" alt="Screenshot 2024-10-28 at 21 19 58" src="https://github.com/user-attachments/assets/3241e807-dfef-4bda-b1c5-dc8409eda913">

