### PR TITLE
Fix demo game using wrong content for one tile.

### DIFF
--- a/src/textual/demo/game.py
+++ b/src/textual/demo/game.py
@@ -223,7 +223,7 @@ class Tile(containers.Vertical):
             width, height = self.tile_size
             self.styles.width = width
             self.styles.height = height
-            column, row = self.position
+            column, row = self.start_position
             self.set_scroll(column * width, row * height)
         self.offset = self.position * self.tile_size
 


### PR DESCRIPTION
I noticed while playing with the demo app that the sliding puzzle game didn't seem to recognize a correctly solved puzzle. It seemed to be 'one off', where it wanted the blank tile in the bottom right corner but the content for that corner was actually in one of the two adjacent tiles. After much too long investigating, but happily learning a bit about textual in the process, I finally found the content was getting set incorrectly because it was using the tile current position to set the content, but the tile had already moved once in the initial shuffle.

The fix is quite simple using `Tile.start_position`, instead of `Tile.position` when setting the tile's scroll position.

*Checklist*

- No new or modified functions / classes, so no docstring updates.
- No documentation changes needed. The game just solves correctly.
- Trivial demo app fix so changelog item is probably not needed either.
