### PR TITLE
Fixed missing word in the Content guide docs

### DIFF
--- a/docs/guide/content.md
+++ b/docs/guide/content.md
@@ -119,7 +119,7 @@ This is equivalent to the following (but saves typing a few characters):
 [bold]Hello[/bold], World!
 ```
 
-Auto-closing tags recommended when it is clear which tag they are intended to close. 
+Auto-closing tags are recommended when it is clear which tag they are intended to close. 
 
 ### Styles
 


### PR DESCRIPTION
Fixed missing word in the Content guide docs:

> Auto-closing tags **are** recommended when it is clear which tag they are intended to close.

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
