### PR TITLE
Broaden tests for mode 2026 detection.

### DIFF
--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -299,7 +299,7 @@ def test_escape_sequence_resulting_in_multiple_keypresses(parser):
     assert events[1].key == "shift+insert"
 
 
-@pytest.mark.parametrize("parameter", range(1, 4))
+@pytest.mark.parametrize("parameter", range(1, 5))
 def test_terminal_mode_reporting_synchronized_output_supported(parser, parameter):
     sequence = f"\x1b[?2026;{parameter}$y"
     events = list(parser.feed(sequence))

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -299,8 +299,9 @@ def test_escape_sequence_resulting_in_multiple_keypresses(parser):
     assert events[1].key == "shift+insert"
 
 
-def test_terminal_mode_reporting_synchronized_output_supported(parser):
-    sequence = "\x1b[?2026;1$y"
+@pytest.mark.parametrize("parameter", range(1, 4))
+def test_terminal_mode_reporting_synchronized_output_supported(parser, parameter):
+    sequence = f"\x1b[?2026;{parameter}$y"
     events = list(parser.feed(sequence))
     assert len(events) == 1
     assert isinstance(events[0], TerminalSupportsSynchronizedOutput)


### PR DESCRIPTION
Terminals seem to report status 2 more often than status 1.

Let's broaden the test to cover all possible statuses (0-4 inclusive).