### PR TITLE
Simple valid empty fix

### DIFF
--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -149,7 +149,7 @@ class Input(ScrollView):
     | ctrl+k | Delete everything to the right of the cursor. |
     | ctrl+x | Cut selected text. |
     | ctrl+c | Copy selected text. |
-    | ctrl+v | Paste text from the clipboard. | 
+    | ctrl+v | Paste text from the clipboard. |
     """
 
     COMPONENT_CLASSES: ClassVar[set[str]] = {
@@ -187,9 +187,9 @@ class Input(ScrollView):
         }
 
         &:focus {
-            border: tall $border;            
+            border: tall $border;
             background-tint: $foreground 5%;
-            
+
         }
         &>.input--cursor {
             background: $input-cursor-background;
@@ -207,12 +207,12 @@ class Input(ScrollView):
         }
         &.-invalid:focus {
             border: tall $error;
-        }    
+        }
 
         &:ansi {
             background: ansi_default;
             color: ansi_default;
-            &>.input--cursor {     
+            &>.input--cursor {
                 text-style: reverse;
             }
             &>.input--placeholder, &>.input--suggestion {
@@ -224,8 +224,8 @@ class Input(ScrollView):
             }
             &.-invalid:focus {
                 border: tall ansi_red;
-            }  
-            
+            }
+
         }
     }
 
@@ -571,13 +571,14 @@ class Input(ScrollView):
             self.set_class(not valid, "-invalid")
             self.set_class(valid, "-valid")
 
-        # If no validators are supplied, and therefore no validation occurs, we return None.
-        if not self.validators:
+        # Empty inputs are always OK if valid_empty is set.
+        if self.valid_empty and not value:
             self._valid = True
             set_classes()
             return None
 
-        if self.valid_empty and not value:
+        # If no validators are supplied, and therefore no validation occurs, we return None.
+        if not self.validators:
             self._valid = True
             set_classes()
             return None

--- a/tests/input/test_input_validation.py
+++ b/tests/input/test_input_validation.py
@@ -214,6 +214,7 @@ async def test_valid_empty():
         input = app.query_one(Input)
 
         await pilot.press("1", "backspace")
+        assert input.value == ''
 
         assert not input.has_class("-valid")
         assert input.has_class("-invalid")

--- a/tests/input/test_input_validation.py
+++ b/tests/input/test_input_validation.py
@@ -211,15 +211,15 @@ async def test_none_validate_on_means_all_validations_happen():
 async def test_valid_empty():
     app = InputApp(None)
     async with app.run_test() as pilot:
-        input = app.query_one(Input)
+        input = app.query_one(Input)  # valid_empty=False
 
         await pilot.press("1", "backspace")
-        assert input.value == ''
+        assert input.value == ''  # Empty value: invalid
 
         assert not input.has_class("-valid")
         assert input.has_class("-invalid")
 
         input.valid_empty = True
 
-        assert input.has_class("-valid")
+        assert input.has_class("-valid")  # Empty value: now acceptble
         assert not input.has_class("-invalid")


### PR DESCRIPTION
**Please review the following checklist.**

- [n/a] Docstrings on all new or modified functions / classes 
- [n/a] Updated documentation
- [?] Updated CHANGELOG.md (where appropriate)

This PR fixes the error that validates an empty input with no validators as valid even though `valid_empty` is False.
