### PR TITLE
Adding unbind methods to App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors. https://github.com/Textualize/textual/pull/5588
+- Added App.unbind to remove a key bingind from an app.
 
 ## [2.1.2] - 2025-02-26
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1784,6 +1784,17 @@ class App(Generic[ReturnType], DOMNode):
             keys, action, description, show=show, key_display=key_display
         )
 
+    def unbind(
+        self,
+        keys: str,
+    ) -> None:
+        """Unbind all actions binded to keys.
+
+        Args:
+            keys: The keys to unbind. Can be a comma-separated list of keys.
+        """
+        self._bindings.unbind(keys)
+
     def get_key_display(self, binding: Binding) -> str:
         """Format a bound key for display in footer / key panel etc.
 

--- a/src/textual/binding.py
+++ b/src/textual/binding.py
@@ -361,6 +361,22 @@ class BindingsMap:
                 )
             )
 
+    def unbind(
+        self,
+        keys: str,
+    ) -> None:
+        """Unbind all actions binded to keys.
+
+        Args:
+            keys: The keys to unbind. Can be a comma-separated list of keys.
+        """
+        all_keys = [key.strip() for key in keys.split(",")]
+        for key in all_keys:
+            try:
+                del self.key_to_bindings[key]
+            except KeyError:
+                raise NoBinding(f"No binding for {key}") from None
+
     def get_bindings_for_key(self, key: str) -> list[Binding]:
         """Get a list of bindings for a given key.
 


### PR DESCRIPTION
Adding a method to `App` that allows to unbind a key previously bound.

```python
class MyApp(App):
    def on_mount(self):
        self.bind("a", action="action1", description="description1")

app = MyApp()

app.unbind("a")  # removes the 'a' binding
```

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

I don't know if an update to documentation is needed as I correctly (ig ?) wrote the docstrings of the methods written in app.py and binding.py...

This may be linked to #2242 but disabling with `unbind` may be more permanent.