### PR TITLE
refactor: reduce dependency on typing-extensions

### DIFF
--- a/examples/five_by_five.py
+++ b/examples/five_by_five.py
@@ -15,7 +15,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Footer, Label, Markdown
 
 if TYPE_CHECKING:
-    from typing_extensions import Final
+    from typing import Final
 
 
 class Help(Screen):

--- a/src/textual/_animator.py
+++ b/src/textual/_animator.py
@@ -4,9 +4,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
-
-from typing_extensions import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, runtime_checkable
 
 from textual import _time
 from textual._callback import invoke

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping, Tuple
-
-from typing_extensions import Final
+from typing import Final, Mapping, Tuple
 
 from textual.keys import Keys
 

--- a/src/textual/_layout_resolve.py
+++ b/src/textual/_layout_resolve.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Sequence, cast
-
-from typing_extensions import Protocol
+from typing import Protocol, Sequence, cast
 
 
 class EdgeProtocol(Protocol):

--- a/src/textual/_resolve.py
+++ b/src/textual/_resolve.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from fractions import Fraction
 from itertools import accumulate
-from typing import TYPE_CHECKING, Iterable, Sequence, cast
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Iterable, Literal, Sequence, cast
 
 from textual.box_model import BoxModel
 from textual.css.scalar import Scalar

--- a/src/textual/_slug.py
+++ b/src/textual/_slug.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 from collections import defaultdict
 from re import compile
 from string import punctuation
-from typing import Pattern
+from typing import Final, Pattern
 from urllib.parse import quote
-
-from typing_extensions import Final
 
 WHITESPACE_REPLACEMENT: Final[str] = "-"
 """The character to replace undesirable characters with."""

--- a/src/textual/_types.py
+++ b/src/textual/_types.py
@@ -1,6 +1,13 @@
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Literal, Union
-
-from typing_extensions import Protocol
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    List,
+    Literal,
+    Protocol,
+    Union,
+)
 
 if TYPE_CHECKING:
     from rich.segment import Segment

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any, Generator, Iterable
-
-from typing_extensions import Final
+from typing import Any, Final, Generator, Iterable
 
 from textual import constants, events, messages
 from textual._ansi_sequences import ANSI_SEQUENCES_KEYS, IGNORE_SEQUENCE

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -131,8 +131,10 @@ from textual.worker import NoActiveWorker, get_current_worker
 from textual.worker_manager import WorkerManager
 
 if TYPE_CHECKING:
+    from typing import Coroutine, Literal
+
     from textual_dev.client import DevtoolsClient
-    from typing_extensions import Coroutine, Literal, Self, TypeAlias
+    from typing_extensions import Self, TypeAlias
 
     from textual._types import MessageTarget
 

--- a/src/textual/canvas.py
+++ b/src/textual/canvas.py
@@ -13,11 +13,11 @@ from array import array
 from collections import defaultdict
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import NamedTuple, Sequence
+from typing import Literal, NamedTuple, Sequence
 
 from rich.segment import Segment
 from rich.style import Style
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 from textual._box_drawing import BOX_CHARACTERS, Quad, combine_quads
 from textual.color import Color

--- a/src/textual/color.py
+++ b/src/textual/color.py
@@ -34,14 +34,13 @@ import re
 from colorsys import hls_to_rgb, rgb_to_hls
 from functools import lru_cache
 from operator import itemgetter
-from typing import Callable, NamedTuple
+from typing import Callable, Final, NamedTuple
 
 import rich.repr
 from rich.color import Color as RichColor
 from rich.color import ColorType
 from rich.color_triplet import ColorTriplet
 from rich.terminal_theme import TerminalTheme
-from typing_extensions import Final
 
 from textual._color_constants import ANSI_COLORS, COLOR_NAME_TO_RGB
 from textual.css.scalar import percentage_string_to_float

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -29,6 +29,7 @@ from typing import (
     AsyncIterator,
     Callable,
     ClassVar,
+    Final,
     Iterable,
     NamedTuple,
 )
