### PR TITLE
test: fix failing tests when run in parallel

### DIFF
--- a/tests/text_area/test_selection_bindings.py
+++ b/tests/text_area/test_selection_bindings.py
@@ -255,7 +255,7 @@ async def test_cursor_page_down(app: TextAreaApp):
         await pilot.press("pagedown")
         margin = 2
         assert text_area.selection == Selection.cursor(
-            (app.console.height - 1 - margin, 1)
+            (app.size.height - margin, 1)
         )
 
 
@@ -268,7 +268,7 @@ async def test_cursor_page_up(app: TextAreaApp):
         await pilot.press("pageup")
         margin = 2
         assert text_area.selection == Selection.cursor(
-            (100 - app.console.height + 1 + margin, 1)
+            (100 - app.size.height + margin, 1)
         )
 
 


### PR DESCRIPTION
Fixes #5327.

Normally when running tests with Textual, the default size of the simulated app is 80x24. However it seems when tests are run in parallel with xdist on Python 3.13, `app.console.height` returns the _actual_ height of the terminal, causing tests to fail.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
