### PR TITLE
added textual.getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added textual.getters 
 
+### Changed
+
+- Potential breaking change: Changed default query search to breadth first
+
 ## [3.6.0] - 2025-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added textual.getters 
+- Added textual.getters https://github.com/Textualize/textual/pull/5930
 
 ### Changed
 
-- Potential breaking change: Changed default `query_one` and `query_exactly_one` search to breadth first
+- Potential breaking change: Changed default `query_one` and `query_exactly_one` search to breadth first https://github.com/Textualize/textual/pull/5930
 
 ## [3.6.0] - 2025-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added textual.getters 
+
 ## [3.6.0] - 2025-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Potential breaking change: Changed default query search to breadth first
+- Potential breaking change: Changed default `query_one` and `query_exactly_one` search to breadth first
 
 ## [3.6.0] - 2025-07-06
 

--- a/docs/api/getters.md
+++ b/docs/api/getters.md
@@ -1,0 +1,5 @@
+---
+title: "textual.getters"
+---
+
+::: textual.getters

--- a/examples/dictionary.py
+++ b/examples/dictionary.py
@@ -6,7 +6,7 @@ except ImportError:
     raise ImportError("Please install httpx with 'pip install httpx' ")
 
 
-from textual import work
+from textual import getters, work
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Input, Markdown
@@ -16,6 +16,9 @@ class DictionaryApp(App):
     """Searches a dictionary API as-you-type."""
 
     CSS_PATH = "dictionary.tcss"
+
+    results = getters.query_one("#results", Markdown)
+    input = getters.query_one(Input)
 
     def compose(self) -> ComposeResult:
         yield Input(placeholder="Search for a word", id="dictionary-search")
@@ -28,7 +31,7 @@ class DictionaryApp(App):
             self.lookup_word(message.value)
         else:
             # Clear the results
-            await self.query_one("#results", Markdown).update("")
+            await self.results.update("")
 
     @work(exclusive=True)
     async def lookup_word(self, word: str) -> None:
@@ -40,12 +43,12 @@ class DictionaryApp(App):
             try:
                 results = response.json()
             except Exception:
-                self.query_one("#results", Markdown).update(response.text)
+                self.results.update(response.text)
                 return
 
-        if word == self.query_one(Input).value:
+        if word == self.input.value:
             markdown = self.make_word_markdown(results)
-            self.query_one("#results", Markdown).update(markdown)
+            self.results.update(markdown)
 
     def make_word_markdown(self, results: object) -> str:
         """Convert the results into markdown."""

--- a/mkdocs-nav.yml
+++ b/mkdocs-nav.yml
@@ -202,6 +202,7 @@ nav:
       - "api/filter.md"
       - "api/fuzzy_matcher.md"
       - "api/geometry.md"
+      - "api/getters.md"
       - "api/layout.md"
       - "api/lazy.md"
       - "api/logger.md"

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1322,7 +1322,7 @@ class DOMNode(MessagePump):
             filter_type: type[WalkType],
             *,
             with_self: bool = False,
-            method: WalkMethod = "breadth",
+            method: WalkMethod = "depth",
             reverse: bool = False,
         ) -> list[WalkType]: ...
 
@@ -1331,7 +1331,7 @@ class DOMNode(MessagePump):
             self,
             *,
             with_self: bool = False,
-            method: WalkMethod = "breadth",
+            method: WalkMethod = "depth",
             reverse: bool = False,
         ) -> list[DOMNode]: ...
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1322,7 +1322,7 @@ class DOMNode(MessagePump):
             filter_type: type[WalkType],
             *,
             with_self: bool = False,
-            method: WalkMethod = "depth",
+            method: WalkMethod = "breadth",
             reverse: bool = False,
         ) -> list[WalkType]: ...
 
@@ -1331,7 +1331,7 @@ class DOMNode(MessagePump):
             self,
             *,
             with_self: bool = False,
-            method: WalkMethod = "depth",
+            method: WalkMethod = "breadth",
             reverse: bool = False,
         ) -> list[DOMNode]: ...
 
@@ -1484,7 +1484,7 @@ class DOMNode(MessagePump):
         else:
             cache_key = None
 
-        for node in walk_depth_first(base_node, with_root=False):
+        for node in walk_breadth_first(base_node, with_root=False):
             if not match(selector_set, node):
                 continue
             if expect_type is not None and not isinstance(node, expect_type):
@@ -1555,7 +1555,7 @@ class DOMNode(MessagePump):
         else:
             cache_key = None
 
