### PR TITLE
fix: fix regexes for mouse escape sequences

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -18,7 +18,7 @@ from textual.message import Message
 # to be unsuccessful?
 _MAX_SEQUENCE_SEARCH_THRESHOLD = 32
 
-_re_mouse_event = re.compile("^" + re.escape("\x1b[") + r"(<?[-?\d;]+[mM]|M...)\Z")
+_re_mouse_event = re.compile("^" + re.escape("\x1b[") + r"(<?[-\d;]+[mM]|M...)\Z")
 _re_terminal_mode_response = re.compile(
     "^" + re.escape("\x1b[") + r"\?(?P<mode_id>\d+);(?P<setting_parameter>\d)\$y"
 )
@@ -50,7 +50,7 @@ IS_ITERM = (
 
 
 class XTermParser(Parser[Message]):
-    _re_sgr_mouse = re.compile(r"\x1b\[<(-?\d+);(-?\d+);(-?\d+)([Mm])")
+    _re_sgr_mouse = re.compile(r"\x1b\[<(\d+);(-?\d+);(-?\d+)([Mm])")
 
     def __init__(self, debug: bool = False) -> None:
         self.last_x = 0.0


### PR DESCRIPTION
Fix potential issues with the regexes for mouse escape sequences, which were recently updated to allow negative coordinates.

- Fix the updated character class `[-?\d;]`. This will match the literal character `?` which I assume was not the intention.
- Fix the regex for SGR mouse sequences, where the first parameter is the button value and should not be negative.

_(Note for reviewers: These regexes are the same as my original PR #5688 which was superseded, so if I've just misunderstood why the updated regexes are more correct please let me know!)_

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
