### PR TITLE
fix(MarkdownFence): gracefully handle missing Static child in _retheme callback

### DIFF
--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -20,6 +20,7 @@ from textual._slug import TrackedSlugs
 from textual.app import ComposeResult
 from textual.await_complete import AwaitComplete
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.events import Mount
 from textual.message import Message
 from textual.reactive import reactive, var
@@ -425,7 +426,7 @@ class MarkdownOrderedList(MarkdownList):
 
     MarkdownOrderedList Vertical {
         height: auto;
-        width: 1fr;        
+        width: 1fr;
     }
     """
 
@@ -651,7 +652,10 @@ class MarkdownFence(MarkdownBlock):
             if self.app.current_theme.dark
             else self._markdown.code_light_theme
         )
-        self.get_child_by_type(Static).update(self._block())
+        try:
+            self.get_child_by_type(Static).update(self._block())
+        except NoMatches:
+            pass
 
     def compose(self) -> ComposeResult:
         yield Static(


### PR DESCRIPTION
This PR addresses a race condition in the MarkdownFence widget where the _retheme callback can be invoked before the widget's child (Static) is mounted. In such cases, calling self.get_child_by_type(Static).update(self._block()) would raise a NoMatches exception, potentially causing unwanted crashes.

Crash stacktrace:

```
╭───────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────╮
│ /Users/xxxx/Documents/xxxxx/xxxxxxx/xxxxxxxxxx/venv/lib/python3.13/site-packages/textual/widgets/_markdown.py:638 in _on_mount      │
│                                                                                                                                      │
│    635 │                                                                                        ╭──────── locals ────────╮           │
│    636 │   def _on_mount(self, _: Mount) -> None:                                               │    _ = Mount()         │           │
│    637 │   │   """Watch app theme switching."""                                                 │ self = MarkdownFence() │           │
│ ❱  638 │   │   self.watch(self.app, "theme", self._retheme)                                     ╰────────────────────────╯           │
│    639 │                                                                                                                             │
│    640 │   def _retheme(self) -> None:                                                                                               │
│    641 │   │   """Rerender when the theme changes."""                                                                                │
│                                                                                                                                      │
│ /Users/xxxx/Documents/xxxxx/xxxxxxx/xxxxxxxxxx/venv/lib/python3.13/site-packages/textual/dom.py:1244 in watch                       │
│                                                                                                                                      │
│   1241 │   │   │   callback: A callback to run when attribute changes.                                                               │
│   1242 │   │   │   init: Check watchers on first call.                                                                               │
│   1243 │   │   """                                                                                                                   │
│ ❱ 1244 │   │   _watch(self, obj, attribute_name, callback, init=init)                                                                │
│   1245 │                                                                                                                             │
│   1246 │   def get_pseudo_classes(self) -> set[str]:                                                                                 │
│   1247 │   │   """Pseudo classes for a widget.                                                                                       │
│                                                                                                                                      │
│ ╭──────────────────────────────────────────── locals ─────────────────────────────────────────────╮                                  │
│ │ attribute_name = 'theme'                                                                        │                                  │
│ │       callback = <bound method MarkdownFence._retheme of MarkdownFence()>                       │                                  │
│ │           init = True                                                                           │                                  │
│ │            obj = Compi(title='Compi', classes={'-dark-mode'}, pseudo_classes={'dark', 'focus'}) │                                  │
│ │           self = MarkdownFence()                                                                │                                  │
│ ╰─────────────────────────────────────────────────────────────────────────────────────────────────╯                                  │
│                                                                                                                                      │
│ /Users/xxxx/Documents/xxxxx/xxxxxxx/xxxxxxxxxx/venv/lib/python3.13/site-packages/textual/reactive.py:486 in _watch                  │
│                                                                                                                                      │
│   483 │   │   return                                                                                                                 │
│   484 │   if init:                                                                                                                   │
│   485 │   │   current_value = getattr(obj, attribute_name, None)                                                                     │
│ ❱ 486 │   │   invoke_watcher(obj, callback, current_value, current_value)                                                            │
│   487 │   watcher_list.append((node, callback))                                                                                      │
│   488                                                                                                                                │
│                                                                                                                                      │
│ ╭───────────────────────────────────────────────────── locals ──────────────────────────────────────────────────────╮                │
│ │ attribute_name = 'theme'                                                                                          │                │
│ │       callback = <bound method MarkdownFence._retheme of MarkdownFence()>                                         │                │
│ │  current_value = 'textual-dark'                                                                                   │                │
│ │           init = True                                                                                             │                │
│ │           node = MarkdownFence()                                                                                  │                │
│ │            obj = Compi(title='Compi', classes={'-dark-mode'}, pseudo_classes={'dark', 'focus'})                   │                │
│ │   watcher_list = [                                                                                                │                │
│ │                  │   (                                                                                            │                │
│ │                  │   │   ExtendedTextArea(id='chat_input'),                                                       │                │
│ │                  │   │   <bound method TextArea._app_theme_changed of ExtendedTextArea(id='chat_input')>          │                │
│ │                  │   ),                                                                                           │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),                 │                │
│ │                  │   ... +1089                                                                                    │                │
│ │                  ]                                                                                                │                │
│ │       watchers = {                                                                                                │                │
│ │                  │   'theme': [                                                                                   │                │
│ │                  │   │   (                                                                                        │                │
│ │                  │   │   │   ExtendedTextArea(id='chat_input'),                                                   │                │
│ │                  │   │   │   <bound method TextArea._app_theme_changed of ExtendedTextArea(id='chat_input')>      │                │
│ │                  │   │   ),                                                                                       │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   (MarkdownFence(), <bound method MarkdownFence._retheme of MarkdownFence()>),             │                │
│ │                  │   │   ... +1089                                                                                │                │
│ │                  │   ],                                                                                           │                │
│ │                  │   'title': [(Header(), <function Header._on_mount.<locals>.set_title at 0x16ece84a0>)],        │                │
│ │                  │   'sub_title': [                                                                               │                │
│ │                  │   │   (Header(), <function Header._on_mount.<locals>.set_sub_title at 0x16ecebd80>)            │                │
│ │                  │   ]                                                                                            │                │
│ │                  }                                                                                                │                │
│ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                │
│                                                                                                                                      │
│ /Users/xxxx/Documents/xxxxx/xxxxxxx/xxxxxxxxxx/venv/lib/python3.13/site-packages/textual/widgets/_markdown.py:647 in _retheme       │
│                                                                                                                                      │
│    644 │   │   │   if self.app.current_theme.dark                                               ╭──────── locals ────────╮           │
│    645 │   │   │   else self._markdown.code_light_theme                                         │ self = MarkdownFence() │           │
│    646 │   │   )                                                                                ╰────────────────────────╯           │
│ ❱  647 │   │   self.get_child_by_type(Static).update(self._block())                                                                  │
│    648 │                                                                                                                             │
│    649 │   def compose(self) -> ComposeResult:                                                                                       │
│    650 │   │   yield Static(                                                                                                         │
│                                                                                                                                      │
│ /Users/xxxx/Documents/xxxxx/xxxxxxx/xxxxxxxxxx/venv/lib/python3.13/site-packages/textual/widget.py:1003 in get_child_by_type        │
│                                                                                                                                      │
│   1000 │   │   │   if type(child) is expect_type:                                                                                    │
│   1001 │   │   │   │   assert isinstance(child, expect_type)                                                                         │
│   1002 │   │   │   │   return child                                                                                                  │
│ ❱ 1003 │   │   raise NoMatches(f"No immediate child of type {expect_type}; {self._nodes}")                                           │
│   1004 │                                                                                                                             │
│   1005 │   def get_component_rich_style(self, *names: str, partial: bool = False) -> Style:                                          │
│   1006 │   │   """Get a *Rich* style for a component.                                                                                │
│                                                                                                                                      │
│ ╭──────────────────────── locals ────────────────────────╮                                                                           │
│ │ expect_type = <class 'textual.widgets._static.Static'> │                                                                           │
│ │        self = MarkdownFence()                          │                                                                           │
│ ╰────────────────────────────────────────────────────────╯                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
NoMatches: No immediate child of type <class 'textual.widgets._static.Static'>; <NodeList []>
```