### PR TITLE
docs: fix references to rounded borders

### DIFF
--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -219,7 +219,7 @@ Consequently, a `Static` selector will also style the button because the `Alert`
 ```css
 Static {
   background: blue;
-  border: rounded green;
+  border: round green;
 }
 ```
 
@@ -230,7 +230,7 @@ Static {
 You may have noticed that the `border` rule exists in both `Static` and `Alert`.
 When this happens, Textual will use the most recently defined sub-class.
 So `Alert` wins over `Static`, and `Static` wins over `Widget` (the base class of all widgets).
-Hence if both rules were in a stylesheet, `Alert` widgets would have a "solid red" border and not a "rounded green" border.
+Hence if both rules were in a stylesheet, `Alert` widgets would have a "solid red" border and not a "round green" border.
 
 ### ID selector
 

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -299,7 +299,7 @@ class BoxProperty:
 
         Returns:
             A ``tuple[EdgeType, Style]`` containing the string type of the box and
-                its style. Example types are "rounded", "solid", and "dashed".
+                its style. Example types are "round", "solid", and "dashed".
         """
         return obj.get_rule(self.name) or ("", self._default_color)  # type: ignore[return-value]
 

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -311,16 +311,16 @@ class StylesBase:
     """If `relative` offset is applied to widgets current position, if `absolute` it is applied to (0, 0)."""
 
     border = BorderProperty(layout=True)
-    """Set the border of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the border of the widget e.g. ("round", "green") or "none"."""
 
     border_top = BoxProperty(Color(0, 255, 0))
-    """Set the top border of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the top border of the widget e.g. ("round", "green") or "none"."""
     border_right = BoxProperty(Color(0, 255, 0))
-    """Set the right border of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the right border of the widget e.g. ("round", "green") or "none"."""
     border_bottom = BoxProperty(Color(0, 255, 0))
-    """Set the bottom border of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the bottom border of the widget e.g. ("round", "green") or "none"."""
     border_left = BoxProperty(Color(0, 255, 0))
-    """Set the left border of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the left border of the widget e.g. ("round", "green") or "none"."""
 
     border_title_align = StringEnumProperty(VALID_ALIGN_HORIZONTAL, "left")
     """The alignment of the border title text."""
@@ -328,17 +328,17 @@ class StylesBase:
     """The alignment of the border subtitle text."""
 
     outline = BorderProperty(layout=False)
-    """Set the outline of the widget e.g. ("rounded", "green") or "none".
+    """Set the outline of the widget e.g. ("round", "green") or "none".
     The outline is drawn *on top* of the widget, rather than around it like border.
     """
     outline_top = BoxProperty(Color(0, 255, 0))
-    """Set the top outline of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the top outline of the widget e.g. ("round", "green") or "none"."""
     outline_right = BoxProperty(Color(0, 255, 0))
-    """Set the right outline of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the right outline of the widget e.g. ("round", "green") or "none"."""
     outline_bottom = BoxProperty(Color(0, 255, 0))
-    """Set the bottom outline of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the bottom outline of the widget e.g. ("round", "green") or "none"."""
     outline_left = BoxProperty(Color(0, 255, 0))
-    """Set the left outline of the widget e.g. ("rounded", "green") or "none"."""
+    """Set the left outline of the widget e.g. ("round", "green") or "none"."""
 
     keyline = KeylineProperty()
     """Keyline parameters."""

--- a/tests/css/test_styles.py
+++ b/tests/css/test_styles.py
@@ -96,15 +96,15 @@ def test_render_styles_border():
     # Base has border-top: heavy red
     assert styles_view.border_top == ("heavy", Color.parse("red"))
 
-    inline.border_left = ("rounded", "green")
-    # Base has border-top heavy red, inline has border-left: rounded green
+    inline.border_left = ("round", "green")
+    # Base has border-top heavy red, inline has border-left: round green
     assert styles_view.border_top == ("heavy", Color.parse("red"))
-    assert styles_view.border_left == ("rounded", Color.parse("green"))
+    assert styles_view.border_left == ("round", Color.parse("green"))
     assert styles_view.border == (
         ("heavy", Color.parse("red")),
         ("", Color(0, 255, 0)),
         ("", Color(0, 255, 0)),
-        ("rounded", Color.parse("green")),
+        ("round", Color.parse("green")),
     )
 
 


### PR DESCRIPTION
Fix 'rounded' border references in docs to 'round'.
