### PR TITLE
docs(containers): add summary of container types

### DIFF
--- a/src/textual/containers.py
+++ b/src/textual/containers.py
@@ -1,8 +1,10 @@
 """
 Container widgets for quick styling.
 
-With the exception of `Center` and `Middle` containers will fill all of the space in the parent widget.
-
+- [`Horizontal`][textual.containers.Horizontal] and [`Vertical`][textual.containers.Vertical] containers stretch to fill available space.
+- [`HorizontalGroup`][textual.containers.HorizontalGroup] and [`VerticalGroup`][textual.containers.VerticalGroup] fit to the height of their contents.
+- [`HorizontalScroll`][textual.containers.HorizontalScroll] and [`VerticalScroll`][textual.containers.VerticalScroll] add automatic scrollbars.
+- [`Center`][textual.containers.Center], [`Right`][textual.containers.Right], and [`Middle`][textual.containers.Middle] set alignment.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Add a summary of the different container types to the [containers API reference](https://textual.textualize.io/api/containers/).

I spotted this documentation is now out-of-date where it states that:

> With the exception of Center and Middle containers will fill all of the space in the parent widget.

Rather than simply adding other widgets like `VerticalGroup` and `HorizontalGroup` to this list, a summary of the different container types (copied from the How-To guide) might be more helpful.


**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
