### PR TITLE
Fixed typo in the Tree widget bindings' docs

### DIFF
--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -553,7 +553,7 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
     | Key(s) | Description |
     | :- | :- |
     | enter | Select the current item. |
-    | space | Toggle the expand/collapsed space of the current item. |
+    | space | Toggle the expand/collapsed state of the current item. |
     | up | Move the cursor up. |
     | down | Move the cursor down. |
     """


### PR DESCRIPTION
Fixed typo in the Tree widget bindings' docs:

> Toggle the expand/collapsed ~space~ **state** of the current item.

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)