-        children = walk_depth_first(base_node, with_root=False)
+        children = walk_breadth_first(base_node, with_root=False)
         iter_children = iter(children)
         for node in iter_children:
             if not match(selector_set, node):

--- a/src/textual/getters.py
+++ b/src/textual/getters.py
@@ -1,13 +1,13 @@
-from __future__ import annotations
-
 """
 Descriptors to define properties on your widget, screen, or App.
 
 """
 
+from __future__ import annotations
+
 from typing import Generic, overload
 
-from textual.css.query import QueryType
+from textual.css.query import NoMatches, QueryType, WrongType
 from textual.dom import DOMNode
 from textual.widget import Widget
 
@@ -15,8 +15,8 @@ from textual.widget import Widget
 class query_one(Generic[QueryType]):
     """Create a query one property.
 
-    A query one property calls [query_one][textual.dom.DOMNode.query_one] when accessed, and returns
-    a widget.
+    A query one property calls [Widget.query_one][textual.dom.DOMNode.query_one] when accessed, and returns
+    a widget. If the widget doesn't exist, then the property will raise the same exceptions as `Widget.query_one`.
 
 
     Example:
@@ -29,7 +29,8 @@ class query_one(Generic[QueryType]):
             output_log = getters.query_one("#output", RichLog)
 
             def compose(self) -> ComposeResult:
-                yield RichLog(id="output")
+                with containers.Vertical():
+                    yield RichLog(id="output")
 
             def on_mount(self) -> None:
                 self.output_log.write("Screen started")
@@ -96,3 +97,81 @@ class query_one(Generic[QueryType]):
             return self
         query_node = obj.query_one(self.selector, self.expect_type)
         return query_node
+
+
+class child_by_id(Generic[QueryType]):
+    """Create a child_by_id property, which returns the child with the given ID.
+
+    This is similar using [query_one][textual.getters.query_one] with an id selector, except that
+    only the immediate children are considered. It is also more efficient, as it doesn't need to search the DOM.
+
+
+    Example:
+        ```python
+        from textual import getters
+
+        class MyScreen(screen):
+
+            # Note this is at the class level
+            output_log = getters.child_by_id("#output", RichLog)
+
+            def compose(self) -> ComposeResult:
+                yield RichLog(id="output")
+
+            def on_mount(self) -> None:
+                self.output_log.write("Screen started")
+        ```
+
+
+    """
+
+    child_id: str
+    expect_type: type[Widget]
+
+    @overload
+    def __init__(self, child_id: str) -> None:
+        self.child_id = child_id
+        self.expect_type = Widget
+
+    @overload
+    def __init__(self, child_id: str, expect_type: type[QueryType]) -> None:
+        self.child_id = child_id
+        self.expect_type = expect_type
+
+    def __init__(
+        self,
+        child_id: str,
+        expect_type: type[QueryType] | None = None,
+    ) -> None:
+        if expect_type is None:
+            self.expect_type = Widget
+        else:
+            self.expect_type = expect_type
+        self.child_id = child_id
+
+    @overload
+    def __get__(
+        self: "child_by_id[QueryType]", obj: DOMNode, obj_type: type[DOMNode]
+    ) -> QueryType: ...
+
+    @overload
+    def __get__(
+        self: "child_by_id[QueryType]", obj: None, obj_type: type[DOMNode]
+    ) -> "child_by_id[QueryType]": ...
+
+    def __get__(
+        self: "child_by_id[QueryType]", obj: DOMNode | None, obj_type: type[DOMNode]
+    ) -> QueryType | Widget | "child_by_id":
+        """Get the widget matching the selector and/or type."""
+        if obj is None:
+            return self
+        child = obj._nodes._get_by_id(self.child_id)
+        if child is None:
+            raise NoMatches(f"No child found with id={id!r}")
+        if not isinstance(child, self.expect_type):
+            if not isinstance(child, self.expect_type):
+                raise WrongType(
+                    f"Child with id={id!r} is wrong type; expected {self.expect_type}, got"
+                    f" {type(child)}"
+                )
+        return child

--- a/src/textual/getters.py
+++ b/src/textual/getters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Descriptors to define properties on your widget, screen, or App.
 

--- a/src/textual/getters.py
+++ b/src/textual/getters.py
@@ -1,0 +1,96 @@
+"""
+Descriptors to define properties on your widget, screen, or App.
+
+"""
+
+from typing import Generic, overload
+
+from textual.css.query import QueryType
+from textual.dom import DOMNode
+from textual.widget import Widget
+
+
+class query_one(Generic[QueryType]):
+    """Create a query one property.
+
+    A query one property calls [query_one][textual.dom.DOMNode.query_one] when accessed, and returns
+    a widget.
+
+
+    Example:
+        ```python
+        from textual import getters
+
+        class MyScreen(screen):
+
+            # Note this is at the class level
+            output_log = getters.query_one("#output", RichLog)
+
+            def compose(self) -> ComposeResult:
+                yield RichLog(id="output")
+
+            def on_mount(self) -> None:
+                self.output_log.write("Screen started")
+                # Equivalent to the following line:
+                # self.query_one("#output", RichLog).write("Screen started")
+        ```
+
+
+    """
+
+    selector: str
+    expect_type: type[Widget]
+
+    @overload
+    def __init__(self, selector: str) -> None:
+        self.selector = selector
+        self.expect_type = Widget
+
+    @overload
+    def __init__(self, selector: type[QueryType]) -> None:
+        self.selector = selector.__name__
+        self.expect_type = selector
+
+    @overload
+    def __init__(self, selector: str, expect_type: type[QueryType]) -> None:
+        self.selector = selector
+        self.expect_type = expect_type
+
+    @overload
+    def __init__(self, selector: type[QueryType], expect_type: type[QueryType]) -> None:
+        self.selector = selector.__name__
+        self.expect_type = expect_type
+
+    def __init__(
+        self,
+        selector: str | type[QueryType],
+        expect_type: type[QueryType] | None = None,
+    ) -> None:
+        if expect_type is None:
+            self.expect_type = Widget
+        else:
+            self.expect_type = expect_type
+        if isinstance(selector, str):
+            self.selector = selector
+        else:
+            self.selector = selector.__name__
+            self.expect_type = selector
+
+    @overload
+    def __get__(
+        self: "query_one[QueryType]", obj: DOMNode, obj_type: type[DOMNode]
+    ) -> QueryType: ...
+
+    @overload
+    def __get__(
+        self: "query_one[QueryType]", obj: None, obj_type: type[DOMNode]
+    ) -> "query_one[QueryType]": ...
+
+    def __get__(
+        self: "query_one[QueryType]", obj: DOMNode | None, obj_type: type[DOMNode]
+    ) -> QueryType | Widget | "query_one":
+        """Get the widget matching the selector and/or type."""
+        if obj is None:
+            return self
+        query_node = obj.query_one(self.selector, self.expect_type)
+        return query_node

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -1,0 +1,45 @@
+import pytest
+
+from textual import containers, getters
+from textual.app import App, ComposeResult
+from textual.css.query import NoMatches, WrongType
+from textual.widget import Widget
+from textual.widgets import Input, Label
+
+
+async def get_getters() -> None:
+    """Check the getter descriptors work, and return expected errors."""
+
+    class QueryApp(App):
+        label1 = getters.query_one("#label1", Label)
+        label2 = getters.child_by_id("label2", Label)
+        label1_broken = getters.query_one("#label1", Input)
+        label2_broken = getters.child_by_id("label2", Input)
+        label1_missing = getters.query_one("#foo", Widget)
+        label2_missing = getters.child_by_id("bar", Widget)
+
+        def compose(self) -> ComposeResult:
+            with containers.Vertical():
+                yield Label(id="label1", classes=".red")
+            yield Label(id="label2", classes=".green")
+
+    app = QueryApp()
+    async with app.run_test():
+
+        assert isinstance(app.label1, Label)
+        assert app.label1.id == "label1"
+
+        assert isinstance(app.label2, Label)
+        assert app.label2.id == "label2"
+
+        with pytest.raises(WrongType):
+            app.label1_broken
+
+        with pytest.raises(WrongType):
+            app.label2_broken
+
+        with pytest.raises(NoMatches):
+            app.label1_missing
+
+        with pytest.raises(NoMatches):
+            app.label2_missing


### PR DESCRIPTION
Good for DRY

- Adds `getters.query_one`
- Adds `getters.child_by_id`

These create nicely typed properties which return a Widget.


```python
class MyWidget(Widget):
    @property
    def my_input(self) -> Input:
        return self.query_one("#my_input", Input)
```

Can be replaced with:

```python
class MyWidget(Widget):
    my_input = getters.query_one("#my_input", Input)
```

Works nicely, just don't look behind the curtain.