### PR TITLE
Support MouseScrollLeft and MouseScrollRight control sequences.

### DIFF
--- a/docs/events/click.md
+++ b/docs/events/click.md
@@ -20,5 +20,7 @@ See [MouseEvent][textual.events.MouseEvent] for the list of properties and metho
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/leave.md
+++ b/docs/events/leave.md
@@ -9,5 +9,7 @@
 - [MouseDown](mouse_down.md)
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_down.md
+++ b/docs/events/mouse_down.md
@@ -16,5 +16,7 @@ See [MouseEvent][textual.events.MouseEvent] for the full list of properties and 
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_move.md
+++ b/docs/events/mouse_move.md
@@ -16,5 +16,7 @@ See [MouseEvent][textual.events.MouseEvent] for the full list of properties and 
 - [MouseDown](mouse_down.md)
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_scroll_down.md
+++ b/docs/events/mouse_scroll_down.md
@@ -16,5 +16,7 @@ See [MouseEvent][textual.events.MouseEvent] for the full list of properties and 
 - [MouseDown](mouse_down.md)
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_scroll_left.md
+++ b/docs/events/mouse_scroll_left.md
@@ -1,15 +1,22 @@
-::: textual.events.Enter
+---
+title: MouseScrollLeft
+---
+
+::: textual.events.MouseScrollLeft
     options:
       heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
 
 ## See also
 
 - [Click](click.md)
