### PR TITLE
Bugfix Select.selection with no value selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Static and Label now accept Content objects, satisfying type checkers https://github.com/Textualize/textual/pull/5618
 - Fixed click selection not being disabled when allow_select was set to false https://github.com/Textualize/textual/issues/5627
 - Fixed crash on clicking line API border https://github.com/Textualize/textual/pull/5641
+- Fixed Select.selection now correctly returns None if Select.BLANK is selected instead of an AssertionError
 
 ### Added
 

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -477,7 +477,8 @@ class Select(Generic[SelectType], Vertical, can_focus=True):
 
         """
         value = self.value
-        assert not isinstance(value, NoSelection)
+        if isinstance(value, NoSelection):
+            return None
         return value
 
     def _setup_variables_for_options(

--- a/tests/select/test_blank_and_clear.py
+++ b/tests/select/test_blank_and_clear.py
@@ -63,3 +63,13 @@ async def test_clear_fails_if_allow_blank_is_false():
         assert not select.is_blank()
         with pytest.raises(InvalidSelectValueError):
             select.clear()
+
+async def test_selection_is_none_with_blank():
+    class SelectApp(App[None]):
+        def compose(self):
+            yield Select(SELECT_OPTIONS)
+
+    app = SelectApp()
+    async with app.run_test():
+        select = app.query_one(Select)
+        assert select.selection is None


### PR DESCRIPTION
Based on the docs `Select.selection` should return `None` if no value is selected, i.e. the value is `Select.Blank`. It just raised an assertion error though. Fixed the issue and added a test.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
Already present, just fixed behavior to represent actual description
- [x] Updated documentation
Already present, just fixed behavior to represent actual description
- [x] Updated CHANGELOG.md (where appropriate)
