### PR TITLE
Fix doc markup

### DIFF
--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -219,7 +219,7 @@ class Matcher:
             candidate: The candidate string to match against the query.
 
         Returns:
-            A [rich.text.Text][`Text`] object with highlighted matches.
+            A [`Text`][rich.text.Text] object with highlighted matches.
         """
         content = Content.from_markup(candidate)
         score, offsets = self.fuzzy_search.match(self.query, candidate)


### PR DESCRIPTION
https://textual.textualize.io/api/fuzzy_matcher/#textual.fuzzy.Matcher.highlight had incorrect markup. Fix it so it actually links as intended.

Before:
![image](https://github.com/user-attachments/assets/5b2ba104-bf42-4096-96a0-56cc97890beb)

I didn't investigate how to build the docs locally but swapping the order looks consistent with how other similar links (e.g. one in `docs/widgets/tabs.md`) are written.