### PR TITLE
Invalidate CSS

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -786,6 +786,9 @@ class App(Generic[ReturnType], DOMNode):
 
         self._hover_effects_timer: Timer | None = None
 
+        self._css_update_count: int = -1
+        """Incremented when CSS is invalidated."""
+
         if self.ENABLE_COMMAND_PALETTE:
             for _key, binding in self._bindings:
                 if binding.action in {"command_palette", "app.command_palette"}:
@@ -1189,6 +1192,10 @@ class App(Generic[ReturnType], DOMNode):
         variables = design.generate()
         return variables
 
+    def _invalidate_css(self) -> None:
+        """Invalidate CSS, so it will be refreshed."""
+        self._css_update_count += 1
+
     def watch_dark(self, dark: bool) -> None:
         """Watches the dark bool.
 
@@ -1198,16 +1205,19 @@ class App(Generic[ReturnType], DOMNode):
         self.set_class(dark, "-dark-mode", update=False)
         self.set_class(not dark, "-light-mode", update=False)
         self._refresh_truecolor_filter(self.ansi_theme)
+        self._invalidate_css()
         self.call_next(self.refresh_css)
 
     def watch_ansi_theme_dark(self, theme: TerminalTheme) -> None:
         if self.dark:
             self._refresh_truecolor_filter(theme)
+            self._invalidate_css()
             self.call_next(self.refresh_css)
 
     def watch_ansi_theme_light(self, theme: TerminalTheme) -> None:
         if not self.dark:
             self._refresh_truecolor_filter(theme)
+            self._invalidate_css()
             self.call_next(self.refresh_css)
 
     @property
@@ -2203,7 +2213,7 @@ class App(Generic[ReturnType], DOMNode):
             screen, await_mount = self._get_screen(new_screen)
             stack.append(screen)
             self._load_screen_css(screen)
-            self.refresh_css()
+
             screen.post_message(events.ScreenResume())
         else:
             # Mode is not defined
@@ -2213,6 +2223,8 @@ class App(Generic[ReturnType], DOMNode):
             screen.post_message(events.ScreenResume())
             await_mount = AwaitMount(stack[0], [])
 
+        if screen._css_update_count != self._css_update_count:
+            self.refresh_css()
         screen._screen_resized(self.size)
 
         self._screen_stacks[mode] = stack
@@ -2248,7 +2260,8 @@ class App(Generic[ReturnType], DOMNode):
             await_mount = AwaitMount(self.screen, [])
 
         self._current_mode = mode
-        self.refresh_css()
+        if self.screen._css_update_count != self._css_update_count:
+            self.refresh_css()
         self.screen._screen_resized(self.size)
         self.screen.post_message(events.ScreenResume())
 
@@ -3365,6 +3378,7 @@ class App(Generic[ReturnType], DOMNode):
         stylesheet.update(self.app, animate=animate)
         try:
             self.screen._refresh_layout(self.size)
+            self.screen._css_update_count = self._css_update_count
         except ScreenError:
             pass
         # The other screens in the stack will need to know about some style
@@ -3373,6 +3387,7 @@ class App(Generic[ReturnType], DOMNode):
         for screen in self.screen_stack:
             if screen != self.screen:
                 stylesheet.update(screen, animate=animate)
+                screen._css_update_count = self._css_update_count
 
     def _display(self, screen: Screen, renderable: RenderableType | None) -> None:
         """Display a renderable within a sync.

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -786,7 +786,7 @@ class App(Generic[ReturnType], DOMNode):
 
         self._hover_effects_timer: Timer | None = None
 
-        self._css_update_count: int = -1
+        self._css_update_count: int = 0
         """Incremented when CSS is invalidated."""
 
         if self.ENABLE_COMMAND_PALETTE:
@@ -2213,6 +2213,8 @@ class App(Generic[ReturnType], DOMNode):
             screen, await_mount = self._get_screen(new_screen)
             stack.append(screen)
             self._load_screen_css(screen)
+            if screen._css_update_count != self._css_update_count:
+                self.refresh_css()
 
             screen.post_message(events.ScreenResume())
         else:
@@ -2223,8 +2225,6 @@ class App(Generic[ReturnType], DOMNode):
             screen.post_message(events.ScreenResume())
             await_mount = AwaitMount(stack[0], [])
 
-        if screen._css_update_count != self._css_update_count:
-            self.refresh_css()
         screen._screen_resized(self.size)
 
         self._screen_stacks[mode] = stack

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -267,7 +267,7 @@ class Screen(Generic[ScreenResultType], Widget):
         self.bindings_updated_signal: Signal[Screen] = Signal(self, "bindings_updated")
         """A signal published when the bindings have been updated"""
 
-        self._css_update_count = 0
+        self._css_update_count = -1
         """Track updates to CSS."""
 
     @property

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -267,6 +267,9 @@ class Screen(Generic[ScreenResultType], Widget):
         self.bindings_updated_signal: Signal[Screen] = Signal(self, "bindings_updated")
         """A signal published when the bindings have been updated"""
 
+        self._css_update_count = 0
+        """Track updates to CSS."""
+
     @property
     def is_modal(self) -> bool:
         """Is the screen modal?"""


### PR DESCRIPTION
Adds a mechanism to avoid refreshing CSS when switching modes.

This is an improvement on https://github.com/Textualize/textual/pull/5211