### PR TITLE
don't call get_event_loop() if it's deprecated, handle RuntimeError from get_event_loop after asyncio.run

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -367,3 +367,20 @@ async def test_app_run_async() -> None:
     app = MyApp()
     result = await app.run_async()
     assert result == 42
+
+
+def test_app_loop_run_after_asyncio_run() -> None:
+    """Test that App.run runs after asyncio.run has run."""
+
+    class MyApp(App[int]):
+        def on_mount(self) -> None:
+            self.exit(42)
+
+    async def amain():
+        pass
+
+    asyncio.run(amain())
+
+    app = MyApp()
+    result = app.run()
+    assert result == 42


### PR DESCRIPTION
Fixes #5797 and #5788

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
