### PR TITLE
Fix gh-5894: Mouse capture issues on Windows

### DIFF
--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -95,7 +95,6 @@ class WindowsDriver(Driver):
         self.write("\x1b[?1049h")  # Enable alt screen
         self._enable_mouse_support()
         self.write("\x1b[?25l")  # Hide cursor
-        self.write("\033[?1003h")
         self.write("\033[?1004h")  # Enable FocusIn/FocusOut.
         self.flush()
         self._enable_bracketed_paste()


### PR DESCRIPTION
#5894 reports that when running a Textual app under Windows Terminal with `mouse=False`, the console gets polluted with garbage characters when the mouse is moved during and after the app's execution.

The issue is caused by an [extraneous line](https://github.com/Textualize/textual/blob/d4740a12a61bc0330b3d71b864ec8ee25a3f8fe3/src/textual/drivers/windows_driver.py#L98) in Textual's Window driver. That line enables mouse support regardless of the `mouse` flag. However, mouse inputs are not handled when `mouse=False`; nor does the clean-up routine disable the mouse support when `mouse=False`. As a result, control sequences that encode mouse events are treated as regular input, and the screen gets polluted.

This PR fixes the issue by removing that extraneous line.