### PR TITLE
Fix scroll placements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [0.86.2] - Unreleased
+## [0.86.2] - 2024-11-18
 
 ### Fixed
 
@@ -2552,6 +2552,9 @@ https://textual.textualize.io/blog/2022/11/08/version-040/#version-040
 - New handler system for messages that doesn't require inheritance
 - Improved traceback handling
 
+
+[0.86.2]: https://github.com/Textualize/textual/compare/v0.86.1...v0.86.2
+[0.86.1]: https://github.com/Textualize/textual/compare/v0.86.0...v0.86.1
 [0.86.0]: https://github.com/Textualize/textual/compare/v0.85.2...v0.86.0
 [0.85.2]: https://github.com/Textualize/textual/compare/v0.85.1...v0.85.2
 [0.85.1]: https://github.com/Textualize/textual/compare/v0.85.0...v0.85.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.86.2] - Unreleased
+
+### Fixed
+
+- Fixed visibility glitch for widgets with an offset https://github.com/Textualize/textual/pull/5253
+
 ## [0.86.1] - 2024-11-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "0.86.1"
+version = "0.86.2"
 homepage = "https://github.com/Textualize/textual"
 repository = "https://github.com/Textualize/textual"
 documentation = "https://textual.textualize.io/"

--- a/src/textual/_arrange.py
+++ b/src/textual/_arrange.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 
 from textual._partition import partition
-from textual.geometry import Region, Size, Spacing
+from textual.geometry import NULL_OFFSET, NULL_SPACING, Region, Size, Spacing
 from textual.layout import DockArrangeResult, WidgetPlacement
 
 if TYPE_CHECKING:
