### PR TITLE
docs(lazy): fix docstring code embed

### DIFF
--- a/src/textual/lazy.py
+++ b/src/textual/lazy.py
@@ -83,7 +83,7 @@ class Reveal(Widget):
                 yield Logs()
                 yield Sparklines()
             yield Footer()
-    ```
+        ```
     """
 
     DEFAULT_CSS = """


### PR DESCRIPTION
Fixed simple docstring indentation error causing code formatting to break in docs.
