### PR TITLE
fix(log): add missing scroll_end to write_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Static and Label now accept Content objects, satisfying type checkers https://github.com/Textualize/textual/pull/5618
 - Fixed click selection not being disabled when allow_select was set to false https://github.com/Textualize/textual/issues/5627
 - Fixed crash on clicking line API border https://github.com/Textualize/textual/pull/5641
+- Added missing `scroll_end` parameter to the `Log.write_line` method https://github.com/Textualize/textual/pull/5672
 
 ### Added
 

--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -195,16 +195,21 @@ class Log(ScrollView, can_focus=True):
             self.scroll_end(animate=False, immediate=True, x_axis=False)
         return self
 
-    def write_line(self, line: str) -> Self:
+    def write_line(
+        self,
+        line: str,
+        scroll_end: bool | None = None,
+    ) -> Self:
         """Write content on a new line.
 
         Args:
             line: String to write to the log.
+            scroll_end: Scroll to the end after writing, or `None` to use `self.auto_scroll`.
 
         Returns:
             The `Log` instance.
         """
-        self.write_lines([line])
+        self.write_lines([line], scroll_end)
         return self
 
     def write_lines(


### PR DESCRIPTION
Add `scroll_end` parameter to the `Log.write_line` method. The other write methods have this parameter, but must have been just overlooked for `write_line`.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