@@ -36,7 +37,7 @@ from typing import (
 import rich.repr
 from rich.align import Align
 from rich.text import Text
-from typing_extensions import Final, TypeAlias
+from typing_extensions import TypeAlias
 
 from textual import on, work
 from textual.binding import Binding, BindingType

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -5,9 +5,9 @@ This module contains constants, which may be set in environment variables.
 from __future__ import annotations
 
 import os
-from typing import get_args
+from typing import Final, get_args
 
-from typing_extensions import Final, TypeGuard
+from typing_extensions import TypeGuard
 
 from textual._types import AnimationLevel
 

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 from functools import cached_property, total_ordering
 from operator import itemgetter
-from typing import Callable, Iterable, NamedTuple, Sequence, Union
+from typing import Callable, Final, Iterable, NamedTuple, Sequence, Union
 
 import rich.repr
 from rich._wrap import divide_line
@@ -22,7 +22,7 @@ from rich.segment import Segment
 from rich.style import Style as RichStyle
 from rich.terminal_theme import TerminalTheme
 from rich.text import Text
-from typing_extensions import Final, TypeAlias
+from typing_extensions import TypeAlias
 
 from textual._cells import cell_len
 from textual._context import active_app

--- a/src/textual/css/_help_text.py
+++ b/src/textual/css/_help_text.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Sequence
-
-from typing_extensions import Literal
+from typing import Iterable, Literal, Sequence
 
 from textual.color import ColorParseError
 from textual.css._error_tools import friendly_list

--- a/src/textual/css/constants.py
+++ b/src/textual/css/constants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 if typing.TYPE_CHECKING:
-    from typing_extensions import Final
+    from typing import Final
 
 VALID_VISIBILITY: Final = {"visible", "hidden"}
 VALID_DISPLAY: Final = {"block", "none"}

--- a/src/textual/css/types.py
+++ b/src/textual/css/types.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
-
-from typing_extensions import Literal
+from typing import Literal, Tuple
 
 from textual.color import Color
 

--- a/src/textual/document/_document.py
+++ b/src/textual/document/_document.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING, NamedTuple, Tuple, overload
-
-from typing_extensions import Literal, get_args
+from typing import TYPE_CHECKING, Literal, NamedTuple, Tuple, get_args, overload
 
 if TYPE_CHECKING:
     from tree_sitter import Node, Query

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     # Unused & ignored imports are needed for the docs to link to these objects:
     from textual.css.query import WrongType  # type: ignore  # noqa: F401
 
-from typing_extensions import Literal
+from typing import Literal
 
 _re_identifier = re.compile(IDENTIFIER)
 

--- a/src/textual/drivers/_writer_thread.py
+++ b/src/textual/drivers/_writer_thread.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import threading
 from queue import Queue
-from typing import IO
-
-from typing_extensions import Final
+from typing import IO, Final
 
 MAX_QUEUED_WRITES: Final[int] = 30
 

--- a/src/textual/features.py
+++ b/src/textual/features.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
-    from typing_extensions import Final
+    from typing import Final
 
 FEATURES: Final = {"devtools", "debug", "headless"}
 

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
+    Final,
     Literal,
     NamedTuple,
     Tuple,
@@ -18,8 +19,6 @@ from typing import (
     Union,
     cast,
 )
-
-from typing_extensions import Final
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias

--- a/src/textual/notifications.py
+++ b/src/textual/notifications.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from time import time
-from typing import Iterator
+from typing import Iterator, Literal
 from uuid import uuid4
 
 from rich.repr import Result
-from typing_extensions import Literal, Self, TypeAlias
+from typing_extensions import Self, TypeAlias
 
 from textual.message import Message
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -63,7 +63,7 @@ from textual.widgets import Tooltip
 from textual.widgets._toast import ToastRack
 
 if TYPE_CHECKING:
-    from typing_extensions import Final
+    from typing import Final
 
     from textual.command import Provider
 

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import rich.repr
 from rich.cells import cell_len
 from rich.console import ConsoleRenderable, RenderableType
-from typing_extensions import Literal, Self
+from typing_extensions import Self
 
 from textual import events
 

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -4,7 +4,16 @@ import functools
 from dataclasses import dataclass
 from itertools import chain, zip_longest
 from operator import itemgetter
-from typing import Any, Callable, ClassVar, Generic, Iterable, NamedTuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Generic,
+    Iterable,
+    Literal,
+    NamedTuple,
+    TypeVar,
+)
 
 import rich.repr
 from rich.console import RenderableType
