### PR TITLE
feat(bar): Add support for custom icons

### DIFF
--- a/src/textual/renderables/bar.py
+++ b/src/textual/renderables/bar.py
@@ -18,6 +18,10 @@ class Bar:
         gradient: Optional gradient object.
     """
 
+    HALF_BAR_LEFT: str = "╺"
+    BAR: str = "━"
+    HALF_BAR_RIGHT: str = "╸"
+
     def __init__(
         self,
         highlight_range: tuple[float, float] = (0, 0),
@@ -40,10 +44,6 @@ class Bar:
         highlight_style = console.get_style(self.highlight_style)
         background_style = console.get_style(self.background_style)
 
-        half_bar_right = "╸"
-        half_bar_left = "╺"
-        bar = "━"
-
         width = self.width or options.max_width
         start, end = self.highlight_range
 
@@ -53,7 +53,7 @@ class Bar:
         output_bar = Text("", end="")
 
         if start == end == 0 or end < 0 or start > end:
-            output_bar.append(Text(bar * width, style=background_style, end=""))
+            output_bar.append(Text(self.BAR * width, style=background_style, end=""))
             yield output_bar
             return
 
@@ -67,10 +67,10 @@ class Bar:
 
         # Initial non-highlighted portion of bar
         output_bar.append(
-            Text(bar * (int(start - 0.5)), style=background_style, end="")
+            Text(self.BAR * (int(start - 0.5)), style=background_style, end="")
         )
         if not half_start and start > 0:
-            output_bar.append(Text(half_bar_right, style=background_style, end=""))
+            output_bar.append(Text(self.HALF_BAR_RIGHT, style=background_style, end=""))
 
         highlight_bar = Text("", end="")
         # The highlighted portion
@@ -78,13 +78,19 @@ class Bar:
         if half_start:
             highlight_bar.append(
                 Text(
-                    half_bar_left + bar * (bar_width - 1), style=highlight_style, end=""
+                    self.HALF_BAR_LEFT + self.BAR * (bar_width - 1),
+                    style=highlight_style,
+                    end="",
                 )
             )
         else:
-            highlight_bar.append(Text(bar * bar_width, style=highlight_style, end=""))
+            highlight_bar.append(
+                Text(self.BAR * bar_width, style=highlight_style, end="")
+            )
         if half_end:
-            highlight_bar.append(Text(half_bar_right, style=highlight_style, end=""))
+            highlight_bar.append(
+                Text(self.HALF_BAR_RIGHT, style=highlight_style, end="")
+            )
 
         if self.gradient is not None:
             _apply_gradient(highlight_bar, self.gradient, width)
@@ -92,9 +98,9 @@ class Bar:
 
         # The non-highlighted tail
         if not half_end and end - width != 0:
-            output_bar.append(Text(half_bar_left, style=background_style, end=""))
+            output_bar.append(Text(self.HALF_BAR_LEFT, style=background_style, end=""))
         output_bar.append(
-            Text(bar * (int(width) - int(end) - 1), style=background_style, end="")
+            Text(self.BAR * (int(width) - int(end) - 1), style=background_style, end="")
         )
 
         # Fire actions when certain ranges are clicked (e.g. for tabs)

--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -72,11 +72,13 @@ class Bar(Widget, can_focus=False):
         disabled: bool = False,
         clock: Clock | None = None,
         gradient: Gradient | None = None,
+        bar_renderable: BarRenderable = BarRenderable,
     ):
         """Create a bar for a [`ProgressBar`][textual.widgets.ProgressBar]."""
         self._clock = (clock or Clock()).clone()
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
         self.set_reactive(Bar.gradient, gradient)
+        self.bar_renderable = bar_renderable
 
     def _validate_percentage(self, percentage: float | None) -> float | None:
         """Avoid updating the bar, if the percentage increase is too small to render."""
@@ -104,7 +106,7 @@ class Bar(Widget, can_focus=False):
                 if self.percentage < 1
                 else self.get_component_rich_style("bar--complete")
             )
-            return BarRenderable(
+            return self.bar_renderable(
                 highlight_range=(0, self.size.width * self.percentage),
                 highlight_style=Style.from_color(bar_style.color),
                 background_style=Style.from_color(bar_style.bgcolor),
@@ -133,7 +135,7 @@ class Bar(Widget, can_focus=False):
             end = start + highlighted_bar_width
 
         bar_style = self.get_component_rich_style("bar--indeterminate")
-        return BarRenderable(
+        return self.bar_renderable(
             highlight_range=(max(0, start), min(end, width)),
             highlight_style=Style.from_color(bar_style.color),
             background_style=Style.from_color(bar_style.bgcolor),
@@ -239,6 +241,7 @@ class ProgressBar(Widget, can_focus=False):
         disabled: bool = False,
         clock: Clock | None = None,
         gradient: Gradient | None = None,
+        bar_renderable: BarRenderable = BarRenderable,
     ):
         """Create a Progress Bar widget.
 
