### PR TITLE
Fix typo in checker03.py

### DIFF
--- a/docs/examples/guide/widgets/checker03.py
+++ b/docs/examples/guide/widgets/checker03.py
@@ -49,7 +49,7 @@ class CheckerBoard(ScrollView):
             for column in range(self.board_size)
         ]
         strip = Strip(segments, self.board_size * 8)
-        # Crop the strip so that is covers the visible area
+        # Crop the strip so that it covers the visible area
         strip = strip.crop(scroll_x, scroll_x + self.size.width)
         return strip
 


### PR DESCRIPTION
Change "is" to the intended "it".


**Please review the following checklist.**

- [x ] Docstrings on all new or modified functions / classes 
- [x ] Updated documentation
- [x ] Updated CHANGELOG.md (where appropriate)
