### PR TITLE
Input widget: Validation for initial value

### DIFF
--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -431,6 +431,7 @@ class Input(ScrollView):
             self.tooltip = tooltip
 
         self.select_on_focus = select_on_focus
+        self.validate(self.value)
 
     def _position_to_cell(self, position: int) -> int:
         """Convert an index within the value to cell position.


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

In the existing Input implementation, validation is not performed in the initial state. Therefore, the styling based on validation results is only applied when the Input value changes or receives focus.

If this is not the intended behavior, performing validation during initialization would ensure the correct validation state for the initial value.