### PR TITLE
fix: fix alignment with auto and min height/width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Fixed issue with alignment in containers with auto and min height/width https://github.com/Textualize/textual/issues/5608
+
 ### Added
 
 - Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors. https://github.com/Textualize/textual/pull/5588

--- a/src/textual/_arrange.py
+++ b/src/textual/_arrange.py
@@ -100,12 +100,34 @@ def arrange(
             if styles.align_horizontal != "left" or styles.align_vertical != "top":
                 bounding_region = WidgetPlacement.get_bounds(layout_placements)
                 container_width, container_height = dock_region.size
+
+                align_width = container_width
+                if styles.is_auto_width:
+                    align_width = (
+                        int(
+                            styles.min_width.resolve(
+                                size, viewport, Fraction(container_width)
+                            )
+                        )
+                        if styles.min_width
+                        else 0
+                    )
+
+                align_height = container_height
+                if styles.is_auto_height:
+                    align_height = (
+                        int(
+                            styles.min_height.resolve(
+                                size, viewport, Fraction(container_height)
+                            )
+                        )
+                        if styles.min_height
+                        else 0
+                    )
+
                 placement_offset += styles._align_size(
                     bounding_region.size,
-                    Size(
-                        0 if styles.is_auto_width else container_width,
-                        0 if styles.is_auto_height else container_height,
-                    ),
+                    Size(align_width, align_height),
                 ).clamped
 
             if placement_offset:

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_alignment_with_auto_and_min_height.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_alignment_with_auto_and_min_height.svg
@@ -1,0 +1,150 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1035532477-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1035532477-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1035532477-r1 { fill: #e0e0e0 }
+.terminal-1035532477-r2 { fill: #c5c8c6 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1035532477-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-1035532477-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1035532477-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-1035532477-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">AlignmentApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1035532477-clip-terminal)">
+    <rect fill="#ffc0cb" x="0" y="1.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="244" y="1.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#ffc0cb" x="0" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="73.2" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ffc0cb" x="170.8" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="244" y="25.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#ffc0cb" x="0" y="50.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="244" y="50.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1035532477-matrix">
+    <text class="terminal-1035532477-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1035532477-line-0)">
+</text><text class="terminal-1035532477-r1" x="73.2" y="44.4" textLength="97.6" clip-path="url(#terminal-1035532477-line-1)">centered</text><text class="terminal-1035532477-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1035532477-line-1)">
+</text><text class="terminal-1035532477-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1035532477-line-2)">
+</text><text class="terminal-1035532477-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1035532477-line-3)">
+</text><text class="terminal-1035532477-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1035532477-line-4)">
+</text><text class="terminal-1035532477-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1035532477-line-5)">
+</text><text class="terminal-1035532477-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1035532477-line-6)">
+</text><text class="terminal-1035532477-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1035532477-line-7)">
+</text><text class="terminal-1035532477-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1035532477-line-8)">
+</text><text class="terminal-1035532477-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1035532477-line-9)">
+</text><text class="terminal-1035532477-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1035532477-line-10)">
+</text><text class="terminal-1035532477-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1035532477-line-11)">
+</text><text class="terminal-1035532477-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1035532477-line-12)">
+</text><text class="terminal-1035532477-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1035532477-line-13)">
+</text><text class="terminal-1035532477-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1035532477-line-14)">
+</text><text class="terminal-1035532477-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1035532477-line-15)">
+</text><text class="terminal-1035532477-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1035532477-line-16)">
+</text><text class="terminal-1035532477-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1035532477-line-17)">
+</text><text class="terminal-1035532477-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1035532477-line-18)">
+</text><text class="terminal-1035532477-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1035532477-line-19)">
+</text><text class="terminal-1035532477-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1035532477-line-20)">
+</text><text class="terminal-1035532477-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1035532477-line-21)">
+</text><text class="terminal-1035532477-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1035532477-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_markdown_theme_switching.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_markdown_theme_switching.svg
@@ -19,140 +19,140 @@
         font-weight: 700;
     }
 
-    .terminal-99830303-matrix {
+    .terminal-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-99830303-title {
+    .terminal-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-99830303-r1 { fill: #c5c8c6 }
-.terminal-99830303-r2 { fill: #1f1f1f }
-.terminal-99830303-r3 { fill: #004578;font-weight: bold }
-.terminal-99830303-r4 { fill: #d2d2d2 }
-.terminal-99830303-r5 { fill: #008000;font-weight: bold }
-.terminal-99830303-r6 { fill: #bbbbbb }
-.terminal-99830303-r7 { fill: #0000ff }
-.terminal-99830303-r8 { fill: #000000 }
-.terminal-99830303-r9 { fill: #87adad;font-style: italic; }
-.terminal-99830303-r10 { fill: #008000 }
-.terminal-99830303-r11 { fill: #ba2121 }
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #1f1f1f }
+.terminal-r3 { fill: #004578;font-weight: bold }
+.terminal-r4 { fill: #d2d2d2 }
+.terminal-r5 { fill: #008000;font-weight: bold }
+.terminal-r6 { fill: #bbbbbb }
+.terminal-r7 { fill: #0000ff }
+.terminal-r8 { fill: #000000 }
+.terminal-r9 { fill: #87adad;font-style: italic; }
+.terminal-r10 { fill: #008000 }
+.terminal-r11 { fill: #ba2121 }
     </style>
 
     <defs>
-    <clipPath id="terminal-99830303-clip-terminal">
+    <clipPath id="terminal-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-99830303-line-0">
+    <clipPath id="terminal-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-1">
+<clipPath id="terminal-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-2">
+<clipPath id="terminal-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-3">
+<clipPath id="terminal-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-4">
+<clipPath id="terminal-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-5">
+<clipPath id="terminal-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-6">
+<clipPath id="terminal-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-7">
+<clipPath id="terminal-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-8">
+<clipPath id="terminal-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-9">
+<clipPath id="terminal-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-10">
+<clipPath id="terminal-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-11">
+<clipPath id="terminal-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-12">
+<clipPath id="terminal-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-13">
+<clipPath id="terminal-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-14">
+<clipPath id="terminal-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-15">
+<clipPath id="terminal-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-16">
+<clipPath id="terminal-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-17">
+<clipPath id="terminal-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-18">
+<clipPath id="terminal-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-19">
+<clipPath id="terminal-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-20">
+<clipPath id="terminal-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-21">
+<clipPath id="terminal-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-99830303-line-22">
+<clipPath id="terminal-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-99830303-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">MarkdownThemeSwitcherApp</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">MarkdownThemeSwitcherApp</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-99830303-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
     <rect fill="#d8d8d8" x="0" y="1.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="1.5" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="1.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="25.9" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="50.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="414.8" y="50.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="561.2" y="50.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="74.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="99.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="85.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="97.6" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="146.4" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="183" y="123.5" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="48.8" y="147.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="97.6" y="147.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="158.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="170.8" y="147.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="341.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="353.8" y="147.9" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="172.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="196.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-99830303-matrix">
-    <text class="terminal-99830303-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-99830303-line-0)">
-</text><text class="terminal-99830303-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-99830303-line-1)">
-</text><text class="terminal-99830303-r3" x="414.8" y="68.8" textLength="146.4" clip-path="url(#terminal-99830303-line-2)">This&#160;is&#160;a&#160;H1</text><text class="terminal-99830303-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-99830303-line-2)">
-</text><text class="terminal-99830303-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-99830303-line-3)">
-</text><text class="terminal-99830303-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-99830303-line-4)">
-</text><text class="terminal-99830303-r5" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-99830303-line-5)">def</text><text class="terminal-99830303-r7" x="97.6" y="142" textLength="48.8" clip-path="url(#terminal-99830303-line-5)">main</text><text class="terminal-99830303-r8" x="146.4" y="142" textLength="36.6" clip-path="url(#terminal-99830303-line-5)">():</text><text class="terminal-99830303-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-99830303-line-5)">
-</text><text class="terminal-99830303-r9" x="48.8" y="166.4" textLength="48.8" clip-path="url(#terminal-99830303-line-6)">│&#160;&#160;&#160;</text><text class="terminal-99830303-r10" x="97.6" y="166.4" textLength="61" clip-path="url(#terminal-99830303-line-6)">print</text><text class="terminal-99830303-r8" x="158.6" y="166.4" textLength="12.2" clip-path="url(#terminal-99830303-line-6)">(</text><text class="terminal-99830303-r11" x="170.8" y="166.4" textLength="170.8" clip-path="url(#terminal-99830303-line-6)">&quot;Hello&#160;world!&quot;</text><text class="terminal-99830303-r8" x="341.6" y="166.4" textLength="12.2" clip-path="url(#terminal-99830303-line-6)">)</text><text class="terminal-99830303-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-99830303-line-6)">
-</text><text class="terminal-99830303-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-99830303-line-7)">
-</text><text class="terminal-99830303-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-99830303-line-8)">
-</text><text class="terminal-99830303-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-99830303-line-9)">
-</text><text class="terminal-99830303-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-99830303-line-10)">
-</text><text class="terminal-99830303-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-99830303-line-11)">
-</text><text class="terminal-99830303-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-99830303-line-12)">
-</text><text class="terminal-99830303-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-99830303-line-13)">
-</text><text class="terminal-99830303-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-99830303-line-14)">
-</text><text class="terminal-99830303-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-99830303-line-15)">
-</text><text class="terminal-99830303-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-99830303-line-16)">
-</text><text class="terminal-99830303-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-99830303-line-17)">
-</text><text class="terminal-99830303-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-99830303-line-18)">
-</text><text class="terminal-99830303-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-99830303-line-19)">
-</text><text class="terminal-99830303-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-99830303-line-20)">
-</text><text class="terminal-99830303-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-99830303-line-21)">
-</text><text class="terminal-99830303-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-99830303-line-22)">
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r3" x="414.8" y="68.8" textLength="146.4" clip-path="url(#terminal-line-2)">This&#160;is&#160;a&#160;H1</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r5" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-line-5)">def</text><text class="terminal-r7" x="97.6" y="142" textLength="48.8" clip-path="url(#terminal-line-5)">main</text><text class="terminal-r8" x="146.4" y="142" textLength="36.6" clip-path="url(#terminal-line-5)">():</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r9" x="48.8" y="166.4" textLength="48.8" clip-path="url(#terminal-line-6)">│&#160;&#160;&#160;</text><text class="terminal-r10" x="97.6" y="166.4" textLength="61" clip-path="url(#terminal-line-6)">print</text><text class="terminal-r8" x="158.6" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">(</text><text class="terminal-r11" x="170.8" y="166.4" textLength="170.8" clip-path="url(#terminal-line-6)">&quot;Hello&#160;world!&quot;</text><text class="terminal-r8" x="341.6" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">)</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
 </text>
     </g>
     </g>

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_markdown_theme_switching.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_markdown_theme_switching.svg
@@ -19,140 +19,140 @@
         font-weight: 700;
     }
 
-    .terminal-matrix {
+    .terminal-99830303-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-title {
+    .terminal-99830303-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-r1 { fill: #c5c8c6 }
-.terminal-r2 { fill: #1f1f1f }
-.terminal-r3 { fill: #004578;font-weight: bold }
-.terminal-r4 { fill: #d2d2d2 }
-.terminal-r5 { fill: #008000;font-weight: bold }
-.terminal-r6 { fill: #bbbbbb }
-.terminal-r7 { fill: #0000ff }
-.terminal-r8 { fill: #000000 }
-.terminal-r9 { fill: #87adad;font-style: italic; }
-.terminal-r10 { fill: #008000 }
-.terminal-r11 { fill: #ba2121 }
+    .terminal-99830303-r1 { fill: #c5c8c6 }
+.terminal-99830303-r2 { fill: #1f1f1f }
+.terminal-99830303-r3 { fill: #004578;font-weight: bold }
+.terminal-99830303-r4 { fill: #d2d2d2 }
+.terminal-99830303-r5 { fill: #008000;font-weight: bold }
+.terminal-99830303-r6 { fill: #bbbbbb }
+.terminal-99830303-r7 { fill: #0000ff }
+.terminal-99830303-r8 { fill: #000000 }
+.terminal-99830303-r9 { fill: #87adad;font-style: italic; }
+.terminal-99830303-r10 { fill: #008000 }
+.terminal-99830303-r11 { fill: #ba2121 }
     </style>
 
     <defs>
-    <clipPath id="terminal-clip-terminal">
+    <clipPath id="terminal-99830303-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-line-0">
+    <clipPath id="terminal-99830303-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-1">
+<clipPath id="terminal-99830303-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-2">
+<clipPath id="terminal-99830303-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-3">
+<clipPath id="terminal-99830303-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-4">
+<clipPath id="terminal-99830303-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-5">
+<clipPath id="terminal-99830303-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-6">
+<clipPath id="terminal-99830303-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-7">
+<clipPath id="terminal-99830303-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-8">
+<clipPath id="terminal-99830303-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-9">
+<clipPath id="terminal-99830303-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-10">
+<clipPath id="terminal-99830303-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-11">
+<clipPath id="terminal-99830303-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-12">
+<clipPath id="terminal-99830303-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-13">
+<clipPath id="terminal-99830303-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-14">
+<clipPath id="terminal-99830303-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-15">
+<clipPath id="terminal-99830303-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-16">
+<clipPath id="terminal-99830303-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-17">
+<clipPath id="terminal-99830303-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-18">
+<clipPath id="terminal-99830303-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-19">
+<clipPath id="terminal-99830303-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-20">
+<clipPath id="terminal-99830303-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-21">
+<clipPath id="terminal-99830303-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-line-22">
+<clipPath id="terminal-99830303-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">MarkdownThemeSwitcherApp</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-99830303-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">MarkdownThemeSwitcherApp</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-99830303-clip-terminal)">
     <rect fill="#d8d8d8" x="0" y="1.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="1.5" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="1.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="25.9" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="50.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="414.8" y="50.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="561.2" y="50.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="74.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="99.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="85.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="97.6" y="123.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="146.4" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="183" y="123.5" width="768.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="48.8" y="147.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="97.6" y="147.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="158.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="170.8" y="147.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="341.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="353.8" y="147.9" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#f8f8f8" x="24.4" y="172.3" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="24.4" y="196.7" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="951.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#d8d8d8" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-matrix">
-    <text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
-</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
-</text><text class="terminal-r3" x="414.8" y="68.8" textLength="146.4" clip-path="url(#terminal-line-2)">This&#160;is&#160;a&#160;H1</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
-</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
-</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
-</text><text class="terminal-r5" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-line-5)">def</text><text class="terminal-r7" x="97.6" y="142" textLength="48.8" clip-path="url(#terminal-line-5)">main</text><text class="terminal-r8" x="146.4" y="142" textLength="36.6" clip-path="url(#terminal-line-5)">():</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
-</text><text class="terminal-r9" x="48.8" y="166.4" textLength="48.8" clip-path="url(#terminal-line-6)">│&#160;&#160;&#160;</text><text class="terminal-r10" x="97.6" y="166.4" textLength="61" clip-path="url(#terminal-line-6)">print</text><text class="terminal-r8" x="158.6" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">(</text><text class="terminal-r11" x="170.8" y="166.4" textLength="170.8" clip-path="url(#terminal-line-6)">&quot;Hello&#160;world!&quot;</text><text class="terminal-r8" x="341.6" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">)</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
-</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
-</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
-</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
-</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
-</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
-</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
-</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
-</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
-</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
-</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
-</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
-</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
-</text><text class="terminal-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
-</text><text class="terminal-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
-</text><text class="terminal-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
-</text><text class="terminal-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+    <g class="terminal-99830303-matrix">
+    <text class="terminal-99830303-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-99830303-line-0)">
+</text><text class="terminal-99830303-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-99830303-line-1)">
+</text><text class="terminal-99830303-r3" x="414.8" y="68.8" textLength="146.4" clip-path="url(#terminal-99830303-line-2)">This&#160;is&#160;a&#160;H1</text><text class="terminal-99830303-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-99830303-line-2)">
+</text><text class="terminal-99830303-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-99830303-line-3)">
+</text><text class="terminal-99830303-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-99830303-line-4)">
+</text><text class="terminal-99830303-r5" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-99830303-line-5)">def</text><text class="terminal-99830303-r7" x="97.6" y="142" textLength="48.8" clip-path="url(#terminal-99830303-line-5)">main</text><text class="terminal-99830303-r8" x="146.4" y="142" textLength="36.6" clip-path="url(#terminal-99830303-line-5)">():</text><text class="terminal-99830303-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-99830303-line-5)">
+</text><text class="terminal-99830303-r9" x="48.8" y="166.4" textLength="48.8" clip-path="url(#terminal-99830303-line-6)">│&#160;&#160;&#160;</text><text class="terminal-99830303-r10" x="97.6" y="166.4" textLength="61" clip-path="url(#terminal-99830303-line-6)">print</text><text class="terminal-99830303-r8" x="158.6" y="166.4" textLength="12.2" clip-path="url(#terminal-99830303-line-6)">(</text><text class="terminal-99830303-r11" x="170.8" y="166.4" textLength="170.8" clip-path="url(#terminal-99830303-line-6)">&quot;Hello&#160;world!&quot;</text><text class="terminal-99830303-r8" x="341.6" y="166.4" textLength="12.2" clip-path="url(#terminal-99830303-line-6)">)</text><text class="terminal-99830303-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-99830303-line-6)">
+</text><text class="terminal-99830303-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-99830303-line-7)">
+</text><text class="terminal-99830303-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-99830303-line-8)">
+</text><text class="terminal-99830303-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-99830303-line-9)">
+</text><text class="terminal-99830303-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-99830303-line-10)">
+</text><text class="terminal-99830303-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-99830303-line-11)">
+</text><text class="terminal-99830303-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-99830303-line-12)">
+</text><text class="terminal-99830303-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-99830303-line-13)">
+</text><text class="terminal-99830303-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-99830303-line-14)">
+</text><text class="terminal-99830303-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-99830303-line-15)">
+</text><text class="terminal-99830303-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-99830303-line-16)">
+</text><text class="terminal-99830303-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-99830303-line-17)">
+</text><text class="terminal-99830303-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-99830303-line-18)">
+</text><text class="terminal-99830303-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-99830303-line-19)">
+</text><text class="terminal-99830303-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-99830303-line-20)">
+</text><text class="terminal-99830303-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-99830303-line-21)">
+</text><text class="terminal-99830303-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-99830303-line-22)">
 </text>
     </g>
     </g>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -3767,3 +3767,34 @@ def test_panel_border_title_colors(snap_compare):
                 label.border_title = "Border title"
 
     assert snap_compare(BorderTitleApp())
+
+
+def test_alignment_with_auto_and_min_height(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/5608
+
+    You should see a blue label that is centered both horizontally and vertically
+    within a pink container. The container has auto width and height, but also
+    a min-width of 20 and a min-height of 3.
+    """
+
+    class AlignmentApp(App):
+        CSS = """
+        Container {
+            align: center middle;
+            height: auto;
+            min-height: 3;
+            width: auto;
+            min-width: 20;
+            background: pink;
+        }
+
+        Label {
+            background: blue;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            with Container():
+                yield Label("centered")
+
+    assert(snap_compare(AlignmentApp()))


### PR DESCRIPTION
Fix issue with alignment in containers with auto _and_ min height/width. Currently the size of the parent passed to `_align_size` doesn't account for any min height/width when the container has auto dimensions.

Fixes #5608

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
