### PR TITLE
Add App.dom_ready_signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Added `App.dom_ready_signal`. This signal is published one time when the App first finishes loading. Its purpose is to provide a simple way for widget libraries to do work only when the DOM is ready, since they cannot use the `Ready` event sent to the App class.
+
 ### Fixed
 
 - Fixed `VERTICAL_BREAKPOINTS` doesn't work https://github.com/Textualize/textual/pull/5785

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -791,6 +791,16 @@ class App(Generic[ReturnType], DOMNode):
         perform work after the app has resumed.
         """
 
+        self.dom_ready_signal: Signal[App] = Signal(self, "dom-ready")
+        """Signal that is published when the app is finished loading and the
+        DOM is ready. Note that this signal is only sent once when the app first loads.
+
+        This is intended for third-party widget libraries that need to perform 
+        actions requiring a fully loaded DOM (such as querying for widgets) but 
+        cannot override the App class's `on_ready` method. Subscribers must be 
+        DOMNode instances (such as widgets or other DOM components).
+        """
+
         self.set_class(self.current_theme.dark, "-dark-mode")
         self.set_class(not self.current_theme.dark, "-light-mode")
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -1269,6 +1269,7 @@ class Screen(Generic[ScreenResultType], Widget):
         else:
             self.app.post_message(events.Ready())
             self.app._dom_ready = True
+            self.call_next(self.app.dom_ready_signal.publish, self.app)
 
     async def _on_update(self, message: messages.Update) -> None:
         message.stop()


### PR DESCRIPTION
So - as I've mentioned in the Discord server before, if one is making a widget library, there are sometimes occasions when the widget needs to know when the DOM is completely ready. When making a widget library, you can't simply listen for the `Ready` event sent to the App class. I've had a couple conversations with some other people that make widget libraries which has lead me to believe that a simple, universal solution to this issue would be very useful.

There are various hacks to get around this of course. Previously to achieve this goal, I've been using a worker that just watches for `App._dom_ready` on a loop, that seemed to be the most foolproof and simple method. However, I recently taught myself about the Signal API and I realized it would actually be the perfect solution to this problem. Widget libraries can simply subscribe to this signal, and thus be alerted when the DOM is ready regardless of where it is in the DOM hierarchy.

I'm really hoping that this addition is a cake and not a puppy - that is to say, the addition of this signal should not have any affect on anything else or add any maintenance headaches.

I have tested this out in my own libraries and it works exactly as I intended, as well as of course passing all tests and whatnot. I feel quite confident about this PR since I think its solving a real problem in a simple and direct manner. Please let me know if you think there's any issues with this idea or if you'd like it to be modified - The Docstring maybe does not have the greatest wording!

