### PR TITLE
Align `OptionList` page key case to match ancestors

### DIFF
--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -124,8 +124,8 @@ class OptionList(ScrollView, can_focus=True):
         Binding("end", "last", "Last", show=False),
         Binding("enter", "select", "Select", show=False),
         Binding("home", "first", "First", show=False),
-        Binding("pagedown", "page_down", "Page down", show=False),
-        Binding("pageup", "page_up", "Page up", show=False),
+        Binding("pagedown", "page_down", "Page Down", show=False),
+        Binding("pageup", "page_up", "Page Up", show=False),
         Binding("up", "cursor_up", "Up", show=False),
     ]
     """


### PR DESCRIPTION
The `OptionList` widgets uses slightly different case style for the binding descriptions vs its ancestors, resulting in this in the `HelpPanel`:

![Screenshot 2024-12-30 at 13 04 02](https://github.com/user-attachments/assets/e6c9d6b4-37bd-4d03-90e2-776f5f2c60ad)

(up/down lower case, left/right title case)

This PR tweaks the `OptionList` to bring it in line.