### PR TITLE
fix(datatable): simplify default css

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -343,7 +343,6 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         }
 
         &:dark {
-            background: $surface;
             & > .datatable--even-row {
                 background: $surface-darken-1 40%;
             }


### PR DESCRIPTION
Remove the background CSS in the `:dark` pseudo selector, as this is already the default background for the `DataTable`.

Currently this duplication makes styling a custom widget that extends the `DataTable` unintuitive (see #5481).


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
