### PR TITLE
Select update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed `Pilot.click` not working with `times` parameter https://github.com/Textualize/textual/pull/5398
-- Fixed select refocusing itself too late
+- Fixed select refocusing itself too late https://github.com/Textualize/textual/pull/5420
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed `Pilot.click` not working with `times` parameter https://github.com/Textualize/textual/pull/5398
+- Fixed select refocusing itself too late
 
 ### Added
 

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -610,7 +610,7 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
                 value = self.value
                 for index, (_prompt, prompt_value) in enumerate(self._options):
                     if value == prompt_value:
-                        self.call_after_refresh(overlay.select, index)
+                        overlay.select(index)
                         break
                 self.query_one(SelectCurrent).has_value = True
 
@@ -637,12 +637,8 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
         if value != self.value:
             self.value = value
 
-        async def update_focus() -> None:
-            """Update focus and reset overlay."""
-            self.focus()
-            self.expanded = False
-
-        self.call_after_refresh(update_focus)  # Prevents a little flicker
+        self.focus()
+        self.expanded = False
 
     def action_show_overlay(self) -> None:
         """Show the overlay."""

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_select_refocus.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_select_refocus.svg
@@ -1,0 +1,157 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2075506993-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2075506993-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2075506993-r1 { fill: #e0e0e0 }
+.terminal-2075506993-r2 { fill: #272727 }
+.terminal-2075506993-r3 { fill: #191919 }
+.terminal-2075506993-r4 { fill: #c5c8c6 }
+.terminal-2075506993-r5 { fill: #7f7f7f }
+.terminal-2075506993-r6 { fill: #ddedf9;font-weight: bold }
+.terminal-2075506993-r7 { fill: #0178d4 }
+.terminal-2075506993-r8 { fill: #e0e0e0;font-weight: bold }
+.terminal-2075506993-r9 { fill: #7f7f7f;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2075506993-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-2075506993-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2075506993-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-2075506993-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">TUI</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2075506993-clip-terminal)">
+    <rect fill="#272727" x="0" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="1.5" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="963.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="109.8" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="183" y="25.9" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="927.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="939.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="50.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="50.3" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="74.7" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="963.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="109.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="146.4" y="99.1" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="927.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="939.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="123.5" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="147.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="147.9" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="172.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="109.8" y="172.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="183" y="172.3" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="927.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="939.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="963.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="196.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="73.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="85.4" y="196.7" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="963.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-2075506993-matrix">
+    <text class="terminal-2075506993-r1" x="0" y="20" textLength="73.2" clip-path="url(#terminal-2075506993-line-0)">Hello!</text><text class="terminal-2075506993-r2" x="73.2" y="20" textLength="12.2" clip-path="url(#terminal-2075506993-line-0)">▊</text><text class="terminal-2075506993-r3" x="85.4" y="20" textLength="878.4" clip-path="url(#terminal-2075506993-line-0)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-2075506993-r3" x="963.8" y="20" textLength="12.2" clip-path="url(#terminal-2075506993-line-0)">▎</text><text class="terminal-2075506993-r4" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2075506993-line-0)">
+</text><text class="terminal-2075506993-r2" x="73.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-1)">▊</text><text class="terminal-2075506993-r5" x="109.8" y="44.4" textLength="73.2" clip-path="url(#terminal-2075506993-line-1)">Select</text><text class="terminal-2075506993-r5" x="927.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-1)">▼</text><text class="terminal-2075506993-r3" x="963.8" y="44.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-1)">▎</text><text class="terminal-2075506993-r4" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-1)">
+</text><text class="terminal-2075506993-r2" x="73.2" y="68.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-2)">▊</text><text class="terminal-2075506993-r3" x="85.4" y="68.8" textLength="878.4" clip-path="url(#terminal-2075506993-line-2)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-2075506993-r3" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-2)">▎</text><text class="terminal-2075506993-r4" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-2)">
+</text><text class="terminal-2075506993-r6" x="0" y="93.2" textLength="73.2" clip-path="url(#terminal-2075506993-line-3)">Hello!</text><text class="terminal-2075506993-r7" x="73.2" y="93.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-3)">▊</text><text class="terminal-2075506993-r3" x="85.4" y="93.2" textLength="878.4" clip-path="url(#terminal-2075506993-line-3)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-2075506993-r3" x="963.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-3)">▎</text><text class="terminal-2075506993-r4" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-3)">
+</text><text class="terminal-2075506993-r7" x="73.2" y="117.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-4)">▊</text><text class="terminal-2075506993-r8" x="109.8" y="117.6" textLength="36.6" clip-path="url(#terminal-2075506993-line-4)">foo</text><text class="terminal-2075506993-r9" x="927.2" y="117.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-4)">▼</text><text class="terminal-2075506993-r3" x="963.8" y="117.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-4)">▎</text><text class="terminal-2075506993-r4" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-4)">
+</text><text class="terminal-2075506993-r7" x="73.2" y="142" textLength="12.2" clip-path="url(#terminal-2075506993-line-5)">▊</text><text class="terminal-2075506993-r3" x="85.4" y="142" textLength="878.4" clip-path="url(#terminal-2075506993-line-5)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-2075506993-r3" x="963.8" y="142" textLength="12.2" clip-path="url(#terminal-2075506993-line-5)">▎</text><text class="terminal-2075506993-r4" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2075506993-line-5)">
+</text><text class="terminal-2075506993-r1" x="0" y="166.4" textLength="73.2" clip-path="url(#terminal-2075506993-line-6)">Hello!</text><text class="terminal-2075506993-r2" x="73.2" y="166.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-6)">▊</text><text class="terminal-2075506993-r3" x="85.4" y="166.4" textLength="878.4" clip-path="url(#terminal-2075506993-line-6)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-2075506993-r3" x="963.8" y="166.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-6)">▎</text><text class="terminal-2075506993-r4" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-6)">
+</text><text class="terminal-2075506993-r2" x="73.2" y="190.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-7)">▊</text><text class="terminal-2075506993-r5" x="109.8" y="190.8" textLength="73.2" clip-path="url(#terminal-2075506993-line-7)">Select</text><text class="terminal-2075506993-r5" x="927.2" y="190.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-7)">▼</text><text class="terminal-2075506993-r3" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-7)">▎</text><text class="terminal-2075506993-r4" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-7)">
+</text><text class="terminal-2075506993-r2" x="73.2" y="215.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-8)">▊</text><text class="terminal-2075506993-r3" x="85.4" y="215.2" textLength="878.4" clip-path="url(#terminal-2075506993-line-8)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-2075506993-r3" x="963.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-8)">▎</text><text class="terminal-2075506993-r4" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-8)">
+</text><text class="terminal-2075506993-r4" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-9)">
+</text><text class="terminal-2075506993-r4" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2075506993-line-10)">
+</text><text class="terminal-2075506993-r4" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-11)">
+</text><text class="terminal-2075506993-r4" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-12)">
+</text><text class="terminal-2075506993-r4" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-13)">
+</text><text class="terminal-2075506993-r4" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-14)">
+</text><text class="terminal-2075506993-r4" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2075506993-line-15)">
+</text><text class="terminal-2075506993-r4" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-16)">
+</text><text class="terminal-2075506993-r4" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-17)">
+</text><text class="terminal-2075506993-r4" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2075506993-line-18)">
+</text><text class="terminal-2075506993-r4" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2075506993-line-19)">
+</text><text class="terminal-2075506993-r4" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2075506993-line-20)">
+</text><text class="terminal-2075506993-r4" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2075506993-line-21)">
+</text><text class="terminal-2075506993-r4" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2075506993-line-22)">
+</text>
+    </g>
+    </g>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5416

The Select widget used `call_after_refresh` which delayed refocusing the main control when the drop-down was dismissed. This would happen after the Changed handler focused anything, and made it appear as if the focus simply wasn't working.

The fix was to remove those `call_after_refresh` calls, which I suspect were there to workaround various OptionList issues which were recently fixed.