### PR TITLE
Fix the outdated hello world demo script

### DIFF
--- a/src/textual/demo/home.py
+++ b/src/textual/demo/home.py
@@ -66,7 +66,7 @@ A modern Python API from the developer of [Rich](https://github.com/Textualize/r
 
 ```python
 # Start building!
-from textual import App, ComposeResult
+from textual.app import App, ComposeResult
 from textual.widgets import Label
 
 class MyApp(App):


### PR DESCRIPTION
When I try to reproduce the hello world demo script shown in demoApp, I found that `App` and `ComposeResult` has been moved to `app` module, this change should have been updated the corresponding  demo code but it didn't, so I help updated it:)
 
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
