### PR TITLE
enable speedups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Content markup can now accept component classes when preceded by a dot, e.g. "Hello [.my_custo_style]World[/]!" https://github.com/Textualize/textual/pull/5981
 - Breaking change: `Visual.render_strips` has a new signature. If you aren't explicitly building Visuals then this won't effect you. https://github.com/Textualize/textual/pull/5981
 - Breaking change: The component classes on Markdown have been moved to MarkdownBlock. This won't affect you unless you have customize the Markdown CSS https://github.com/Textualize/textual/pull/5981
+- The textual-speedups library will now be imported automatically if it is installed. Set `TEXTUAL_SPEEDUPS=0` to disable.
 
 ### Removed
 

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -1316,7 +1316,7 @@ class Spacing(NamedTuple):
         )
 
 
-if not TYPE_CHECKING and os.environ.get("TEXTUAL_SPEEDUPS") == "1":
+if not TYPE_CHECKING and os.environ.get("TEXTUAL_SPEEDUPS", "1") == "1":
     try:
         from textual_speedups import Offset, Region, Size, Spacing
     except ImportError:


### PR DESCRIPTION
Import textual_speedups package by default if it is installed.

Note, that textual_speedups is not a dependancy. You will still need to explicitly add it to your environment if you wish to use it.