### PR TITLE
ci: run tests with Python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash
@@ -35,18 +35,18 @@ jobs:
           cache: "poetry"
       - name: Install dependencies
         run: poetry install --no-interaction --extras syntax
-        if: ${{ matrix.python-version != '3.12' }}
-      - name: Install dependencies for 3.12 # https://github.com/Textualize/textual/issues/3491#issuecomment-1854156476
+        if: ${{ matrix.python-version != '3.13' }}
+      - name: Install dependencies for 3.13
         run: poetry install --no-interaction
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.13' }}
       - name: Test with pytest
         run: |
           poetry run pytest tests -v --cov=./src/textual --cov-report=xml:./coverage.xml --cov-report term-missing
-        if: ${{ matrix.python-version != '3.12' }}
-      - name: Test with pytest for 3.12 # https://github.com/Textualize/textual/issues/3491#issuecomment-1854156476
+        if: ${{ matrix.python-version != '3.13' }}
+      - name: Test with pytest for 3.13
         run: |
           poetry run pytest tests -v --cov=./src/textual --cov-report=xml:./coverage.xml --cov-report term-missing -m 'not syntax'
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.13' }}
       - name: Upload snapshot report
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Update CI to run tests with Python 3.13. All jobs look like they ran successfully, but hopefully I haven't missed something!

- Excludes the `syntax` tests for Python 3.13. as the tree-sitter version used by Textual fails to build
- Update job for Python 3.12 to include the `syntax` tests, now that those dependencies can be installed