@@ -13,7 +22,7 @@ from rich.protocol import is_renderable
 from rich.segment import Segment
 from rich.style import Style
 from rich.text import Text, TextType
-from typing_extensions import Literal, Self, TypeAlias
+from typing_extensions import Self, TypeAlias
 
 from textual import events
 from textual._segment_tools import line_crop

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, Iterable, NamedTuple
+from typing import TYPE_CHECKING, ClassVar, Iterable, Literal, NamedTuple
 
 from rich.cells import cell_len, get_character_cell_size
 from rich.console import RenderableType
 from rich.highlighter import Highlighter
 from rich.text import Text
-from typing_extensions import Literal
 
 from textual import events
 from textual.expand_tabs import expand_tabs_inline

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import Flag, auto
-from typing import TYPE_CHECKING, Iterable, Pattern
+from typing import TYPE_CHECKING, Iterable, Literal, Pattern
 
 from rich.console import RenderableType
 from rich.segment import Segment
 from rich.text import Text
-from typing_extensions import Literal
 
 from textual import events
 from textual.strip import Strip

--- a/src/textual/widgets/_placeholder.py
+++ b/src/textual/widgets/_placeholder.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from itertools import cycle
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, Literal
 from weakref import WeakKeyDictionary
 
-from typing_extensions import Literal, Self
+from typing_extensions import Self
 
 from textual import events
 

--- a/src/textual/widgets/_rule.py
+++ b/src/textual/widgets/_rule.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Literal
 
 from rich.console import Console, ConsoleOptions
 from rich.segment import Segment
 from rich.style import Style
-from typing_extensions import Literal
 
 from textual.app import RenderResult
 from textual.css._error_tools import friendly_list

--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from asyncio import gather
 from dataclasses import dataclass
 from itertools import zip_longest
-from typing import Awaitable
+from typing import Awaitable, Final
 
 from rich.repr import Result
-from typing_extensions import Final
 
 from textual import events
 from textual.app import ComposeResult

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -6,12 +6,11 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Iterable, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, ClassVar, Iterable, Literal, Optional, Sequence, Tuple
 
 from rich.console import RenderableType
 from rich.style import Style
 from rich.text import Text
-from typing_extensions import Literal
 
 from textual._text_area_theme import TextAreaTheme
 from textual._tree_sitter import TREE_SITTER, get_language

--- a/tests/snapshot_tests/snapshot_apps/data_table_style_order.py
+++ b/tests/snapshot_tests/snapshot_apps/data_table_style_order.py
@@ -1,4 +1,4 @@
-from typing_extensions import Literal
+from typing import Literal
 
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Label

--- a/tests/test_tooltips.py
+++ b/tests/test_tooltips.py
@@ -1,6 +1,6 @@
 """Tests for the tooltips."""
 
-from typing_extensions import Final
+from typing import Final
 
 from textual.app import App, ComposeResult
 from textual.widgets import Static


### PR DESCRIPTION
Remove imports from typing-extensions that are no longer needed since Textual now requires Python 3.8+.

(Inspired by https://github.com/Textualize/rich/pull/3700)


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
