### PR TITLE
fix(tabbed content): prevent duplicate ids error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed duplicated key displays in the help panel https://github.com/Textualize/textual/issues/5037
 - Fixed `TextArea` mouse selection with tab characters https://github.com/Textualize/textual/issues/5212
+- Fixed crash in `TabbedContent` when removing then adding panes https://github.com/Textualize/textual/issues/5215
 
 ### Added
 

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -331,6 +331,7 @@ class TabbedContent(Widget):
         self.titles = [self.render_str(title) for title in titles]
         self._tab_content: list[Widget] = []
         self._initial = initial
+        self._tabs_counter = 0
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
 
     @property
@@ -383,6 +384,8 @@ class TabbedContent(Widget):
             for content in pane_content
         ]
 
+        self._tabs_counter = len(tabs)
+
         # Yield the tabs, and ensure they're linked to this TabbedContent.
         # It's important to associate the Tabs with the TabbedContent, so that this
         # TabbedContent can determine whether a message received from a Tabs instance
@@ -418,12 +421,13 @@ class TabbedContent(Widget):
             Only one of `before` or `after` can be provided. If both are
             provided an exception is raised.
         """
+        self._tabs_counter += 1
         if isinstance(before, TabPane):
             before = before.id
         if isinstance(after, TabPane):
             after = after.id
         tabs = self.get_child_by_type(ContentTabs)
-        pane = self._set_id(pane, tabs.tab_count + 1)
+        pane = self._set_id(pane, self._tabs_counter)
         assert pane.id is not None
         pane.display = False
         return AwaitComplete(

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -914,3 +914,23 @@ async def test_disabling_tab_within_tabbed_content_stays_isolated():
         await pilot.pause()
         assert app.query_one("Tab#duplicate").disabled is True
         assert app.query_one("TabPane#duplicate").disabled is False
+
+
+async def test_remove_and_add_pane_no_duplicate_id_error():
+    """Ensure that removing then adding panes does not raise a `DuplicateIds` exception.
+
+    Regression test for https://github.com/Textualize/textual/issues/5215
+    """
+
+    class TabbedApp(App[None]):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield Label("tab-1")
+                yield Label("tab-2")
+
+    app = TabbedApp()
+    async with app.run_test() as pilot:
+        # If no exception is raised, the test will pass
+        tabbed_content = pilot.app.query_one(TabbedContent)
+        await tabbed_content.remove_pane("tab-1")
+        await tabbed_content.add_pane(TabPane("Tab 3", Label("tab-3")))


### PR DESCRIPTION
Fixes #5215.

I've marked this as a draft as I'm not sure if this counter should reflect the `Tabs` widget?

> After looking into this a bit deeper, it seems the `Tabs` widget already assigns ID's based on a counter. However this counter only increments when the tab ID hasn't been provided.
> 
> Should the `TabbedContent` reflect this setting of ID's? This would make these widgets more consistent, but might be a breaking change.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
