### PR TITLE
cleared tabs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed `Link` binding to open the link https://github.com/Textualize/textual/issues/5564
+- Fixed issue with clear_panes breaking tabbed content https://github.com/Textualize/textual/pull/5573
 
 ## [2.1.0] - 2025-02-19
 

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -527,7 +527,6 @@ class Tabs(Widget, can_focus=True):
         underline.highlight_start = 0
         underline.highlight_end = 0
         self.post_message(self.Cleared(self))
-        # self.call_after_refresh(self.post_message, self.Cleared(self))
         self.active = ""
         return AwaitComplete(self.query("#tabs-list > Tab").remove())
 

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -526,7 +526,8 @@ class Tabs(Widget, can_focus=True):
         underline = self.query_one(Underline)
         underline.highlight_start = 0
         underline.highlight_end = 0
-        self.call_after_refresh(self.post_message, self.Cleared(self))
+        self.post_message(self.Cleared(self))
+        # self.call_after_refresh(self.post_message, self.Cleared(self))
         self.active = ""
         return AwaitComplete(self.query("#tabs-list > Tab").remove())
 


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5572

This was caused by Tabs delaying sending the Cleared message until after refresh. It resulted in that message being handled after adding the pane, and thus immediately clearing it.

`call_after_refresh` was probably added a while back to solve some kind of update issue, which has since been fixes.