### PR TITLE
Update truecolor_style to use background.rich_color in Tint class

### DIFF
--- a/src/textual/renderables/tint.py
+++ b/src/textual/renderables/tint.py
@@ -60,7 +60,7 @@ class Tint:
                 yield segment
             else:
                 style = (
-                    truecolor_style(style, background)
+                    truecolor_style(style, background.rich_color)
                     if style is not None
                     else NULL_STYLE
                 )


### PR DESCRIPTION
Fixed an issue in the Tint.process_segments method where passing a Textual Color object to truecolor_style() instead of a Rich color value was causing the demo game to crash on startup.

✅ pytest tests/renderables/test_tint.py -v