### PR TITLE
 Use alias _App for App in type hints under TYPE_CHECKING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix inability to copy text outside of an input/textarea when it was focused https://github.com/Textualize/textual/pull/6148
 - Fix issue when copying text after a double click https://github.com/Textualize/textual/pull/6148
+- Fixed type hint aliasing for App under TYPE_CHECKING. 
 
 ## [6.2.0] - 2025-09-30
 

--- a/src/textual/__init__.py
+++ b/src/textual/__init__.py
@@ -36,7 +36,7 @@ LogCallable: TypeAlias = "Callable"
 if TYPE_CHECKING:
     from importlib.metadata import version
 
-    from textual.app import App
+    from textual.app import App as _App
 
     __version__ = version("textual")
     """The version of Textual."""
@@ -65,7 +65,7 @@ class Logger:
         log_callable: LogCallable | None,
         group: LogGroup = LogGroup.INFO,
         verbosity: LogVerbosity = LogVerbosity.NORMAL,
-        app: App | None = None,
+        app: _App | None = None,
     ) -> None:
         self._log = log_callable
         self._group = group
@@ -73,7 +73,7 @@ class Logger:
         self._app = None if app is None else weakref.ref(app)
 
     @property
-    def app(self) -> App | None:
+    def app(self) -> _App | None:
         """The associated application, or `None` if there isn't one."""
         return None if self._app is None else self._app()
 


### PR DESCRIPTION
Hi,

First of all, thanks for such a great library, really enjoy using it 🙌 

I have found small issue. `App` imported in `__init__` of `textual`, but it imported only in `if TYPE_CHECKING` block, because of that mypy and other tools think that `from textual import App` is valid code.

```py
from textual import App
```
```
$ mypy example.py
Success: no issues found in 1 source file
```

This PR will import `App` as `_App`, so IDEs and other tools will show an error for:
```py
from textual import App
```

**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
