### PR TITLE
Improve `Signal` Typing

### DIFF
--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -43,9 +43,9 @@ class Signal(Generic[SignalT]):
         """
         self._owner = ref(owner)
         self._name = name
-        self._subscriptions: WeakKeyDictionary[DOMNode, list[SignalCallbackType]] = (
-            WeakKeyDictionary()
-        )
+        self._subscriptions: WeakKeyDictionary[
+            DOMNode, list[SignalCallbackType[SignalT]]
+        ] = WeakKeyDictionary()
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "owner", self.owner
@@ -60,7 +60,7 @@ class Signal(Generic[SignalT]):
     def subscribe(
         self,
         node: DOMNode,
-        callback: SignalCallbackType,
+        callback: SignalCallbackType[SignalT],
         immediate: bool = False,
     ) -> None:
         """Subscribe a node to this signal.
@@ -84,13 +84,13 @@ class Signal(Generic[SignalT]):
 
         if immediate:
 
-            def signal_callback(data: object) -> None:
+            def signal_callback(data: SignalT) -> None:
                 """Invoke the callback immediately."""
                 callback(data)
 
         else:
 
-            def signal_callback(data: object) -> None:
+            def signal_callback(data: SignalT) -> None:
                 """Post the callback to the node, to call at the next opertunity."""
                 node.call_next(callback, data)
 

--- a/src/textual/signal.py
+++ b/src/textual/signal.py
@@ -18,7 +18,7 @@ from textual import log
 
 if TYPE_CHECKING:
     from textual.dom import DOMNode
-    from textual.message_pump import MessagePump
+
 SignalT = TypeVar("SignalT")
 
 SignalCallbackType = Union[
@@ -43,9 +43,9 @@ class Signal(Generic[SignalT]):
         """
         self._owner = ref(owner)
         self._name = name
-        self._subscriptions: WeakKeyDictionary[
-            MessagePump, list[SignalCallbackType]
-        ] = WeakKeyDictionary()
+        self._subscriptions: WeakKeyDictionary[DOMNode, list[SignalCallbackType]] = (
+            WeakKeyDictionary()
+        )
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "owner", self.owner
@@ -59,7 +59,7 @@ class Signal(Generic[SignalT]):
 
     def subscribe(
         self,
-        node: MessagePump,
+        node: DOMNode,
         callback: SignalCallbackType,
         immediate: bool = False,
     ) -> None:
@@ -97,7 +97,7 @@ class Signal(Generic[SignalT]):
         callbacks = self._subscriptions.setdefault(node, [])
         callbacks.append(signal_callback)
 
-    def unsubscribe(self, node: MessagePump) -> None:
+    def unsubscribe(self, node: DOMNode) -> None:
         """Unsubscribe a node from this signal.
 
         Args:


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

Updates the `Signal` class to use the generic type for callbacks. This allows type checker to know what the full type of the callable should be when subscribing.