### PR TITLE
Added function to tree widget to find a node by the data field

### DIFF
--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -1046,6 +1046,30 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         except KeyError:
             raise UnknownNodeID(f"Unknown NodeID ({node_id}) in tree") from None
 
+    def get_node_with_data(self, value: str | int, *keys) -> TreeNode[TreeDataType] | None:
+        """Returns the first node that got a matching value in the json data field
+        under the chain of *keys given.
+
+        usage example: Tree.get_node_with_data(42, 'database', 'id')
+        Args:
+            value: str|int of the desired data in the data json
+            *keys: chain of keys to the nested value
+
+        Returns:
+            The first Node with the desired value or None
+        """
+        for treeline in self._tree_lines:
+            if treeline.node.data:
+                data = treeline.node.data
+                try:
+                    for key in keys:
+                        data = data[key]
+                    if data == value:
+                        return treeline.node
+                except(KeyError, TypeError):
+                    continue
+        return None # if nothing was found
+
     def validate_cursor_line(self, value: int) -> int:
         """Prevent cursor line from going outside of range.
 


### PR DESCRIPTION
Based on the monologue discussion https://github.com/Textualize/textual/discussions/5315

I added a function to the Tree Widget for finding a node based on the supplied data field. Its probably inefficient but I couldn't think of a better way to achieve what I wanted with arbitrary json data. There is also the case that there might be a list instead of a dictionary where one might want to find a node that matches any one value. 

I could extend the functionality to find _all_ matching nodes and make it match any one value in a list or nested list if there is interest for the basic idea. 

Maybe finding notes based on supplied data is to much of a deviation from the base implementation.

**Please review the following checklist.**

- [ X] Docstrings on all new or modified functions / classes 
- [  ] Updated documentation
- [  ] Updated CHANGELOG.md (where appropriate)