@@ -265,6 +268,7 @@ class ProgressBar(Widget, can_focus=False):
             disabled: Whether the widget is disabled or not.
             clock: An optional clock object (leave as default unless testing).
             gradient: An optional Gradient object (will replace CSS styles in the bar).
+            bar_renderable: A custom Bar object that is rendered as the bar.
         """
         self._clock = clock or Clock()
         self._eta = ETA()
@@ -274,6 +278,7 @@ class ProgressBar(Widget, can_focus=False):
         self.show_percentage = show_percentage
         self.show_eta = show_eta
         self.set_reactive(ProgressBar.gradient, gradient)
+        self.bar_renderable = bar_renderable
 
     def on_mount(self) -> None:
         self.update()
@@ -283,7 +288,7 @@ class ProgressBar(Widget, can_focus=False):
     def compose(self) -> ComposeResult:
         if self.show_bar:
             yield (
-                Bar(id="bar", clock=self._clock)
+                Bar(id="bar", clock=self._clock, bar_renderable=self.bar_renderable)
                 .data_bind(ProgressBar.percentage)
                 .data_bind(ProgressBar.gradient)
             )


### PR DESCRIPTION
You can super a `textual.renderable.bar.Bar` class and change <kbd>HALF_BAR_LEFT</kbd>, <kbd>BAR</kbd>, and <kbd>HALF_BAR_RIGHT</kbd>, before passing the class as a keyword argument in the `textual.widgets.ProgressBar` widget as <kbd>bar_renderable</kbd>. The keyword arg's name might be weird.

Image:
<img width="1377" height="323" alt="image" src="https://github.com/user-attachments/assets/399752a3-18db-432c-b09d-f7ccbf1ec664" />

Code Snippet
```py
from textual.app import App, ComposeResult
from textual.renderables.bar import Bar as BarRenderable
from textual.widgets import ProgressBar
from textual.color import Gradient
class SignsRenderable(BarRenderable):
    HALF_BAR_LEFT = "-"
    BAR = "="
    HALF_BAR_RIGHT = "-"
class ArrowsRenderable(BarRenderable):
    HALF_BAR_LEFT = ">"
    BAR = "="
    HALF_BAR_RIGHT = ">"
class ThickBarRenderable(BarRenderable):
    HALF_BAR_LEFT = "▐"
    BAR = "█"
    HALF_BAR_RIGHT = "▌"
class SlashBarRenderable(BarRenderable):
    HALF_BAR_LEFT = "\\"
    BAR = "|"
    HALF_BAR_RIGHT = "/"
class Application(App):
    DEFAULT_CSS = """
    .bar--indeterminate { color: #bf616a !important; background: #2e3440 !important }
    """
    def compose(self) -> ComposeResult:
        gradient = Gradient.from_colors("#8fbcbb", "#88c0d0", "#81a1c1", "#5e81ac")
        for widget in [ThickBarRenderable, SignsRenderable, SlashBarRenderable, ArrowsRenderable]:
            yield ProgressBar(bar_renderable=widget, gradient=gradient)
        yield ProgressBar(gradient=gradient)
    def on_mount(self) -> None:
        self.progress_timer = self.set_interval(1 / 10, self.make_progress, pause=True)
        self.set_timer(4.0, self.start_progress)
    def start_progress(self) -> None:
        for bar in self.query(ProgressBar):
            bar.update(total=100)
        self.progress_timer.resume()
    def make_progress(self) -> None:
        for bar in self.query(ProgressBar):
            bar.advance(1)
Application().run()
```

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
