### PR TITLE
test(modal): change click to mouse down in flaky test

### DIFF
--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -92,7 +92,7 @@ async def test_modal_pop_screen():
         await pilot.pause(0.4)
         await app.wait_for_refresh()
         # Check clicking the footer brings up the quit screen
-        await pilot.click(Footer)
+        await pilot.mouse_down(Footer)
         await pilot.pause()
         assert isinstance(pilot.app.screen, QuitScreen)
         # Check activating the quit button exits the app


### PR DESCRIPTION
`test_modal_pop_screen()` is apparently still flaky in CI even after increasing the pauses in #6116.

Try changing the Footer `click` to `mouse_down` instead to avoid the `NoWidget` error in the pilot mouse events.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
