### PR TITLE
in band resize protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed duplicated key displays in the help panel https://github.com/Textualize/textual/issues/5037
 
+### Added
+
+- Added support for in-band terminal resize protocol https://github.com/Textualize/textual/pull/5217
+
+### Changed
+
+- `Driver.process_event` is now `Driver.process_message` https://github.com/Textualize/textual/pull/5217
+
 ## [0.85.2] - 2024-11-02
 
 - Fixed broken focus-within https://github.com/Textualize/textual/pull/5190

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `Driver.process_event` is now `Driver.process_message` https://github.com/Textualize/textual/pull/5217
+- `Driver.send_event` is now `Driver.send_message` https://github.com/Textualize/textual/pull/5217
 
 ## [0.85.2] - 2024-11-02
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -216,9 +216,12 @@ class XTermParser(Parser[Message]):
                         bracketed_paste = False
                     break
                 if match := _re_in_band_window_resize.fullmatch(sequence):
-                    height, width, _pixel_height, _pixel_width = match.groups()
+                    height, width, pixel_height, pixel_width = [
+                        group.partition(":")[0] for group in match.groups()
+                    ]
                     resize_event = events.Resize.from_dimensions(
-                        int(width), int(height)
+                        (int(width), int(height)),
+                        (int(pixel_width), int(pixel_height)),
                     )
                     on_token(resize_event)
                     break

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -283,7 +283,7 @@ class XTermParser(Parser[Message]):
             Keys
         """
 
-        if (match := _re_extended_key.match(sequence)) is not None:
+        if (match := _re_extended_key.fullmatch(sequence)) is not None:
             number, modifiers, end = match.groups()
             number = number or 1
             if not (key := FUNCTIONAL_KEYS.get(f"{number}{end}", "")):

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1678,7 +1678,7 @@ class App(Generic[ReturnType], DOMNode):
                     char = key if len(key) == 1 else None
                 key_event = events.Key(key, char)
                 key_event.set_sender(app)
-                driver.send_event(key_event)
+                driver.send_message(key_event)
                 await wait_for_idle(0)
                 await app._animator.wait_until_complete()
                 await wait_for_idle(0)
@@ -4470,6 +4470,7 @@ class App(Generic[ReturnType], DOMNode):
         self.log.debug(message)
 
     def _on_idle(self) -> None:
+        """Send app resize events on idle, so we don't do more resizing that necessary."""
         event = self._resize_event
         if event is not None:
             self._resize_event = None

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -4463,4 +4463,7 @@ class App(Generic[ReturnType], DOMNode):
     def _on_terminal_supports_in_band_window_resize(
         self, message: messages.TerminalSupportInBandWindowResize
     ) -> None:
+        """There isn't much we can do with this information currently, so
+        we will just log it.
+        """
         self.log.debug(message)

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -4458,3 +4458,9 @@ class App(Generic[ReturnType], DOMNode):
             self.notify(
                 "Failed to save screenshot", title="Screenshot", severity="error"
             )
+
+    @on(messages.TerminalSupportInBandWindowResize)
+    def _on_terminal_supports_in_band_window_resize(
+        self, message: messages.TerminalSupportInBandWindowResize
+    ) -> None:
+        self.log.debug(message)

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -64,21 +64,21 @@ class Driver(ABC):
         """Can this driver be suspended?"""
         return False
 
-    def send_event(self, event: events.Event) -> None:
-        """Send an event to the target app.
+    def send_message(self, message: messages.Message) -> None:
+        """Send a message to the target app.
 
         Args:
-            event: An event.
+            message: A message.
         """
         asyncio.run_coroutine_threadsafe(
-            self._app._post_message(event), loop=self._loop
+            self._app._post_message(message), loop=self._loop
         )
 
     def process_message(self, message: messages.Message) -> None:
         """Perform additional processing on a message, prior to sending.
 
         Args:
