### PR TITLE
refactor(static): remove unused _check_renderable function

### DIFF
--- a/src/textual/widgets/_static.py
+++ b/src/textual/widgets/_static.py
@@ -2,30 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from rich.protocol import is_renderable
-
 if TYPE_CHECKING:
     from textual.app import RenderResult
 
-from textual.errors import RenderError
 from textual.visual import Visual, VisualType, visualize
 from textual.widget import Widget
-
-
-def _check_renderable(renderable: object):
-    """Check if a renderable conforms to the Rich Console protocol
-    (https://rich.readthedocs.io/en/latest/protocol.html)
-
-    Args:
-        renderable: A potentially renderable object.
-
-    Raises:
-        RenderError: If the object can not be rendered.
-    """
-    if not is_renderable(renderable) and not hasattr(renderable, "visualize"):
-        raise RenderError(
-            f"unable to render {renderable.__class__.__name__!r} type; must be a str, Text, Rich renderable oor Textual Visual instance"
-        )
 
 
 class Static(Widget, inherit_bindings=False):


### PR DESCRIPTION
Remove the `_check_renderable` function, which has been unused since the new render protocol was introduced in Textual v0.86.0.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
