### PR TITLE
Ensure ansi colors have triplets during conversion

### DIFF
--- a/src/textual/filter.py
+++ b/src/textual/filter.py
@@ -252,6 +252,14 @@ class ANSIToTruecolor(LineFilter):
             )
         # Convert dim style to RGB
         if style.dim and color is not None:
+            if color.triplet is None:
+                color = RichColor.from_rgb(
+                    *color.get_truecolor(terminal_theme, foreground=True)
+                )
+            if background.triplet is None:
+                background = RichColor.from_rgb(
+                    *background.get_truecolor(terminal_theme, foreground=False)
+                )
             color = dim_color(background, color)
             style += NO_DIM
 

--- a/tests/test_ansi_truecolor_filter.py
+++ b/tests/test_ansi_truecolor_filter.py
@@ -1,0 +1,25 @@
+from rich.color import Color as RichColor
+from rich.color import ColorType
+from rich.segment import Segment
+from rich.style import Style
+from rich.terminal_theme import MONOKAI
+
+from textual.color import Color
+from textual.filter import ANSIToTruecolor
+
+
+def test_ansi_to_truecolor_8_bit_dim():
+    """Test that converting an 8-bit color with dim doesn't crash."""
+    # Given
+    ansi_filter = ANSIToTruecolor(MONOKAI)
+    test_color = RichColor("color(253)", ColorType.EIGHT_BIT, number=253)
+    test_style = Style(color=test_color, dim=True)
+    segments = [Segment("This should not crash", style=test_style)]
+    background_color = Color(0, 0, 0)
+
+    # When
+    # This line will crash if the bug is present
+    new_segments = ansi_filter.apply(segments, background_color)
+
+    # Then
+    assert new_segments is not None


### PR DESCRIPTION
fixes #5946

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes
- ~~[ ] Updated documentation~~
- ~~[ ] Updated CHANGELOG.md (where appropriate)~~

Trivial change, probably not worth updating changelog?