### PR TITLE
TextArea improvements - lazy language import and allow installation of only required languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors. https://github.com/Textualize/textual/pull/5588
 
+### Changed
+
+- tree-sitter languages are now loaded lazily, improving cold-start time https://github.com/Textualize/textual/pull/5639
+
 ## [2.1.2] - 2025-02-26
 
 ### Fixed

--- a/src/textual/_tree_sitter.py
+++ b/src/textual/_tree_sitter.py
@@ -1,49 +1,39 @@
 from __future__ import annotations
+from importlib import import_module
+
+from textual import log
+
 
 try:
-    import tree_sitter_bash
-    import tree_sitter_css
-    import tree_sitter_go
-    import tree_sitter_html
-    import tree_sitter_java
-    import tree_sitter_javascript
-    import tree_sitter_json
-    import tree_sitter_markdown
-    import tree_sitter_python
-    import tree_sitter_regex
-    import tree_sitter_rust
-    import tree_sitter_sql
-    import tree_sitter_toml
-    import tree_sitter_xml
-    import tree_sitter_yaml
     from tree_sitter import Language
+
+    _LANGUAGE_CACHE: dict[str, Language] = {}
 
     _tree_sitter = True
 
-    _languages = {
-        "python": Language(tree_sitter_python.language()),
-        "json": Language(tree_sitter_json.language()),
-        "markdown": Language(tree_sitter_markdown.language()),
-        "yaml": Language(tree_sitter_yaml.language()),
-        "toml": Language(tree_sitter_toml.language()),
-        "rust": Language(tree_sitter_rust.language()),
-        "html": Language(tree_sitter_html.language()),
-        "css": Language(tree_sitter_css.language()),
-        "xml": Language(tree_sitter_xml.language_xml()),
-        "regex": Language(tree_sitter_regex.language()),
-        "sql": Language(tree_sitter_sql.language()),
-        "javascript": Language(tree_sitter_javascript.language()),
-        "java": Language(tree_sitter_java.language()),
-        "bash": Language(tree_sitter_bash.language()),
-        "go": Language(tree_sitter_go.language()),
-    }
-
     def get_language(language_name: str) -> Language | None:
-        return _languages.get(language_name)
+        if language_name in _LANGUAGE_CACHE:
+            return _LANGUAGE_CACHE[language_name]
+
+        try:
+            module = import_module(f"tree_sitter_{language_name}")
+        except ImportError:
+            return None
+        else:
+            try:
+                language = Language(module.language(), name=language_name)
+            except (OSError, AttributeError):
+                log.warning(f"Could not load language {language_name!r}.")
+                return None
+            else:
+                _LANGUAGE_CACHE[language_name] = language
+                return language
 
 except ImportError:
     _tree_sitter = False
-    _languages = {}
+
+    def get_language(language_name: str) -> Language | None:
+        return None
+
 
 TREE_SITTER = _tree_sitter
-BUILTIN_LANGUAGES: dict[str, "Language"] = _languages

--- a/src/textual/_tree_sitter.py
+++ b/src/textual/_tree_sitter.py
@@ -21,7 +21,12 @@ try:
             return None
         else:
             try:
-                language = Language(module.language(), name=language_name)
+                if language_name == "xml":
+                    # xml uses language_xml() instead of language()
+                    # it's the only outlier amongst the languages in the `textual[syntax]` extra
+                    language = Language(module.language_xml(), name=language_name)
+                else:
+                    language = Language(module.language(), name=language_name)
             except (OSError, AttributeError):
                 log.warning(f"Could not load language {language_name!r}.")
                 return None

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2944,9 +2944,9 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             *renderables: Text or Rich renderable(s) to display on exit.
         """
-        assert all(
-            is_renderable(renderable) for renderable in renderables
-        ), "Can only call panic with strings or Rich renderables"
+        assert all(is_renderable(renderable) for renderable in renderables), (
+            "Can only call panic with strings or Rich renderables"
+        )
 
         def render(renderable: RenderableType) -> list[Segment]:
             """Render a panic renderables."""

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2944,9 +2944,9 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             *renderables: Text or Rich renderable(s) to display on exit.
         """
