### PR TITLE
Slim horizontal scrollbar

### DIFF
--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -216,9 +216,10 @@ class ScrollBarRender:
                         )
 
             else:
-                segments = [_Segment(blank * width_thickness, _Style(bgcolor=back))] * (
-                    int(size)
-                )
+                # Render a slim horizontal bar
+                segments = [
+                    _Segment(blank * width_thickness, _Style(bgcolor=back))
+                ] * int(size)
 
                 for i in range(start_index, end_index):
                     segments[i] = _Segment(


### PR DESCRIPTION
Hello, I would like to propose a change to enable the user to render a slim horizontal scrollbar with any 1/8th glyph of choice.

This change would allow the user to monkey patch the ScrollBar.renderer method by means of a new class var in the `ScrollBarRender` class: `SLIM_HORIZONTAL_BAR`.

Along with the additional class variable, the change proposes adding a condition in the `render_bar` method of the `ScrollBarRender` class, to reduce impact for the current `textual` code base to an absolute minimum, because the condition only applies if the user sets the `SLIM_HORIZONTAL_BAR`, one of my concerns was smooth scrolling which leaves this intact if there's no monkey patching setting `SLIM_HORIZONTAL_BAR`.

As an example how it would look for the user, (applied to my app):
[__main__.py](https://github.com/matmaer/chezmoi-mousse/blob/b1ae7b377c9e04a5b14649dbc6ddef06db3375da/src/chezmoi_mousse/__main__.py)

Currently I can achieve the same goal by simply overriding the `render_bar` method: 
[__main__.py](https://github.com/matmaer/chezmoi-mousse/blob/master/src/chezmoi_mousse/__main__.py)

The tests all ran without a problem as far as I can tell, with a small doubt for the snapshot tests, they initially failed but now run successfully.

Updating the docs, changelog and some doc strings are still to do. If the PR is acceptable, I'll be glad to work on this.  

I probably overlook important things so I welcome any feedback and I'm fine with any way this PR turns out. I'm a happy `textual` camper as I can just override the render_bar method but maybe, or hopefully, other users could benefit from the change.
