### PR TITLE
Explain `self.app` in the guide more explicitly [Documentation]

### DIFF
--- a/docs/guide/command_palette.md
+++ b/docs/guide/command_palette.md
@@ -86,6 +86,8 @@ The following example will display a blank screen initially, but if you bring up
   5. Highlights matching letters in the search.
   6. Adds our custom command provider and the default command provider.
 
+The above example uses [`self.app`][textual.command.Provider.app] to call `open_file`, a method we've defined on our app class. You normally won’t need to access the app class directly, since passing data through messages or other patterns keeps components more loosely coupled. However, when you need to call methods defined on the app class—such as `open_file` in our case—or work with shared app-wide state, [`self.app`][textual.message_pump.MessagePump.app] is the normal way to reach the running app instance. It's accessible from any widget, screen, or command provider.
+
 There are four methods you can override in a command provider: [`startup`][textual.command.Provider.startup], [`search`][textual.command.Provider.search], [`discover`][textual.command.Provider.discover] and [`shutdown`][textual.command.Provider.shutdown].
 All of these methods should be coroutines (`async def`). Only `search` is required, the other methods are optional.
 Let's explore those methods in detail.

--- a/docs/guide/command_palette.md
+++ b/docs/guide/command_palette.md
@@ -86,7 +86,9 @@ The following example will display a blank screen initially, but if you bring up
   5. Highlights matching letters in the search.
   6. Adds our custom command provider and the default command provider.
 
-The above example uses [`self.app`][textual.command.Provider.app] to call `open_file`, a method we've defined on our app class. You normally won’t need to access the app class directly, since passing data through messages or other patterns keeps components more loosely coupled. However, when you need to call methods defined on the app class—such as `open_file` in our case—or work with shared app-wide state, [`self.app`][textual.message_pump.MessagePump.app] is the normal way to reach the running app instance. It's accessible from any widget, screen, or command provider.
+!!! note
+
+    Unlike widgets and screens, command providers aren’t part of Textual’s normal widget hierarchy—they’re plain Python classes. For convenience, Textual still sets a [self.app][textual.command.Provider.app] attribute on them, giving you access to the running app instance. As with widgets and screens, you won’t often need to reach into the app directly, but it’s the right approach when you need to call app-level methods such as `open_file()` in this example.
 
 There are four methods you can override in a command provider: [`startup`][textual.command.Provider.startup], [`search`][textual.command.Provider.search], [`discover`][textual.command.Provider.discover] and [`shutdown`][textual.command.Provider.shutdown].
 All of these methods should be coroutines (`async def`). Only `search` is required, the other methods are optional.

--- a/docs/guide/screens.md
+++ b/docs/guide/screens.md
@@ -180,6 +180,8 @@ From the quit screen you can click either Quit to exit the app immediately, or C
 Note the `request_quit` action in the app which pushes a new instance of `QuitScreen`.
 This makes the quit screen active. If you click Cancel, the quit screen calls [pop_screen][textual.app.App.pop_screen] to return the default screen. This also removes and deletes the `QuitScreen` object.
 
+This example also shows [`self.app`][textual.message_pump.MessagePump.app], which gives you access to the running app instance from within a screen. You won’t often need to reach into the app directly, since it's usually preferable for widgets or screens to communicate through messages. But when you do need to call app-level methods—such as [`pop_screen()`][textual.app.App.pop_screen] in this example—[`self.app`][textual.message_pump.MessagePump.app] is the normal way to do it. You can access it on any widget or screen that is mounted in the app.
+
 There are two flaws with this modal screen, which we can fix in the same way.
 
 The first flaw is that the app adds a new quit screen every time you press ++q++, even when the quit screen is still visible.


### PR DESCRIPTION
**Please review the following checklist.**

- [N/A] Docstrings on all new or modified functions / classes 
- [yes] Updated documentation
- [N/A] Updated CHANGELOG.md (where appropriate)

So a bit of explanation, I noticed from combing through the guide, and from general experience helping people in the Discord server, that the `self.app` attribute is not explicitly explained anywhere in the guide. I figured a PR would be in order to add an explicit explanation somewhere!

`self.app` is used in 3 examples: The first two are in the Screens section, [`modal01.py`](https://github.com/Textualize/textual/blob/main/docs/examples/guide/screens/modal01.py) and [`modal02.py`](https://github.com/Textualize/textual/blob/main/docs/examples/guide/screens/modal02.py) (which are two versions of the same example). The third is in the Command Palette section, in the [`command02.py`](https://github.com/Textualize/textual/blob/main/docs/examples/guide/command_palette/command02.py) example.

I figured the place it would make most sense to explain it would be right after its first used in the Screens section. There I added a paragraph that is a normal in-line section of the guide. I thought that was appropriate here, since in my opinion it is fairly essential information pertaining to the example.

I also placed a second admonition in the Command Palette section. That's because Command Providers are not widgets or screens (don't inherit from Message Pump), yet they have the self.app attribute tacked on anyway, and they're I believe one of 2 or 3 Textual objects that also have it added. So I thought an extra admonition here would be appropriate to make it clear that this is not on **every** Textual object, it was just added on here.

What do you think? I have a feeling this should be explained more explicitly _somewhere_ at least. Happy to change any wording or move stuff around.