### PR TITLE
docs: fix 'into' grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ In addition to serving your apps locally, you can serve apps with [Textual Web](
 
 Textual Web's firewall-busting technology can serve an unlimited number of applications.
 
-Since Textual apps have low system requirements, you can install them anywhere Python also runs. Turning any device in to a connected device.
+Since Textual apps have low system requirements, you can install them anywhere Python also runs. Turning any device into a connected device.
 No desktop required!
 
 

--- a/docs/examples/guide/widgets/checker04.py
+++ b/docs/examples/guide/widgets/checker04.py
@@ -52,7 +52,7 @@ class CheckerBoard(ScrollView):
             """Get region relative to widget from square coordinate."""
             x, y = square_offset
             region = Region(x * 8, y * 4, 8, 4)
-            # Move the region in to the widgets frame of reference
+            # Move the region into the widgets frame of reference
             region = region.translate(-self.scroll_offset)
             return region
 

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -1,6 +1,6 @@
 # App Basics
 
-In this chapter we will cover how to use Textual's App class to create an application. Just enough to get you up to speed. We will go in to more detail in the following chapters.
+In this chapter we will cover how to use Textual's App class to create an application. Just enough to get you up to speed. We will go into more detail in the following chapters.
 
 ## The App class
 
@@ -30,7 +30,7 @@ If we run this app with `python simple02.py` you will see a blank terminal, some
 ```{.textual path="docs/examples/app/simple02.py"}
 ```
 
-When you call [App.run()][textual.app.App.run] Textual puts the terminal in to a special state called *application mode*. When in application mode the terminal will no longer echo what you type. Textual will take over responding to user input (keyboard and mouse) and will update the visible portion of the terminal (i.e. the *screen*).
+When you call [App.run()][textual.app.App.run] Textual puts the terminal into a special state called *application mode*. When in application mode the terminal will no longer echo what you type. Textual will take over responding to user input (keyboard and mouse) and will update the visible portion of the terminal (i.e. the *screen*).
 
 If you hit ++ctrl+q++ Textual will exit application mode and return you to the command prompt. Any content you had in the terminal prior to application mode will be restored.
 
@@ -42,7 +42,7 @@ If you hit ++ctrl+q++ Textual will exit application mode and return you to the c
 
 !!! tip "Added in version 0.55.0"
 
-You can also run apps in _inline_ mode, which will cause the app to appear beneath the prompt (and won't go in to application mode).
+You can also run apps in _inline_ mode, which will cause the app to appear beneath the prompt (and won't go into application mode).
 Inline apps are useful for tools that integrate closely with the typical workflow of a terminal.
 
 To run an app in inline mode set the `inline` parameter to `True` when you call [App.run()][textual.app.App.run]. See [Style Inline Apps](../how-to/style-inline-apps.md) for how to apply additional styles to inline apps.

--- a/docs/guide/devtools.md
+++ b/docs/guide/devtools.md
@@ -62,7 +62,7 @@ textual run -c textual colors
 ## Serve
 
 The devtools can also serve your application in a browser.
-Effectively turning your terminal app in to a web application!
+Effectively turning your terminal app into a web application!
 
 The `serve` sub-command is similar to `run`. Here's how you can serve an app launched from a Python file:
 
@@ -144,7 +144,7 @@ textual console -v
 
 ### Decreasing verbosity
 
-Log messages are classififed in to groups, and the `-x` flag can be used to **exclude** all message from a group. The groups are: `EVENT`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `PRINT`, `SYSTEM`, `LOGGING` and `WORKER`. The group a message belongs to is printed after its timestamp.
+Log messages are classififed into groups, and the `-x` flag can be used to **exclude** all message from a group. The groups are: `EVENT`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `PRINT`, `SYSTEM`, `LOGGING` and `WORKER`. The group a message belongs to is printed after its timestamp.
 
 Multiple groups may be excluded, for example to exclude everything except warning, errors, and `print` statements:
 

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -20,7 +20,7 @@ This processing of messages is done within an asyncio Task which is started when
 
     The FastAPI docs have an [excellent introduction](https://fastapi.tiangolo.com/async/) to Python async programming.
 
-By way of an example, let's consider what happens if you were to type "Text" in to a `Input` widget. When you hit the ++t++ key, Textual creates a [key][textual.events.Key] event and sends it to the widget's message queue. Ditto for ++e++, ++x++, and ++t++.
+By way of an example, let's consider what happens if you were to type "Text" into a `Input` widget. When you hit the ++t++ key, Textual creates a [key][textual.events.Key] event and sends it to the widget's message queue. Ditto for ++e++, ++x++, and ++t++.
 
 The widget's task will pick the first message from the queue (a key event for the ++t++ key) and call the `on_key` method with the event as the first argument. In other words it will call `Input.on_key(event)`, which updates the display to show the new letter.
 
@@ -334,4 +334,4 @@ Let's look at an example which looks up word definitions from an [api](https://d
     ```{.textual path="docs/examples/events/dictionary.py"}
     ```
 
-Note the highlighted line in the above code which calls `asyncio.create_task` to run a coroutine in the background. Without this you would find typing in to the text box to be unresponsive.
+Note the highlighted line in the above code which calls `asyncio.create_task` to run a coroutine in the background. Without this you would find typing into the text box to be unresponsive.

--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -105,7 +105,7 @@ The following example shows how focus works in practice.
     ```{.textual path="docs/examples/guide/input/key03.py", press="H,e,l,l,o,tab,W,o,r,l,d,!"}
     ```
 
-The app splits the screen in to quarters, with a `RichLog` widget in each quarter. If you click any of the text logs, you should see that it is highlighted to show that the widget has focus. Key events will be sent to the focused widget only.
+The app splits the screen into quarters, with a `RichLog` widget in each quarter. If you click any of the text logs, you should see that it is highlighted to show that the widget has focus. Key events will be sent to the focused widget only.
 
 !!! tip
 
@@ -255,4 +255,4 @@ Most mice have a scroll wheel which you can use to scroll the window underneath 
 
 !!! information
 
-    Terminal emulators will typically convert trackpad gestures in to scroll events.
+    Terminal emulators will typically convert trackpad gestures into scroll events.

--- a/docs/guide/reactivity.md
+++ b/docs/guide/reactivity.md
@@ -134,7 +134,7 @@ The following example modifies "refresh01.py" so that the greeting has an automa
     ```{.textual path="docs/examples/guide/reactivity/refresh02.py" press="n,a,m,e"}
     ```
 
-If you type in to the input now, the greeting will expand to fit the content. If you were to set `layout=False` on the reactive attribute, you should see that the box remains the same size when you type.
+If you type into the input now, the greeting will expand to fit the content. If you were to set `layout=False` on the reactive attribute, you should see that the box remains the same size when you type.
 
 ## Validation
 
@@ -171,7 +171,7 @@ Watch method names begin with `watch_` followed by the name of the attribute, an
 If the method accepts a single argument, it will be called with the new assigned value.
 If the method accepts *two* positional arguments, it will be called with both the *old* value and the *new* value.
 
-The following app will display any color you type in to the input. Try it with a valid color in Textual CSS. For example `"darkorchid"` or `"#52de44"`.
+The following app will display any color you type into the input. Try it with a valid color in Textual CSS. For example `"darkorchid"` or `"#52de44"`.
 
 === "watch01.py"
 
@@ -311,7 +311,7 @@ Compute methods are the final superpower offered by the `reactive` descriptor. T
 
 You could be forgiven in thinking this sounds a lot like Python's property decorator. The difference is that Textual will cache the value of compute methods, and update them when any other reactive attribute changes.
 
-The following example uses a computed attribute. It displays three inputs for each color component (red, green, and blue). If you enter numbers in to these inputs, the background color of another widget changes.
+The following example uses a computed attribute. It displays three inputs for each color component (red, green, and blue). If you enter numbers into these inputs, the background color of another widget changes.
 
 === "computed01.py"
 
@@ -319,7 +319,7 @@ The following example uses a computed attribute. It displays three inputs for ea
     --8<-- "docs/examples/guide/reactivity/computed01.py"
     ```
 
-    1. Combines color components in to a Color object.
+    1. Combines color components into a Color object.
     2. The watch method is called when the _result_ of `compute_color` changes.
 
 === "computed01.tcss"

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -91,7 +91,7 @@ Knowing which test has failed will help you quickly track down where your code w
 ## Simulating key presses
 
 We've seen how the [`press`][textual.pilot.Pilot] method simulates keys.
-You can also supply multiple keys to simulate the user typing in to the app.
+You can also supply multiple keys to simulate the user typing into the app.
 Here's an example of simulating the user typing the word "hello".
 
 ```python

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -407,7 +407,7 @@ Textual will call this method as required to get content for every row of charac
 --8<-- "docs/images/render_line.excalidraw.svg"
 </div>
 
-Let's look at an example before we go in to the details. The following Textual app implements a widget with the line API that renders a checkerboard pattern. This might form the basis of a chess / checkers game. Here's the code:
+Let's look at an example before we go into the details. The following Textual app implements a widget with the line API that renders a checkerboard pattern. This might form the basis of a chess / checkers game. Here's the code:
 
 === "checker01.py"
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -157,14 +157,14 @@ Here's what the above app defines:
 --8<-- "docs/examples/tutorial/stopwatch01.py"
 ```
 
-The final three lines create an instance of the app and calls the [run()][textual.app.App.run] method which puts your terminal in to *application mode* and runs the app until you exit with ++ctrl+q++. This happens within a `__name__ == "__main__"` block so we could run the app with `python stopwatch01.py` or import it as part of a larger project.
+The final three lines create an instance of the app and calls the [run()][textual.app.App.run] method which puts your terminal into *application mode* and runs the app until you exit with ++ctrl+q++. This happens within a `__name__ == "__main__"` block so we could run the app with `python stopwatch01.py` or import it as part of a larger project.
 
 ## Designing a UI with widgets
 
 Textual has a large number of [builtin widgets](./widget_gallery.md).
 For our app we will need new widgets, which we can create by extending and combining the builtin widgets.
 
-Before we dive in to building widgets, let's first sketch a design for the app &mdash; so we know what we're aiming for.
+Before we dive into building widgets, let's first sketch a design for the app &mdash; so we know what we're aiming for.
 
 
 <div class="excalidraw">

--- a/docs/widgets/select.md
+++ b/docs/widgets/select.md
@@ -9,7 +9,7 @@ A Select widget is a compact control to allow the user to select between a numbe
 - [ ] Container
 
 
-The options in a select control may be passed in to the constructor or set later with [set_options][textual.widgets.Select.set_options].
+The options in a select control may be passed into the constructor or set later with [set_options][textual.widgets.Select.set_options].
 Options should be given as a sequence of tuples consisting of two values: the first is the string (or [Rich Renderable](https://rich.readthedocs.io/en/latest/protocol.html)) to display in the control and list of options, the second is the value of option.
 
 The value of the currently selected option is stored in the `value` attribute of the widget, and the `value` attribute of the [Changed][textual.widgets.Select.Changed] message.

--- a/examples/dictionary.py
+++ b/examples/dictionary.py
@@ -48,7 +48,7 @@ class DictionaryApp(App):
             self.query_one("#results", Markdown).update(markdown)
 
     def make_word_markdown(self, results: object) -> str:
-        """Convert the results in to markdown."""
+        """Convert the results into markdown."""
         lines = []
         if isinstance(results, dict):
             lines.append(f"# {results['title']}")

--- a/examples/example.md
+++ b/examples/example.md
@@ -12,7 +12,7 @@ This is H3 Content
 
 #### This is H4
 
-Header level 4 content. Drilling down in to finer headings.
+Header level 4 content. Drilling down into finer headings.
 
 ##### This is H5
 
@@ -85,7 +85,7 @@ In the future I think we could add controls to export the code, copy to the clip
 ```python
 @lru_cache(maxsize=1024)
 def split(self, cut_x: int, cut_y: int) -> tuple[Region, Region, Region, Region]:
-    """Split a region in to 4 from given x and y offsets (cuts).
+    """Split a region into 4 from given x and y offsets (cuts).
 
     ```
                 cut_x ↓

--- a/src/textual/_arrange.py
+++ b/src/textual/_arrange.py
@@ -61,7 +61,7 @@ def arrange(
     layers = _build_layers(display_widgets)
 
     for widgets in layers.values():
-        # Partition widgets in to split widgets and non-split widgets
+        # Partition widgets into split widgets and non-split widgets
         non_split_widgets, split_widgets = partition(get_split, widgets)
         if split_widgets:
             _split_placements, dock_region = _arrange_split_widgets(

--- a/src/textual/_binary_encode.py
+++ b/src/textual/_binary_encode.py
@@ -26,7 +26,7 @@ class DecodeError(Exception):
 
 
 def dump(data: object) -> bytes:
-    """Encodes a data structure in to bytes.
+    """Encodes a data structure into bytes.
 
     Args:
         data: Data structure

--- a/src/textual/_compositor.py
+++ b/src/textual/_compositor.py
@@ -1,6 +1,6 @@
 """
 
-The compositor handles combining widgets in to a single screen (i.e. compositing).
+The compositor handles combining widgets into a single screen (i.e. compositing).
 
 It also stores the results of that process, so that Textual knows the widgets on
 the screen and their locations. The compositor uses this information to answer

--- a/src/textual/_partition.py
+++ b/src/textual/_partition.py
@@ -8,7 +8,7 @@ T = TypeVar("T")
 def partition(
     predicate: Callable[[T], object], iterable: Iterable[T]
 ) -> tuple[list[T], list[T]]:
-    """Partition a sequence in to two list from a given predicate. The first list will contain
+    """Partition a sequence into two list from a given predicate. The first list will contain
     the values where the predicate is False, the second list will contain the remaining values.
 
     Args:

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2845,7 +2845,7 @@ class App(Generic[ReturnType], DOMNode):
 
         Args:
             widget: Widget to focus.
-            scroll_visible: Scroll widget in to view.
+            scroll_visible: Scroll widget into view.
         """
         self.screen.set_focus(widget, scroll_visible)
 

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -85,7 +85,7 @@ class Binding:
     """Make this binding a system binding, which removes it from the key panel."""
 
     def parse_key(self) -> tuple[list[str], str]:
-        """Parse a key in to a list of modifiers, and the actual key.
+        """Parse a key into a list of modifiers, and the actual key.
 
         Returns:
             A tuple of (MODIFIER LIST, KEY).

--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -110,11 +110,11 @@ hsla{OPEN_BRACE}({DECIMAL}{COMMA}{PERCENT}{COMMA}{PERCENT}{COMMA}{DECIMAL}){CLOS
     re.VERBOSE,
 )
 
-# Fast way to split a string of 6 characters in to 3 pairs of 2 characters
+# Fast way to split a string of 6 characters into 3 pairs of 2 characters
 _split_pairs3: Callable[[str], tuple[str, str, str]] = itemgetter(
     slice(0, 2), slice(2, 4), slice(4, 6)
 )
-# Fast way to split a string of 8 characters in to 4 pairs of 2 characters
+# Fast way to split a string of 8 characters into 4 pairs of 2 characters
 _split_pairs4: Callable[[str], tuple[str, str, str, str]] = itemgetter(
     slice(0, 2), slice(2, 4), slice(4, 6), slice(6, 8)
 )

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -475,7 +475,7 @@ class Content(Visual):
         """Get the style of a character at give offset.
 
         Args:
-            offset (int): Offset in to text (negative indexing supported)
+            offset (int): Offset into text (negative indexing supported)
 
         Returns:
             Style: A Style instance.
@@ -828,7 +828,7 @@ class Content(Visual):
         include_separator: bool = False,
         allow_blank: bool = False,
     ) -> list[Content]:
-        """Split rich text in to lines, preserving styles.
+        """Split rich text into lines, preserving styles.
 
         Args:
             separator (str, optional): String to split on. Defaults to "\\\\n".

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -1172,7 +1172,7 @@ class FractionalProperty:
 
 
 class AlignProperty:
-    """Combines the horizontal and vertical alignment properties in to a single property."""
+    """Combines the horizontal and vertical alignment properties into a single property."""
 
     def __set_name__(self, owner: StylesBase, name: str) -> None:
         self.horizontal = f"{name}_horizontal"

--- a/src/textual/css/scalar.py
+++ b/src/textual/css/scalar.py
@@ -242,7 +242,7 @@ class Scalar(NamedTuple):
     @classmethod
     @lru_cache(maxsize=1024)
     def parse(cls, token: str, percent_unit: Unit = Unit.WIDTH) -> Scalar:
-        """Parse a string in to a Scalar
+        """Parse a string into a Scalar
 
         Args:
             token: A string containing a scalar, e.g. "3.14fr"
@@ -267,7 +267,7 @@ class Scalar(NamedTuple):
     def resolve(
         self, size: Size, viewport: Size, fraction_unit: Fraction | None = None
     ) -> Fraction:
-        """Resolve scalar with units in to a dimensions.
+        """Resolve scalar with units into a dimensions.
 
         Args:
             size: Size of the container.
@@ -348,7 +348,7 @@ class ScalarOffset(NamedTuple):
         yield None, str(self.y)
 
     def resolve(self, size: Size, viewport: Size) -> Offset:
-        """Resolve the offset in to cells.
+        """Resolve the offset into cells.
 
         Args:
             size: Size of container.

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -660,7 +660,7 @@ class StylesBase:
         """
 
     def merge_rules(self, rules: RulesMap) -> None:
-        """Merge rules in to Styles.
+        """Merge rules into Styles.
 
         Args:
             rules: A mapping of rules.

--- a/src/textual/demo/widgets.py
+++ b/src/textual/demo/widgets.py
@@ -255,7 +255,7 @@ class ListViews(containers.VerticalGroup):
     LISTS_MD = """\
 ## List Views and Option Lists
 
-A List View turns any widget in to a user-navigable and selectable list.
+A List View turns any widget into a user-navigable and selectable list.
 An Option List for a field to present a list of strings to select from.
 
     """

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -291,7 +291,7 @@ class LinuxDriver(Driver):
     def _request_terminal_sync_mode_support(self) -> None:
         """Writes an escape sequence to query the terminal support for the sync protocol."""
         # Terminals should ignore this sequence if not supported.
-        # Apple terminal doesn't, and writes a single 'p' in to the terminal,
+        # Apple terminal doesn't, and writes a single 'p' into the terminal,
         # so we will make a special case for Apple terminal (which doesn't support sync anyway).
         if not self.input_tty:
             return

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -246,7 +246,7 @@ class LinuxInlineDriver(Driver):
     def _request_terminal_sync_mode_support(self) -> None:
         """Writes an escape sequence to query the terminal support for the sync protocol."""
         # Terminals should ignore this sequence if not supported.
-        # Apple terminal doesn't, and writes a single 'p' in to the terminal,
+        # Apple terminal doesn't, and writes a single 'p' into the terminal,
         # so we will make a special case for Apple terminal (which doesn't support sync anyway).
         if os.environ.get("TERM_PROGRAM", "") != "Apple_Terminal":
             self.write("\033[?2026$p")

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -408,7 +408,7 @@ class Region(NamedTuple):
         """Calculate the smallest offset required to translate a window so that it contains
         another region.
 
-        This method is used to calculate the required offset to scroll something in to view.
+        This method is used to calculate the required offset to scroll something into view.
 
         Args:
             window_region: The window region.
@@ -433,7 +433,7 @@ class Region(NamedTuple):
             and (window_right > right >= window_left)
         ):
             # The region does not fit
-            # The window needs to scroll on the X axis to bring region in to view
+            # The window needs to scroll on the X axis to bring region into view
             delta_x = min(
                 left - window_left,
                 left - (window_right - region.width),
@@ -447,7 +447,7 @@ class Region(NamedTuple):
             (window_bottom > top_ >= window_top)
             and (window_bottom > bottom >= window_top)
         ):
-            # The window needs to scroll on the Y axis to bring region in to view
+            # The window needs to scroll on the Y axis to bring region into view
             delta_y = min(
                 top_ - window_top,
                 top_ - (window_bottom - region.height),
@@ -846,7 +846,7 @@ class Region(NamedTuple):
 
     @lru_cache(maxsize=1024)
     def split(self, cut_x: int, cut_y: int) -> tuple[Region, Region, Region, Region]:
-        """Split a region in to 4 from given x and y offsets (cuts).
+        """Split a region into 4 from given x and y offsets (cuts).
 
         ```
                    cut_x ↓
@@ -886,7 +886,7 @@ class Region(NamedTuple):
 
     @lru_cache(maxsize=1024)
     def split_vertical(self, cut: int) -> tuple[Region, Region]:
-        """Split a region in to two, from a given x offset.
+        """Split a region into two, from a given x offset.
 
         ```
                  cut ↓
@@ -915,7 +915,7 @@ class Region(NamedTuple):
 
     @lru_cache(maxsize=1024)
     def split_horizontal(self, cut: int) -> tuple[Region, Region]:
-        """Split a region in to two, from a given y offset.
+        """Split a region into two, from a given y offset.
 
         ```
                     ┌─────────┐

--- a/src/textual/layout.py
+++ b/src/textual/layout.py
@@ -164,7 +164,7 @@ class WidgetPlacement(NamedTuple):
 
         Args:
             constrain_region: The container region when applying constrain rules.
-            absolute_offset: Default absolute offset that moves widget in to screen coordinates.
+            absolute_offset: Default absolute offset that moves widget into screen coordinates.
 
         Returns:
             Processes placement, may be the same instance.

--- a/src/textual/layouts/grid.py
+++ b/src/textual/layouts/grid.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class GridLayout(Layout):
-    """Used to layout Widgets in to a grid."""
+    """Used to layout Widgets into a grid."""
 
     name = "grid"
 

--- a/src/textual/lazy.py
+++ b/src/textual/lazy.py
@@ -18,7 +18,7 @@ class Lazy(Widget):
     Making a widget lazy is beneficial for widgets which start out invisible, such as tab panes.
 
     Note that since lazy widgets aren't mounted immediately (by definition), they will not appear
-    in queries for a brief interval until they are mounted. Your code should take this in to account.
+    in queries for a brief interval until they are mounted. Your code should take this into account.
 
     Example:
         ```python

--- a/src/textual/messages.py
+++ b/src/textual/messages.py
@@ -78,7 +78,7 @@ class InvokeLater(Message, verbose=True, bubble=False):
 
 @rich.repr.auto
 class ScrollToRegion(Message, bubble=False):
-    """Ask the parent to scroll a given region in to view."""
+    """Ask the parent to scroll a given region into view."""
 
     def __init__(self, region: Region) -> None:
         self.region = region

--- a/src/textual/renderables/text_opacity.py
+++ b/src/textual/renderables/text_opacity.py
@@ -33,7 +33,7 @@ def _get_blended_style_cached(
 
 
 class TextOpacity:
-    """Blend foreground in to background."""
+    """Blend foreground into background."""
 
     def __init__(self, renderable: RenderableType, opacity: float = 1.0) -> None:
         """Wrap a renderable to blend foreground color into the background color.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -879,7 +879,7 @@ class Screen(Generic[ScreenResultType], Widget):
 
         Args:
             widget: Widget to focus, or None to un-focus.
-            scroll_visible: Scroll widget in to view.
+            scroll_visible: Scroll widget into view.
             from_app_focus: True if this focus is due to the app itself having regained
                 focus. False if the focus is being set because a widget within the app
                 regained focus.

--- a/src/textual/strip.py
+++ b/src/textual/strip.py
@@ -39,7 +39,7 @@ def get_line_length(segments: Iterable[Segment]) -> int:
 
 
 class StripRenderable:
-    """A renderable which renders a list of strips in to lines."""
+    """A renderable which renders a list of strips into lines."""
 
     def __init__(self, strips: list[Strip], width: int | None = None) -> None:
         self._strips = strips
@@ -276,7 +276,7 @@ class Strip:
 
     @classmethod
     def join(cls, strips: Iterable[Strip | None]) -> Strip:
-        """Join a number of strips in to one.
+        """Join a number of strips into one.
 
         Args:
             strips: An iterable of Strips.
@@ -516,7 +516,7 @@ class Strip:
         return strip
 
     def divide(self, cuts: Iterable[int]) -> Sequence[Strip]:
-        """Divide the strip in to multiple smaller strips by cutting at given (cell) indices.
+        """Divide the strip into multiple smaller strips by cutting at given (cell) indices.
 
         Args:
             cuts: An iterable of cell positions as ints.

--- a/src/textual/visual.py
+++ b/src/textual/visual.py
@@ -42,7 +42,7 @@ class SupportsVisual(Protocol):
     """An object that supports the textualize protocol."""
 
     def visualize(self, widget: Widget, obj: object) -> Visual | None:
-        """Convert the result of a Widget.render() call in to a Visual, using the Visual protocol.
+        """Convert the result of a Widget.render() call into a Visual, using the Visual protocol.
 
         Args:
             widget: The widget that generated the render.
@@ -190,7 +190,7 @@ class Style:
 
     @cached_property
     def rich_style(self) -> RichStyle:
-        """Convert this Styles in to a Rich style.
+        """Convert this Styles into a Rich style.
 
         Returns:
             A Rich style object.
@@ -241,7 +241,7 @@ class Visual(ABC):
     def render_strips(
         self, widget: Widget, width: int, height: int | None, style: Style
     ) -> list[Strip]:
-        """Render the visual in to an iterable of strips.
+        """Render the visual into an iterable of strips.
 
         Args:
             base_style: The base style.

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1085,7 +1085,7 @@ class Widget(DOMNode):
         return visual_style
 
     def render_str(self, text_content: str | Text) -> Text:
-        """Convert str in to a Text object.
+        """Convert str into a Text object.
 
         If you pass in an existing Text object it will be returned unaltered.
 
@@ -2082,7 +2082,7 @@ class Widget(DOMNode):
 
     @property
     def _focus_sort_key(self) -> tuple[int, int]:
-        """Key function to sort widgets in to focus order."""
+        """Key function to sort widgets into focus order."""
         x, y, _, _ = self.virtual_region
         top, _, _, left = self.styles.margin
         return y - top, x - left
@@ -3128,7 +3128,7 @@ class Widget(DOMNode):
         level: AnimationLevel = "basic",
         immediate: bool = False,
     ) -> bool:
-        """Scroll scrolling to bring a widget in to view.
+        """Scroll scrolling to bring a widget into view.
 
         Args:
             widget: A descendant widget.
@@ -3211,7 +3211,7 @@ class Widget(DOMNode):
         y_axis: bool = True,
         immediate: bool = False,
     ) -> Offset:
-        """Scrolls a given region in to view, if required.
+        """Scrolls a given region into view, if required.
 
         This method will scroll the least distance required to move `region` fully within
         the scrollable area.
@@ -3818,7 +3818,7 @@ class Widget(DOMNode):
         return line
 
     def render_lines(self, crop: Region) -> list[Strip]:
-        """Render the widget in to lines.
+        """Render the widget into lines.
 
         Args:
             crop: Region within visible area to render.

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -2344,7 +2344,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         return y_offsets[y]
 
     def _render_line(self, y: int, x1: int, x2: int, base_style: Style) -> Strip:
-        """Render a (possibly cropped) line in to a Strip (a list of segments
+        """Render a (possibly cropped) line into a Strip (a list of segments
             representing a horizontal line).
 
         Args:

--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -267,7 +267,7 @@ class Log(ScrollView, can_focus=True):
         return strip
 
     def _render_line(self, y: int, scroll_x: int, width: int) -> Strip:
-        """Render a line in to a cropped strip.
+        """Render a line into a cropped strip.
 
         Args:
             y: Y offset of line.
@@ -287,7 +287,7 @@ class Log(ScrollView, can_focus=True):
         return line
 
     def _render_line_strip(self, y: int, rich_style: Style) -> Strip:
-        """Render a line in to a Strip.
+        """Render a line into a Strip.
 
         Args:
             y: Y offset of line.

--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -1199,7 +1199,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         """Scroll to the given node.
 
         Args:
-            node: Node to scroll in to view.
+            node: Node to scroll into view.
             animate: Animate scrolling.
         """
         line = node._line

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -1414,12 +1414,12 @@ def test_missing_vertical_scroll(snap_compare):
 
 
 def test_vertical_min_height(snap_compare):
-    """Test vertical min height takes border in to account."""
+    """Test vertical min height takes border into account."""
     assert snap_compare(SNAPSHOT_APPS_DIR / "vertical_min_height.py")
 
 
 def test_vertical_max_height(snap_compare):
-    """Test vertical max height takes border in to account."""
+    """Test vertical max height takes border into account."""
     assert snap_compare(SNAPSHOT_APPS_DIR / "vertical_max_height.py")
 
 


### PR DESCRIPTION
Sorry I realise this is pedantic. After spotting 'in to' should be 'into' in the README, I went ahead and changed it everywhere. 

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
