### PR TITLE
test(footer): increase initial pause in flaky test

### DIFF
--- a/tests/footer/test_footer.py
+++ b/tests/footer/test_footer.py
@@ -50,7 +50,7 @@ async def test_footer_bindings() -> None:
 
     app = PriorityBindingApp()
     async with app.run_test() as pilot:
-        await pilot.pause()
+        await pilot.pause(0.4)
         assert app_binding_count == 0
         await app.wait_for_refresh()
         # await pilot.click("Footer", offset=(1, 0))

--- a/tests/footer/test_footer.py
+++ b/tests/footer/test_footer.py
@@ -50,16 +50,17 @@ async def test_footer_bindings() -> None:
 
     app = PriorityBindingApp()
     async with app.run_test() as pilot:
-        await pilot.pause(0.4)
         assert app_binding_count == 0
+        # Pause to ensure the footer is fully composed to avoid flakiness in CI
+        await pilot.pause(0.4)
         await app.wait_for_refresh()
-        # await pilot.click("Footer", offset=(1, 0))
+
         footer_key_clicked = await pilot.click("FooterKey")
-        assert footer_key_clicked
+        assert footer_key_clicked is True  # Sanity check
         await pilot.pause()
         assert app_binding_count == 1
-        # await pilot.click("Footer")
+
         footer_key_clicked = await pilot.click("FooterKey")
-        assert footer_key_clicked
+        assert footer_key_clicked is True  # Sanity check
         await pilot.pause()
         assert app_binding_count == 2

--- a/tests/footer/test_footer.py
+++ b/tests/footer/test_footer.py
@@ -53,9 +53,13 @@ async def test_footer_bindings() -> None:
         await pilot.pause()
         assert app_binding_count == 0
         await app.wait_for_refresh()
-        await pilot.click("Footer", offset=(1, 0))
+        # await pilot.click("Footer", offset=(1, 0))
+        footer_key_clicked = await pilot.click("FooterKey")
+        assert footer_key_clicked
         await pilot.pause()
         assert app_binding_count == 1
-        await pilot.click("Footer")
+        # await pilot.click("Footer")
+        footer_key_clicked = await pilot.click("FooterKey")
+        assert footer_key_clicked
         await pilot.pause()
         assert app_binding_count == 2


### PR DESCRIPTION
Increase the initial pause in `test_footer_bindings` and add sanity check to ensure the footer key is actually clicked.

Hopefully actually fixes #6020 this time!

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
