### PR TITLE
strip control codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed smooth scrolling broken on iTerm over SSH https://github.com/Textualize/textual/pull/5551
 - Fixed height of auto container which contains auto height children https://github.com/Textualize/textual/pull/5552
+- Fixed `Content.from_markup` not stripping control codes https://github.com/Textualize/textual/pull/5557
 
 ## [2.0.4] - 2025-02-17
 

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -193,6 +193,7 @@ class Content(Visual):
             if variables:
                 raise ValueError("A literal string is require to substitute variables.")
             return markup
+        markup = _strip_control_codes(markup)
         from textual.markup import to_content
 
         content = to_content(markup, template_variables=variables or None)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -223,3 +223,9 @@ def test_escape():
     content = Content.from_markup("\\[bold]Not really bold")
     assert content.plain == "[bold]Not really bold"
     assert content.spans == []
+
+
+def test_strip_control_codes():
+    """Test that control codes are removed from content."""
+    assert Content("foo\r\nbar").plain == "foo\nbar"
+    assert Content.from_markup("foo\r\nbar").plain == "foo\nbar"


### PR DESCRIPTION
Fix `Content.from_markup` not stripping control codes.