### PR TITLE
Use `os.get_terminal_size` as the primary

### DIFF
--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -108,7 +108,7 @@ class LinuxDriver(Driver):
         import shutil
 
         try:
-            width, height = shutil.get_terminal_size()
+            width, height = os.get_terminal_size()
         except (AttributeError, ValueError, OSError):
             try:
                 width, height = shutil.get_terminal_size()

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -66,7 +66,7 @@ class LinuxInlineDriver(Driver):
         import shutil
 
         try:
-            width, height = shutil.get_terminal_size()
+            width, height = os.get_terminal_size()
         except (AttributeError, ValueError, OSError):
             try:
                 width, height = shutil.get_terminal_size()


### PR DESCRIPTION
The function `shutil.get_terminal_size` returns environment variables `COLUMNS` and `LINES` when those exist. But this information is stale after resizing the terminal. First try to retrieve from `os.get_terminal_size` and only after fall back to `shutil`.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
