### PR TITLE
Fix for Content.__radd__

### DIFF
--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -760,10 +760,10 @@ class Content(Visual):
             return content
         return NotImplemented
 
-    def __radd__(self, other: Content | str) -> Content:
-        if not isinstance(other, (Content, str)):
+    def __radd__(self, other: str) -> Content:
+        if not isinstance(other, str):
             return NotImplemented
-        return self + other
+        return Content(other) + self
 
     @classmethod
     def _trim_spans(cls, text: str, spans: list[Span]) -> list[Span]:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -136,6 +136,14 @@ def test_add() -> None:
     assert content.spans == [Span(0, 3, "red"), Span(4, 7, "blue")]
     assert content.cell_length == 7
 
+def test_radd() -> NOne
+    """Test reverse addition."""
+    assert "foo" + Content("bar") == Content("foobar")
+
+    # Test spans after addition
+    content = "foo " + Content.styled("bar", "blue")
+    assert str(content) == "foo bar"
+    assert content.spans == [Span(4, 7, "blue")]
 
 def test_from_markup():
     """Test simple parsing of content markup."""


### PR DESCRIPTION
`Content.__radd__` does not currently behave as expected. For example:

```
>>> from textual.content import Content
>>> Content('foo') + 'bar'  # works as expected
Content('foobar')
>>> 'foo' + Content('bar') # expected: Content('foobar')
Content('barfoo')
```

The problem is that `Content.__radd__` (which implements  `other + self`) returns `self + other`, which is incorrect for concatenation. This pull requests fixes that and adds tests for it. (Existing tests only test for the empty string, for which `a + b == b + a` happens to hold, unlike most strings.)