### PR TITLE
ci: update artifact action

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,7 +49,8 @@ jobs:
         if: ${{ matrix.python-version == '3.8' }}
       - name: Upload snapshot report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snapshot-report-textual
           path: snapshot_report.html
+          overwrite: true


### PR DESCRIPTION
Fix failing workflow by updating artifact action to v4 (v3 is deprecated):

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

There are key differences from the previous version, where artifacts are now immutable. Hopefully I've understood correctly that the artifact should be overwritten?

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md