+- [Enter](enter.md)
 - [Leave](leave.md)
 - [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
-- [MouseScrollLeft](mouse_scroll_left.md)
 - [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_scroll_right.md
+++ b/docs/events/mouse_scroll_right.md
@@ -1,15 +1,22 @@
-::: textual.events.Enter
+---
+title: MouseScrollRight
+---
+
+::: textual.events.MouseScrollRight
     options:
       heading_level: 1
+
+See [MouseEvent][textual.events.MouseEvent] for the full list of properties and methods.
 
 ## See also
 
 - [Click](click.md)
+- [Enter](enter.md)
 - [Leave](leave.md)
 - [MouseDown](mouse_down.md)
+- [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
 - [MouseScrollLeft](mouse_scroll_left.md)
-- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_scroll_up.md
+++ b/docs/events/mouse_scroll_up.md
@@ -17,4 +17,6 @@ See [MouseEvent][textual.events.MouseEvent] for the full list of properties and 
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseUp](mouse_up.md)

--- a/docs/events/mouse_up.md
+++ b/docs/events/mouse_up.md
@@ -17,4 +17,6 @@ See [MouseEvent][textual.events.MouseEvent] for the full list of properties and 
 - [MouseEvent][textual.events.MouseEvent]
 - [MouseMove](mouse_move.md)
 - [MouseScrollDown](mouse_scroll_down.md)
+- [MouseScrollLeft](mouse_scroll_left.md)
+- [MouseScrollRight](mouse_scroll_right.md)
 - [MouseScrollUp](mouse_scroll_up.md)

--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -262,6 +262,8 @@ If you want your app to respond to a mouse click you should prefer the Click eve
 
 Most mice have a scroll wheel which you can use to scroll the window underneath the cursor. Scrollable containers in Textual will handle these automatically, but you can handle [MouseScrollDown](../events/mouse_scroll_down.md) and [MouseScrollUp](../events/mouse_scroll_up.md) if you want build your own scrolling functionality.
 
+For terminals that support horizontal mouse wheel, Textual sends [MouseScrollLeft](../events/mouse_scroll_left.md) and [MouseScrollRight](../events/mouse_scroll_right.md), and scrollable containers handle them automatically.
+
 !!! information
 
     Terminal emulators will typically convert trackpad gestures into scroll events.

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -100,9 +100,12 @@ class XTermParser(Parser[Message]):
             event_class: type[events.MouseEvent]
 
             if buttons & 64:
-                event_class = (
-                    events.MouseScrollDown if buttons & 1 else events.MouseScrollUp
-                )
+                event_class = [
+                    events.MouseScrollUp,
+                    events.MouseScrollDown,
+                    events.MouseScrollLeft,
+                    events.MouseScrollRight,
+                ][buttons & 3]
                 button = 0
             else:
                 button = (buttons + 1) & 3

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -606,6 +606,24 @@ class MouseScrollUp(MouseEvent, bubble=True, verbose=True):
     """
 
 
+@rich.repr.auto
+class MouseScrollRight(MouseEvent, bubble=True, verbose=True):
+    """Sent when the mouse wheel is scrolled *right*.
+
+    - [X] Bubbles
+    - [X] Verbose
+    """
+
+
+@rich.repr.auto
+class MouseScrollLeft(MouseEvent, bubble=True, verbose=True):
+    """Sent when the mouse wheel is scrolled *left*.
+
+    - [X] Bubbles
+    - [X] Verbose
+    """
+
+
 class Click(MouseEvent, bubble=True):
     """Sent when a widget is clicked.
 

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -113,7 +113,12 @@ _JUSTIFY_MAP: dict[str, JustifyMethod] = {
 
 
 _MOUSE_EVENTS_DISALLOW_IF_DISABLED = (events.MouseEvent, events.Enter, events.Leave)
-_MOUSE_EVENTS_ALLOW_IF_DISABLED = (events.MouseScrollDown, events.MouseScrollUp)
+_MOUSE_EVENTS_ALLOW_IF_DISABLED = (
+    events.MouseScrollDown,
+    events.MouseScrollUp,
+    events.MouseScrollRight,
+    events.MouseScrollLeft,
+)
 
 
 @rich.repr.auto
@@ -4568,6 +4573,18 @@ class Widget(DOMNode):
                 self.release_anchor()
                 if self._scroll_up_for_pointer(animate=False):
                     event.stop()
+
+    def _on_mouse_scroll_right(self, event: events.MouseScrollRight) -> None:
+        if self.allow_horizontal_scroll:
+            self.release_anchor()
+            if self._scroll_right_for_pointer(animate=False):
+                event.stop()
+
+    def _on_mouse_scroll_left(self, event: events.MouseScrollLeft) -> None:
+        if self.allow_horizontal_scroll:
+            self.release_anchor()
+            if self._scroll_left_for_pointer(animate=False):
+                event.stop()
 
     def _on_scroll_to(self, message: ScrollTo) -> None:
         if self._allow_scroll:

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -8,6 +8,8 @@ from textual.events import (
     MouseDown,
     MouseMove,
     MouseScrollDown,
+    MouseScrollLeft,
+    MouseScrollRight,
     MouseScrollUp,
     MouseUp,
     Paste,
@@ -277,6 +279,56 @@ def test_mouse_scroll_down(parser, sequence, shift, meta):
     event = events[0]
 
     assert isinstance(event, MouseScrollDown)
+    assert event.x == 17
+    assert event.y == 24
+    assert event.shift is shift
+    assert event.meta is meta
+
+
+@pytest.mark.parametrize(
+    "sequence, shift, meta",
+    [
+        ("\x1b[<66;18;25M", False, False),
+        ("\x1b[<70;18;25M", True, False),
+        ("\x1b[<74;18;25M", False, True),
+    ],
+)
+def test_mouse_scroll_left(parser, sequence, shift, meta):
+    """Scrolling the mouse with and without modifiers held down.
+    We don't currently capture modifier keys in scroll events.
+    """
+    events = list(parser.feed(sequence))
+
+    assert len(events) == 1
+
+    event = events[0]
+
+    assert isinstance(event, MouseScrollLeft)
+    assert event.x == 17
+    assert event.y == 24
+    assert event.shift is shift
+    assert event.meta is meta
+
+
+@pytest.mark.parametrize(
+    "sequence, shift, meta",
+    [
+        ("\x1b[<67;18;25M", False, False),
+        ("\x1b[<71;18;25M", True, False),
+        ("\x1b[<75;18;25M", False, True),
+    ],
+)
+def test_mouse_scroll_right(parser, sequence, shift, meta):
+    """Scrolling the mouse with and without modifiers held down.
+    We don't currently capture modifier keys in scroll events.
+    """
+    events = list(parser.feed(sequence))
+
+    assert len(events) == 1
+
+    event = events[0]
+
+    assert isinstance(event, MouseScrollRight)
     assert event.x == 17
     assert event.y == 24
     assert event.shift is shift


### PR DESCRIPTION
### Background

Horizontal scrolling is useful in certain scenarios, such as browsing a `DataTable` with many rows and columns or moving around in a map in all four directions. Since most input devices do not have a dedicated horizontal scroll wheel, most terminal emulators only send control sequences for vertical (but not horizontal) scroll. Textual performs horizontal scrolling when a vertical scroll sequence is received with the CTRL or SHIFT key pressed; see [source code](https://github.com/Textualize/textual/blob/d935c03492917db3b43b4f9d84c2f017b3ab7f37/src/textual/widget.py#L4558).

Some terminal emulators do send a specific control sequence on horizontal mouse scrolling. For example, [iTerm2](https://iterm2.com) sends `^[[66;x;yM` for scroll-left and `^[[67;x;yM` for scroll-right, with `x` and `y` replaced by the cursor coordinates. These control codes are left unspecified under [xterm](https://www.xfree86.org/4.8.0/ctlseqs.html#Mouse%20Tracking) when the mouse wheel is in action. Most terminal emulators, such as Windows Terminal or MacOS Terminal, do not send these codes.

At the moment, Textual ignores the second lowest bit of the control code when the mouse wheel is in action. Consequently, for a terminal emulator that sends `66` or `67`, scroll-left (`66`) is treated as scroll-up (`64`) and scroll-right (`67`) is treated as scroll-down (`65`); see [source code](https://github.com/Textualize/textual/blob/d935c03492917db3b43b4f9d84c2f017b3ab7f37/src/textual/_xterm_parser.py#L104).

### Change

This PR adds support for control codes `66` and `67`. When these control codes are received and the mouse wheel is in action, the `MouseScrollLeft` or `MouseScrollRight` event is sent accordingly. These events are then handled by scrollable containers to perform horizontal scrolling.

### Checklist

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] ~Updated CHANGELOG.md~ (skipped -- probably better to update at release time)

### Demo

The following script creates a `DataTable` with many rows and columns. Run the script under iTerm2 (MacOS only) and "scroll" the Magic Mouse in all four directions to have the DataTable scroll accordingly.

```python
from textual.app import App, ComposeResult
from textual.widgets import DataTable

class MyApp(App):
    def compose(self) -> ComposeResult:
        table = DataTable()
        table.add_columns(*[f"Column{j}" for j in range(100)])
        for i in range(100):
            table.add_rows([[f"Cell({i},{j})" for j in range(100)]])
        yield table

if __name__ == "__main__":
    MyApp().run()
```