### PR TITLE
Update `Widget.set_loading` Docstring

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -958,10 +958,9 @@ class Widget(DOMNode):
         Args:
             loading: `True` to put the widget into a loading state, or `False` to reset the loading state.
         """
-        LOADING_INDICATOR_CLASS = "-textual-loading-indicator"
         if loading:
             loading_indicator = self.get_loading_widget()
-            loading_indicator.add_class(LOADING_INDICATOR_CLASS)
+            loading_indicator.add_class("-textual-loading-indicator")
             self._cover(loading_indicator)
         else:
             self._uncover()

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -957,9 +957,6 @@ class Widget(DOMNode):
 
         Args:
             loading: `True` to put the widget into a loading state, or `False` to reset the loading state.
-
-        Returns:
-            An optional awaitable.
         """
         LOADING_INDICATOR_CLASS = "-textual-loading-indicator"
         if loading:

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -953,7 +953,8 @@ class Widget(DOMNode):
     def set_loading(self, loading: bool) -> None:
         """Set or reset the loading state of this widget.
 
-        A widget in a loading state will display a LoadingIndicator that obscures the widget.
+        A widget in a loading state will display a `LoadingIndicator` or a custom widget
+        set through overriding the `get_loading_widget` method.
 
         Args:
             loading: `True` to put the widget into a loading state, or `False` to reset the loading state.


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

The original implementation returned an `Awaitable` which was since then removed. This PR removes the outdated return header from the docstring and adds some minor tweaks.