### PR TITLE
remove RadioButton glyph edges to prevent rendering artifacts in term…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added missing `scroll_end` parameter to the `Log.write_line` method https://github.com/Textualize/textual/pull/5672
 - Restored support for blink https://github.com/Textualize/textual/pull/5675
 - Fixed scrolling breaking on DataTable with `overflow: hidden` https://github.com/Textualize/textual/pull/5681
+- Fixed ToggleButton glyph edges drawing lines through RadioButton https://github.com/Textualize/textual/pull/5722
 
 ### Added
 

--- a/src/textual/widgets/_radio_button.py
+++ b/src/textual/widgets/_radio_button.py
@@ -15,6 +15,12 @@ class RadioButton(ToggleButton):
     BUTTON_INNER = "\u25cf"
     """The character used for the inside of the button."""
 
+    BUTTON_LEFT = ""
+    """Unused left character from toggle button (empty to avoid unwanted rendering artifacts in some terminals)."""
+
+    BUTTON_RIGHT = ""
+    """Unused right character from toggle button (empty to avoid unwanted rendering artifacts in some terminals)."""
+
     class Changed(ToggleButton.Changed):
         """Posted when the value of the radio button changes.
 


### PR DESCRIPTION
closes #5721 

🛠️ Summary

This PR fixes a rendering issue in the RadioButton widget where an extra line or visual artifact appears around the toggle glyph (●) in certain terminal environments (e.g. Ubuntu 22.04.5 LTS with GNOME Terminal).
✅ Fix

The issue was caused by inherited BUTTON_LEFT and BUTTON_RIGHT characters from the ToggleButton base class. These characters, while visually subtle in some environments, render poorly or as visible lines in others.

To resolve this, BUTTON_LEFT and BUTTON_RIGHT are explicitly set to empty strings in RadioButton:

BUTTON_LEFT = ""
BUTTON_RIGHT = ""

This ensures only the intended center glyph (●) is rendered, avoiding any extra characters or alignment issues.

Bug screenshot:
![Screenshot from 2025-04-08 13-48-03](https://github.com/user-attachments/assets/2c8ec174-00d7-46c1-b304-884c054138ed)

Fixed screenshot:
![Screenshot from 2025-04-08 13-11-50](https://github.com/user-attachments/assets/108664a2-cba9-40b9-b6f5-3a16efa58c28)

💻 Environment

Tested on:

    Ubuntu 22.04.5 LTS

    GNOME Terminal (default)

    Textual version: [insert version if needed]

**Please review the following checklist.**

- [X] Docstrings on all new or modified functions / classes 
- [X] Updated documentation
- [X] Updated CHANGELOG.md (where appropriate)
