### PR TITLE
eager tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Eager tasks are now enabled On Python3.12 and above
+
 ## [6.1.0] - 2025-08-01
 
 ### Added

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -2166,7 +2166,9 @@ class App(Generic[ReturnType], DOMNode):
 
         self._thread_init()
 
-        app._loop = asyncio.get_running_loop()
+        loop = app._loop = asyncio.get_running_loop()
+        if hasattr(asyncio, "eager_task_factory"):
+            loop.set_task_factory(asyncio.eager_task_factory)
         with app._context():
             try:
                 await app._process_messages(

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections import defaultdict
 from itertools import groupby
 from typing import TYPE_CHECKING
@@ -311,7 +312,8 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
                 event.stop()
                 event.prevent_default()
 
-    def on_mount(self) -> None:
+    async def on_mount(self) -> None:
+        await asyncio.sleep(0)
         self.call_next(self.bindings_changed, self.screen)
 
         def bindings_changed(screen: Screen) -> None:


### PR DESCRIPTION
Make tasks eager on Python3.12 and above.

Background: https://discuss.python.org/t/make-asyncio-eager-task-factory-default/75164