### PR TITLE
test(modal): add sanity check for flaky test in CI

### DIFF
--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -89,7 +89,7 @@ async def test_modal_pop_screen():
     app = ModalApp()
     async with app.run_test() as pilot:
         # Pause to ensure the footer is fully composed to avoid flakiness in CI
-        await pilot.pause()
+        await pilot.pause(0.4)
         await app.wait_for_refresh()
         # Check clicking the footer brings up the quit screen
         footer_key_clicked = await pilot.mouse_down("FooterKey")

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -89,7 +89,7 @@ async def test_modal_pop_screen():
     app = ModalApp()
     async with app.run_test() as pilot:
         # Pause to ensure the footer is fully composed to avoid flakiness in CI
-        await pilot.pause(0.4)
+        await pilot.pause()
         await app.wait_for_refresh()
         # Check clicking the footer brings up the quit screen
         footer_key_clicked = await pilot.mouse_down("FooterKey")

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -89,11 +89,11 @@ async def test_modal_pop_screen():
     app = ModalApp()
     async with app.run_test() as pilot:
         # Pause to ensure the footer is fully composed to avoid flakiness in CI
-        await pilot.pause()
+        await pilot.pause(0.4)
         await app.wait_for_refresh()
-        await pilot.pause()
         # Check clicking the footer brings up the quit screen
-        await pilot.click(Footer, offset=(1, 0))
+        footer_key_clicked = await pilot.mouse_down("FooterKey")
+        assert footer_key_clicked is True  # Sanity check
         await pilot.pause()
         assert isinstance(pilot.app.screen, QuitScreen)
         # Check activating the quit button exits the app


### PR DESCRIPTION
Note that the test will even fail locally with this change instead:

```diff
-        footer_key_clicked = await pilot.mouse_down("FooterKey")
+        footer_key_clicked = await pilot.click("FooterKey")
         assert footer_key_clicked is True  # Sanity check
         await pilot.pause()
```

```
>           assert footer_key_clicked is True  # Sanity check
E           assert False is True
```

Since the footer reacts to mouse *down*, when the click has finished on mouse *up* the screen is now the modal screen.