### PR TITLE
test(modal): increase pauses in flaky test

### DIFF
--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -86,9 +86,11 @@ Button {
 async def test_modal_pop_screen():
     # https://github.com/Textualize/textual/issues/4656
 
-    async with ModalApp().run_test() as pilot:
+    app = ModalApp()
+    async with app.run_test() as pilot:
         # Pause to ensure the footer is fully composed to avoid flakiness in CI
         await pilot.pause(0.4)
+        await app.wait_for_refresh()
         # Check clicking the footer brings up the quit screen
         await pilot.click(Footer)
         await pilot.pause()

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -87,9 +87,11 @@ async def test_modal_pop_screen():
     # https://github.com/Textualize/textual/issues/4656
 
     async with ModalApp().run_test() as pilot:
-        await pilot.pause()
+        # Pause to ensure the footer is fully composed to avoid flakiness in CI
+        await pilot.pause(0.4)
         # Check clicking the footer brings up the quit screen
         await pilot.click(Footer)
+        await pilot.pause()
         assert isinstance(pilot.app.screen, QuitScreen)
         # Check activating the quit button exits the app
         await pilot.press("enter")


### PR DESCRIPTION
It looks like `test_modal_pop_screen()` has started being flaky in CI.

Increase the initial pause to ensure the footer is fully composed when clicked. This seemed to be the fix for a similar flaky test in #6032.

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
