### PR TITLE
Bash alias command substitution window resize bug

### DIFF
--- a/src/textual/drivers/headless_driver.py
+++ b/src/textual/drivers/headless_driver.py
@@ -18,26 +18,19 @@ class HeadlessDriver(Driver):
     def _get_terminal_size(self) -> tuple[int, int]:
         if self._size is not None:
             return self._size
-        try:
-            width = int(os.environ['COLUMNS'])
-        except (KeyError, ValueError):
-            width: int | None = 0
+        width: int | None = 80
+        height: int | None = 25
+        import shutil
 
         try:
-            height = int(os.environ['LINES'])
-        except (KeyError, ValueError):
-            height: int | None = 0
-
-        if width <= 0 or height <= 0:
+            width, height = shutil.get_terminal_size()
+        except (AttributeError, ValueError, OSError):
             try:
-                width, height = os.get_terminal_size(self._file.fileno())
+                width, height = shutil.get_terminal_size()
             except (AttributeError, ValueError, OSError):
-                try:
-                    width, height = os.get_terminal_size(self._file.fileno())
-                except (AttributeError, ValueError, OSError):
-                    pass
-            width = width or 80
-            height = height or 25
+                pass
+        width = width or 80
+        height = height or 25
         return width, height
 
     def write(self, data: str) -> None:

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -102,19 +102,26 @@ class LinuxDriver(Driver):
         Returns:
             The size of the terminal as a tuple of (WIDTH, HEIGHT).
         """
-        width: int | None = 80
-        height: int | None = 25
-        import shutil
+        try:
+            width = int(os.environ['COLUMNS'])
+        except (KeyError, ValueError):
+            width: int | None = 0
 
         try:
-            width, height = shutil.get_terminal_size()
-        except (AttributeError, ValueError, OSError):
+            height = int(os.environ['LINES'])
+        except (KeyError, ValueError):
+            height: int | None = 0
+
+        if width <= 0 or height <= 0:
             try:
-                width, height = shutil.get_terminal_size()
+                width, height = os.get_terminal_size(self._file.fileno())
             except (AttributeError, ValueError, OSError):
-                pass
-        width = width or 80
-        height = height or 25
+                try:
+                    width, height = os.get_terminal_size(self._file.fileno())
+                except (AttributeError, ValueError, OSError):
+                    pass
+            width = width or 80
+            height = height or 25
         return width, height
 
     def _enable_mouse_support(self) -> None:

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -61,19 +61,26 @@ class LinuxInlineDriver(Driver):
         Returns:
             The size of the terminal as a tuple of (WIDTH, HEIGHT).
         """
-        width: int | None = 80
-        height: int | None = 25
-        import shutil
+        try:
+            width = int(os.environ['COLUMNS'])
+        except (KeyError, ValueError):
+            width: int | None = 0
 
         try:
-            width, height = shutil.get_terminal_size()
-        except (AttributeError, ValueError, OSError):
+            height = int(os.environ['LINES'])
+        except (KeyError, ValueError):
+            height: int | None = 0
+
+        if width <= 0 or height <= 0:
             try:
-                width, height = shutil.get_terminal_size()
+                width, height = os.get_terminal_size(self._file.fileno())
             except (AttributeError, ValueError, OSError):
-                pass
-        width = width or 80
-        height = height or 25
+                try:
+                    width, height = os.get_terminal_size(self._file.fileno())
+                except (AttributeError, ValueError, OSError):
+                    pass
+            width = width or 80
+            height = height or 25
         return width, height
 
     def _enable_mouse_support(self) -> None:


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

Greetings,

I'm making this PR following a conversation with @xavierog (thanks to him) on Discord. I asked him for help regarding my TUI application.

My application was not resized correctly, the display was bugged and for example the Footer was disappearing, the thing is that I was running the Python application from a bash alias using command substitution (`alias cmd='$(python3 tui-app.py)'`), @xavierog discovered that the Textual driver was using `shutil.get_terminal_size()` to get the window size, but in that specific case, the function is failling because the command is ran from a bash command substitution.

This PR aim to fix that specific (and probably uncommon) situation, I ran all tests and here is the results:
```
================================== short test summary info ==================================
FAILED tests/snapshot_tests/test_snapshots.py::test_text_area_themes[css] - AssertionError: assert False
FAILED tests/snapshot_tests/test_snapshots.py::test_text_area_themes[monokai] - AssertionError: assert False
FAILED tests/snapshot_tests/test_snapshots.py::test_text_area_themes[dracula] - AssertionError: assert False
FAILED tests/snapshot_tests/test_snapshots.py::test_text_area_themes[vscode_dark] - AssertionError: assert False
FAILED tests/snapshot_tests/test_snapshots.py::test_text_area_themes[github_light] - AssertionError: assert False
FAILED tests/snapshot_tests/test_snapshots.py::test_text_area_wrapping_and_folding - AssertionError: assert False
FAILED tests/text_area/test_languages.py::test_setting_unknown_language - Failed: DID NOT RAISE <class 'textual.widgets._text_area.LanguageDoesNotExist'>
FAILED tests/text_area/test_languages.py::test_register_language - ImportError: cannot import name 'get_language' from 'textual._tree_sitter' (/root/textua...
FAILED tests/text_area/test_languages.py::test_update_highlight_query - AssertionError: assert 0 > 0
======== 9 failed, 3104 passed, 2 skipped, 4 xfailed, 1 warning in 259.55s (0:04:19) ========
```

I had the same results with a fresh `Textual` clone so I don't think my changes broke any tests.

