### PR TITLE
Ensure theme variables available on initial render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed theme variables being unavailable in code until refresh_css was called https://github.com/Textualize/textual/pull/5254
+
 ## [0.86.1] - 2024-11-16
 
 ### Fixed

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -636,6 +636,9 @@ class App(Generic[ReturnType], DOMNode):
 
         self._css_has_errors = False
 
+        self.theme_variables: dict[str, str] = {}
+        """Variables generated from the current theme."""
+
         # Note that the theme must be set *before* self.get_css_variables() is called
         # to ensure that the variables are retrieved from the currently active theme.
         self.stylesheet = Stylesheet(variables=self.get_css_variables())
@@ -764,9 +767,6 @@ class App(Generic[ReturnType], DOMNode):
 
         self._css_update_count: int = 0
         """Incremented when CSS is invalidated."""
-
-        self.theme_variables: dict[str, str] = {}
-        """Variables generated from the current theme."""
 
         if self.ENABLE_COMMAND_PALETTE:
             for _key, binding in self._bindings:

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_theme_variables_available_in_code.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_theme_variables_available_in_code.svg
@@ -1,0 +1,151 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-4162468071-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-4162468071-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-4162468071-r1 { fill: #57a5e2 }
+.terminal-4162468071-r2 { fill: #e0e0e0 }
+.terminal-4162468071-r3 { fill: #c5c8c6 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-4162468071-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-4162468071-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4162468071-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-4162468071-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">ThemeVariablesApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4162468071-clip-terminal)">
+    <rect fill="#0c304c" x="0" y="1.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="280.6" y="1.5" width="695.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-4162468071-matrix">
+    <text class="terminal-4162468071-r1" x="0" y="20" textLength="280.6" clip-path="url(#terminal-4162468071-line-0)">$text-primary&#160;=&#160;#57A5E2</text><text class="terminal-4162468071-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-4162468071-line-0)">
+</text><text class="terminal-4162468071-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-4162468071-line-1)">
+</text><text class="terminal-4162468071-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-4162468071-line-2)">
+</text><text class="terminal-4162468071-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-4162468071-line-3)">
+</text><text class="terminal-4162468071-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-4162468071-line-4)">
+</text><text class="terminal-4162468071-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-4162468071-line-5)">
+</text><text class="terminal-4162468071-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-4162468071-line-6)">
+</text><text class="terminal-4162468071-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-4162468071-line-7)">
+</text><text class="terminal-4162468071-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-4162468071-line-8)">
+</text><text class="terminal-4162468071-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-4162468071-line-9)">
+</text><text class="terminal-4162468071-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-4162468071-line-10)">
+</text><text class="terminal-4162468071-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-4162468071-line-11)">
+</text><text class="terminal-4162468071-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-4162468071-line-12)">
+</text><text class="terminal-4162468071-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-4162468071-line-13)">
+</text><text class="terminal-4162468071-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-4162468071-line-14)">
+</text><text class="terminal-4162468071-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-4162468071-line-15)">
+</text><text class="terminal-4162468071-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-4162468071-line-16)">
+</text><text class="terminal-4162468071-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-4162468071-line-17)">
+</text><text class="terminal-4162468071-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-4162468071-line-18)">
+</text><text class="terminal-4162468071-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-4162468071-line-19)">
+</text><text class="terminal-4162468071-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-4162468071-line-20)">
+</text><text class="terminal-4162468071-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-4162468071-line-21)">
+</text><text class="terminal-4162468071-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-4162468071-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -2571,3 +2571,20 @@ def test_tabs_remove_tab_updates_highlighting(snap_compare):
 
     app = TabsApp()
     assert snap_compare(app, press="r")
+
+
+def test_theme_variables_available_in_code(snap_compare):
+    """Test that theme variables are available in code."""
+
+    class ThemeVariablesApp(App):
+        def compose(self) -> ComposeResult:
+            yield Label("Hello")
+
+        def on_mount(self) -> None:
+            variables = self.theme_variables
+            label = self.query_one(Label)
+            label.update(f"$text-primary = {variables['text-primary']}")
+            label.styles.background = variables["primary-muted"]
+            label.styles.color = variables["text-primary"]
+
+    assert snap_compare(ThemeVariablesApp())


### PR DESCRIPTION
Since the `textual borders` demo programmatically sets the border to a colour from the theme variables, this will need to be released before the demo will work correctly with themes.

We need to release this PR before we can merge the PR below.

https://github.com/Textualize/textual-dev/pull/39
