### PR TITLE
Support for tuple keys in add_columns function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added support to allow support for manual keys in add_columns as well. Was discussed in: https://github.com/Textualize/textual/discussions/5922
+
 ### Fixed
 
 - Fixed issue with the "transparent" CSS value not being transparent when set using python https://github.com/Textualize/textual/pull/5890

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -4,7 +4,16 @@ import functools
 from dataclasses import dataclass
 from itertools import chain, zip_longest
 from operator import itemgetter
-from typing import Any, Callable, ClassVar, Generic, Iterable, NamedTuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Generic,
+    Iterable,
+    NamedTuple,
+    TypeVar,
+    Union,
+)
 
 import rich.repr
 from rich.console import RenderableType
@@ -1716,20 +1725,41 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self.check_idle()
         return row_key
 
-    def add_columns(self, *labels: TextType) -> list[ColumnKey]:
-        """Add a number of columns.
+    def add_columns(
+        self, *columns: Union[TextType, tuple[TextType, str]]
+    ) -> list[ColumnKey]:
+        """Add multiple columns to the DataTable.
 
         Args:
-            *labels: Column headers.
+            *columns: Column specifications. Each can be either:
+                - A string or Text object (label only, auto-generated key)
+                - A tuple of (label, key) for manual key control
 
         Returns:
             A list of the keys for the columns that were added. See
                 the `add_column` method docstring for more information on how
                 these keys are used.
+
+        Examples:
+            ```python
+            # Add columns with auto-generated keys
+            keys = table.add_columns("Name", "Age", "City")
+
+            # Add columns with manual keys
+            keys = table.add_columns(
+                ("Name", "name_col"),
+                ("Age", "age_col"),
+                "City"  # Mixed with auto-generated key
+            )
+            ```
         """
         column_keys = []
-        for label in labels:
-            column_key = self.add_column(label, width=None)
+        for column in columns:
+            if isinstance(column, tuple):
+                label, key = column
+                column_key = self.add_column(label, width=None, key=key)
+            else:
+                column_key = self.add_column(column, width=None)
             column_keys.append(column_key)
         return column_keys
 

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -299,6 +299,25 @@ async def test_add_columns():
         assert len(table.columns) == 3
 
 
+async def test_add_columns_with_tuples():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        column_keys = table.add_columns(
+            ("Column 1", "col1"), "Column 2", ("Column 3", "col3")
+        )
+        assert len(column_keys) == 3
+        assert len(table.columns) == 3
+
+        assert column_keys[0] == "col1"
+        assert column_keys[1] != "col1"
+        assert column_keys[2] == "col3"
+
+        assert table.columns[column_keys[0]].label.plain == "Column 1"
+        assert table.columns[column_keys[1]].label.plain == "Column 2"
+        assert table.columns[column_keys[2]].label.plain == "Column 3"
+
+
 async def test_add_columns_user_defined_keys():
     app = DataTableApp()
     async with app.run_test():


### PR DESCRIPTION
I prefer to use `add_columns` over `add_column`. But when I want to grab individual cell values or using similar functions I run into some issues and I haven't been able to find a robust way of dealing with it.

This addition the the `add_columns` function should solve any issues of getting a proper column key, as the user would be allowed to set the keys themselves, similar to the option you have with `add_column`. Personally I miss this feature on the `add_columns` function. I do not know if that is shared, but I figured I would propose a solution at least.

I opened a discussion here: https://github.com/Textualize/textual/discussions/5922

**Checklist**
- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation (assuming auto generation on textual.textualize.io)
- [x] Updated CHANGELOG.md (where appropriate)