### PR TITLE
SelectType must be Hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [Unreleased]
+
+### Fixed
+
+- Fix type hint for SelectType: only hashable types are allowed.
+
 # [5.3.0] - 2025-08-07
 
 ### Added

--- a/src/textual/widgets/_select.py
+++ b/src/textual/widgets/_select.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Iterable, TypeVar, Union
+from typing import TYPE_CHECKING, Generic, Hashable, Iterable, TypeVar, Union
 
 import rich.repr
 from rich.console import RenderableType
@@ -261,7 +261,7 @@ class SelectCurrent(Horizontal):
         self.post_message(self.Toggle())
 
 
-SelectType = TypeVar("SelectType")
+SelectType = TypeVar("SelectType", bound=Hashable)
 """The type used for data in the Select."""
 SelectOption: TypeAlias = "tuple[str, SelectType]"
 """The type used for options in the Select."""


### PR DESCRIPTION
Because of the internal use of a set for `_legal_values`, only hashable options are allowed. This makes sure the type checkers correctly flag dictionaries (or lists) being passed as options.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
