### PR TITLE
Fixed CSS transparency bug in _style_properties.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed issue with the "transparent" CSS value not being transparent when set using python
+
 ## [3.5.0] - 2025-06-20
 
 ### Changed

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -984,7 +984,6 @@ class ColorProperty:
                     continue
                 try:
                     parsed_color = Color.parse(token)
-                    _r, _g, _b, alpha, _, _ = parsed_color
                 except ColorParseError as error:
                     raise StyleValueError(
                         f"Invalid color value '{token}'",
@@ -992,7 +991,7 @@ class ColorProperty:
                             self.name, context="inline", error=error, value=token
                         ),
                     )
-            parsed_color = parsed_color.with_alpha(alpha)
+            parsed_color = parsed_color.multiply_alpha(alpha)
 
             if obj.set_rule(self.name, parsed_color):
                 obj.refresh(children=True)

--- a/src/textual/css/_style_properties.py
+++ b/src/textual/css/_style_properties.py
@@ -984,6 +984,7 @@ class ColorProperty:
                     continue
                 try:
                     parsed_color = Color.parse(token)
+                    _r, _g, _b, alpha, _, _ = parsed_color
                 except ColorParseError as error:
                     raise StyleValueError(
                         f"Invalid color value '{token}'",

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_setting_transparency.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_setting_transparency.svg
@@ -1,0 +1,154 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #00008b }
+.terminal-r3 { fill: #0178d4 }
+.terminal-r4 { fill: #e0e0e0 }
+.terminal-r5 { fill: #121212 }
+.terminal-r6 { fill: #191919 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">TransparentPythonApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#00008b" x="0" y="1.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="183" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="1.5" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="1.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="25.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="183" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="207.4" y="25.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="207.4" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#262626" x="219.6" y="25.9" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="768.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="25.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="50.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="183" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="50.3" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="50.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="74.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="183" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="74.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="74.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="99.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="183" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="99.1" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="99.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="123.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="123.5" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="123.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="147.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="147.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#0a0a8f" x="207.4" y="147.9" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="147.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="172.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="172.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#0a0a8f" x="207.4" y="172.3" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="172.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="196.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="196.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="196.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="221.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="221.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="221.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="245.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="245.5" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="245.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="269.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="269.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#0a0a8f" x="207.4" y="269.9" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="269.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="294.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="294.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#0a0a8f" x="207.4" y="294.3" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="294.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="318.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="318.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="318.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="343.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="343.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="343.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="367.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="367.5" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="367.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="391.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0023a0" x="207.4" y="391.9" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0023a0" x="500.2" y="391.9" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="391.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="416.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0023a0" x="207.4" y="416.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#0023a0" x="207.4" y="416.3" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="416.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="440.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="440.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="597.8" y="440.7" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="440.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="465.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="465.1" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="465.1" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="465.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="489.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="489.5" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="707.6" y="489.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="489.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="513.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="207.4" y="513.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="280.6" y="513.9" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="768.6" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="780.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="513.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="538.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#191919" x="183" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="195.2" y="538.3" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="793" y="538.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#00008b" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r2" x="183" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▊</text><text class="terminal-r3" x="195.2" y="20" textLength="585.6" clip-path="url(#terminal-line-0)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-r3" x="780.8" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▎</text><text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▊</text><text class="terminal-r5" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">B</text><text class="terminal-r4" x="219.6" y="44.4" textLength="549" clip-path="url(#terminal-line-1)">aseline&#160;normal&#160;TextArea,&#160;not&#160;transparent&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r3" x="780.8" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▎</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r2" x="183" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▊</text><text class="terminal-r3" x="780.8" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▎</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r2" x="183" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">▊</text><text class="terminal-r3" x="780.8" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">▎</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r2" x="183" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">▊</text><text class="terminal-r3" x="195.2" y="117.6" textLength="585.6" clip-path="url(#terminal-line-4)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-r3" x="780.8" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">▎</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r2" x="183" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">▊</text><text class="terminal-r6" x="195.2" y="142" textLength="597.8" clip-path="url(#terminal-line-5)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▎</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r2" x="183" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▊</text><text class="terminal-r4" x="207.4" y="166.4" textLength="561.2" clip-path="url(#terminal-line-6)">This&#160;TextArea&#160;made&#160;transparent&#160;by&#160;adding&#160;a&#160;&#160;&#160;&#160;</text><text class="terminal-r6" x="780.8" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▎</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r2" x="183" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">▊</text><text class="terminal-r4" x="207.4" y="190.8" textLength="561.2" clip-path="url(#terminal-line-7)">CSS&#160;class&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r6" x="780.8" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">▎</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r2" x="183" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">▊</text><text class="terminal-r6" x="780.8" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">▎</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r2" x="183" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">▊</text><text class="terminal-r6" x="195.2" y="239.6" textLength="597.8" clip-path="url(#terminal-line-9)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▎</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r2" x="183" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">▊</text><text class="terminal-r6" x="195.2" y="264" textLength="597.8" clip-path="url(#terminal-line-10)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▎</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r2" x="183" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">▊</text><text class="terminal-r4" x="207.4" y="288.4" textLength="561.2" clip-path="url(#terminal-line-11)">This&#160;TextArea&#160;made&#160;transparent&#160;by&#160;setting&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r6" x="780.8" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">▎</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r2" x="183" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">▊</text><text class="terminal-r4" x="207.4" y="312.8" textLength="561.2" clip-path="url(#terminal-line-12)">style&#160;with&#160;python&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r6" x="780.8" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">▎</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r2" x="183" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">▊</text><text class="terminal-r6" x="780.8" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">▎</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r2" x="183" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">▊</text><text class="terminal-r6" x="195.2" y="361.6" textLength="597.8" clip-path="url(#terminal-line-14)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▎</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r2" x="183" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">▊</text><text class="terminal-r6" x="195.2" y="386" textLength="597.8" clip-path="url(#terminal-line-15)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▎</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r2" x="183" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">▊</text><text class="terminal-r4" x="207.4" y="410.4" textLength="292.8" clip-path="url(#terminal-line-16)">1)&#160;This&#160;is&#160;an&#160;OptionList</text><text class="terminal-r6" x="780.8" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">▎</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r2" x="183" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">▊</text><text class="terminal-r6" x="780.8" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">▎</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r2" x="183" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▊</text><text class="terminal-r4" x="207.4" y="459.2" textLength="390.4" clip-path="url(#terminal-line-18)">2)&#160;With&#160;a&#160;transparent&#160;background</text><text class="terminal-r6" x="780.8" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▎</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r2" x="183" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▊</text><text class="terminal-r6" x="780.8" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▎</text><text class="terminal-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r2" x="183" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">▊</text><text class="terminal-r4" x="207.4" y="508" textLength="500.2" clip-path="url(#terminal-line-20)">3)&#160;Made&#160;transparent&#160;by&#160;setting&#160;style&#160;with</text><text class="terminal-r6" x="780.8" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">▎</text><text class="terminal-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r2" x="183" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">▊</text><text class="terminal-r4" x="207.4" y="532.4" textLength="73.2" clip-path="url(#terminal-line-21)">python</text><text class="terminal-r6" x="780.8" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">▎</text><text class="terminal-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r2" x="183" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">▊</text><text class="terminal-r6" x="195.2" y="556.8" textLength="597.8" clip-path="url(#terminal-line-22)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▎</text><text class="terminal-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -3540,6 +3540,55 @@ def test_focus_within_transparent(snap_compare):
     assert snap_compare(FocusWithinTransparentApp(), press=["tab"])
 
 
+
+def test_setting_transparency(snap_compare):
+    """Check that setting a widget's background color to transparent
+    works as expected using python.
+    Regression test for https://github.com/Textualize/textual/pull/5890"""
+
+    class TransparentPythonApp(App):
+
+        CSS = """
+        Screen { 
+            background: darkblue;
+            align: center middle; 
+        }
+
+        TextArea {
+            height: 5;
+            width: 50;
+            &.-transparent { background: transparent; }
+        }
+        
+        OptionList {
+            height: 8;
+            width: 50;
+        }
+        """
+
+        def compose(self):
+
+            yield TextArea("Baseline normal TextArea, not transparent")
+            text_area2 = TextArea(
+                "This TextArea made transparent by adding a CSS class", classes="-transparent"
+            )
+            yield text_area2
+            text_area3 = TextArea(
+                "This TextArea made transparent by setting style with python"
+            )
+            text_area3.styles.background = "transparent"
+            yield text_area3 
+            option_list = OptionList(
+                "1) This is an OptionList\n",
+                "2) With a transparent background\n",
+                "3) Made transparent by setting style with python",
+            )
+            option_list.styles.background = "transparent"
+            yield option_list
+
+    assert snap_compare(TransparentPythonApp())
+
+
 def test_option_list_wrapping(snap_compare):
     """You should see a 40 cell wide Option list with a single line, ending in an ellipsis."""
 


### PR DESCRIPTION
**Please review the following checklist.**

- [ N/A ] Docstrings on all new or modified functions / classes 
- [ N/A  ] Updated documentation
- [X] Updated CHANGELOG.md (where appropriate)

I believe I've found the fix for this issue as originally reported in the Discord help channel.

So first off, original MRE showcasing the problem since, as requested, we're going straight to PR without an attached issue:

```py
from textual.app import App
from textual.widgets import Switch, Static
from textual.containers import Container

class TextualApp(App[None]):

    CSS = """
    Screen { background: darkblue; align: center middle; }
    #my_container {
        width: 50%; height: 50%;
        align: center middle;
        border: solid yellow;
        background: red;
        &.-transparent { background: transparent; }        
    }
    """

    def compose(self):
        with Container(id="my_container"):
            yield Static("Make container transparent:")
            yield Switch()

    def on_switch_changed(self, event: Switch.Changed):

        my_container = self.query_one("#my_container")
        if event.value:
            my_container.styles.background = "transparent"  # before fix: this doesn't work
            # my_container.add_class("-transparent")     # adding a CSS class works fine however
        else:
            my_container.styles.background = "red"
            # my_container.remove_class("-transparent")

TextualApp().run()
```

The issue was that in the `ColorProperties` class in css/_style_properties.py, it was not accounting for the case where a named color might have alpha built into it. Which is of course only one named color, "transparency".

Line in question:
https://github.com/Textualize/textual/blob/6e4f77bb48080aacac03c6141eeed0cf11b5e92e/src/textual/css/_style_properties.py#L994

In the fix, I've added an extra line:

```
      try:
          parsed_color = Color.parse(token)
          _r, _g, _b, alpha, _, _ = parsed_color    # new line
```                   

Previously it would only get the alpha `if token.endswith("%")`, which was missing the edge case where the string is "transparent". Now after parsing the string, it extracts whatever alpha value is to re-use it for the `parsed_color.with_alpha(alpha)` call.

I thought this was a nice solution since its a one-line addition, which is a bit more elegant than making an extra condition just for the "transparent" string. But regardless, I'm pretty sure this is the root of the issue. Let me know if you think this is maybe not the best way to fix it.