### PR TITLE
Rename textual markup to content markup

### DIFF
--- a/docs/guide/content.md
+++ b/docs/guide/content.md
@@ -15,11 +15,11 @@ In this chapter, we will cover all these methods.
 When building a custom widget you can embed color and style information in the string returned from the Widget's [`render()`][textual.widget.Widget.render] method.
 Markup is specified as a string which contains 
 Text enclosed in square brackets (`[]`) won't appear in the output, but will modify the style of the text that follows.
-This is known as *Textual markup*.
+This is known as *content markup*.
 
-Before we explore Textual markup in detail, let's first demonstrate some of what it can do.
+Before we explore content markup in detail, let's first demonstrate some of what it can do.
 In the following example, we have two widgets.
-The top has Textual markup enabled, while the bottom widget has Textual markup *disabled*.
+The top has content markup enabled, while the bottom widget has content markup *disabled*.
 
 Notice how the markup *tags* change the style in the first widget, but are left unaltered in the second:
 
@@ -40,7 +40,7 @@ Notice how the markup *tags* change the style in the first widget, but are left 
 
 ### Playground
 
-Textual comes with a markup playground where you can enter Textual markup and see the result's live.
+Textual comes with a markup playground where you can enter content markup and see the result's live.
 To launch the playground, run the following command:
 
 ```

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -28,7 +28,7 @@ The highlighted lines define a custom widget class with just a [render()][textua
 Textual will display whatever is returned from render in the [content](./content.md) area of your widget.
 
 Note that the text contains tags in square brackets, i.e. `[b]`.
-This is [Textual markup](./content.md#markup) which allows you to embed various styles within your content.
+This is [content markup](./content.md#markup) which allows you to embed various styles within your content.
 If you run this you will find that `World` is in bold.
 
 ```{.textual path="docs/examples/guide/widgets/hello01.py"}

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -145,7 +145,7 @@ class Content(Visual):
 
     @cached_property
     def markup(self) -> str:
-        """Get Textual markup to render this Text.
+        """Get content markup to render this Text.
 
         Returns:
             str: A string potentially creating markup tags.
@@ -215,7 +215,7 @@ class Content(Visual):
 
     @classmethod
     def from_markup(cls, markup: str | Content, **variables: object) -> Content:
-        """Create content from Textual markup, optionally combined with template variables.
+        """Create content from markup, optionally combined with template variables.
 
         If `markup` is already a Content instance, it will be returned unmodified.
 
@@ -228,7 +228,7 @@ class Content(Visual):
             ```
 
         Args:
-            markup: Textual markup, or Content.
+            markup: Content markup, or Content.
             **variables: Optional template variables used
 
         Returns:

--- a/src/textual/markup.py
+++ b/src/textual/markup.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 
 class MarkupError(Exception):
-    """An error occurred parsing Textual markup."""
+    """An error occurred parsing content markup."""
 
 
 expect_markup_tag = (
@@ -73,7 +73,7 @@ expect_markup_expression = (
 
 
 class MarkupTokenizer(TokenizerState):
-    """Tokenizes Textual markup."""
+    """Tokenizes content markup."""
 
     EXPECT = expect_markup.expect_eof()
     STATE_MAP = {

--- a/src/textual/notifications.py
+++ b/src/textual/notifications.py
@@ -40,7 +40,7 @@ class Notification:
     """The timeout (in seconds) for the notification."""
 
     markup: bool = False
-    """Render the notification message as Textual Markup?"""
+    """Render the notification message as content markup?"""
 
     raised_at: float = field(default_factory=time)
     """The time when the notification was raised (in Unix time)."""

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -410,6 +410,7 @@ class Widget(DOMNode):
             id: The ID of the widget in the DOM.
             classes: The CSS classes for the widget.
             disabled: Whether the widget is disabled or not.
+            markup: Enable content markup?
         """
         self._render_markup = markup
         _null_size = NULL_SIZE
@@ -4618,7 +4619,7 @@ class Widget(DOMNode):
             title: The title for the notification.
             severity: The severity of the notification.
             timeout: The timeout (in seconds) for the notification, or `None` for default.
-            markup: Render the message as Textual markup?
+            markup: Render the message as content markup?
 
         See [`App.notify`][textual.app.App.notify] for the full
         documentation for this method.

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -261,7 +261,7 @@ class OptionList(ScrollView, can_focus=True):
             id: The ID of the OptionList in the DOM.
             classes: Initial CSS classes.
             disabled: Disable the widget?
-            markup: Strips should be rendered as Textual markup if `True`, or plain text if `False`.
+            markup: Strips should be rendered as content markup if `True`, or plain text if `False`.
         """
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
         self._markup = markup

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -136,7 +136,7 @@ def test_add() -> None:
 
 
 def test_from_markup():
-    """Test simple parsing of Textual markup."""
+    """Test simple parsing of content markup."""
     content = Content.from_markup("[red]Hello[/red] [blue]World[/blue]")
     assert len(content) == 11
     assert content.plain == "Hello World"


### PR DESCRIPTION
Renamed "Textual markup" to "Content markup", which is a more apt name.