### PR TITLE
sync primitives

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -865,6 +865,17 @@ class App(Generic[ReturnType], DOMNode):
 
         return super().__init_subclass__(*args, **kwargs)
 
+    def _thread_init(self):
+        """Initialize threading primitives for the current thread.
+
+        https://github.com/Textualize/textual/issues/5845
+
+        """
+        self._message_queue
+        self._mounted_event
+        self._exception_event
+        self._thread_id = threading.get_ident()
+
     def _get_dom_base(self) -> DOMNode:
         """When querying from the app, we want to query the default screen."""
         return self.default_screen
@@ -2094,8 +2105,9 @@ class App(Generic[ReturnType], DOMNode):
                     run_auto_pilot(auto_pilot, pilot), name=repr(pilot)
                 )
 
+        self._thread_init()
+
         app._loop = asyncio.get_running_loop()
-        app._thread_id = threading.get_ident()
         with app._context():
             try:
                 await app._process_messages(
@@ -3120,6 +3132,9 @@ class App(Generic[ReturnType], DOMNode):
         terminal_size: tuple[int, int] | None = None,
         message_hook: Callable[[Message], None] | None = None,
     ) -> None:
+
+        self._thread_init()
+
         async def app_prelude() -> bool:
             """Work required before running the app.
 

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -152,6 +152,7 @@ class Timer:
         count = 0
         _repeat = self._repeat
         _interval = self._interval
+        self._active  # Force instantiation in same thread
         await self._active.wait()
         start = _time.get_time()
 

--- a/tests/test_message_pump.py
+++ b/tests/test_message_pump.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 from textual._dispatch_key import dispatch_key
@@ -169,3 +171,22 @@ async def test_prevent_default():
     async with app.run_test() as pilot:
         await pilot.click(MyButton)
         assert app_button_pressed
+
+
+async def test_thread_safe_post_message():
+    class TextMessage(Message):
+        pass
+
+    class TestApp(App):
+
+        def on_mount(self) -> None:
+            msg = TextMessage()
+            threading.Thread(target=self.post_message, args=(msg,)).start()
+
+        def on_text_message(self, message):
+            self.exit()
+
+    app = TestApp()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5845

A recent update made the threading objects instantiate lazily, with cached_property. This was done because in Python3.8 objects like Event are bound to the thread where they are instantiated, and would break if you tried to use them in another thread with a different async loop.

Unfortunately that fix broke the thread safety of post_message. This update forces the async primitives to instantiate in the async task where they are used.

This is a bit of a patch until we drop 3.8 (soon).