### PR TITLE
Remove `maintain_selection_offset` Flag

### DIFF
--- a/src/textual/document/_document.py
+++ b/src/textual/document/_document.py
@@ -483,4 +483,3 @@ class Selection(NamedTuple):
 
     def __le__(self, location: Location) -> bool:
         return location >= min(self.start, self.end)
-

--- a/src/textual/document/_document.py
+++ b/src/textual/document/_document.py
@@ -466,3 +466,21 @@ class Selection(NamedTuple):
         """Return True if the selection has 0 width, i.e. it's just a cursor."""
         start, end = self
         return start == end
+
+    def __contains__(self, location: Location) -> bool:
+        start, end = self
+        start, end = sorted((start, end))
+        return start <= location <= end
+
+    def __gt__(self, location: Location) -> bool:
+        return location < max(self.start, self.end)
+
+    def __ge__(self, location: Location) -> bool:
+        return location <= max(self.start, self.end)
+
+    def __lt__(self, location: Location) -> bool:
+        return location > min(self.start, self.end)
+
+    def __le__(self, location: Location) -> bool:
+        return location >= min(self.start, self.end)
+

--- a/src/textual/document/_edit.py
+++ b/src/textual/document/_edit.py
@@ -22,9 +22,6 @@ class Edit:
     to_location: Location
     """The end location of the insert"""
 
-    maintain_selection_offset: bool
-    """If True, the selection will maintain its offset to the replacement range."""
-
     _original_selection: Selection | None = field(init=False, default=None)
     """The Selection when the edit was originally performed, to be restored on undo."""
 
@@ -92,13 +89,10 @@ class Edit:
             else selection_end_row
         )
 
-        if self.maintain_selection_offset:
-            self._updated_selection = Selection(
-                start=(target_selection_start_row, target_selection_start_column),
-                end=(target_selection_end_row, target_selection_end_column),
-            )
-        else:
-            self._updated_selection = Selection.cursor(edit_result.end_location)
+        self._updated_selection = Selection(
+            start=(target_selection_start_row, target_selection_start_column),
+            end=(target_selection_end_row, target_selection_end_column),
+        )
 
         self._edit_result = edit_result
         return edit_result

--- a/src/textual/document/_edit.py
+++ b/src/textual/document/_edit.py
@@ -31,7 +31,9 @@ class Edit:
     _edit_result: EditResult | None = field(init=False, default=None)
     """The result of doing the edit."""
 
-    def _update_location(self, location: Location, delete: Selection, insert: Selection, target: Location) -> Location:
+    def _update_location(
+        self, location: Location, delete: Selection, insert: Selection, target: Location
+    ) -> Location:
         """Move a given location with respect to deletion and insertion ranges of an edit.
 
         Args:
@@ -66,7 +68,6 @@ class Edit:
             loc_ = (loc_[0] + shift[0], loc_[1] + shift[1])
 
         return loc_
-
 
     def do(self, text_area: TextArea, record_selection: bool = True) -> EditResult:
         """Perform the edit operation.

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -2110,55 +2110,41 @@ TextArea {
         self,
         text: str,
         location: Location | None = None,
-        *,
-        maintain_selection_offset: bool = True,
     ) -> EditResult:
         """Insert text into the document.
 
         Args:
             text: The text to insert.
             location: The location to insert text, or None to use the cursor location.
-            maintain_selection_offset: If True, the active Selection will be updated
-                such that the same text is selected before and after the selection,
-                if possible. Otherwise, the cursor will jump to the end point of the
-                edit.
 
         Returns:
             An `EditResult` containing information about the edit.
         """
         if location is None:
             location = self.cursor_location
-        return self.edit(Edit(text, location, location, maintain_selection_offset))
+        return self.edit(Edit(text, location, location))
 
     def delete(
         self,
         start: Location,
         end: Location,
-        *,
-        maintain_selection_offset: bool = True,
     ) -> EditResult:
         """Delete the text between two locations in the document.
 
         Args:
             start: The start location.
             end: The end location.
-            maintain_selection_offset: If True, the active Selection will be updated
-                such that the same text is selected before and after the selection,
-                if possible. Otherwise, the cursor will jump to the end point of the
-                edit.
 
         Returns:
             An `EditResult` containing information about the edit.
         """
-        return self.edit(Edit("", start, end, maintain_selection_offset))
+        return self.edit(Edit("", start, end))
 
     def replace(
         self,
         insert: str,
         start: Location,
         end: Location,
-        *,
-        maintain_selection_offset: bool = True,
     ) -> EditResult:
         """Replace text in the document with new text.
 
@@ -2166,15 +2152,11 @@ TextArea {
             insert: The text to insert.
             start: The start location
             end: The end location.
-            maintain_selection_offset: If True, the active Selection will be updated
-                such that the same text is selected before and after the selection,
-                if possible. Otherwise, the cursor will jump to the end point of the
-                edit.
 
         Returns:
             An `EditResult` containing information about the edit.
         """
