### PR TITLE
docs(widget): add missing `markup` param description to docstring

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -409,6 +409,7 @@ class Widget(DOMNode):
             id: The ID of the widget in the DOM.
             classes: The CSS classes for the widget.
             disabled: Whether the widget is disabled or not.
+            markup: True if markup should be parsed and rendered.
         """
         self._render_markup = markup
         _null_size = NULL_SIZE


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

The `Widget.__init__` docstring was missing the newly added markup parameter in the arguments.