### PR TITLE
Added Blur message to Input widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `from_app_focus` to `Focus` event to indicate if a widget is being focused because the app itself has regained focus or not https://github.com/Textualize/textual/pull/5379
 - - Added `Select.type_to_search` which allows you to type to move the cursor to a matching option https://github.com/Textualize/textual/pull/5403
+- Added `Blur` message to `Input` widget (matching `Submitted` and `Changed`) to make it easier to synchronize with `validate_on` parameter when set to 'blur'.
 
 ### Changed
 
 - The content of an `Input` will now only be automatically selected when the widget is focused by the user, not when the app itself has regained focus (similar to web browsers). https://github.com/Textualize/textual/pull/5379
 - Updated `TextArea` and `Input` behavior when there is a selection and the user presses left or right https://github.com/Textualize/textual/pull/5400
 - Footer can now be scrolled horizontally without holding `shift` https://github.com/Textualize/textual/pull/5404
+- Modified _on_blur method in `Input` to post a `Blur` message
 
 
 ## [1.0.0] - 2024-12-12

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -284,6 +284,29 @@ class Input(ScrollView):
             """Alias for self.input."""
             return self.input
 
+    @dataclass
+    class Blur(Message):
+        """Posted when the widget is blurred (loses focus).
+
+        Can be handled using `on_input_blur` in a subclass of `Input` or in a parent
+        widget in the DOM.
+        """
+
+        input: Input
+        """The `Input` widget that was changed."""
+
+        value: str
+        """The value that the input was changed to."""
+
+        validation_result: ValidationResult | None = None
+        """The result of validating the value (formed by combining the results from each validator), or None
+            if validation was not performed (for example when no validators are specified in the `Input`s init)"""
+
+        @property
+        def control(self) -> Input:
+            """Alias for self.input."""
+            return self.input
+
     def __init__(
         self,
         value: str | None = None,
@@ -636,8 +659,10 @@ class Input(ScrollView):
 
     def _on_blur(self, event: Blur) -> None:
         self._pause_blink()
-        if "blur" in self.validate_on:
-            self.validate(self.value)
+        validation_result = (
+            self.validate(self.value) if "blur" in self.validate_on else None
+        )
+        self.post_message(self.Blur(self, self.value, validation_result))
 
     def _on_focus(self, event: Focus) -> None:
         self._restart_blink()


### PR DESCRIPTION
I realized working with the Input widget that its options for `validate_on` are "submitted", "changed", and "blur". However, there's only messages for Submitted and Changed. This makes it trickier to synchronize a function with the blur validator than it is with the other two validators, which I believe in this situation does not make sense.

Now I had figured a Blur event most likely does not exist for a reason (i.e. perhaps if one widget has it then why wouldn't all of them). But in this situation I can't help but feel like its existence is warranted in order to make the `validate_on=['blur']` parameter be able to be used in a manner that's identical to "submitted" and "changed" without needing to subclass the Input widget.