-            event: An event to send.
+            event: A message to process.
         """
         # NOTE: This runs in a thread.
         # Avoid calling methods on the app.
@@ -111,7 +111,7 @@ class Driver(ABC):
                 self._down_buttons.clear()
                 move_event = self._last_move_event
                 for button in buttons:
-                    self.send_event(
+                    self.send_message(
                         MouseUp(
                             x=move_event.x,
                             y=move_event.y,
@@ -128,7 +128,7 @@ class Driver(ABC):
                     )
             self._last_move_event = message
 
-        self.send_event(message)
+        self.send_message(message)
 
     @abstractmethod
     def write(self, data: str) -> None:

--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, Iterator, Literal, TextIO
 
-from textual import events, log
+from textual import events, log, messages
 from textual.events import MouseUp
 
 if TYPE_CHECKING:
@@ -74,36 +74,36 @@ class Driver(ABC):
             self._app._post_message(event), loop=self._loop
         )
 
-    def process_event(self, event: events.Event) -> None:
-        """Perform additional processing on an event, prior to sending.
+    def process_message(self, message: messages.Message) -> None:
+        """Perform additional processing on a message, prior to sending.
 
         Args:
             event: An event to send.
         """
         # NOTE: This runs in a thread.
         # Avoid calling methods on the app.
-        event.set_sender(self._app)
+        message.set_sender(self._app)
         if self.cursor_origin is None:
             offset_x = 0
             offset_y = 0
         else:
             offset_x, offset_y = self.cursor_origin
-        if isinstance(event, events.MouseEvent):
-            event.x -= offset_x
-            event.y -= offset_y
-            event.screen_x -= offset_x
-            event.screen_y -= offset_y
+        if isinstance(message, events.MouseEvent):
+            message.x -= offset_x
+            message.y -= offset_y
+            message.screen_x -= offset_x
+            message.screen_y -= offset_y
 
-        if isinstance(event, events.MouseDown):
-            if event.button:
-                self._down_buttons.append(event.button)
-        elif isinstance(event, events.MouseUp):
-            if event.button and event.button in self._down_buttons:
-                self._down_buttons.remove(event.button)
-        elif isinstance(event, events.MouseMove):
+        if isinstance(message, events.MouseDown):
+            if message.button:
+                self._down_buttons.append(message.button)
+        elif isinstance(message, events.MouseUp):
+            if message.button and message.button in self._down_buttons:
+                self._down_buttons.remove(message.button)
+        elif isinstance(message, events.MouseMove):
             if (
                 self._down_buttons
-                and not event.button
+                and not message.button
                 and self._last_move_event is not None
             ):
                 # Deduplicate self._down_buttons while preserving order.
@@ -118,17 +118,17 @@ class Driver(ABC):
                             delta_x=0,
                             delta_y=0,
                             button=button,
-                            shift=event.shift,
-                            meta=event.meta,
-                            ctrl=event.ctrl,
+                            shift=message.shift,
+                            meta=message.meta,
+                            ctrl=message.ctrl,
                             screen_x=move_event.screen_x,
                             screen_y=move_event.screen_y,
-                            style=event.style,
+                            style=message.style,
                         )
                     )
-            self._last_move_event = event
+            self._last_move_event = message
 
-        self.send_event(event)
+        self.send_event(message)
 
     @abstractmethod
     def write(self, data: str) -> None:

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -143,6 +143,12 @@ class LinuxDriver(Driver):
     def _enable_in_band_window_resize(self) -> None:
         self.write("\x1b[?2048h")
 
+    def _enable_line_wrap(self) -> None:
+        self.write("x1b[?7h")
+
+    def _disable_line_wrap(self) -> None:
+        self.write("x1b[?7l")
+
     def _disable_in_band_window_resize(self) -> None:
         if self._in_band_window_resize:
             self.write("\x1b[?2048l")
@@ -269,6 +275,7 @@ class LinuxDriver(Driver):
         self._request_terminal_sync_mode_support()
         self._query_in_band_window_resize()
         self._enable_bracketed_paste()
+        self._disable_line_wrap()
 
         # Appears to fix an issue enabling mouse support in iTerm 3.5.0
         self._enable_mouse_support()
@@ -345,6 +352,7 @@ class LinuxDriver(Driver):
     def stop_application_mode(self) -> None:
         """Stop application mode, restore state."""
         self._disable_bracketed_paste()
+        self._enable_line_wrap()
         self._disable_in_band_window_resize()
         self.disable_input()
 

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -155,12 +155,12 @@ class LinuxInlineDriver(Driver):
                         if isinstance(event, events.CursorPosition):
                             self.cursor_origin = (event.x, event.y)
                         else:
-                            self.process_event(event)
+                            self.process_message(event)
             for event in tick():
                 if isinstance(event, events.CursorPosition):
                     self.cursor_origin = (event.x, event.y)
                 else:
