### PR TITLE
Assign names to threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added Widget.preflight_checks to perform some debug checks after a widget is instantiated, to catch common errors. https://github.com/Textualize/textual/pull/5588
 
+## Changed
+
+- Assigned names to Textual-specific threads: `textual-input`, `textual-output`. These should become visible in monitoring tools (ps, top, htop) as of Python 3.14. https://github.com/Textualize/textual/pull/5654
+
 ## [2.1.2] - 2025-02-26
 
 ### Fixed

--- a/src/textual/drivers/_writer_thread.py
+++ b/src/textual/drivers/_writer_thread.py
@@ -13,7 +13,7 @@ class WriterThread(threading.Thread):
     """A thread / file-like to do writes to stdout in the background."""
 
     def __init__(self, file: IO[str]) -> None:
-        super().__init__(daemon=True)
+        super().__init__(daemon=True, name="textual-output")
         self._queue: Queue[str | None] = Queue(MAX_QUEUED_WRITES)
         self._file = file
 

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -276,7 +276,7 @@ class LinuxDriver(Driver):
         self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 
         self.flush()
-        self._key_thread = Thread(target=self._run_input_thread)
+        self._key_thread = Thread(target=self._run_input_thread, name="textual-input")
         send_size_event()
         self._key_thread.start()
         self._request_terminal_sync_mode_support()

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -237,7 +237,7 @@ class LinuxInlineDriver(Driver):
 
             termios.tcsetattr(self.fileno, termios.TCSANOW, newattr)
 
-        self._key_thread = Thread(target=self._run_input_thread)
+        self._key_thread = Thread(target=self._run_input_thread, name="textual-input")
         send_size_event()
         self._key_thread.start()
         self._request_terminal_sync_mode_support()

--- a/src/textual/drivers/web_driver.py
+++ b/src/textual/drivers/web_driver.py
@@ -62,7 +62,9 @@ class WebDriver(Driver):
         self.fileno = sys.__stdout__.fileno()
         self._write = partial(os.write, self.fileno)
         self.exit_event = Event()
-        self._key_thread: Thread = Thread(target=self.run_input_thread)
+        self._key_thread: Thread = Thread(
+            target=self.run_input_thread, name="textual-input"
+        )
         self._input_reader = InputReader()
 
         self._deliveries: dict[str, BinaryIO | TextIO] = {}

--- a/src/textual/drivers/win32.py
+++ b/src/textual/drivers/win32.py
@@ -223,7 +223,7 @@ class EventMonitor(threading.Thread):
         self.app = app
         self.exit_event = exit_event
         self.process_event = process_event
-        super().__init__()
+        super().__init__(name="textual-input")
 
     def run(self) -> None:
         exit_requested = self.exit_event.is_set


### PR DESCRIPTION
As of Python 3.14, these names should be reflected by system tools like ps, top or htop.

Example with 3.14.0a5 and `htop`:
![image](https://github.com/user-attachments/assets/d94a59c1-82ab-4612-823e-eb94468dd404)

**Checklist:**

- :x:  Docstrings on all new or modified functions / classes -- definitely unnecessary
- :x: Updated documentation -- presumably unnecessary?
- :white_check_mark:  Updated CHANGELOG.md (where appropriate)



