### PR TITLE
fix(scrollbar): fix scrollbar background opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Pilot.click` not working with `times` parameter https://github.com/Textualize/textual/pull/5398
 - Fixed select refocusing itself too late https://github.com/Textualize/textual/pull/5420
 - Fixed Log widget not refreshing on resize https://github.com/Textualize/textual/pull/5460
+- Fixed scrollbars ignoring background opacity https://github.com/Textualize/textual/issues/5458
 
 
 ## [1.0.0] - 2024-12-12

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -286,7 +286,7 @@ class ScrollBar(Widget):
         else:
             background = styles.scrollbar_background
             color = styles.scrollbar_color
-        if background.a > 0:
+        if background.a < 1:
             base_background, _ = self.parent._opacity_background_colors
             background = base_background + background
         color = background + color

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -286,6 +286,8 @@ class ScrollBar(Widget):
         else:
             background = styles.scrollbar_background
             color = styles.scrollbar_color
+        base_background, _ = self.parent._opacity_background_colors
+        background = base_background + background
         color = background + color
         scrollbar_style = Style.from_color(color.rich_color, background.rich_color)
         if self.screen.styles.scrollbar_color.a == 0:

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -286,8 +286,9 @@ class ScrollBar(Widget):
         else:
             background = styles.scrollbar_background
             color = styles.scrollbar_color
-        base_background, _ = self.parent._opacity_background_colors
-        background = base_background + background
+        if background.a > 0:
+            base_background, _ = self.parent._opacity_background_colors
+            background = base_background + background
         color = background + color
         scrollbar_style = Style.from_color(color.rich_color, background.rich_color)
         if self.screen.styles.scrollbar_color.a == 0:

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_scrollbar_background_with_opacity.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_scrollbar_background_with_opacity.svg
@@ -1,0 +1,151 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-54597080-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-54597080-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-54597080-r1 { fill: #e0e0e0 }
+.terminal-54597080-r2 { fill: #c5c8c6 }
+.terminal-54597080-r3 { fill: #101029 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-54597080-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-54597080-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-54597080-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-54597080-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">ScrollbarOpacityApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-54597080-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="147.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="147.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00ffff" x="610" y="147.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="147.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="172.3" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00ffff" x="610" y="172.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="172.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="196.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="196.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="196.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="196.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="221.1" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="221.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="221.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="221.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="245.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="245.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="245.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="245.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="269.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="269.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="269.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="269.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="294.3" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="294.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="294.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="294.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="318.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="318.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="318.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="318.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="343.1" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="343.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="343.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="343.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="367.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="475.8" y="367.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="367.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="367.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="391.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="488" y="391.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="391.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="391.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="244" y="416.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="488" y="416.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#101029" x="610" y="416.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="416.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-54597080-matrix">
+    <text class="terminal-54597080-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-54597080-line-0)">
+</text><text class="terminal-54597080-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-54597080-line-1)">
+</text><text class="terminal-54597080-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-54597080-line-2)">
+</text><text class="terminal-54597080-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-54597080-line-3)">
+</text><text class="terminal-54597080-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-54597080-line-4)">
+</text><text class="terminal-54597080-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-54597080-line-5)">
+</text><text class="terminal-54597080-r1" x="244" y="166.4" textLength="231.8" clip-path="url(#terminal-54597080-line-6)">This&#160;is&#160;some&#160;text&#160;0</text><text class="terminal-54597080-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-54597080-line-6)">
+</text><text class="terminal-54597080-r1" x="244" y="190.8" textLength="231.8" clip-path="url(#terminal-54597080-line-7)">This&#160;is&#160;some&#160;text&#160;1</text><text class="terminal-54597080-r3" x="610" y="190.8" textLength="122" clip-path="url(#terminal-54597080-line-7)">▄▄▄▄▄▄▄▄▄▄</text><text class="terminal-54597080-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-54597080-line-7)">
+</text><text class="terminal-54597080-r1" x="244" y="215.2" textLength="231.8" clip-path="url(#terminal-54597080-line-8)">This&#160;is&#160;some&#160;text&#160;2</text><text class="terminal-54597080-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-54597080-line-8)">
+</text><text class="terminal-54597080-r1" x="244" y="239.6" textLength="231.8" clip-path="url(#terminal-54597080-line-9)">This&#160;is&#160;some&#160;text&#160;3</text><text class="terminal-54597080-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-54597080-line-9)">
+</text><text class="terminal-54597080-r1" x="244" y="264" textLength="231.8" clip-path="url(#terminal-54597080-line-10)">This&#160;is&#160;some&#160;text&#160;4</text><text class="terminal-54597080-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-54597080-line-10)">
+</text><text class="terminal-54597080-r1" x="244" y="288.4" textLength="231.8" clip-path="url(#terminal-54597080-line-11)">This&#160;is&#160;some&#160;text&#160;5</text><text class="terminal-54597080-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-54597080-line-11)">
+</text><text class="terminal-54597080-r1" x="244" y="312.8" textLength="231.8" clip-path="url(#terminal-54597080-line-12)">This&#160;is&#160;some&#160;text&#160;6</text><text class="terminal-54597080-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-54597080-line-12)">
+</text><text class="terminal-54597080-r1" x="244" y="337.2" textLength="231.8" clip-path="url(#terminal-54597080-line-13)">This&#160;is&#160;some&#160;text&#160;7</text><text class="terminal-54597080-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-54597080-line-13)">
+</text><text class="terminal-54597080-r1" x="244" y="361.6" textLength="231.8" clip-path="url(#terminal-54597080-line-14)">This&#160;is&#160;some&#160;text&#160;8</text><text class="terminal-54597080-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-54597080-line-14)">
+</text><text class="terminal-54597080-r1" x="244" y="386" textLength="231.8" clip-path="url(#terminal-54597080-line-15)">This&#160;is&#160;some&#160;text&#160;9</text><text class="terminal-54597080-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-54597080-line-15)">
+</text><text class="terminal-54597080-r1" x="244" y="410.4" textLength="244" clip-path="url(#terminal-54597080-line-16)">This&#160;is&#160;some&#160;text&#160;10</text><text class="terminal-54597080-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-54597080-line-16)">
+</text><text class="terminal-54597080-r1" x="244" y="434.8" textLength="244" clip-path="url(#terminal-54597080-line-17)">This&#160;is&#160;some&#160;text&#160;11</text><text class="terminal-54597080-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-54597080-line-17)">
+</text><text class="terminal-54597080-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-54597080-line-18)">
+</text><text class="terminal-54597080-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-54597080-line-19)">
+</text><text class="terminal-54597080-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-54597080-line-20)">
+</text><text class="terminal-54597080-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-54597080-line-21)">
+</text><text class="terminal-54597080-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-54597080-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -3251,3 +3251,30 @@ def test_arbitrary_selection(snap_compare):
         terminal_size=(175, 50),
         run_before=run_before,
     )
+
+
+def test_scrollbar_background_with_opacity(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/5458
+    The scrollbar background should match the background of the widget."""
+
+    class ScrollbarOpacityApp(App):
+        CSS = """
+        Screen {
+            align: center middle;
+        }
+
+        VerticalScroll {
+            width: 50%;
+            height: 50%;
+            background: blue 10%;
+            scrollbar-background: blue 10%;
+            scrollbar-color: cyan;
+            scrollbar-size-vertical: 10;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            with VerticalScroll():
+                yield Static("\n".join(f"This is some text {n}" for n in range(100)))
+
+    assert snap_compare(ScrollbarOpacityApp())


### PR DESCRIPTION
Fixes #5458.

This assumes that when the scrollbar background has opacity, it should blend with the 'base' background and not the background of its widget.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
