### PR TITLE
fix(tabs): update mismatched types

### DIFF
--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -23,6 +23,7 @@ from textual.widgets import Static
 
 if TYPE_CHECKING:
     from textual.content import Content, ContentType
+    from textual.visual import VisualType
 
 
 class Underline(Widget):
@@ -179,9 +180,9 @@ class Tab(Static):
         self._label = self.render_str(label)
         self.update(self._label)
 
-    def update(self, content: ContentType = "") -> None:
+    def update(self, content: VisualType = "") -> None:
         self.post_message(self.Relabelled(self))
-        return super().update(self.render_str(content))
+        return super().update(content)
 
     @property
     def label_text(self) -> str:

--- a/src/textual/widgets/_tabs.py
+++ b/src/textual/widgets/_tabs.py
@@ -22,7 +22,6 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 if TYPE_CHECKING:
-    from textual.content import Content, ContentType
     from textual.visual import VisualType
 
 
@@ -151,7 +150,7 @@ class Tab(Static):
 
     def __init__(
         self,
-        label: ContentType,
+        label: TextType,
         *,
         id: str | None = None,
         classes: str | None = None,
@@ -166,18 +165,18 @@ class Tab(Static):
             disabled: Whether the tab is disabled or not.
         """
         super().__init__(id=id, classes=classes, disabled=disabled)
-        self._label: Content
+        self._label: Text
         # Setter takes Text or str
         self.label = label  # type: ignore[assignment]
 
     @property
-    def label(self) -> Content:
+    def label(self) -> Text:
         """The label for the tab."""
         return self._label
 
     @label.setter
-    def label(self, label: ContentType) -> None:
-        self._label = self.render_str(label)
+    def label(self, label: TextType) -> None:
+        self._label = Text.from_markup(label) if isinstance(label, str) else label
         self.update(self._label)
 
     def update(self, content: VisualType = "") -> None:

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -10,15 +10,28 @@ from textual.widgets._tabs import Underline
 
 async def test_tab_label():
     """It should be possible to access a tab's label."""
-    assert Tab("Pilot").label_text == "Pilot"
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tab = pilot.app.query_one(Tab)
+        assert tab.label_text == "Pilot"
 
 
 async def test_tab_relabel():
     """It should be possible to relabel a tab."""
-    tab = Tab("Pilot")
-    assert tab.label_text == "Pilot"
-    tab.label = "Aeryn"
-    assert tab.label_text == "Aeryn"
+
+    class TabsApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Tabs("Pilot")
+
+    async with TabsApp().run_test() as pilot:
+        tab = pilot.app.query_one(Tab)
+        assert tab.label_text == "Pilot"
+        tab.label = "Aeryn"
+        assert tab.label_text == "Aeryn"
 
 
 async def test_compose_empty_tabs():


### PR DESCRIPTION
Revert the type of the `Tab` label to `TextType`.

Currently there's a mismatch between the expected types for `Tabs` and `Tab`, which can cause the app to crash. While `Tabs` still expects a `TextType`, the `Tab` was recently updated to expect a `ContentType`.

Since the tabs documentation is based on using `Text` objects, I think reverting this changes makes sense, especially given that `Tab` seems to be the only widget that now exclusively expects `ContentType`.

This might _technically_ be a breaking change, but the current incompatibility of types means that the tabs were broken anyway.

Fixes #5635.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
