### PR TITLE
tweak to select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Updated the tutorial (text and code) https://github.com/Textualize/textual/pull/5257
+- The Select widget no longer scrolls it's container when expanded
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Updated the tutorial (text and code) https://github.com/Textualize/textual/pull/5257
-- The Select widget no longer scrolls it's container when expanded
+- The Select widget no longer scrolls it's container when expanded https://github.com/Textualize/textual/pull/5265
 
 ### Fixed
 

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -214,7 +214,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
 
         & > SelectOverlay {
             width: 1fr;
-            display: none;
+            visibility: hidden;
             height: auto;
             max-height: 12;
             overlay: screen;
@@ -240,7 +240,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
             }
 
             & > SelectOverlay {
-                display: block;
+                visibility: visible;
             }
         }
 
@@ -494,7 +494,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         self._setup_options_renderables()
         self._init_selected_option(self._value)
 
-    def _watch_expanded(self, expanded: bool) -> None:
+    async def _watch_expanded(self, expanded: bool) -> None:
         """Display or hide overlay."""
         try:
             overlay = self.query_one(SelectOverlay)
@@ -503,17 +503,18 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
             return
         self.set_class(expanded, "-expanded")
         if expanded:
+            select_current = self.query_one(SelectCurrent)
             overlay.focus()
             if self.value is self.BLANK:
                 overlay.select(None)
-                self.query_one(SelectCurrent).has_value = False
+                select_current.has_value = False
             else:
                 value = self.value
                 for index, (_prompt, prompt_value) in enumerate(self._options):
                     if value == prompt_value:
                         overlay.select(index)
                         break
-                self.query_one(SelectCurrent).has_value = True
+                select_current.has_value = True
 
     @on(SelectCurrent.Toggle)
     def _select_current_toggle(self, event: SelectCurrent.Toggle) -> None:

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -494,7 +494,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         self._setup_options_renderables()
         self._init_selected_option(self._value)
 
-    async def _watch_expanded(self, expanded: bool) -> None:
+    def _watch_expanded(self, expanded: bool) -> None:
         """Display or hide overlay."""
         try:
             overlay = self.query_one(SelectOverlay)

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -504,7 +504,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         self.set_class(expanded, "-expanded")
         if expanded:
             select_current = self.query_one(SelectCurrent)
-            overlay.focus()
+            overlay.focus(scroll_visible=False)
             if self.value is self.BLANK:
                 overlay.select(None)
                 select_current.has_value = False


### PR DESCRIPTION
Trying to fix the issue where the select drop-down sometimes appears blank.

I think it may be because of race condition in OptionList, where the order of messages may cause a failure to render.

This *may* work around it. Rather than display:none I've used visibility:hidden. This is because visibility:hidden will still go through a layout procedure and get dimensions even if it can't be seen. 

Also prevented the expanded select from scrolling the container. It is not really needed as the drop-down has the constrain rules which will make it visible.

This is a workaround, until we can look at OptionList in more detail.

If anyone sees the blank Select after this has gone in, let me know!