### PR TITLE
Update Input widget documentation

### DIFF
--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -134,6 +134,7 @@ If you set `valid_empty=True` then empty values will bypass any validators, and 
 
 - [Input.Changed][textual.widgets.Input.Changed]
 - [Input.Submitted][textual.widgets.Input.Submitted]
+- [Input.Blurred][textual.widgets.Input.Blurred]
 
 ## Bindings
 

--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -78,8 +78,7 @@ input = Input(validate_on=["submitted"])
 
 Validation is considered to have failed if *any* of the validators fail.
 
-You can check whether the validation succeeded or failed inside an [Input.Changed][textual.widgets.Input.Changed] or
-[Input.Submitted][textual.widgets.Input.Submitted] handler by looking at the `validation_result` attribute on these events.
+You can check whether the validation succeeded or failed inside an [Input.Changed][textual.widgets.Input.Changed], [Input.Submitted][textual.widgets.Input.Submitted], or [Input.Blurred][textual.widgets.Input.Blurred] handler by looking at the `validation_result` attribute on these events.
 
 In the example below, we show how to combine multiple validators and update the UI to tell the user
 why validation failed.


### PR DESCRIPTION
**Please review the following checklist.**

- [N/A] Docstrings on all new or modified functions / classes 
- [X] Updated documentation
- [N/A] Updated CHANGELOG.md (where appropriate)

I realized that the Input widget documentation needed to be updated for a previous PR I made, which added the `Blurred` message to the Input widget. My apologies, I was newer to this at the time and didn't realize I should have updated that at the same time. This PR updates the Input widget reference page in the two places where `Input.Changed` and `Input.Submitted` are mentioned.