### PR TITLE
visual tooltips

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -88,7 +88,7 @@ from textual.rlock import RLock
 from textual.selection import Selection
 from textual.strip import Strip
 from textual.style import Style as VisualStyle
-from textual.visual import Visual, visualize
+from textual.visual import Visual, VisualType, visualize
 
 if TYPE_CHECKING:
     from textual.app import App, ComposeResult
@@ -452,7 +452,7 @@ class Widget(DOMNode):
         self._rich_style_cache: dict[tuple[str, ...], tuple[Style, Style]] = {}
         self._visual_style_cache: dict[tuple[str, ...], VisualStyle] = {}
 
-        self._tooltip: RenderableType | None = None
+        self._tooltip: VisualType | None = None
         """The tooltip content."""
         self.absolute_offset: Offset | None = None
         """Force an absolute offset for the widget (used by tooltips)."""
@@ -709,12 +709,12 @@ class Widget(DOMNode):
         return self.disabled or self.loading
 
     @property
-    def tooltip(self) -> RenderableType | None:
+    def tooltip(self) -> VisualType | None:
         """Tooltip for the widget, or `None` for no tooltip."""
         return self._tooltip
 
     @tooltip.setter
-    def tooltip(self, tooltip: RenderableType | None):
+    def tooltip(self, tooltip: VisualType | None):
         self._tooltip = tooltip
         try:
             self.screen._update_tooltip(self)

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -23,6 +23,7 @@ from textual.containers import (
     VerticalScroll,
     HorizontalGroup,
 )
+from textual.content import Content
 from textual.pilot import Pilot
 from textual.reactive import var
 from textual.renderables.gradient import LinearGradient
@@ -3549,3 +3550,30 @@ def test_add_separator(snap_compare):
             await pilot.pause(0.4)
 
     snap_compare(FocusTest(), run_before=run_before)
+
+
+def test_visual_tooltip(snap_compare):
+    """Test Visuals such as Content work in tooltips.
+
+    You should see a tooltip under a label.
+    The tooltip should have the word "Tooltip" highlighted in the accent color.
+
+    """
+
+    class TooltipApp(App[None]):
+        TOOLTIP_DELAY = 0.4
+
+        def compose(self) -> ComposeResult:
+            progress_bar = Label("Hello, World")
+            progress_bar.tooltip = Content.from_markup(
+                "Hello, [bold $accent]Tooltip[/]!"
+            )
+            yield progress_bar
+
+    async def run_before(pilot: Pilot) -> None:
+        await pilot.pause()
+        await pilot.hover(Label)
+        await pilot.pause(0.4)
+        await pilot.pause()
+
+    snap_compare(TooltipApp(), run_before=run_before)


### PR DESCRIPTION
Test that tooltips work with the Visual API.

This was mostly a typing issue, as the tooltip attribute was typed as a RenderableType.