### PR TITLE
add delay to screenshot

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1237,7 +1237,7 @@ class App(Generic[ReturnType], DOMNode):
         yield SystemCommand(
             "Save screenshot",
             "Save an SVG 'screenshot' of the current screen",
-            self.deliver_screenshot,
+            lambda: self.set_timer(0.1, self.deliver_screenshot),
         )
 
     def get_default_screen(self) -> Screen:


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/5955

There is a frame where the footer hasn't been built. This is usually invisible but it is captured by the screenshot. The fix is to add a short delay to allow the full frame to be rendered.