-                    self.process_event(event)
+                    self.process_message(event)
 
         try:
             while not self.exit_event.is_set():

--- a/src/textual/drivers/web_driver.py
+++ b/src/textual/drivers/web_driver.py
@@ -195,12 +195,12 @@ class WebDriver(Driver):
                         if packet_type == "D":
                             # Treat as stdin
                             for event in parser.feed(decode(payload)):
-                                self.process_event(event)
+                                self.process_message(event)
                         else:
                             # Process meta information separately
                             self._on_meta(packet_type, payload)
                 for event in parser.tick():
-                    self.process_event(event)
+                    self.process_message(event)
         except _ExitInput:
             pass
         except Exception:

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -101,7 +101,7 @@ class WindowsDriver(Driver):
         self._enable_bracketed_paste()
 
         self._event_thread = win32.EventMonitor(
-            loop, self._app, self.exit_event, self.process_event
+            loop, self._app, self.exit_event, self.process_message
         )
         self._event_thread.start()
 

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -115,6 +115,7 @@ class Resize(Event, bubble=False):
         size: Size,
         virtual_size: Size,
         container_size: Size | None = None,
+        pixel_size: Size | None = None,
     ) -> None:
         self.size = size
         """The new size of the Widget."""
@@ -122,20 +123,33 @@ class Resize(Event, bubble=False):
         """The virtual size (scrollable size) of the Widget."""
         self.container_size = size if container_size is None else container_size
         """The size of the Widget's container widget."""
+        self.pixel_size = pixel_size
+        """Size of terminal window in pixels if known, or `None` if not known."""
         super().__init__()
 
     @classmethod
-    def from_dimensions(cls, width: int, height: int) -> Resize:
-        size = Size(width, height)
-        return Resize(size, size, size)
+    def from_dimensions(
+        cls, cells: tuple[int, int], pixels: tuple[int, int] | None
+    ) -> Resize:
+        """Construct from basic dimensions.
+
+        Args:
+            cells: tuple of (<width>, <height>) in cells.
+            pixels: tuple of (<width>, <height>) in pixels if known, or `None` if not known.
+
+        """
+        size = Size(*cells)
+        pixel_size = Size(*pixels) if pixels is not None else None
+        return Resize(size, size, size, pixel_size)
 
     def can_replace(self, message: "Message") -> bool:
         return isinstance(message, Resize)
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "size", self.size
-        yield "virtual_size", self.virtual_size
+        yield "virtual_size", self.virtual_size, self.size
         yield "container_size", self.container_size, self.size
+        yield "pixel_size", self.pixel_size, None
 
 
 class Compose(Event, bubble=False, verbose=True):

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -124,6 +124,11 @@ class Resize(Event, bubble=False):
         """The size of the Widget's container widget."""
         super().__init__()
 
+    @classmethod
+    def from_dimensions(cls, width: int, height: int) -> Resize:
+        size = Size(width, height)
+        return Resize(size, size, size)
+
     def can_replace(self, message: "Message") -> bool:
         return isinstance(message, Resize)
 

--- a/src/textual/messages.py
+++ b/src/textual/messages.py
@@ -110,7 +110,7 @@ class TerminalSupportInBandWindowResize(Message):
     https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83"""
 
     def __init__(self, supported: bool, enabled: bool) -> None:
-        """_summary_
+        """Initialize message.
 
         Args:
             supported: Is the protocol supported?

--- a/src/textual/messages.py
+++ b/src/textual/messages.py
@@ -103,10 +103,6 @@ class TerminalSupportsSynchronizedOutput(Message):
 class TerminalSupportInBandWindowResize(Message):
     """Reports if the in-band window resize protocol is supported.
 
-    !!! note
-
-        This is used internally. The app will never see this.
-
     https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83"""
 
     def __init__(self, supported: bool, enabled: bool) -> None:

--- a/src/textual/messages.py
+++ b/src/textual/messages.py
@@ -97,3 +97,46 @@ class TerminalSupportsSynchronizedOutput(Message):
     Used to make the App aware that the terminal emulator supports synchronised output.
     @link https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
     """
