### PR TITLE
refactor(select): utilize add_options method

### DIFF
--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -415,8 +415,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
 
         option_list = self.query_one(SelectOverlay)
         option_list.clear_options()
-        for option in self._select_options:
-            option_list.add_option(option)
+        option_list.add_options(self._select_options)
 
     def _init_selected_option(self, hint: SelectType | NoSelection = BLANK) -> None:
         """Initialises the selected option for the `Select`."""


### PR DESCRIPTION
Refactor the `Select` widget to utilize the `add_options` method, rather than looping `add_option`.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
