### PR TITLE
Fix query wrong type

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -41,7 +41,7 @@ from textual.css.constants import VALID_DISPLAY, VALID_VISIBILITY
 from textual.css.errors import DeclarationError, StyleValueError
 from textual.css.match import match
 from textual.css.parse import parse_declarations, parse_selectors
-from textual.css.query import InvalidQueryFormat, NoMatches, TooManyMatches
+from textual.css.query import InvalidQueryFormat, NoMatches, TooManyMatches, WrongType
 from textual.css.styles import RenderStyles, Styles
 from textual.css.tokenize import IDENTIFIER
 from textual.css.tokenizer import TokenError
@@ -64,9 +64,6 @@ if TYPE_CHECKING:
     from textual.screen import Screen
     from textual.widget import Widget
     from textual.worker import Worker, WorkType, ResultType
-
-    # Unused & ignored imports are needed for the docs to link to these objects:
-    from textual.css.query import WrongType  # type: ignore  # noqa: F401
 
 from typing_extensions import Literal
 
@@ -1488,7 +1485,9 @@ class DOMNode(MessagePump):
             if not match(selector_set, node):
                 continue
             if expect_type is not None and not isinstance(node, expect_type):
-                continue
+                raise WrongType(
+                    f"Node matching {query_selector!r} is not of expected type {expect_type.__name__!r}; found {node}"
+                )
             if cache_key is not None:
                 base_node._query_one_cache[cache_key] = node
             return node
@@ -1565,7 +1564,9 @@ class DOMNode(MessagePump):
             for later_node in iter_children:
                 if match(selector_set, later_node):
                     if expect_type is not None and not isinstance(node, expect_type):
-                        continue
+                        raise WrongType(
+                            f"Node matching {query_selector!r} is not of expected type {expect_type.__name__!r}; found {node}"
+                        )
                     raise TooManyMatches(
                         "Call to query_one resulted in more than one matched node"
                     )

--- a/src/textual/getters.py
+++ b/src/textual/getters.py
@@ -178,7 +178,7 @@ class child_by_id(Generic[QueryType]):
             return self
         child = obj._nodes._get_by_id(self.child_id)
         if child is None:
-            raise NoMatches(f"No child found with id={id!r}")
+            raise NoMatches(f"No child found with id={self.child_id!r}")
         if not isinstance(child, self.expect_type):
             if not isinstance(child, self.expect_type):
                 raise WrongType(

--- a/src/textual/getters.py
+++ b/src/textual/getters.py
@@ -176,7 +176,7 @@ class child_by_id(Generic[QueryType]):
         """Get the widget matching the selector and/or type."""
         if obj is None:
             return self
-        child = obj._nodes._get_by_id(self.child_id)
+        child = obj._get_dom_base()._nodes._get_by_id(self.child_id)
         if child is None:
             raise NoMatches(f"No child found with id={self.child_id!r}")
         if not isinstance(child, self.expect_type):

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -998,7 +998,7 @@ class Widget(DOMNode):
             NoMatches: if no children could be found for this ID
             WrongType: if the wrong type was found.
         """
-        child = self._nodes._get_by_id(id)
+        child = self._get_dom_base()._nodes._get_by_id(id)
         if child is None:
             raise NoMatches(f"No child found with id={id!r}")
         if expect_type is None:

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -3,14 +3,15 @@ import pytest
 from textual import containers, getters
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches, WrongType
+from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Input, Label
 
 
-async def get_getters() -> None:
+async def test_getters() -> None:
     """Check the getter descriptors work, and return expected errors."""
 
-    class QueryApp(App):
+    class GetterScreen(Screen):
         label1 = getters.query_one("#label1", Label)
         label2 = getters.child_by_id("label2", Label)
         label1_broken = getters.query_one("#label1", Input)
@@ -20,26 +21,32 @@ async def get_getters() -> None:
 
         def compose(self) -> ComposeResult:
             with containers.Vertical():
-                yield Label(id="label1", classes=".red")
-            yield Label(id="label2", classes=".green")
+                yield Label(id="label1", classes="red")
+            yield Label(id="label2", classes="green")
+
+    class QueryApp(App):
+
+        def get_default_screen(self) -> Screen:
+            return GetterScreen()
 
     app = QueryApp()
     async with app.run_test():
+        screen: GetterScreen = app.screen
 
-        assert isinstance(app.label1, Label)
-        assert app.label1.id == "label1"
+        assert isinstance(screen.label1, Label)
+        assert screen.label1.id == "label1"
 
-        assert isinstance(app.label2, Label)
-        assert app.label2.id == "label2"
-
-        with pytest.raises(WrongType):
-            app.label1_broken
+        assert isinstance(screen.label2, Label)
+        assert screen.label2.id == "label2"
 
         with pytest.raises(WrongType):
-            app.label2_broken
+            screen.label1_broken
+
+        with pytest.raises(WrongType):
+            screen.label2_broken
 
         with pytest.raises(NoMatches):
-            app.label1_missing
+            screen.label1_missing
 
         with pytest.raises(NoMatches):
-            app.label2_missing
+            screen.label2_missing

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -3,7 +3,6 @@ import pytest
 from textual import containers, getters
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches, WrongType
-from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Input, Label
 
@@ -11,7 +10,8 @@ from textual.widgets import Input, Label
 async def test_getters() -> None:
     """Check the getter descriptors work, and return expected errors."""
 
-    class GetterScreen(Screen):
+    class QueryApp(App):
+
         label1 = getters.query_one("#label1", Label)
         label2 = getters.child_by_id("label2", Label)
         label1_broken = getters.query_one("#label1", Input)
@@ -24,29 +24,23 @@ async def test_getters() -> None:
                 yield Label(id="label1", classes="red")
             yield Label(id="label2", classes="green")
 
-    class QueryApp(App):
-
-        def get_default_screen(self) -> Screen:
-            return GetterScreen()
-
     app = QueryApp()
     async with app.run_test():
-        screen: GetterScreen = app.screen
 
-        assert isinstance(screen.label1, Label)
-        assert screen.label1.id == "label1"
+        assert isinstance(app.label1, Label)
+        assert app.label1.id == "label1"
 
-        assert isinstance(screen.label2, Label)
-        assert screen.label2.id == "label2"
-
-        with pytest.raises(WrongType):
-            screen.label1_broken
+        assert isinstance(app.label2, Label)
+        assert app.label2.id == "label2"
 
         with pytest.raises(WrongType):
-            screen.label2_broken
+            app.label1_broken
+
+        with pytest.raises(WrongType):
+            app.label2_broken
 
         with pytest.raises(NoMatches):
-            screen.label1_missing
+            app.label1_missing
 
         with pytest.raises(NoMatches):
-            screen.label2_missing
+            app.label2_missing


### PR DESCRIPTION
Thanks to @TomJGooding for spotting a test wasn't running.

Enable the test revealed a few bugs. Namely `WrongType` wasn't being thrown by the original implementation, contrary to the docs.