### PR TITLE
Remove typo from why-no-ansi-themes.question.md

### DIFF
--- a/questions/why-no-ansi-themes.question.md
+++ b/questions/why-no-ansi-themes.question.md
@@ -7,7 +7,7 @@ alt_titles:
 
 Textual will not generate escape sequences for the 16 themeable *ANSI* colors.
 
-This is an intentional design decision we took for for the following reasons:
+This is an intentional design decision we took for the following reasons:
 
 - Not everyone has a carefully chosen ANSI color theme. Color combinations which may look fine on your system, may be unreadable on another machine. There is very little an app author or Textual can do to resolve this. Asking users to simply pick a better theme is not a good solution, since not all users will know how.
 - ANSI colors can't be manipulated in the way Textual can do with other colors. Textual can blend colors and produce light and dark shades from an original color, which is used to create more readable text and user interfaces. Color blending will also be used to power future accessibility features.


### PR DESCRIPTION
In [questions/why-no-ansi-themes.question.md](https://github.com/Textualize/textual/blob/e9be1898ca185de61c8b29569bb307a2a1e22166/questions/why-no-ansi-themes.question.md#L10), there is a typo on line 10:

https://github.com/Textualize/textual/blob/e9be1898ca185de61c8b29569bb307a2a1e22166/questions/why-no-ansi-themes.question.md?plain=1#L10

The word `for` is printed twice consecutively, misconstruing the meaning of the sentence.

This PR corrects the typo be removing one of the `for`'s, which corrects the meaning of the sentence (see the image below):
![Screenshot From 2025-05-20 14-35-03](https://github.com/user-attachments/assets/6f609975-1bfd-4cb9-adb6-86e4730d0062)

---
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)