### PR TITLE
delay update for footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Reduced number of layout operations required to update the screen https://github.com/Textualize/textual/pull/6108
 - The :hover pseudo-class no applies to the first widget under the mouse with a hover style set https://github.com/Textualize/textual/pull/6132
 - The footer key hover background is more visible https://github.com/Textualize/textual/pull/6132
+- Made `App.delay_update` public
 
 ### Added
 

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -1019,7 +1019,7 @@ class App(Generic[ReturnType], DOMNode):
         if not self._batch_count:
             self.check_idle()
 
-    def _delay_update(self, delay: float = 0.05) -> None:
+    def delay_update(self, delay: float = 0.05) -> None:
         """Delay updates for a short period of time.
 
         May be used to mask a brief transition.
@@ -1035,7 +1035,7 @@ class App(Generic[ReturnType], DOMNode):
             if not self._batch_count:
                 self.screen.refresh()
 
-        self.set_timer(delay, end_batch, name="_delay_update")
+        self.set_timer(delay, end_batch, name="delay_update")
 
     @contextmanager
     def _context(self) -> Generator[None, None, None]:

--- a/src/textual/command.py
+++ b/src/textual/command.py
@@ -1230,7 +1230,7 @@ class CommandPalette(SystemModalScreen[None]):
                 # decide what to do with it (hopefully it'll run it).
                 self._cancel_gather_commands()
                 self.app.post_message(CommandPalette.Closed(option_selected=True))
-                self.app._delay_update()
+                self.app.delay_update()
                 self.dismiss()
                 self.app.call_later(self._selected_command.command)
 

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -331,6 +331,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
         self._bindings_ready = True
         if not screen.app.app_focus:
             return
+        self.app.delay_update()
         if self.is_attached and screen is self.screen:
             await self.recompose()
 
@@ -351,12 +352,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
     async def on_mount(self) -> None:
         await asyncio.sleep(0)
         self.call_next(self.bindings_changed, self.screen)
-
-        def bindings_changed(screen: Screen) -> None:
-            """Update bindings after a short delay to avoid flicker."""
-            self.call_after_refresh(self.bindings_changed, screen)
-
-        self.screen.bindings_updated_signal.subscribe(self, bindings_changed)
+        self.screen.bindings_updated_signal.subscribe(self, self.bindings_changed)
 
     def on_unmount(self) -> None:
         self.screen.bindings_updated_signal.unsubscribe(self)


### PR DESCRIPTION
The fix for a little janky flicker in the footer causes flaky tests. This is an alternative solution for the same issue. Delaying the update by 50ms masks the transition.

Also makes `App.delay_update` public.