### PR TITLE
fix markup escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.1 - 2024-02-16
+
+### Fixed
+
+- Fixed escape tags in Content markup
+
 ## 2.0.0 - 2025-02-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed escape tags in Content markup
+- Fixed escape tags in Content markup https://github.com/Textualize/textual/pull/5536
 
 ## 2.0.0 - 2025-02-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual"
-version = "2.0.0"
+version = "2.0.1"
 homepage = "https://github.com/Textualize/textual"
 repository = "https://github.com/Textualize/textual"
 documentation = "https://textual.textualize.io/"

--- a/src/textual/markup.py
+++ b/src/textual/markup.py
@@ -48,7 +48,6 @@ expect_markup = Expect(
     "markup tag",
     open_closing_tag=r"(?<!\\)\[/",
     open_tag=r"(?<!\\)\[",
-    end_tag=r"(?<!\\)\]",
 ).extract_text()
 
 expect_markup_expression = (
@@ -344,7 +343,6 @@ def _to_content(
             return template_text
 
     for token in iter_tokens:
-
         token_name = token.name
         if token_name == "text":
             value = process_text(token.value.replace("\\[", "["))
@@ -353,6 +351,7 @@ def _to_content(
 
         elif token_name == "open_tag":
             tag_text = []
+
             for token in iter_tokens:
                 if token.name == "end_tag":
                     break

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -216,3 +216,9 @@ def test_assemble():
         Span(28, 35, style="blue"),
         Span(41, 66, style="underline"),
     ]
+
+
+def test_escape():
+    content = Content.from_markup("\\[bold]Not really bold")
+    assert content.plain == "[bold]Not really bold"
+    assert content.spans == []

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -219,6 +219,7 @@ def test_assemble():
 
 
 def test_escape():
+    """Test that escaping the first square bracket."""
     content = Content.from_markup("\\[bold]Not really bold")
     assert content.plain == "[bold]Not really bold"
     assert content.spans == []


### PR DESCRIPTION
Fix markup escaping.

Previously the following would erroneously omit the close square brackets.

```
"\[bold]Not really bold"
```