### PR TITLE
boost for first letter matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change default quit key to `ctrl+q` https://github.com/Textualize/textual/pull/5352
 - Changed delete line binding on TextArea to use `ctrl+shift+x` https://github.com/Textualize/textual/pull/5352
 - The command palette will now select the top item automatically https://github.com/Textualize/textual/pull/5361
+- Implemented a better matching algorithm for the command palette https://github.com/Textualize/textual/pull/5365
 
 ### Fixed
 

--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -267,7 +267,7 @@ class ItemGrid(Widget, inherit_bindings=False):
         stretch_height: bool = True,
         regular: bool = False,
     ) -> None:
-        """Initialize a Widget.
+        """
 
         Args:
             *children: Child widgets.

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -118,7 +118,7 @@ class FuzzySearch:
 
             """
             # This is a heuristic, and can be tweaked for better results
-            # 2 points for a first letter, 1.0 for other letters
+            # 2 points for a first letter, 1 for other letters
             score: float = sum(
                 (2.0 if offset in first_letters else 1.0) for offset in search.offsets
             )
@@ -211,19 +211,3 @@ class Matcher:
         for offset in offsets:
             text.stylize(self._match_style, offset, offset + 1)
         return text
-
-
-if __name__ == "__main__":
-    TEST = "Savess Screens shot"
-    from rich import print
-    from rich.text import Text
-
-    fuzzy = FuzzySearch()
-
-    for score, offsets in fuzzy._match("ss", TEST):
-        text = Text(TEST)
-        for offset in offsets:
-            text.stylize("reverse", offset, offset + 1)
-        print("--")
-        print(score)
-        print(text)

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -128,8 +128,11 @@ class FuzzySearch:
         pop = stack.pop
         query_size = len(query)
         find = candidate.find
+        # Limit the number of loops out of an abundance of caution.
+        # This would be hard to reach without contrived data.
+        remaining_loops = 50
 
-        while stack:
+        while stack and (remaining_loops := remaining_loops - 1):
             search = pop()
             offset = find(query[search.query_offset], search.candidate_offset)
             if offset != -1:
@@ -205,5 +208,6 @@ class Matcher:
         if not score:
             return text
         for offset in offsets:
-            text.stylize(self._match_style, offset, offset + 1)
+            if not candidate[offset].isspace():
+                text.stylize(self._match_style, offset, offset + 1)
         return text

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -40,6 +40,10 @@ class Matcher:
             ".*?".join(f"({escape(character)})" for character in query),
             flags=0 if case_sensitive else IGNORECASE,
         )
+        self._first_word_regex = compile(
+            ".*?".join(f"(\\b{escape(character)})" for character in query),
+            flags=0 if case_sensitive else IGNORECASE,
+        )
         self._cache: LRUCache[str, float] = LRUCache(1024 * 4)
 
     @property
@@ -90,6 +94,11 @@ class Matcher:
                 last_offset = offset
 
             score = 1.0 - ((group_count - 1) / len(candidate))
+
+            if first_words := self._first_word_regex.match(candidate):
+                multiplier = len(first_words.groups())
+                # boost if the query matches first words
+                score *= multiplier
         self._cache[candidate] = score
         return score
 

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -55,13 +55,11 @@ def match(
     push = stack.append
     pop = stack.pop
     query_size = len(query)
+    find = candidate.find
 
     while stack:
         search = stack[-1]
-        offset = candidate.find(
-            query[search.query_offset],
-            search.candidate_offset,
-        )
+        offset = find(query[search.query_offset], search.candidate_offset)
         if offset == -1:
             pop()
         else:

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -78,13 +78,9 @@ class FuzzySearch:
         cache_key = (query, candidate, self.case_sensitive)
         if cache_key in self.cache:
             return self.cache[cache_key]
-
-        matches = sorted(self._match(query, candidate), key=itemgetter(0))
-        result: tuple[float, tuple[int, ...]]
-        if not matches:
-            result = (0.0, ())
-        else:
-            result = matches[-1]
+        result = max(
+            self._match(query, candidate), key=itemgetter(0), default=(0.0, ())
+        )
         self.cache[cache_key] = result
         return result
 

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -23,9 +23,10 @@ class Search(NamedTuple):
     offsets: tuple[int, ...] = ()
 
     def branch(self, offset: int) -> tuple[Search, Search]:
+        _, query_offset, offsets = self
         return (
-            Search(offset + 1, self.query_offset + 1, self.offsets + (offset,)),
-            Search(offset + 1, self.query_offset, self.offsets),
+            Search(offset + 1, query_offset + 1, offsets + (offset,)),
+            Search(offset + 1, query_offset, offsets),
         )
 
 

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -118,9 +118,10 @@ class FuzzySearch:
             score: float = sum(
                 (2.0 if offset in first_letters else 1.0) for offset in search.offsets
             )
-            # A single group gets a boost, as the user may be typing out an entire word
-            if search.groups == 1:
-                score *= 1.5
+            # Boost to favor less groups
+            offset_count = len(search.offsets)
+            normalized_groups = (offset_count - (search.groups - 1)) / offset_count
+            score *= 1 + (normalized_groups**2)
             return score
 
         stack: list[_Search] = [_Search()]

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -118,13 +118,13 @@ class FuzzySearch:
 
             """
             # This is a heuristic, and can be tweaked for better results
