### PR TITLE
Have Styles and RenderStyles keep a weak reference to node

### DIFF
--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -883,7 +883,7 @@ class Styles(StylesBase):
     def copy(self) -> Styles:
         """Get a copy of this Styles object."""
         return Styles(
-            _node=self.node,
+            _node_ref=self.node,
             _rules=self.get_rules(),
             important=self.important,
         )

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -621,6 +621,7 @@ class Stylesheet:
             for component in sorted(component_classes):
                 virtual_node = DOMNode(classes=component)
                 virtual_node._attach(node)
+                node._virtual_nodes.append(virtual_node)  # keep alive
                 self.apply(virtual_node, animate=False)
                 if (
                     not refresh_node

--- a/src/textual/css/stylesheet.py
+++ b/src/textual/css/stylesheet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import weakref
 from collections import defaultdict
 from itertools import chain
 from operator import itemgetter
@@ -621,7 +622,6 @@ class Stylesheet:
             for component in sorted(component_classes):
                 virtual_node = DOMNode(classes=component)
                 virtual_node._attach(node)
-                node._virtual_nodes.append(virtual_node)  # keep alive
                 self.apply(virtual_node, animate=False)
                 if (
                     not refresh_node
@@ -630,6 +630,12 @@ class Stylesheet:
                     # If the styles have changed we want to refresh the node
                     refresh_node = True
                 node._component_styles[component] = virtual_node.styles
+                node._component_styles_nodes.append(virtual_node)
+                weakref.finalize(
+                    virtual_node.styles,
+                    node._component_styles_nodes.remove,
+                    virtual_node,
+                )
             if refresh_node:
                 node.refresh()
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -201,6 +201,7 @@ class DOMNode(MessagePump):
         check_identifiers("class name", *_classes)
         self._classes.update(_classes)
 
+        self._virtual_nodes: List[DOMNode] = []
         self._nodes: NodeList = NodeList(self)
         self._css_styles: Styles = Styles(self)
         self._inline_styles: Styles = Styles(self)

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -201,7 +201,6 @@ class DOMNode(MessagePump):
         check_identifiers("class name", *_classes)
         self._classes.update(_classes)
 
-        self._virtual_nodes: List[DOMNode] = []
         self._nodes: NodeList = NodeList(self)
         self._css_styles: Styles = Styles(self)
         self._inline_styles: Styles = Styles(self)
@@ -210,6 +209,10 @@ class DOMNode(MessagePump):
         )
         # A mapping of class names to Styles set in COMPONENT_CLASSES
         self._component_styles: dict[str, RenderStyles] = {}
+        # Hold strong references to the virtual nodes created for the RenderStyles objects
+        # in COMPONENT_CLASSES.  A virtual node is removed when the corresponding RenderStyles
+        # object is garbage collected, via weakref.finalize().
+        self._component_styles_nodes: list[DOMNode] = []
 
         self._auto_refresh: float | None = None
         self._auto_refresh_timer: Timer | None = None

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -207,12 +207,9 @@ class DOMNode(MessagePump):
         self.styles: RenderStyles = RenderStyles(
             self, self._css_styles, self._inline_styles
         )
-        # A mapping of class names to Styles set in COMPONENT_CLASSES
-        self._component_styles: dict[str, RenderStyles] = {}
-        # Hold strong references to the virtual nodes created for the RenderStyles objects
-        # in COMPONENT_CLASSES.  A virtual node is removed when the corresponding RenderStyles
-        # object is garbage collected, via weakref.finalize().
-        self._component_styles_nodes: list[DOMNode] = []
+        # A mapping of class names to virtual nodes whose 'styles' attribute
+        # corresponds to Styles set in COMPONENT_CLASSES
+        self._component_styles_nodes: dict[str, DOMNode] = {}
 
         self._auto_refresh: float | None = None
         self._auto_refresh_timer: Timer | None = None
@@ -583,9 +580,9 @@ class DOMNode(MessagePump):
         styles = RenderStyles(self, Styles(), Styles())
 
         for name in names:
-            if name not in self._component_styles:
+            if name not in self._component_styles_nodes:
                 raise KeyError(f"No {name!r} key in COMPONENT_CLASSES")
-            component_styles = self._component_styles[name]
+            component_styles = self._component_styles_nodes[name].styles
             styles.node = component_styles.node
             styles.base.merge(component_styles.base)
             styles.inline.merge(component_styles.inline)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -4338,7 +4338,7 @@ class Widget(DOMNode):
         self._arrangement_cache.clear()
         self._nodes._clear()
         self._render_cache = _RenderCache(NULL_SIZE, [])
-        self._component_styles.clear()
+        self._component_styles_nodes.clear()
         self._query_one_cache.clear()
 
     async def _on_idle(self, event: events.Idle) -> None:


### PR DESCRIPTION
### Background

j0shm4n [reported in discord](https://discord.com/channels/1026214085173461072/1033754296224841768/1400971110232752280) that adding and removing `TabPane`s repeatedly had memory usage grow until indeterministic time points. After some investigation, this appears to be due to the (added and then removed) `TabPane` objects being kept alive by reference cycles until they are collected by CPython's [generational garbage collector](https://docs.python.org/3/library/gc.html).

To illustrate this, run the following script and press the key sequence `a a a a a a a a d d d d d d d d g`, which adds eight tabs, removes them all, and then generates a GraphViz file showing (part of) the reference graph of the living `TabPane` objects. The script makes use of the `objgraph` package, which may be installed by `pip install objgraph`.

<details>

<summary>Demo Script</summary>

```python
import gc
import objgraph
import uuid
import weakref

from textual.app import App, ComposeResult
from textual.widgets import Header, Footer, TabbedContent, TabPane


g_panes: weakref.WeakSet[TabPane] = weakref.WeakSet()


class Test(App[None]):
    BINDINGS = [
        ("a", "add_tab", "Add Tab"),
        ("d", "delete_tab", "Close Tab"),
        ("g", "generate_graph", "Generate Object Graph"),
        ("0", "gc0", "GC(0)"),
        ("1", "gc1", "GC(1)"),
        ("2", "gc2", "GC(2)"),
    ]

    def compose(self) -> ComposeResult:
        yield Header()
        yield TabbedContent()
        yield Footer()

    async def action_add_tab(self) -> None:
        tabbed_content = self.query_one(TabbedContent)
        pane_id = f"tab_{uuid.uuid4().hex[:8]}"
        pane = TabPane(pane_id, id=pane_id)
        await tabbed_content.add_pane(pane)
        tabbed_content.active = pane_id
        g_panes.add(pane)

    async def action_delete_tab(self) -> None:
        tabbed_content: TabbedContent = self.query_one(TabbedContent)
        pane_id = tabbed_content.active
        if pane_id:
            await tabbed_content.remove_pane(pane_id)

    def action_gc0(self) -> None:
        gc.collect(0)
        self.notify("GC(0) complete")

    def action_gc1(self) -> None:
        gc.collect(1)
        self.notify("GC(1) complete")

    def action_gc2(self) -> None:
        gc.collect(2)
        self.notify("GC(2) complete")

    def action_generate_graph(self) -> None:
        objgraph.show_backrefs(
            list(g_panes), max_depth=6, filename=f"backref-panes.dot"
        )
        self.notify("Object graph generated")


if __name__ == "__main__":
    Test().run()
```

</details>

The generated GraphViz file may be viewed by e.g. [GraphViz Online](https://dreampuf.github.io/GraphvizOnline/). It looks like below:

![backref-main](https://github.com/user-attachments/assets/22dbf833-9088-4bd5-a479-1393946c6c70)

The graph shows that one instance of `TabPane` is kept alive by `FIFOCache`, and seven other instances are kept alive by reference cycles to (and from) `Styles` and `RenderStyles` members. The reference-cycled objects are collected automatically at certain times or when `gc.collect(2)` is called to perform a full garbage collection. This may be verified by pressing `2` before `g` to see that the resulting object graph doesn't contain any "dangling" reference cycles.

### Change

While reference cycles are ultimately garbage collected and hence not really memory leaks, they do make the memory footprint larger than necessary if the program adds and removes widgets repeatedly. In addition, the cyclic reference between `DOMNode` and `Styles`/`RenderStyles` makes less obvious the ownership relation between the objects.

This PR makes `Styles` and `RenderStyles` object keep a weak (rather than strong) reference to the associated `DOMNode`. With this change, performing the same steps in the Demo Script generates the following object graph:

![backref-pr](https://github.com/user-attachments/assets/805eece9-dac7-4d02-a47f-91c1f0f0653f)

Note that there is no more reference cycles involving `DOMNode`.

### Backward compatibility

A side effect of the change is that code that relies on the `Styles` or `RenderStyles` object keeping alive the associated node would break. Such code must be updated to keep a strong reference to the node explicitly. An example is `DOMNode._component_styles`, which held a sole reference to a "virtual node" for each component class. This is fixed by storing the virtual nodes (in `DOMNode._component_styles_nodes`) instead. No other usage is  identified in the test cases.

### Checklist

- [x] Docstrings on all new or modified functions / classes
- [x] ~Updated documentation~
- [x] ~Updated CHANGELOG.md (where appropriate)~