+
+
+@rich.repr.auto
+class TerminalSupportInBandWindowResize(Message):
+    """Reports if the in-band window resize protocol is supported.
+
+    !!! note
+
+        This is used internally. The app will never see this.
+
+    https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83"""
+
+    def __init__(self, supported: bool, enabled: bool) -> None:
+        """_summary_
+
+        Args:
+            supported: Is the protocol supported?
+            enabled: Is the protocol enabled.
+        """
+        self.supported = supported
+        self.enabled = enabled
+        super().__init__()
+
+    def __rich_repr__(self) -> rich.repr.Result:
+        yield "supported", self.supported
+        yield "enabled", self.enabled
+
+    @classmethod
+    def from_setting_parameter(
+        cls, setting_parameter: int
+    ) -> TerminalSupportInBandWindowResize:
+        """Construct the message from the setting parameter.
+
+        Args:
+            setting_parameter: Setting parameter from stdin.
+
+        Returns:
+            New TerminalSupportInBandWindowResize instance.
+        """
+
+        supported = setting_parameter not in (0, 4)
+        enabled = setting_parameter in (1, 3)
+        return TerminalSupportInBandWindowResize(supported, enabled)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -18,8 +18,8 @@ async def test_driver_mouse_down_up_click():
 
     app = MyApp()
     async with app.run_test() as pilot:
-        app._driver.process_event(MouseDown(0, 0, 0, 0, 1, False, False, False))
-        app._driver.process_event(MouseUp(0, 0, 0, 0, 1, False, False, False))
+        app._driver.process_message(MouseDown(0, 0, 0, 0, 1, False, False, False))
+        app._driver.process_message(MouseUp(0, 0, 0, 0, 1, False, False, False))
         await pilot.pause()
         assert len(app.messages) == 3
         assert isinstance(app.messages[0], MouseDown)
@@ -41,8 +41,8 @@ async def test_driver_mouse_down_up_click_widget():
 
     app = MyApp()
     async with app.run_test() as pilot:
-        app._driver.process_event(MouseDown(0, 0, 0, 0, 1, False, False, False))
-        app._driver.process_event(MouseUp(0, 0, 0, 0, 1, False, False, False))
+        app._driver.process_message(MouseDown(0, 0, 0, 0, 1, False, False, False))
+        app._driver.process_message(MouseUp(0, 0, 0, 0, 1, False, False, False))
         await pilot.pause()
         assert len(app.messages) == 1
 
@@ -69,8 +69,8 @@ async def test_driver_mouse_down_drag_inside_widget_up_click():
         assert (width, height) == (button_width, button_height)
 
         # Mouse down on the button, then move the mouse inside the button, then mouse up.
-        app._driver.process_event(MouseDown(0, 0, 0, 0, 1, False, False, False))
-        app._driver.process_event(
+        app._driver.process_message(MouseDown(0, 0, 0, 0, 1, False, False, False))
+        app._driver.process_message(
             MouseUp(
                 button_width - 1,
                 button_height - 1,
@@ -108,8 +108,8 @@ async def test_driver_mouse_down_drag_outside_widget_up_click():
         assert (width, height) == (button_width, button_height)
 
         # Mouse down on the button, then move the mouse outside the button, then mouse up.
-        app._driver.process_event(MouseDown(0, 0, 0, 0, 1, False, False, False))
-        app._driver.process_event(
+        app._driver.process_message(MouseDown(0, 0, 0, 0, 1, False, False, False))
+        app._driver.process_message(
             MouseUp(
                 button_width + 1,
                 button_height + 1,

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -91,7 +91,7 @@ def test_cant_match_escape_sequence_too_long(parser):
     """The sequence did not match, and we hit the maximum sequence search
     length threshold, so each character should be issued as a key-press instead.
     """
-    sequence = "\x1b[123456789123456789123"
+    sequence = "\x1b[123456789123456789123123456789123456789123"
     events = list(parser.feed(sequence))
 
     # Every character in the sequence is converted to a key press


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5205

Having implemented this, it doesn't appear to make any noticeable difference.

I suspect that the for us there is no real benefit in the resize events being in-band. Previously we were handling signals and then posting events, which serialized everything anyway.

The Resize event does report the pixel size of the terminal with this protocol, which may be useful in the future when we add image support.

This also disable line-wrapping on terminals that support it. Currently only Ghostty as far as I can see. The benefit is that resizing the terminal doesn't cause the last line to wrap and scroll up. Further reducing resize jankiness.


https://github.com/user-attachments/assets/d23bd07c-f263-46cc-8c85-af5f5979cf78