-            # 2 points for a first letter, 1 for other letters
+            # Boost first letter matches
             score: float = sum(
                 (2.0 if offset in first_letters else 1.0) for offset in search.offsets
             )
-            # Divide by the number of groups
-            # 1 group no change, 2 groups score is halved etc.
-            score /= search.groups
+            # A single group gets a boost, as the user may be typing out an entire word
+            if search.groups == 1:
+                score *= 1.5
             return score
 
         stack: list[_Search] = [_Search()]

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -131,7 +131,7 @@ class FuzzySearch:
         find = candidate.find
         # Limit the number of loops out of an abundance of caution.
         # This would be hard to reach without contrived data.
-        remaining_loops = 50
+        remaining_loops = 500
 
         while stack and (remaining_loops := remaining_loops - 1):
             search = pop()

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -123,7 +123,7 @@ class FuzzySearch:
                 (2.0 if offset in first_letters else 1.0) for offset in search.offsets
             )
             # Divide by the number of groups
-            # 1 group no change, 2 groups score is halved etc
+            # 1 group no change, 2 groups score is halved etc.
             score /= search.groups
             return score
 

--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -57,7 +57,7 @@ class FuzzySearch:
     """
 
     def __init__(self, case_sensitive: bool = False) -> None:
-        """_summary_
+        """Initialize fuzzy search.
 
         Args:
             case_sensitive: Is the match case sensitive?

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_example_color_command.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_example_color_command.svg
@@ -19,132 +19,132 @@
         font-weight: 700;
     }
 
-    .terminal-3987436012-matrix {
+    .terminal-905867209-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3987436012-title {
+    .terminal-905867209-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3987436012-r1 { fill: #c5c8c6 }
-.terminal-3987436012-r2 { fill: #e0e0e0 }
-.terminal-3987436012-r3 { fill: #ffffff }
+    .terminal-905867209-r1 { fill: #c5c8c6 }
+.terminal-905867209-r2 { fill: #e0e0e0 }
+.terminal-905867209-r3 { fill: #ffffff }
     </style>
 
     <defs>
-    <clipPath id="terminal-3987436012-clip-terminal">
+    <clipPath id="terminal-905867209-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-3987436012-line-0">
+    <clipPath id="terminal-905867209-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-1">
+<clipPath id="terminal-905867209-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-2">
+<clipPath id="terminal-905867209-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-3">
+<clipPath id="terminal-905867209-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-4">
+<clipPath id="terminal-905867209-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-5">
+<clipPath id="terminal-905867209-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-6">
+<clipPath id="terminal-905867209-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-7">
+<clipPath id="terminal-905867209-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-8">
+<clipPath id="terminal-905867209-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-9">
+<clipPath id="terminal-905867209-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-10">
+<clipPath id="terminal-905867209-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-11">
+<clipPath id="terminal-905867209-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-12">
+<clipPath id="terminal-905867209-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-13">
+<clipPath id="terminal-905867209-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-14">
+<clipPath id="terminal-905867209-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-15">
+<clipPath id="terminal-905867209-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-16">
+<clipPath id="terminal-905867209-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-17">
+<clipPath id="terminal-905867209-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-18">
+<clipPath id="terminal-905867209-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-19">
+<clipPath id="terminal-905867209-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-20">
+<clipPath id="terminal-905867209-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-21">
+<clipPath id="terminal-905867209-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3987436012-line-22">
+<clipPath id="terminal-905867209-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3987436012-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-905867209-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3987436012-clip-terminal)">
-    <rect fill="#242f38" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="50.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="74.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="99.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="134.2" y="123.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="147.9" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="172.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="196.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-3987436012-matrix">
-    <text class="terminal-3987436012-r2" x="12.2" y="20" textLength="73.2" clip-path="url(#terminal-3987436012-line-0)">⭘&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3987436012-r2" x="97.6" y="20" textLength="756.4" clip-path="url(#terminal-3987436012-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3987436012-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3987436012-line-0)">
-</text><text class="terminal-3987436012-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-1)">
-</text><text class="terminal-3987436012-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-2)">
-</text><text class="terminal-3987436012-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-3)">
-</text><text class="terminal-3987436012-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-4)">
-</text><text class="terminal-3987436012-r3" x="97.6" y="142" textLength="36.6" clip-path="url(#terminal-3987436012-line-5)">red</text><text class="terminal-3987436012-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3987436012-line-5)">
-</text><text class="terminal-3987436012-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-6)">
-</text><text class="terminal-3987436012-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-7)">
-</text><text class="terminal-3987436012-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-8)">
-</text><text class="terminal-3987436012-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-9)">
-</text><text class="terminal-3987436012-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3987436012-line-10)">
-</text><text class="terminal-3987436012-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-11)">
-</text><text class="terminal-3987436012-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-12)">
-</text><text class="terminal-3987436012-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-13)">
-</text><text class="terminal-3987436012-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-14)">
-</text><text class="terminal-3987436012-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3987436012-line-15)">
-</text><text class="terminal-3987436012-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-16)">
-</text><text class="terminal-3987436012-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-17)">
-</text><text class="terminal-3987436012-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-18)">
-</text><text class="terminal-3987436012-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-19)">
-</text><text class="terminal-3987436012-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3987436012-line-20)">
-</text><text class="terminal-3987436012-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-21)">
-</text><text class="terminal-3987436012-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-22)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-905867209-clip-terminal)">
+    <rect fill="#242f38" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="50.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="74.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="99.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="97.6" y="123.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="195.2" y="123.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="147.9" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="172.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="196.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-905867209-matrix">
+    <text class="terminal-905867209-r2" x="12.2" y="20" textLength="73.2" clip-path="url(#terminal-905867209-line-0)">⭘&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-905867209-r2" x="97.6" y="20" textLength="756.4" clip-path="url(#terminal-905867209-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-905867209-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-905867209-line-0)">
+</text><text class="terminal-905867209-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-905867209-line-1)">
+</text><text class="terminal-905867209-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-905867209-line-2)">
+</text><text class="terminal-905867209-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-905867209-line-3)">
+</text><text class="terminal-905867209-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-905867209-line-4)">
+</text><text class="terminal-905867209-r3" x="97.6" y="142" textLength="97.6" clip-path="url(#terminal-905867209-line-5)">ansi_red</text><text class="terminal-905867209-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-905867209-line-5)">
+</text><text class="terminal-905867209-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-905867209-line-6)">
+</text><text class="terminal-905867209-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-905867209-line-7)">
+</text><text class="terminal-905867209-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-905867209-line-8)">
+</text><text class="terminal-905867209-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-905867209-line-9)">
+</text><text class="terminal-905867209-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-905867209-line-10)">
+</text><text class="terminal-905867209-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-905867209-line-11)">
+</text><text class="terminal-905867209-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-905867209-line-12)">
+</text><text class="terminal-905867209-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-905867209-line-13)">
+</text><text class="terminal-905867209-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-905867209-line-14)">
+</text><text class="terminal-905867209-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-905867209-line-15)">
+</text><text class="terminal-905867209-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-905867209-line-16)">
+</text><text class="terminal-905867209-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-905867209-line-17)">
+</text><text class="terminal-905867209-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-905867209-line-18)">
+</text><text class="terminal-905867209-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-905867209-line-19)">
+</text><text class="terminal-905867209-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-905867209-line-20)">
+</text><text class="terminal-905867209-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-905867209-line-21)">
+</text><text class="terminal-905867209-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-905867209-line-22)">
 </text>
     </g>
     </g>

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_example_color_command.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_example_color_command.svg
@@ -19,132 +19,132 @@
         font-weight: 700;
     }
 
-    .terminal-905867209-matrix {
+    .terminal-3987436012-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-905867209-title {
+    .terminal-3987436012-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-905867209-r1 { fill: #c5c8c6 }
-.terminal-905867209-r2 { fill: #e0e0e0 }
-.terminal-905867209-r3 { fill: #ffffff }
+    .terminal-3987436012-r1 { fill: #c5c8c6 }
+.terminal-3987436012-r2 { fill: #e0e0e0 }
+.terminal-3987436012-r3 { fill: #ffffff }
     </style>
 
     <defs>
-    <clipPath id="terminal-905867209-clip-terminal">
+    <clipPath id="terminal-3987436012-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-905867209-line-0">
+    <clipPath id="terminal-3987436012-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-1">
+<clipPath id="terminal-3987436012-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-2">
+<clipPath id="terminal-3987436012-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-3">
+<clipPath id="terminal-3987436012-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-4">
+<clipPath id="terminal-3987436012-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-5">
+<clipPath id="terminal-3987436012-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-6">
+<clipPath id="terminal-3987436012-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-7">
+<clipPath id="terminal-3987436012-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-8">
+<clipPath id="terminal-3987436012-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-9">
+<clipPath id="terminal-3987436012-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-10">
+<clipPath id="terminal-3987436012-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-11">
+<clipPath id="terminal-3987436012-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-12">
+<clipPath id="terminal-3987436012-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-13">
+<clipPath id="terminal-3987436012-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-14">
+<clipPath id="terminal-3987436012-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-15">
+<clipPath id="terminal-3987436012-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-16">
+<clipPath id="terminal-3987436012-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-17">
+<clipPath id="terminal-3987436012-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-18">
+<clipPath id="terminal-3987436012-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-19">
+<clipPath id="terminal-3987436012-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-20">
+<clipPath id="terminal-3987436012-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-21">
+<clipPath id="terminal-3987436012-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-905867209-line-22">
+<clipPath id="terminal-3987436012-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-905867209-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-3987436012-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-905867209-clip-terminal)">
-    <rect fill="#242f38" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="50.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="74.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="99.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="97.6" y="123.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="195.2" y="123.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="147.9" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="172.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#800000" x="24.4" y="196.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-905867209-matrix">
-    <text class="terminal-905867209-r2" x="12.2" y="20" textLength="73.2" clip-path="url(#terminal-905867209-line-0)">⭘&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-905867209-r2" x="97.6" y="20" textLength="756.4" clip-path="url(#terminal-905867209-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-905867209-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-905867209-line-0)">
-</text><text class="terminal-905867209-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-905867209-line-1)">
-</text><text class="terminal-905867209-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-905867209-line-2)">
-</text><text class="terminal-905867209-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-905867209-line-3)">
-</text><text class="terminal-905867209-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-905867209-line-4)">
-</text><text class="terminal-905867209-r3" x="97.6" y="142" textLength="97.6" clip-path="url(#terminal-905867209-line-5)">ansi_red</text><text class="terminal-905867209-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-905867209-line-5)">
-</text><text class="terminal-905867209-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-905867209-line-6)">
-</text><text class="terminal-905867209-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-905867209-line-7)">
-</text><text class="terminal-905867209-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-905867209-line-8)">
-</text><text class="terminal-905867209-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-905867209-line-9)">
-</text><text class="terminal-905867209-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-905867209-line-10)">
-</text><text class="terminal-905867209-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-905867209-line-11)">
-</text><text class="terminal-905867209-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-905867209-line-12)">
-</text><text class="terminal-905867209-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-905867209-line-13)">
-</text><text class="terminal-905867209-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-905867209-line-14)">
-</text><text class="terminal-905867209-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-905867209-line-15)">
-</text><text class="terminal-905867209-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-905867209-line-16)">
-</text><text class="terminal-905867209-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-905867209-line-17)">
-</text><text class="terminal-905867209-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-905867209-line-18)">
-</text><text class="terminal-905867209-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-905867209-line-19)">
-</text><text class="terminal-905867209-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-905867209-line-20)">
-</text><text class="terminal-905867209-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-905867209-line-21)">
-</text><text class="terminal-905867209-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-905867209-line-22)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3987436012-clip-terminal)">
+    <rect fill="#242f38" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="854" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="866.2" y="1.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="50.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="74.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="99.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="97.6" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="134.2" y="123.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="147.9" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="172.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="24.4" y="196.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-3987436012-matrix">
+    <text class="terminal-3987436012-r2" x="12.2" y="20" textLength="73.2" clip-path="url(#terminal-3987436012-line-0)">⭘&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3987436012-r2" x="97.6" y="20" textLength="756.4" clip-path="url(#terminal-3987436012-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Press&#160;ctrl&#160;+&#160;p&#160;and&#160;type&#160;a&#160;color&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3987436012-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3987436012-line-0)">
+</text><text class="terminal-3987436012-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-1)">
+</text><text class="terminal-3987436012-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-2)">
+</text><text class="terminal-3987436012-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-3)">
+</text><text class="terminal-3987436012-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-4)">
+</text><text class="terminal-3987436012-r3" x="97.6" y="142" textLength="36.6" clip-path="url(#terminal-3987436012-line-5)">red</text><text class="terminal-3987436012-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3987436012-line-5)">
+</text><text class="terminal-3987436012-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-6)">
+</text><text class="terminal-3987436012-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-7)">
+</text><text class="terminal-3987436012-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-8)">
+</text><text class="terminal-3987436012-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-9)">
+</text><text class="terminal-3987436012-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3987436012-line-10)">
+</text><text class="terminal-3987436012-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-11)">
+</text><text class="terminal-3987436012-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-12)">
+</text><text class="terminal-3987436012-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-13)">
+</text><text class="terminal-3987436012-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-14)">
+</text><text class="terminal-3987436012-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3987436012-line-15)">
+</text><text class="terminal-3987436012-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-16)">
+</text><text class="terminal-3987436012-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-17)">
+</text><text class="terminal-3987436012-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3987436012-line-18)">
+</text><text class="terminal-3987436012-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3987436012-line-19)">
+</text><text class="terminal-3987436012-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3987436012-line-20)">
+</text><text class="terminal-3987436012-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3987436012-line-21)">
+</text><text class="terminal-3987436012-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3987436012-line-22)">
 </text>
     </g>
     </g>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1510,7 +1510,7 @@ def test_example_color_command(snap_compare):
     """Test the color_command example."""
     assert snap_compare(
         EXAMPLES_DIR / "color_command.py",
-        press=[App.COMMAND_PALETTE_BINDING, "r", "e", "d", "down", "enter"],
+        press=[App.COMMAND_PALETTE_BINDING, "r", "e", "d", "enter"],
     )
 
 

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -4,28 +4,20 @@ from rich.text import Span
 from textual.fuzzy import Matcher
 
 
-def test_match():
-    matcher = Matcher("foo.bar")
+def test_no_match():
+    """Check non matching score of zero."""
+    matcher = Matcher("x")
+    assert matcher.match("foo") == 0
 
-    # No match
-    assert matcher.match("egg") == 0
-    assert matcher.match("") == 0
 
-    # Perfect match
-    assert matcher.match("foo.bar") == 1.0
-    # Perfect match (with superfluous characters)
-    assert matcher.match("foo.bar sdf") == 1.0
-    assert matcher.match("xz foo.bar sdf") == 1.0
-
-    # Partial matches
-    # 2 Groups
-    assert matcher.match("foo egg.bar") == 1.0 - 1 / 11
-
-    # 3 Groups
-    assert matcher.match("foo .ba egg r") == 1.0 - 2 / 13
+def test_match_single_group():
+    """Check that single groups rang higher."""
+    matcher = Matcher("abc")
+    assert matcher.match("foo abc bar") > matcher.match("fooa barc")
 
 
 def test_boosted_matches():
+    """Check first word matchers rank higher."""
     matcher = Matcher("ss")
 
     # First word matchers should score higher

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -25,6 +25,13 @@ def test_match():
     assert matcher.match("foo .ba egg r") == 1.0 - 2 / 13
 
 
+def test_boosted_matches():
+    matcher = Matcher("ss")
+
+    # First word matchers should score higher
+    assert matcher.match("Save Screenshot") > matcher.match("Show Keys abcde")
+
+
 def test_highlight():
     matcher = Matcher("foo.bar")
 


### PR DESCRIPTION
Tweak to the command palette matcher to boost matches for the first word(s).

Consider the system commands. If I were to type "SS" I would get "**S**how Key**s** and Help Panel". Now I get "**S**ave **S**creenshot" because I'm matching the first letters.

Knowing this makes it easier to get a precise match.