### PR TITLE
fix(text area): fix initial flicker in rendering

### DIFF
--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1021,7 +1021,7 @@ TextArea {
         width, _ = self.scrollable_content_region.size
         cursor_width = 1
         if self.soft_wrap:
-            return width - self.gutter_width - cursor_width
+            return max(0, width - self.gutter_width - cursor_width)
         return 0
 
     def _rewrap_and_refresh_virtual_size(self) -> None:


### PR DESCRIPTION
Fix initial flicker in the `TextArea`, where for a brief moment each character is rendered on a new line before the size is settled.

The width for the `WrappedDocument` is _slightly_ confusing where zero means no wrapping, but the current negative wrap width looks like the bug.

Fixes #5841


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
