### PR TITLE
Smooth scrolling detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed height of auto container which contains auto height children https://github.com/Textualize/textual/pull/5552
 - Fixed `Content.from_markup` not stripping control codes https://github.com/Textualize/textual/pull/5557
 - Fixed `delta_x` and `delta_y` in mouse events when smooth scrolling is enabled https://github.com/Textualize/textual/pull/5556
+- Fixed detection of smooth scrolling
 
 ### Added
 
 - Added `pointer_x`, `pointer_y`, `pointer_screen_x`, and `pointer_screen_y` attributes to mouse events https://github.com/Textualize/textual/pull/5556
+
+### Changed
+
+- Animating the scrollbar while dragging is disabled if smooth scrolling is available
 
 ## [2.0.4] - 2025-02-17
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -795,7 +795,7 @@ class App(Generic[ReturnType], DOMNode):
         self._clipboard: str = ""
         """Contents of local clipboard."""
 
-        self.supports_smooth_scrolling: bool = True
+        self.supports_smooth_scrolling: bool = False
         """Does the terminal support smooth scrolling?"""
 
         if self.ENABLE_COMMAND_PALETTE:
@@ -4654,7 +4654,7 @@ class App(Generic[ReturnType], DOMNode):
         """There isn't much we can do with this information currently, so
         we will just log it.
         """
-        self.supports_smooth_scrolling = True
+        self.supports_smooth_scrolling = message.enabled
         self.log.debug(message)
 
     def _on_idle(self) -> None:

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -379,7 +379,9 @@ class ScrollBar(Widget):
                     (event._screen_x - self.grabbed.x)
                     * (virtual_size / self.window_size)
                 )
-            self.post_message(ScrollTo(x=x, y=y))
+            self.post_message(
+                ScrollTo(x=x, y=y, animate=not self.app.supports_smooth_scrolling)
+            )
         event.stop()
 
     async def _on_click(self, event: events.Click) -> None:


### PR DESCRIPTION
Disable animating scrolling when dragging if smooth scrolling is available. The animation served to make scrolling a little smoother, but had the opposite effect when true scrolling is available.

Fixed the mechanism to detect smooth scrolling.