-        return self.edit(Edit(insert, start, end, maintain_selection_offset))
+        return self.edit(Edit(insert, start, end))
 
     def clear(self) -> EditResult:
         """Delete all text from the document.
@@ -2182,7 +2164,7 @@ TextArea {
         Returns:
             An EditResult relating to the deletion of all content.
         """
-        return self.delete((0, 0), self.document.end, maintain_selection_offset=False)
+        return self.delete((0, 0), self.document.end)
 
     def _delete_via_keyboard(
         self,
@@ -2200,7 +2182,7 @@ TextArea {
         """
         if self.read_only:
             return None
-        return self.delete(start, end, maintain_selection_offset=False)
+        return self.delete(start, end)
 
     def _replace_via_keyboard(
         self,
@@ -2220,7 +2202,7 @@ TextArea {
         """
         if self.read_only:
             return None
-        return self.replace(insert, start, end, maintain_selection_offset=False)
+        return self.replace(insert, start, end)
 
     def action_delete_left(self) -> None:
         """Deletes the character to the left of the cursor and updates the cursor location.

--- a/tests/text_area/test_edit_via_api.py
+++ b/tests/text_area/test_edit_via_api.py
@@ -102,9 +102,7 @@ async def test_insert_character_near_cursor_maintain_selection_offset(
     ],
 )
 async def test_insert_newline_around_cursor_maintain_selection_offset(
-    cursor_location,
-    insert_location,
-    cursor_destination
+    cursor_location, insert_location, cursor_destination
 ):
     app = TextAreaApp()
     async with app.run_test():

--- a/tests/text_area/test_edit_via_api.py
+++ b/tests/text_area/test_edit_via_api.py
@@ -48,19 +48,6 @@ async def test_insert_text_start_maintain_selection_offset():
         assert text_area.selection == Selection.cursor((0, 10))
 
 
-async def test_insert_text_start():
-    """The document is correctly updated on inserting at the start.
-    If we don't maintain the selection offset, the cursor jumps
-    to the end of the edit and the selection is empty."""
-    app = TextAreaApp()
-    async with app.run_test():
-        text_area = app.query_one(TextArea)
-        text_area.move_cursor((0, 5))
-        text_area.insert("Hello", location=(0, 0))
-        assert text_area.text == "Hello" + TEXT
-        assert text_area.selection == Selection.cursor((0, 5))
-
-
 async def test_insert_empty_string():
     app = TextAreaApp()
     async with app.run_test():
@@ -191,7 +178,7 @@ async def test_insert_text_non_cursor_location_dont_maintain_offset():
 
         # Since maintain_selection_offset is False, the selection
         # is reset to a cursor and goes to the end of the insert.
-        assert text_area.selection == Selection.cursor((4, 5))
+        assert text_area.selection == Selection((2, 3), (3, 5))
 
 
 async def test_insert_multiline_text():
@@ -324,21 +311,6 @@ Fear is the little-death that brings total obliteration.
 I will face my fear.
 """
         assert text_area.text == expected_text
-
-
-async def test_delete_within_line_dont_maintain_offset():
-    app = TextAreaApp()
-    async with app.run_test():
-        text_area = app.query_one(TextArea)
-        text_area.delete((0, 6), (0, 10))
-    expected_text = """\
-I must fear.
-Fear is the mind-killer.
-Fear is the little-death that brings total obliteration.
-I will face my fear.
-"""
-    assert text_area.selection == Selection.cursor((0, 6))  # cursor moved
-    assert text_area.text == expected_text
 
 
 async def test_delete_multiple_lines_selection_above():

--- a/tests/text_area/test_edit_via_api.py
+++ b/tests/text_area/test_edit_via_api.py
@@ -56,7 +56,7 @@ async def test_insert_text_start():
     async with app.run_test():
         text_area = app.query_one(TextArea)
         text_area.move_cursor((0, 5))
-        text_area.insert("Hello", location=(0, 0), maintain_selection_offset=False)
+        text_area.insert("Hello", location=(0, 0))
         assert text_area.text == "Hello" + TEXT
         assert text_area.selection == Selection.cursor((0, 5))
 
@@ -181,7 +181,6 @@ async def test_insert_text_non_cursor_location_dont_maintain_offset():
         result = text_area.insert(
             "Hello",
             location=(4, 0),
-            maintain_selection_offset=False,
         )
 
         assert result == EditResult(
@@ -200,7 +199,7 @@ async def test_insert_multiline_text():
     async with app.run_test():
         text_area = app.query_one(TextArea)
         text_area.move_cursor((2, 5))
-        text_area.insert("Hello,\nworld!", maintain_selection_offset=False)
+        text_area.insert("Hello,\nworld!")
         expected_content = """\
 I must not fear.
 Fear is the mind-killer.
@@ -331,7 +330,7 @@ async def test_delete_within_line_dont_maintain_offset():
     app = TextAreaApp()
     async with app.run_test():
         text_area = app.query_one(TextArea)
-        text_area.delete((0, 6), (0, 10), maintain_selection_offset=False)
+        text_area.delete((0, 6), (0, 10))
     expected_text = """\
 I must fear.
 Fear is the mind-killer.

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -339,7 +339,7 @@ async def test_delete_to_start_of_line(selection, expected_result):
         if selection.start > selection.end:
             # the selection is behind the current cursor location and
             # thus shifted by the length of the edit
-            shift = (0, - selection.end[1])
+            shift = (0, -selection.end[1])
             start = selection.start[0] + shift[0], selection.start[1] + shift[1]
             end = selection.end[0] + shift[0], selection.end[1] + shift[1]
 


### PR DESCRIPTION
**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)

Hey :wave:

I am combining realtime syncing provided by [`pycrdt`](https://github.com/y-crdt/pycrdt) with the [`TextArea`](https://textual.textualize.io/widgets/text_area/) widget and I am pretty impressed by how little code it takes to adapt the widget to my needs, given the complexity of `src/textual/document/*.py` and `src/textual/widgets/_text_area.py`.
Good job, @darrenburns!


### Background Story

The edit flow in the released `TextArea` widget is:

```
TextArea.replace/insert/delete/clear  # <-- `maintain_selection_offset` set
  - TextArea.edit
    - Edit.do  # <-- `maintain_selection_offset` evaluated
      - TextArea.document.replace_range
```

with `maintain_selection_offset` deciding in `Edit.do` whether the current selection gets shifted/moved (`True`) or set as cursor to the end of the edit (`False`).

However, this edit flow is not compatible to CRDTs in `pycrdt`.
Changes to those CRDTs are announced via callbacks with event objects passed holding the information about a particular change.
For the [`Text`-CRDT](https://y-crdt.github.io/pycrdt/api_reference/#pycrdt.Text), there is the [`TextEvent`](https://y-crdt.github.io/pycrdt/api_reference/#pycrdt.TextEvent) event object holding info about which text range has been deleted and where a particular piece of text has been inserted.

This mechanism requires text manipulation on the `TextArea` widget - from the user via **keyboard**, the **API** or as update message from **remote** - to be done with the information given in the callback.
It does not provide a way of transporting arbitrary/app-specific metadata, especially not allowing to pass `maintain_selection_offset` flag:

```
TextArea.replace/insert/delete/clear
  - TextCRDT.insert/delete  # <-- `maintain_selection_offset` shall not pass
    - TextArea.on_ytext_event_callback
      - TextArea.edit
        - Edit.do
          - TextArea.document.replace_range
```

I thereby started experimenting whether I could get decent functionality without `maintain_selection_offset`.


### What I Changed

- I removed `maintain_selection_offset` from the API.
- Edits via the API (`insert`, `delete`) do not automatically set the `TextArea` selection as a cursor to the end of the edit anymore (`maintain_selection_offset = False` before), but keep the current selection.
  See also tests for `ctrl + u` (delete to line start)

  <details>
  <summary>comparison <code>ctrl + u</code></summary>

  before:
  ![ctrl_u_old](https://github.com/user-attachments/assets/c925f2fb-0143-4280-9e2f-76c755e308f3)
  now:
  ![ctrl_u_new](https://github.com/user-attachments/assets/e3cff5be-250e-459b-883c-59258ce68c1f)
  </details>

  and `ctrl + k` (delete to line end).

  <details>
  <summary>comparison <code>ctrl + k</code></summary>

  before:
  ![ctrl_k_old](https://github.com/user-attachments/assets/f522e343-6002-49d9-8419-ceaf999d2a3c)
  now:
  ![ctrl_k_new](https://github.com/user-attachments/assets/72448ef8-7d57-468c-9d45-f552fec2f64e)
  </details>

  On `clear`, `maintain_selection_offset` had no effect.
- Edits deleting a range covering the current `TextArea` selection place the selection as a cursor at the end of the edit.

  <details>
  <summary>comparison</summary>

  before:
  ![selection_within_edit_old](https://github.com/user-attachments/assets/b357ade2-7e2e-411e-b2ac-478a9f734bb4)

  now:
  ![selection_within_edit_new](https://github.com/user-attachments/assets/62bb7339-7717-4799-9c85-d886c401972a)
  </details>

- `Selection` now supports the operators `in`, `<`, `<=`, `>` and `>=` for `Location`s (tuples).
- I updated the tests.


What are your thoughts, especially about the new API behavior?