### PR TITLE
fixed docstring in Static

### DIFF
--- a/src/textual/widgets/_static.py
+++ b/src/textual/widgets/_static.py
@@ -34,7 +34,7 @@ class Static(Widget, inherit_bindings=False):
     """A widget to display simple static content, or use as a base class for more complex widgets.
 
     Args:
-        renderable: A Rich renderable, or string containing console markup.
+        content: A Rich renderable, or string containing console markup.
         expand: Expand content if required to fill container.
         shrink: Shrink content if required to fill container.
         markup: True if markup should be parsed and rendered.


### PR DESCRIPTION
Updated the docstring in the Static widget to reflect that `renderable` has been re-named to `content`