### PR TITLE
fix(app): fix garbled inline app output

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -3294,8 +3294,9 @@ class App(Generic[ReturnType], DOMNode):
                         if self._driver.is_inline:
                             cursor_x, cursor_y = self._previous_cursor_position
                             self._driver.write(
-                                Control.move(-cursor_x, -cursor_y + 1).segment.text
+                                Control.move(-cursor_x, -cursor_y).segment.text
                             )
+                            self._driver.flush()
                             if inline_no_clear and not self.app._exit_renderables:
                                 console = Console()
                                 try:


### PR DESCRIPTION
Fix garbled inline app output when `inline_no_clear=True`.

Currently the terminal cursor isn't actually "reset" before printing the screen contents. This doesn't matter for most inline apps as the cursor is already offset at (0, 0). But if the app contains an `Input` widget, this will update the cursor position so the output will be garbled.

Fixes #6064


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
