### PR TITLE
Prevent OptionList causing excessive redraws.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### Fixed
+
+- Fixed `OptionList` causing excessive redrawing https://github.com/Textualize/textual/pull/5766
 
 ## [3.1.1] - 2025-04-22
 

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -165,7 +165,7 @@ class OptionList(ScrollView, can_focus=True):
         }
         & > .option-list--option-hover {
             background: $block-hover-background;
-        }        
+        }
     }
     """
 
@@ -784,8 +784,10 @@ class OptionList(ScrollView, can_focus=True):
                 )
 
         last_divider = self.options and self.options[-1]._divider
-        self.virtual_size = Size(width, len(lines) - (1 if last_divider else 0))
-        self._scroll_update(self.virtual_size)
+        virtual_size = Size(width, len(lines) - (1 if last_divider else 0))
+        if virtual_size != self.virtual_size:
+            self.virtual_size = virtual_size
+            self._scroll_update(virtual_size)
 
     def get_content_width(self, container: Size, viewport: Size) -> int:
         """Get maximum width of options."""


### PR DESCRIPTION
A OptionList with active scrollbars causes high rate, repeated redraws and high CPU usage.

This is easily demonstrated by running:

```
python tests/snapshot_tests/snapshot_apps/loading.py
```

and observing the process in your process monitor of choice.

At least one test runs for a long time as a side effect of this issue, so this PR has the nice side effect of speeding up test runs.

- [ n/a] Docstrings on all new or modified functions / classes 
- [ n/a] Updated documentation
- [ x] Updated CHANGELOG.md (where appropriate)
