### PR TITLE
feat(input): add cursor location properties

### DIFF
--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -469,6 +469,11 @@ class Input(ScrollView):
         return offset
 
     @property
+    def cursor_at_start(self) -> bool:
+        """Flag to indicate if the cursor is at the start"""
+        return self.cursor_position == 0
+
+    @property
     def cursor_at_end(self) -> bool:
         """Flag to indicate if the cursor is at the end"""
         return self.cursor_position == len(self.value)

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -464,12 +464,12 @@ class Input(ScrollView):
     def _cursor_offset(self) -> int:
         """The cell offset of the cursor."""
         offset = self._position_to_cell(self.cursor_position)
-        if self._cursor_at_end:
+        if self.cursor_at_end:
             offset += 1
         return offset
 
     @property
-    def _cursor_at_end(self) -> bool:
+    def cursor_at_end(self) -> bool:
         """Flag to indicate if the cursor is at the end"""
         return self.cursor_position == len(self.value)
 
@@ -640,7 +640,7 @@ class Input(ScrollView):
                 if self._cursor_visible:
                     cursor_style = self.get_component_rich_style("input--cursor")
                     cursor = self.cursor_position
-                    if not show_suggestion and self._cursor_at_end:
+                    if not show_suggestion and self.cursor_at_end:
                         result.pad_right(1)
                     result.stylize(cursor_style, cursor, cursor + 1)
 
@@ -848,7 +848,7 @@ class Input(ScrollView):
         if select:
             self.selection = Selection(start, end + 1)
         else:
-            if self._cursor_at_end and self._suggestion:
+            if self.cursor_at_end and self._suggestion:
                 self.value = self._suggestion
                 self.cursor_position = len(self.value)
             else:

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -570,7 +570,7 @@ class MaskedInput(Input, can_focus=True):
                 result.stylize(style, index, index + 1)
 
         if self._cursor_visible and self.has_focus:
-            if self._cursor_at_end:
+            if self.cursor_at_end:
                 result.pad_right(1)
             cursor_style = self.get_component_rich_style("input--cursor")
             cursor = self.cursor_position


### PR DESCRIPTION
Add cursor location utility properties to the `Input` widget:

- Make the existing `cursor_at_end` property public
- Add corresponding `cursor_at_start` property

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
