### PR TITLE
Fix Markdown widget documentation reactive attributes

### DIFF
--- a/docs/widgets/markdown.md
+++ b/docs/widgets/markdown.md
@@ -29,7 +29,11 @@ The following example displays Markdown from a string.
 
 ## Reactive Attributes
 
-This widget has no reactive attributes.
+| Name                | Type   | Default            | Description                                             |
+|---------------------|--------|--------------------|---------------------------------------------------------|
+| `code_dark_theme`   | `str`  | `"material"`       | The theme to use for code blocks when the App theme is dark. |
+| `code_light_theme`  | `str`  | `"material-light"` | The theme to use for code blocks when the App theme is light. |
+| `code_indent_guides`| `bool` | `True`             | Should code fences display indent guides?              |
 
 ## Messages
 


### PR DESCRIPTION
Add missing reactive attributes table to markdown.md documentation:
- code_dark_theme (str): theme for dark mode code blocks
- code_light_theme (str): theme for light mode code blocks
- code_indent_guides (bool): whether to show indent guides in code


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [X] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
