### PR TITLE
Add `MaskedInput` `compact` Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added 
+
+- Added `compact` parameter to `MaskedInput` https://github.com/Textualize/textual/pull/5952
+
 ### Fixed
 
 - Fixed issue with the "transparent" CSS value not being transparent when set using python https://github.com/Textualize/textual/pull/5890

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -461,6 +461,7 @@ class MaskedInput(Input, can_focus=True):
         classes: str | None = None,
         disabled: bool = False,
         tooltip: RenderableType | None = None,
+        compact: bool = False,
     ) -> None:
         """Initialise the `MaskedInput` widget.
 
@@ -478,6 +479,7 @@ class MaskedInput(Input, can_focus=True):
             classes: Optional initial classes for the widget.
             disabled: Whether the input is disabled or not.
             tooltip: Optional tooltip.
+            compact: Enable compact style (without borders).
         """
         self._template: _Template = None
         super().__init__(
@@ -490,6 +492,7 @@ class MaskedInput(Input, can_focus=True):
             id=id,
             classes=classes,
             disabled=disabled,
+            compact=compact,
         )
 
         self._template = _Template(self, template)

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -462,7 +462,7 @@ class MaskedInput(Input, can_focus=True):
         disabled: bool = False,
         tooltip: RenderableType | None = None,
     ) -> None:
-        """Initialise the `Input` widget.
+        """Initialise the `MaskedInput` widget.
 
         Args:
             template: Template string.


### PR DESCRIPTION
**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)

Added a `compact` parameter to the constructor, as the parent class `Input` received it in a previous update and `MaskedInput` was left out.