### PR TITLE
Scroll on mouse-down (instead of up) in the empty area of a scrollbar

### DIFF
--- a/src/textual/scrollbar.py
+++ b/src/textual/scrollbar.py
@@ -138,8 +138,8 @@ class ScrollBarRender:
             start_index, start_bar = divmod(max(0, start), len_bars)
             end_index, end_bar = divmod(max(0, end), len_bars)
 
-            upper = {"@mouse.up": "scroll_up"}
-            lower = {"@mouse.up": "scroll_down"}
+            upper = {"@mouse.down": "scroll_up"}
+            lower = {"@mouse.down": "scroll_down"}
 
             upper_back_segment = Segment(blank, _Style(bgcolor=back, meta=upper))
             lower_back_segment = Segment(blank, _Style(bgcolor=back, meta=lower))


### PR DESCRIPTION
### Background

It was noticed that when clicking in the empty area of a `textual.scrollbar.ScrollBar`, the content scrolls when the mouse button is released (mouse-up). On the other hand, it was found in discord discussions that most (all?) GUI apps scroll as soon as the mouse is pressed (mouse-down). Therefore it might feel more intuitive for the user if Textual's scrollbar behaves in the same way.

### Change

This PR updates textual's scrollbar to scroll on mouse-down (rather than up) in the empty area of a scrollbar.

### Demo

The following code creates a (large) widget that requires scrolling. Click in the empty area of the vertical and horizontal scroll bars to feel the difference before and after the PR.

```python
from textual.app import App, ComposeResult
from textual.widgets import DataTable

class MyApp(App):
    def compose(self) -> ComposeResult:
        table = DataTable()
        table.add_columns(*[f"Column{j}" for j in range(100)])
        for i in range(100):
            table.add_rows([[f"Cell({i},{j})" for j in range(100)]])
        yield table

if __name__ == "__main__":
    MyApp().run()
```
