### PR TITLE
fixed the "backround" typo

### DIFF
--- a/docs/styles/scrollbar_colors/scrollbar_background.md
+++ b/docs/styles/scrollbar_colors/scrollbar_background.md
@@ -35,7 +35,7 @@ The `scrollbar-background` style sets the background color of the scrollbar.
 ## CSS
 
 ```css
-scrollbar-backround: blue;
+scrollbar-background: blue;
 ```
 
 ## Python

--- a/docs/styles/scrollbar_colors/scrollbar_background_active.md
+++ b/docs/styles/scrollbar_colors/scrollbar_background_active.md
@@ -36,7 +36,7 @@ The `scrollbar-background-active` style sets the background color of the scrollb
 ## CSS
 
 ```css
-scrollbar-backround-active: red;
+scrollbar-background-active: red;
 ```
 
 ## Python


### PR DESCRIPTION
Fixed the typo in the:
"scrollbar-backround" and "scrollbar-backround-active" to
"scrollbar-background" and "scrollbar-background-active".