-        assert all(is_renderable(renderable) for renderable in renderables), (
-            "Can only call panic with strings or Rich renderables"
-        )
+        assert all(
+            is_renderable(renderable) for renderable in renderables
+        ), "Can only call panic with strings or Rich renderables"
 
         def render(renderable: RenderableType) -> list[Segment]:
             """Render a panic renderables."""

--- a/src/textual/document/_syntax_aware_document.py
+++ b/src/textual/document/_syntax_aware_document.py
@@ -16,7 +16,7 @@ class SyntaxAwareDocumentError(Exception):
 
 
 class SyntaxAwareDocument(Document):
-    """A wrapper around a Document which also maintains a tree-sitter syntax
+    """A subclass of Document which also maintains a tree-sitter syntax
     tree when the document is edited.
     """
 

--- a/src/textual/document/_syntax_aware_document.py
+++ b/src/textual/document/_syntax_aware_document.py
@@ -38,10 +38,10 @@ class SyntaxAwareDocument(Document):
             )
 
         super().__init__(text)
-        self._language: Language = language
+        self.language: Language = language
         """The tree-sitter Language."""
 
-        self._parser = Parser(self._language)
+        self._parser = Parser(self.language)
         """The tree-sitter Parser or None if tree-sitter is unavailable."""
 
         self._syntax_tree: Tree = self._parser.parse(self._read_callable)  # type: ignore
@@ -60,7 +60,7 @@ class SyntaxAwareDocument(Document):
         Returns:
             The prepared query.
         """