@@ -133,7 +133,8 @@ def _arrange_dock_widgets(
     region_offset = region.offset
     size = region.size
     width, height = size
-    null_spacing = Spacing()
+    null_spacing = NULL_SPACING
+    null_offset = NULL_OFFSET
 
     top = right = bottom = left = 0
 
@@ -173,6 +174,7 @@ def _arrange_dock_widgets(
         append_placement(
             _WidgetPlacement(
                 dock_region.translate(region_offset),
+                null_offset,
                 null_spacing,
                 dock_widget,
                 top_z,
@@ -202,7 +204,8 @@ def _arrange_split_widgets(
     placements: list[WidgetPlacement] = []
     append_placement = placements.append
     view_region = size.region
-    null_spacing = Spacing()
+    null_spacing = NULL_SPACING
+    null_offset = NULL_OFFSET
 
     for split_widget in split_widgets:
         split = split_widget.styles.split
@@ -226,7 +229,9 @@ def _arrange_split_widgets(
             raise AssertionError("invalid value for split edge")  # pragma: no-cover
 
         append_placement(
-            _WidgetPlacement(split_region, null_spacing, split_widget, 1, True)
+            _WidgetPlacement(
+                split_region, null_offset, null_spacing, split_widget, 1, True
+            )
         )
 
     return placements, view_region

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -605,11 +605,8 @@ class Compositor:
                     sub_clip = clip.intersection(child_region)
 
                     if visible_only:
-                        widget_window = (
-                            sub_clip - child_region.offset + widget.scroll_offset
-                        )
                         placements = arrange_result.get_visible_placements(
-                            widget_window
+                            sub_clip - child_region.offset + widget.scroll_offset
                         )
                     else:
                         placements = arrange_result.placements

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -33,7 +33,7 @@ from textual import errors
 from textual._cells import cell_len
 from textual._context import visible_screen_stack
 from textual._loop import loop_last
-from textual.geometry import NULL_OFFSET, NULL_SPACING, Offset, Region, Size, Spacing
+from textual.geometry import NULL_SPACING, Offset, Region, Size, Spacing
 from textual.map_geometry import MapGeometry
 from textual.strip import Strip, StripRenderable
 
@@ -534,8 +534,6 @@ class Compositor:
         Returns:
             Compositor map and set of widgets.
         """
-
-        ORIGIN = NULL_OFFSET
 
         map: CompositorMap = {}
         widgets: set[Widget] = set()

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -643,7 +643,7 @@ class Compositor:
                         )
 
                     # Add all the widgets
-                    for sub_region, _, sub_widget, z, fixed, overlay in reversed(
+                    for sub_region, _, _, sub_widget, z, fixed, overlay in reversed(
                         placements
                     ):
                         layer_index = get_layer_index(sub_widget.layer, 0)

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -716,19 +716,15 @@ class Compositor:
             elif visible:
                 # Add the widget to the map
 
-                widget_region = region
-
                 if widget.absolute_offset is not None:
                     margin = styles.margin
-                    widget_region = widget_region.at_offset(
-                        widget.absolute_offset + margin.top_left
-                    )
-                    widget_region = widget_region.translate(
-                        styles.offset.resolve(widget_region.grow(margin).size, size)
+                    region = region.at_offset(widget.absolute_offset + margin.top_left)
+                    region = region.translate(
+                        styles.offset.resolve(region.grow(margin).size, size)
                     )
                 has_rule = styles.has_rule
                 if has_rule("constrain_x") or has_rule("constrain_y"):
-                    widget_region = widget_region.constrain(
+                    region = region.constrain(
                         styles.constrain_x,
                         styles.constrain_y,
                         styles.margin,
@@ -736,7 +732,7 @@ class Compositor:
                     )
 
                 map[widget._render_widget] = _MapGeometry(
-                    widget_region,
+                    region,
                     order,
                     clip,
                     region.size,

--- a/src/textual/_spatial_map.py
+++ b/src/textual/_spatial_map.py
@@ -6,7 +6,7 @@ from typing import Generic, Iterable, TypeVar
 
 from typing_extensions import TypeAlias
 
-from textual.geometry import Region
+from textual.geometry import Offset, Region
 
 ValueType = TypeVar("ValueType")
 GridCoordinate: TypeAlias = "tuple[int, int]"
@@ -57,7 +57,7 @@ class SpatialMap(Generic[ValueType]):
         )
 
     def insert(
-        self, regions_and_values: Iterable[tuple[Region, bool, bool, ValueType]]
+        self, regions_and_values: Iterable[tuple[Region, Offset, bool, bool, ValueType]]
     ) -> None:
         """Insert values into the Spatial map.
 
@@ -65,19 +65,19 @@ class SpatialMap(Generic[ValueType]):
         indicates fixed regions. Fixed regions don't scroll and are always visible.
 
         Args:
-            regions_and_values: An iterable of (REGION, FIXED, OVERLAY, VALUE).
+            regions_and_values: An iterable of (REGION, OFFSET, FIXED, OVERLAY, VALUE).
         """
         append_fixed = self._fixed.append
         get_grid_list = self._map.__getitem__
         _region_to_grid = self._region_to_grid_coordinates
         total_region = self.total_region
-        for region, fixed, overlay, value in regions_and_values:
+        for region, offset, fixed, overlay, value in regions_and_values:
             if fixed:
                 append_fixed(value)
             else:
                 if not overlay:
                     total_region = total_region.union(region)
-                for grid in _region_to_grid(region):
+                for grid in _region_to_grid(region + offset):
                     get_grid_list(grid).append(value)
         self.total_region = total_region
 

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -39,6 +39,7 @@ class DockArrangeResult:
             self._spatial_map.insert(
                 (
                     placement.region.grow(placement.margin),
+                    placement.offset,
                     placement.fixed,
                     placement.overlay,
                     placement,
@@ -75,7 +76,7 @@ class DockArrangeResult:
         culled_placements = [
             placement
             for placement in visible_placements
-            if placement.fixed or overlaps(placement.region)
+            if placement.fixed or overlaps(placement.region + placement.offset)
         ]
         return culled_placements
 

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -84,6 +84,7 @@ class WidgetPlacement(NamedTuple):
     """The position, size, and relative order of a widget within its parent."""
 
     region: Region
+    offset: Offset
     margin: Spacing
     widget: Widget
     order: int = 0
@@ -92,7 +93,7 @@ class WidgetPlacement(NamedTuple):
 
     @classmethod
     def translate(
-        cls, placements: list[WidgetPlacement], offset: Offset
+        cls, placements: list[WidgetPlacement], translate_offset: Offset
     ) -> list[WidgetPlacement]:
         """Move all placements by a given offset.
 
@@ -103,10 +104,18 @@ class WidgetPlacement(NamedTuple):
         Returns:
             Placements with adjusted region, or same instance if offset is null.
         """
-        if offset:
+        if translate_offset:
             return [
-                cls(region + offset, margin, layout_widget, order, fixed, overlay)
-                for region, margin, layout_widget, order, fixed, overlay in placements
+                cls(
+                    region + translate_offset,
+                    offset,
+                    margin,
+                    layout_widget,
+                    order,
+                    fixed,
+                    overlay,
+                )
+                for region, offset, margin, layout_widget, order, fixed, overlay in placements
             ]
         return placements
 

--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable
 
 from textual._resolve import resolve
 from textual.css.scalar import Scalar
-from textual.geometry import Region, Size, Spacing
+from textual.geometry import NULL_OFFSET, Region, Size, Spacing
 from textual.layout import ArrangeResult, Layout, WidgetPlacement
 
 if TYPE_CHECKING:
@@ -292,6 +292,7 @@ class GridLayout(Layout):
             add_placement(
                 WidgetPlacement(
                     region + offset,
+                    NULL_OFFSET,
                     (
                         margin
                         if gutter_spacing is None

--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -258,6 +258,7 @@ class GridLayout(Layout):
         rows = resolve(row_scalars, size.height, gutter_horizontal, size, viewport)
 
         placements: list[WidgetPlacement] = []
+        _WidgetPlacement = WidgetPlacement
         add_placement = placements.append
         widgets: list[Widget] = []
         add_widget = widgets.append
@@ -291,16 +292,16 @@ class GridLayout(Layout):
                 .shrink(margin)
             )
 
-            offset = (
+            placement_offset = (
                 styles.offset.resolve(cell_size, viewport)
                 if styles.has_rule("offset")
                 else NULL_OFFSET
             )
 
             add_placement(
-                WidgetPlacement(
-                    region,
-                    offset,
+                _WidgetPlacement(
+                    region + offset,
+                    placement_offset,
                     (
                         margin
                         if gutter_spacing is None

--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -273,21 +273,20 @@ class GridLayout(Layout):
             x2, cell_width = columns[min(max_column, column + column_span)]
             y2, cell_height = rows[min(max_row, row + row_span)]
             cell_size = Size(cell_width + x2 - x, cell_height + y2 - y)
-            width, height, margin = widget._get_box_model(
+            box_width, box_height, margin = widget._get_box_model(
                 cell_size,
                 viewport,
                 Fraction(cell_size.width),
                 Fraction(cell_size.height),
             )
             if self.stretch_height and len(children) > 1:
-                height = (
-                    height
-                    if (height > cell_size.height)
-                    else Fraction(cell_size.height)
-                )
+                if box_height <= cell_size.height:
+                    box_height = Fraction(cell_size.height)
 
             region = (
-                Region(x, y, int(width + margin.width), int(height + margin.height))
+                Region(
+                    x, y, int(box_width + margin.width), int(box_height + margin.height)
+                )
                 .crop_size(cell_size)
                 .shrink(margin)
             )

--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -284,15 +284,23 @@ class GridLayout(Layout):
                     if (height > cell_size.height)
                     else Fraction(cell_size.height)
                 )
+
             region = (
                 Region(x, y, int(width + margin.width), int(height + margin.height))
                 .crop_size(cell_size)
                 .shrink(margin)
             )
+
+            offset = (
+                styles.offset.resolve(cell_size, viewport)
+                if styles.has_rule("offset")
+                else NULL_OFFSET
+            )
+
             add_placement(
                 WidgetPlacement(
-                    region + offset,
-                    NULL_OFFSET,
+                    region,
+                    offset,
                     (
                         margin
                         if gutter_spacing is None

--- a/src/textual/layouts/horizontal.py
+++ b/src/textual/layouts/horizontal.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from typing import TYPE_CHECKING
 
 from textual._resolve import resolve_box_models
-from textual.geometry import Region, Size
+from textual.geometry import NULL_OFFSET, Region, Size
 from textual.layout import ArrangeResult, Layout, WidgetPlacement
 
 if TYPE_CHECKING:
@@ -89,6 +89,7 @@ class HorizontalLayout(Layout):
                         (next_x - x.__floor__()).__floor__(),
                         content_height.__floor__(),
                     ),
+                    NULL_OFFSET,
                     box_margin,
                     widget,
                     0,

--- a/src/textual/layouts/horizontal.py
+++ b/src/textual/layouts/horizontal.py
@@ -84,10 +84,10 @@ class HorizontalLayout(Layout):
             add_placement(
                 _WidgetPlacement(
                     _Region(
-                        int(x),
+                        x.__floor__(),
                         offset_y,
-                        int(next_x - int(x)),
-                        int(content_height),
+                        (next_x - x.__floor__()).__floor__(),
+                        content_height.__floor__(),
                     ),
                     box_margin,
                     widget,

--- a/src/textual/layouts/horizontal.py
+++ b/src/textual/layouts/horizontal.py
@@ -24,6 +24,7 @@ class HorizontalLayout(Layout):
     ) -> ArrangeResult:
         placements: list[WidgetPlacement] = []
         add_placement = placements.append
+        viewport = parent.app.size
 
         child_styles = [child.styles for child in children]
         box_margins: list[Spacing] = [
@@ -52,7 +53,7 @@ class HorizontalLayout(Layout):
             [styles.width for styles in child_styles],
             children,
             size,
-            parent.app.size,
+            viewport,
             resolve_margin,
             resolve_dimension="width",
         )
@@ -75,10 +76,20 @@ class HorizontalLayout(Layout):
 
         _Region = Region
         _WidgetPlacement = WidgetPlacement
+        _Size = Size
         for widget, (content_width, content_height, box_margin), margin in zip(
             children, box_models, margins
         ):
-            overlay = widget.styles.overlay == "screen"
+            styles = widget.styles
+            overlay = styles.overlay == "screen"
+            offset = (
+                styles.offset.resolve(
+                    _Size(content_width.__floor__(), content_height.__floor__()),
+                    viewport,
+                )
+                if styles.has_rule("offset")
+                else NULL_OFFSET
+            )
             offset_y = box_margin.top
             next_x = x + content_width
             add_placement(
@@ -89,7 +100,7 @@ class HorizontalLayout(Layout):
                         (next_x - x.__floor__()).__floor__(),
                         content_height.__floor__(),
                     ),
-                    NULL_OFFSET,
+                    offset,
                     box_margin,
                     widget,
                     0,

--- a/src/textual/layouts/vertical.py
+++ b/src/textual/layouts/vertical.py
@@ -22,6 +22,7 @@ class VerticalLayout(Layout):
     ) -> ArrangeResult:
         placements: list[WidgetPlacement] = []
         add_placement = placements.append
+        viewport = parent.app.size
 
         child_styles = [child.styles for child in children]
         box_margins: list[Spacing] = [
@@ -80,11 +81,21 @@ class VerticalLayout(Layout):
 
         _Region = Region
         _WidgetPlacement = WidgetPlacement
+        _Size = Size
         for widget, (content_width, content_height, box_margin), margin in zip(
             children, box_models, margins
         ):
-            overlay = widget.styles.overlay == "screen"
+            styles = widget.styles
+            overlay = styles.overlay == "screen"
             next_y = y + content_height
+            offset = (
+                styles.offset.resolve(
+                    _Size(content_width.__floor__(), content_height.__floor__()),
+                    viewport,
+                )
+                if styles.has_rule("offset")
+                else NULL_OFFSET
+            )
             add_placement(
                 _WidgetPlacement(
                     _Region(
@@ -93,7 +104,7 @@ class VerticalLayout(Layout):
                         content_width.__floor__(),
                         next_y.__floor__() - y.__floor__(),
                     ),
-                    NULL_OFFSET,
+                    offset,
                     box_margin,
                     widget,
                     0,

--- a/src/textual/layouts/vertical.py
+++ b/src/textual/layouts/vertical.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from typing import TYPE_CHECKING
 
 from textual._resolve import resolve_box_models
-from textual.geometry import Region, Size
+from textual.geometry import NULL_OFFSET, Region, Size
 from textual.layout import ArrangeResult, Layout, WidgetPlacement
 
 if TYPE_CHECKING:
@@ -93,6 +93,7 @@ class VerticalLayout(Layout):
                         content_width.__floor__(),
                         next_y.__floor__() - y.__floor__(),
                     ),
+                    NULL_OFFSET,
                     box_margin,
                     widget,
                     0,

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -437,9 +437,9 @@ class Widget(DOMNode):
         self._content_width_cache: tuple[object, int] = (None, 0)
         self._content_height_cache: tuple[object, int] = (None, 0)
 
-        self._arrangement_cache: FIFOCache[tuple[Size, int], DockArrangeResult] = (
-            FIFOCache(4)
-        )
+        self._arrangement_cache: FIFOCache[
+            tuple[Size, int, Widget], DockArrangeResult
+        ] = FIFOCache(4)
 
         self._styles_cache = StylesCache()
         self._rich_style_cache: dict[tuple[str, ...], tuple[Style, Style]] = {}

--- a/tests/test_arrange.py
+++ b/tests/test_arrange.py
@@ -2,7 +2,7 @@ import pytest
 
 from textual._arrange import TOP_Z, arrange
 from textual.app import App
-from textual.geometry import Region, Size, Spacing
+from textual.geometry import NULL_OFFSET, Region, Size, Spacing
 from textual.layout import WidgetPlacement
 from textual.widget import Widget
 
@@ -27,9 +27,11 @@ def test_arrange_dock_top():
 
     assert result.placements == [
         WidgetPlacement(
-            Region(0, 0, 80, 1), Spacing(), header, order=TOP_Z, fixed=True
+            Region(0, 0, 80, 1), NULL_OFFSET, Spacing(), header, order=TOP_Z, fixed=True
         ),
-        WidgetPlacement(Region(0, 1, 80, 23), Spacing(), child, order=0, fixed=False),
+        WidgetPlacement(
+            Region(0, 1, 80, 23), NULL_OFFSET, Spacing(), child, order=0, fixed=False
+        ),
     ]
     assert result.widgets == {child, header}
 
@@ -45,9 +47,16 @@ def test_arrange_dock_left():
     result = arrange(container, [child, header], Size(80, 24), Size(80, 24))
     assert result.placements == [
         WidgetPlacement(
-            Region(0, 0, 10, 24), Spacing(), header, order=TOP_Z, fixed=True
+            Region(0, 0, 10, 24),
+            NULL_OFFSET,
+            Spacing(),
+            header,
+            order=TOP_Z,
+            fixed=True,
         ),
-        WidgetPlacement(Region(10, 0, 70, 24), Spacing(), child, order=0, fixed=False),
+        WidgetPlacement(
+            Region(10, 0, 70, 24), NULL_OFFSET, Spacing(), child, order=0, fixed=False
+        ),
     ]
     assert result.widgets == {child, header}
 
@@ -63,9 +72,16 @@ def test_arrange_dock_right():
     result = arrange(container, [child, header], Size(80, 24), Size(80, 24))
     assert result.placements == [
         WidgetPlacement(
-            Region(70, 0, 10, 24), Spacing(), header, order=TOP_Z, fixed=True
+            Region(70, 0, 10, 24),
+            NULL_OFFSET,
+            Spacing(),
+            header,
+            order=TOP_Z,
+            fixed=True,
         ),
-        WidgetPlacement(Region(0, 0, 70, 24), Spacing(), child, order=0, fixed=False),
+        WidgetPlacement(
+            Region(0, 0, 70, 24), NULL_OFFSET, Spacing(), child, order=0, fixed=False
+        ),
     ]
     assert result.widgets == {child, header}
 
@@ -81,9 +97,16 @@ def test_arrange_dock_bottom():
     result = arrange(container, [child, header], Size(80, 24), Size(80, 24))
     assert result.placements == [
         WidgetPlacement(
-            Region(0, 23, 80, 1), Spacing(), header, order=TOP_Z, fixed=True
+            Region(0, 23, 80, 1),
+            NULL_OFFSET,
+            Spacing(),
+            header,
+            order=TOP_Z,
+            fixed=True,
         ),
-        WidgetPlacement(Region(0, 0, 80, 23), Spacing(), child, order=0, fixed=False),
+        WidgetPlacement(
+            Region(0, 0, 80, 23), NULL_OFFSET, Spacing(), child, order=0, fixed=False
+        ),
     ]
     assert result.widgets == {child, header}
 

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -4,7 +4,9 @@ from textual.widgets import Static
 
 
 async def test_compositor_scroll_placements():
-    """Regression test for https://github.com/Textualize/textual/issues/5249"""
+    """Regression test for https://github.com/Textualize/textual/issues/5249
+    The Static should remain visible.
+    """
 
     class ScrollApp(App):
         CSS = """

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -36,4 +36,5 @@ async def test_compositor_scroll_placements():
         static = app.query_one("#hello")
         widgets = app.screen._compositor.visible_widgets
         # The static wasn't scrolled out of view, and should be visible
+        # This wasn't the case <= v0.86.1
         assert static in widgets

--- a/tests/test_compositor.py
+++ b/tests/test_compositor.py
@@ -1,0 +1,39 @@
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.widgets import Static
+
+
+async def test_compositor_scroll_placements():
+    """Regression test for https://github.com/Textualize/textual/issues/5249"""
+
+    class ScrollApp(App):
+        CSS = """
+        Screen {
+            overflow: scroll;
+        }
+        Container {
+            width: 200vw;
+        }
+        #hello {
+            width: 20;
+            height: 10;
+            offset: 50 10;
+            background: blue;
+            color: white;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            with Container():
+                yield Static("Hello", id="hello")
+
+        def on_mount(self) -> None:
+            self.query_one("Screen").scroll_to(20, 0, animate=False)
+
+    app = ScrollApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        static = app.query_one("#hello")
+        widgets = app.screen._compositor.visible_widgets
+        # The static wasn't scrolled out of view, and should be visible
+        assert static in widgets

--- a/tests/test_spatial_map.py
+++ b/tests/test_spatial_map.py
@@ -1,7 +1,7 @@
 import pytest
 
 from textual._spatial_map import SpatialMap
-from textual.geometry import Region
+from textual.geometry import Offset, Region
 
 
 @pytest.mark.parametrize(
@@ -44,9 +44,9 @@ def test_get_values_in_region() -> None:
 
     spatial_map.insert(
         [
-            (Region(10, 5, 5, 5), False, False, "foo"),
-            (Region(5, 20, 5, 5), False, False, "bar"),
-            (Region(0, 0, 40, 1), True, False, "title"),
+            (Region(10, 5, 5, 5), Offset(), False, False, "foo"),
+            (Region(5, 20, 5, 5), Offset(), False, False, "bar"),
+            (Region(0, 0, 40, 1), Offset(), True, False, "title"),
         ]
     )
 


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5249

Bump to 0.86.2

A Widget's `offset` wasn't being taken in to account when scrolling. A widget with an offset could be hidden when it should be visible.

This bug won't show up on the snapshot tests, as they prompt a full refresh, and this issue occurs with the fast path scrolling.