### PR TITLE
Fix calculator example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -196,7 +196,7 @@ Click the tabs to see the code behind the example.
 
 === "Calculator example"
 
-    ```{.textual path="examples/calculator.py" columns=100 lines=41 press="3,.,1,4,5,9,2,wait:400"}
+    ```{.textual path="examples/calculator.py" columns=100 lines=41 press="3,.,1,4,1,5,9,2,wait:400"}
     ```
 
 === "calculator.py"


### PR DESCRIPTION
Just a NIT that the example of the calculator is wrong


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
