### PR TITLE
Address two crashing markdown rendering bugs

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -1185,6 +1185,7 @@ class Widget(DOMNode):
         if style.startswith("."):
             for node in self.ancestors_with_self:
                 if not isinstance(node, Widget):
+                    visual_style = None
                     break
                 try:
                     visual_style = node.get_visual_style(style[1:], partial=True)


### PR DESCRIPTION
This is still in progress, and I am not entirely sure how the project would want to address these bugs.

Both of these fixes address crashes for certain markdown renders in my app.

The two issues spotted are:
* Markdown headers can have illegal characters, as `quote()` will return `%` strings which are not permitted by the dom.
* The `_get_style()` function has a code path where `visual_style` is undefined, causing a crash.

The `_get_style()` fix is straightforward enough, I think, though I don't understand the larger context enough to say if this is ideal.

The Markdown header fix is kinda over the top, and I suspect there is a simpler solution that y'all would be comfortable with.