### PR TITLE
fix(markup): fix invalid closing tag parsing

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -232,6 +232,7 @@ def test_assemble():
         ("\\[/foo]", "[/foo]"),
         ("\\[]", "[]"),
         ("\\[0]", "[0]"),
+        ("\\[/", "[/"),
     ],
 )
 def test_escape(markup: str, plain: str) -> None:

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -19,6 +19,8 @@ from textual.markup import MarkupError, to_content
         ("[0]", Content("[0]")),
         ("[red", Content("[red")),
         ("[red]", Content("")),
+        ("[/", Content("[/")),
+        ("[/red", Content("[/red")),
         ("foo", Content("foo")),
         ("foo\n", Content("foo\n")),
         ("foo\nbar", Content("foo\nbar")),


### PR DESCRIPTION
Fix the markup parsing of invalid closing tags missing the closing square bracket.

Currently `[/` is interpreted as an auto-closing tag, which will crash with a `MarkupError` if there's nothing to close.

Fixes #6155


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
