### PR TITLE
fix(pilot): fix missing return in double/triple click methods

### DIFF
--- a/src/textual/pilot.py
+++ b/src/textual/pilot.py
@@ -287,7 +287,7 @@ class Pilot(Generic[ReturnType]):
             True if no selector was specified or if the clicks landed on the selected
                 widget, False otherwise.
         """
-        await self.click(widget, offset, shift, meta, control, times=2)
+        return await self.click(widget, offset, shift, meta, control, times=2)
 
     async def triple_click(
         self,
@@ -332,7 +332,7 @@ class Pilot(Generic[ReturnType]):
             True if no selector was specified or if the clicks landed on the selected
                 widget, False otherwise.
         """
-        await self.click(widget, offset, shift, meta, control, times=3)
+        return await self.click(widget, offset, shift, meta, control, times=3)
 
     async def hover(
         self,


### PR DESCRIPTION
Fix missing return statement in the double/triple click methods, which are documented to return a boolean indicating whether the widget was in fact clicked.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
