### PR TITLE
Update _progress_bar.py

### DIFF
--- a/src/textual/widgets/_progress_bar.py
+++ b/src/textual/widgets/_progress_bar.py
@@ -127,7 +127,11 @@ class Bar(Widget, can_focus=False):
         else:
             speed = 30  # Cells per second.
             # Compute the position of the bar.
-            start = (speed * self._clock.time) % (2 * total_imaginary_width)
+            start = (
+                (speed * self._clock.time) % (2 * total_imaginary_width)
+                if total_imaginary_width != 0.0
+                else 0.0
+            )
             if start > total_imaginary_width:
                 # If the bar is to the right of its width, wrap it back from right to left.
                 start = 2 * total_imaginary_width - start  # = (tiw - (start - tiw))


### PR DESCRIPTION
This library crashes when total_imaginary_width == 0.0 because the modulo cannot divide by zero. Although it's probably a bug if the a user of the library is trying to render something with width == 0, the library doesn't need to crash here.

We can use start = 0.0 as a reasonable value for a width of 0.

I came across this issue because I am using a collection of libraries that ultimately depend on this library. Since I'm not an owner of the libraries using this API, I thought it would be easiest to address this crash instead of changing the usage of libraries that depend on this one.

**Please review the following checklist.**

- [?] Docstrings on all new or modified functions / classes: I don't know enough about the context for render_indeterminate() or RenderResult to provide a useful docstring. I am just trying to fix a crash.
- [?] Updated documentation: I do not know enough about the documentation to determine if this needs additional documentation.
- [?] Updated CHANGELOG.md (where appropriate): I do not know enough about the prevalence of this issue to know if it's worth a CHANGELOG.md update.
