### PR TITLE
Allow user to interupt scroll to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Link` binding to open the link https://github.com/Textualize/textual/issues/5564
 - Fixed issue with clear_panes breaking tabbed content https://github.com/Textualize/textual/pull/5573
 
+## Changed
+
+- The user can now interrupt a scroll to end by grabbing the scrollbar or scrolling in any other way. Press ++end++ or scroll to the end to restore default behavior. This is more intuitive that it may sound.
+
 ## [2.1.0] - 2025-02-19
 
 ### Fixed

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -38,6 +38,8 @@ class ScrollView(ScrollableContainer):
             self.refresh()
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        if new_value >= self.max_scroll_y:
+            self._user_scroll_interrupt = False
         if self.show_vertical_scrollbar and (old_value) != (new_value):
             self.vertical_scrollbar.position = new_value
             self.refresh()

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -38,8 +38,6 @@ class ScrollView(ScrollableContainer):
             self.refresh()
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
-        if new_value >= self.max_scroll_y:
-            self._user_scroll_interrupt = False
         if self.show_vertical_scrollbar and (old_value) != (new_value):
             self.vertical_scrollbar.position = new_value
             self.refresh()

--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -356,6 +356,8 @@ class ScrollBar(Widget):
         event.stop()
 
     def _on_mouse_capture(self, event: events.MouseCapture) -> None:
+        if isinstance(self._parent, Widget):
+            self._parent._user_scroll_interrupt = True
         self.grabbed = event.mouse_position
         self.grabbed_position = self.position
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -502,6 +502,8 @@ class Widget(DOMNode):
         """Used to cache :odd pseudoclass state."""
         self._last_scroll_time = monotonic()
         """Time of last scroll."""
+        self._user_scroll_interrupt: bool = False
+        """Has the user interrupted a scroll to end?"""
 
     @property
     def is_mounted(self) -> bool:
@@ -1698,6 +1700,8 @@ class Widget(DOMNode):
             self._refresh_scroll()
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        if new_value >= self.max_scroll_y:
+            self._user_scroll_interrupt = True
         self.vertical_scrollbar.position = new_value
         if round(old_value) != round(new_value):
             self._refresh_scroll()
@@ -2688,8 +2692,19 @@ class Widget(DOMNode):
             y_axis: Allow scrolling on Y axis?
 
         """
+
+        if self._user_scroll_interrupt and not force:
+            # Do not scroll to end if a user action has interrupted scrolling
+            return
+
         if speed is None and duration is None:
             duration = 1.0
+
+        async def scroll_end_on_complete() -> None:
+            """It's possible new content was added before we reached the end."""
+            self.scroll_y = self.max_scroll_y
+            if on_complete is not None:
+                self.call_next(on_complete)
 
         # In most cases we'd call self.scroll_to and let it handle the call
         # to do things after a refresh, but here we need the refresh to
@@ -2707,7 +2722,7 @@ class Widget(DOMNode):
                 duration=duration,
                 easing=easing,
                 force=force,
-                on_complete=on_complete,
+                on_complete=scroll_end_on_complete,
                 level=level,
             )
 
@@ -4450,6 +4465,7 @@ class Widget(DOMNode):
     def action_scroll_home(self) -> None:
         if not self._allow_scroll:
             raise SkipAction()
+        self._user_scroll_interrupt = True
         self._clear_anchor()
         self.scroll_home(x_axis=self.scroll_y == 0)
 
@@ -4457,6 +4473,7 @@ class Widget(DOMNode):
         if not self._allow_scroll:
             raise SkipAction()
         self._clear_anchor()
+        self._user_scroll_interrupt = False
         self.scroll_end(x_axis=self.scroll_y == self.is_vertical_scroll_end)
 
     def action_scroll_left(self) -> None:
@@ -4474,24 +4491,28 @@ class Widget(DOMNode):
     def action_scroll_up(self) -> None:
         if not self.allow_vertical_scroll:
             raise SkipAction()
+        self._user_scroll_interrupt = True
         self._clear_anchor()
         self.scroll_up()
 
     def action_scroll_down(self) -> None:
         if not self.allow_vertical_scroll:
             raise SkipAction()
+        self._user_scroll_interrupt = True
         self._clear_anchor()
         self.scroll_down()
 
     def action_page_down(self) -> None:
         if not self.allow_vertical_scroll:
             raise SkipAction()
+        self._user_scroll_interrupt = True
         self._clear_anchor()
         self.scroll_page_down()
 
     def action_page_up(self) -> None:
         if not self.allow_vertical_scroll:
             raise SkipAction()
+        self._user_scroll_interrupt = True
         self._clear_anchor()
         self.scroll_page_up()
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1700,8 +1700,6 @@ class Widget(DOMNode):
             self._refresh_scroll()
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
-        if new_value >= self.max_scroll_y:
-            self._user_scroll_interrupt = True
         self.vertical_scrollbar.position = new_value
         if round(old_value) != round(new_value):
             self._refresh_scroll()
@@ -2428,6 +2426,9 @@ class Widget(DOMNode):
             if on_complete is not None:
                 self.call_next(on_complete)
 
+        if y is not None and maybe_scroll_y and y >= self.max_scroll_y:
+            self._user_scroll_interrupt = False
+
         if animate:
             # TODO: configure animation speed
             if duration is None and speed is None:
@@ -2550,6 +2551,11 @@ class Widget(DOMNode):
         Note:
             The call to scroll is made after the next refresh.
         """
+        animator = self.app.animator
+        if x is not None:
+            animator.force_stop_animation(self, "scroll_x")
+        if y is not None:
+            animator.force_stop_animation(self, "scroll_y")
         if immediate:
             self._scroll_to(
                 x,

--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -191,11 +191,7 @@ class Log(ScrollView, can_focus=True):
             self._prune_max_lines()
 
         auto_scroll = self.auto_scroll if scroll_end is None else scroll_end
-        if (
-            auto_scroll
-            and not self.is_vertical_scrollbar_grabbed
-            and is_vertical_scroll_end
-        ):
+        if auto_scroll:
             self.scroll_end(animate=False, immediate=True, x_axis=False)
         return self
 

--- a/src/textual/widgets/_rich_log.py
+++ b/src/textual/widgets/_rich_log.py
@@ -279,11 +279,7 @@ class RichLog(ScrollView, can_focus=True):
         # the new line(s), and the height will definitely have changed.
         self.virtual_size = Size(self._widest_line_width, len(self.lines))
 
-        if (
-            auto_scroll
-            and not self.is_vertical_scrollbar_grabbed
-            and is_vertical_scroll_end
-        ):
+        if auto_scroll:
             self.scroll_end(animate=animate, immediate=False, x_axis=False)
 
         return self


### PR DESCRIPTION
Adds a mechanism that allows a user to interrupt scrolling to end.

For log like widgets, the default is typically to add an item and scroll to the end. The problem with this is that the user can't look at the previous content the window keeps scrolling to the end.

This update adds a mechanism to temporarily disable scrolling to the end, if they drag the scrollbar / scroll with keys. If the user then presses ++end++, or navigates to the end then automatic scroll to end is restored.

There was a mechanism to do this previously, but it didn't work well.