-        return self._language.query(query)
+        return self.language.query(query)
 
     def query_syntax_tree(
         self,

--- a/src/textual/document/_syntax_aware_document.py
+++ b/src/textual/document/_syntax_aware_document.py
@@ -8,7 +8,6 @@ except ImportError:
     TREE_SITTER = False
 
 
-from textual._tree_sitter import BUILTIN_LANGUAGES
 from textual.document._document import Document, EditResult, Location, _utf8_encode
 
 
@@ -19,59 +18,30 @@ class SyntaxAwareDocumentError(Exception):
 class SyntaxAwareDocument(Document):
     """A wrapper around a Document which also maintains a tree-sitter syntax
     tree when the document is edited.
-
-    The primary reason for this split is actually to keep tree-sitter stuff separate,
-    since it isn't supported in Python 3.7. By having the tree-sitter code
-    isolated in this subclass, it makes it easier to conditionally import. However,
-    it does come with other design flaws (e.g. Document is required to have methods
-    which only really make sense on SyntaxAwareDocument).
-
-    If you're reading this and Python 3.7 is no longer supported by Textual,
-    consider merging this subclass into the `Document` superclass.
     """
 
     def __init__(
         self,
         text: str,
-        language: str | Language,
+        language: Language,
     ):
         """Construct a SyntaxAwareDocument.
 
         Args:
             text: The initial text contained in the document.
-            language: The language to use. You can pass a string to use a supported
-                language, or pass in your own tree-sitter `Language` object.
+            language: The tree-sitter language to use.
         """
 
         if not TREE_SITTER:
-            raise RuntimeError("SyntaxAwareDocument unavailable.")
+            raise RuntimeError(
+                "SyntaxAwareDocument unavailable - tree-sitter is not installed."
+            )
 
         super().__init__(text)
-        self.language: Language | None = None
-        """The tree-sitter Language or None if tree-sitter is unavailable."""
+        self._language: Language = language
+        """The tree-sitter Language."""
 
-        self._parser: Parser | None = None
-
-        from textual._tree_sitter import get_language
-
-        # If the language is `None`, then avoid doing any parsing related stuff.
-        if isinstance(language, str):
-            if language not in BUILTIN_LANGUAGES:
-                raise SyntaxAwareDocumentError(f"Invalid language {language!r}")
-            # If tree-sitter-languages is not installed properly, get_language
-            # and get_parser may raise an OSError when unable to load their
-            # resources
-
-            try:
-                self.language = get_language(language)
-            except OSError as e:
-                raise SyntaxAwareDocumentError(
-                    f"Could not find binaries for {language!r}"
-                ) from e
-        else:
-            self.language = language
-
-        self._parser = Parser(self.language)
+        self._parser = Parser(self._language)
         """The tree-sitter Parser or None if tree-sitter is unavailable."""
 
         self._syntax_tree: Tree = self._parser.parse(self._read_callable)  # type: ignore
@@ -90,17 +60,7 @@ class SyntaxAwareDocument(Document):
         Returns:
             The prepared query.
         """
-        if not TREE_SITTER:
-            raise SyntaxAwareDocumentError(
-                "Couldn't prepare query - tree-sitter is not available on this architecture."
-            )
-
-        if self.language is None:
-            raise SyntaxAwareDocumentError(
-                "Couldn't prepare query - no language assigned."
-            )
-
-        return self.language.query(query)
+        return self._language.query(query)
 
     def query_syntax_tree(
         self,
@@ -122,12 +82,6 @@ class SyntaxAwareDocument(Document):
         Returns:
             A tuple containing the nodes and text captured by the query.
         """
-
-        if not TREE_SITTER:
-            raise SyntaxAwareDocumentError(
-                "tree-sitter is not available on this architecture."
-            )
-
         captures_kwargs = {}
         if start_point is not None:
             captures_kwargs["start_point"] = start_point

--- a/src/textual/widgets/text_area.py
+++ b/src/textual/widgets/text_area.py
@@ -1,5 +1,4 @@
 from textual._text_area_theme import TextAreaTheme
-from textual._tree_sitter import BUILTIN_LANGUAGES
 from textual.document._document import (
     Document,
     DocumentBase,
@@ -22,7 +21,6 @@ from textual.widgets._text_area import (
 )
 
 __all__ = [
-    "BUILTIN_LANGUAGES",
     "Document",
     "DocumentBase",
     "DocumentNavigator",

--- a/src/textual/widgets/text_area.py
+++ b/src/textual/widgets/text_area.py
@@ -18,9 +18,11 @@ from textual.widgets._text_area import (
     LanguageDoesNotExist,
     StartColumn,
     ThemeDoesNotExist,
+    BUILTIN_LANGUAGES,
 )
 
 __all__ = [
+    "BUILTIN_LANGUAGES",
     "Document",
     "DocumentBase",
     "DocumentNavigator",

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -2544,7 +2544,7 @@ def test_pseudo_classes(snap_compare):
 
         def compose(self) -> ComposeResult:
             for item_number in range(5):
-                yield Label(f"Item {item_number+1}")
+                yield Label(f"Item {item_number + 1}")
 
         def on_mount(self) -> None:
             # Mounting a new widget should updated previous widgets, as the last of type has changed
@@ -3444,7 +3444,6 @@ def test_empty_option_list(snap_compare):
     """
 
     class OptionListAutoCrash(App[None]):
-
         CSS = """
         OptionList {
             width: auto;
@@ -3467,7 +3466,6 @@ def test_focus_within_transparent(snap_compare):
         pass
 
     class FocusWithinTransparentApp(App[None]):
-
         CSS = """
         Screen {
             layout: horizontal;
@@ -3529,7 +3527,6 @@ def test_add_separator(snap_compare):
     """
 
     class FocusTest(App[None]):
-
         CSS = """
         OptionList {
             height: 1fr;
@@ -3641,7 +3638,6 @@ def test_auto_in_auto(snap_compare):
     """
 
     class MyApp(App):
-
         CSS = """
 
             MyApp {


### PR DESCRIPTION
Launching TextArea with the `syntax` extras has a large upfront cost the first time it's run in a new virtualenv.

A one-off compilation step is performed when the language is imported, and since all languages were being imported at the module level, it was adding a 1-2 second overhead at startup on the first run.

Subsequent launches within the same venv had little overhead (a few milliseconds).

<img width="762" alt="image" src="https://github.com/user-attachments/assets/b421e054-555c-4a4f-b2b9-4b22e4c443c0" />

### Lazy importing of tree-sitter languages

This PR updates the TextArea to lazily import the languages, only when they're used, trimming 1-2 seconds off of these "cold starts".

### Allowing users to install only what they need

With this PR, users don't need to install the `syntax` extras which includes a bunch of languages. They can instead just install `tree-sitter` plus the languages they require.

For example, with Posting I uninstalled the syntax extras then done this:

```bash
uv add tree-sitter tree-sitter-json tree-sitter-html tree-sitter-xml
```

...and it just worked without any code changes. Apps no longer need to pull in a bunch of transitive dependencies that they don't need.

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
