### PR TITLE
docs(button): update spacing note

### DIFF
--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -51,7 +51,7 @@ This widget has no component classes.
 
 ## Additional Notes
 
-- The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` has the `height` set to 3 lines and a `min-width` of 16 columns. To create a button with zero visible padding, you will need to change these values and also remove the border with `border: none;`.
+- The spacing between the text and the edges of a button are _not_ due to padding. The default styling for a `Button` includes borders and a `min-width` of 16 columns. To remove the spacing, set `border: none;` in your CSS and adjust the minimum width as needed.
 
 ---
 


### PR DESCRIPTION
Update the note in the button docs about removing the spacing, as the default CSS was changed from `height: 3` to `auto`.