### PR TITLE
Preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors.
+- Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors. https://github.com/Textualize/textual/pull/5588
 
 ## [2.1.2] - 2025-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors.
+
 ## [2.1.2] - 2025-02-26
 
 ### Fixed

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1026,7 +1026,7 @@ class App(Generic[ReturnType], DOMNode):
     @property
     def debug(self) -> bool:
         """Is debug mode enabled?"""
-        return "debug" in self.features
+        return "debug" in self.features or constants.DEBUG
 
     @property
     def is_headless(self) -> bool:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -504,8 +504,6 @@ class Widget(DOMNode):
         """Time of last scroll."""
         self._user_scroll_interrupt: bool = False
         """Has the user interrupted a scroll to end?"""
-        if self.app.debug:
-            self._preflight()
 
     @property
     def is_mounted(self) -> bool:
@@ -653,10 +651,11 @@ class Widget(DOMNode):
         """Text selection information, or `None` if no text is selected in this widget."""
         return self.screen.selections.get(self, None)
 
-    def _preflight(self) -> None:
+    def preflight_checks(self) -> None:
         """Called in debug mode to do preflight checks.
 
-        Errors are reported via self.log.
+        This is used by Textual to log some common errors, but you could implement this
+        in custom widgets to perform additional checks.
 
         """
 
@@ -1492,6 +1491,8 @@ class Widget(DOMNode):
                 tie_breaker=tie_breaker,
                 scope=scope,
             )
+        if app.debug:
+            app.call_next(self.preflight_checks)
 
     def _get_box_model(
         self,

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -504,6 +504,8 @@ class Widget(DOMNode):
         """Time of last scroll."""
         self._user_scroll_interrupt: bool = False
         """Has the user interrupted a scroll to end?"""
+        if self.app.debug:
+            self._preflight()
 
     @property
     def is_mounted(self) -> bool:
@@ -650,6 +652,19 @@ class Widget(DOMNode):
     def text_selection(self) -> Selection | None:
         """Text selection information, or `None` if no text is selected in this widget."""
         return self.screen.selections.get(self, None)
+
+    def _preflight(self) -> None:
+        """Called in debug mode to do preflight checks.
+
+        Errors are reported via self.log.
+
+        """
+        from textual.screen import Screen
+
+        if not isinstance(self, Screen) and hasattr(self, "CSS"):
+            self.log.warning(
+                f"'{self.__class__.__name__}.CSS' will be ignored (use 'DEFAULT_CSS' class variable for widgets)"
+            )
 
     def _cover(self, widget: Widget) -> None:
         """Set a widget used to replace the visuals of this widget (used for loading indicator).

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -659,12 +659,14 @@ class Widget(DOMNode):
         Errors are reported via self.log.
 
         """
-        from textual.screen import Screen
 
-        if not isinstance(self, Screen) and hasattr(self, "CSS"):
-            self.log.warning(
-                f"'{self.__class__.__name__}.CSS' will be ignored (use 'DEFAULT_CSS' class variable for widgets)"
-            )
+        if hasattr(self, "CSS"):
+            from textual.screen import Screen
+
+            if not isinstance(self, Screen):
+                self.log.warning(
+                    f"'{self.__class__.__name__}.CSS' will be ignored (use 'DEFAULT_CSS' class variable for widgets)"
+                )
 
     def _cover(self, widget: Widget) -> None:
         """Set a widget used to replace the visuals of this widget (used for loading indicator).


### PR DESCRIPTION
Added "preflight_checks" to catch common mistakes.

Initially it will catch using `CSS` rather than `DEFAULT_CSS` in widgets. Which is a common gotcha, most recently reported in this discussion: https://github.com/Textualize/textual/discussions/5584

This error is reported in the dev console:

<img width="945" alt="Screenshot 2025-02-27 at 10 50 42" src="https://github.com/user-attachments/assets/eabfe6e2-5809-4f31-87eb-38fb85488235" />