### PR TITLE
Selection behaviour update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Updated `TextArea` and `Input` behavior when there is a selection and the user presses left or right https://github.com/Textualize/textual/pull/5400
+
 ## [1.0.0] - 2024-12-12
 
 ### Added

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -761,11 +761,14 @@ class Input(ScrollView):
         Args:
             select: If `True`, select the text to the left of the cursor.
         """
+        start, end = self.selection
         if select:
-            start, end = self.selection
             self.selection = Selection(start, end - 1)
         else:
-            self.cursor_position -= 1
+            if self.selection.is_empty:
+                self.cursor_position -= 1
+            else:
+                self.cursor_position = min(start, end)
 
     def action_cursor_right(self, select: bool = False) -> None:
         """Accept an auto-completion or move the cursor one position to the right.
@@ -773,15 +776,18 @@ class Input(ScrollView):
         Args:
             select: If `True`, select the text to the right of the cursor.
         """
+        start, end = self.selection
         if select:
-            start, end = self.selection
             self.selection = Selection(start, end + 1)
         else:
             if self._cursor_at_end and self._suggestion:
                 self.value = self._suggestion
                 self.cursor_position = len(self.value)
             else:
-                self.cursor_position += 1
+                if self.selection.is_empty:
+                    self.cursor_position += 1
+                else:
+                    self.cursor_position = max(start, end)
 
     def action_home(self, select: bool = False) -> None:
         """Move the cursor to the start of the input.

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1835,6 +1835,8 @@ TextArea {
         If the cursor is at the left edge of the document, try to move it to
         the end of the previous line.
 
+        If text is selected, move the cursor to the start of the selection.
+
         Args:
             select: If True, select the text while moving.
         """
@@ -1857,6 +1859,8 @@ TextArea {
         """Move the cursor one location to the right.
 
         If the cursor is at the end of a line, attempt to go to the start of the next line.
+
+        If text is selected, move the cursor to the end of the selection.
 
         Args:
             select: If True, select the text while moving.

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1838,8 +1838,12 @@ TextArea {
         Args:
             select: If True, select the text while moving.
         """
-        target = self.get_cursor_left_location()
-        self.move_cursor(target, select=select)
+        if self.selection.is_empty:
+            target = self.get_cursor_left_location()
+            self.move_cursor(target, select=select)
+        else:
+            start, end = self.selection
+            self.move_cursor(min(start, end), select=select)
 
     def get_cursor_left_location(self) -> Location:
         """Get the location the cursor will move to if it moves left.
@@ -1857,8 +1861,12 @@ TextArea {
         Args:
             select: If True, select the text while moving.
         """
-        target = self.get_cursor_right_location()
-        self.move_cursor(target, select=select)
+        if self.selection.is_empty:
+            target = self.get_cursor_right_location()
+            self.move_cursor(target, select=select)
+        else:
+            start, end = self.selection
+            self.move_cursor(max(start, end), select=select)
 
     def get_cursor_right_location(self) -> Location:
         """Get the location the cursor will move to if it moves right.

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1838,12 +1838,12 @@ TextArea {
         Args:
             select: If True, select the text while moving.
         """
-        if self.selection.is_empty:
-            target = self.get_cursor_left_location()
-            self.move_cursor(target, select=select)
-        else:
-            start, end = self.selection
-            self.move_cursor(min(start, end), select=select)
+        target = (
+            self.get_cursor_left_location()
+            if select or self.selection.is_empty
+            else min(*self.selection)
+        )
+        self.move_cursor(target, select=select)
 
     def get_cursor_left_location(self) -> Location:
         """Get the location the cursor will move to if it moves left.
@@ -1861,12 +1861,12 @@ TextArea {
         Args:
             select: If True, select the text while moving.
         """
-        if self.selection.is_empty:
-            target = self.get_cursor_right_location()
-            self.move_cursor(target, select=select)
-        else:
-            start, end = self.selection
-            self.move_cursor(max(start, end), select=select)
+        target = (
+            self.get_cursor_right_location()
+            if select or self.selection.is_empty
+            else max(*self.selection)
+        )
+        self.move_cursor(target, select=select)
 
     def get_cursor_right_location(self) -> Location:
         """Get the location the cursor will move to if it moves right.

--- a/tests/input/test_input_terminal_cursor.py
+++ b/tests/input/test_input_terminal_cursor.py
@@ -8,7 +8,9 @@ class InputApp(App):
     CSS = "Input { padding: 4 8 }"
 
     def compose(self) -> ComposeResult:
-        yield Input("こんにちは!")
+        # We don't want to select the text on focus, as selected text
+        # has different interactions with the cursor_left action.
+        yield Input("こんにちは!", select_on_focus=False)
 
 
 async def test_initial_terminal_cursor_position():


### PR DESCRIPTION
Subtle change to behaviour in TextArea and Input when text is selected and you press `left` or `right`.

If text is selected and you press `left` or `right`, the cursor should move to the corresponding side of the selection rather than always just moving one cell. This matches operating system and text editor standard behaviour.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
