### PR TITLE
Update containers.py

### DIFF
--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -254,7 +254,7 @@ class ItemGrid(Widget, inherit_bindings=False):
     """
 
     stretch_height: reactive[bool] = reactive(True)
-    min_column_width: reactive[int | None] = reactive(None, layout=True)
+    min_column_width: reactive[int | None] = reactive(1, layout=True)
     regular: reactive[bool] = reactive(False)
 
     def __init__(
@@ -264,7 +264,7 @@ class ItemGrid(Widget, inherit_bindings=False):
         id: str | None = None,
         classes: str | None = None,
         disabled: bool = False,
-        min_column_width: int | None = None,
+        min_column_width: int | None = 1,
         stretch_height: bool = True,
         regular: bool = False,
     ) -> None:


### PR DESCRIPTION
Using None as default for min_column_width breaks automatic horizontal flow of children into columns per the API at https://textual.textualize.io/api/containers/#textual.containers.ItemGrid

Setting to the minimum positive integer that maintains documented behavior. Though this may actually be a deeper issue in layout, I leave that decision to someone more knowledgeable. Other positive integers may also be more desirable and it has been suggested to pick a value that is a power of 2.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
