### PR TITLE
fix: monkey-patch breakpoint builtin function

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -8,6 +8,7 @@ See [app basics](/guide/app) for how to build Textual apps.
 from __future__ import annotations
 
 import asyncio
+import builtins
 import importlib
 import inspect
 import io
@@ -2231,6 +2232,15 @@ class App(Generic[ReturnType], DOMNode):
         Returns:
             App return value.
         """
+
+        # If some part of the user code uses breakpoint(), it's better to
+        # raise an exception than show an empty screen.
+        def disabled_breakpoint():
+            raise RuntimeError(
+                "breakpoint() is disabled in this UI environment to prevent the app from freezing."
+            )
+
+        builtins.breakpoint = disabled_breakpoint
 
         async def run_app() -> ReturnType | None:
             """Run the app."""


### PR DESCRIPTION
When you run the App, calling the builtin function breakpoint() causes the interface to freeze since it waits for user input that can’t be handled properly in this context (Ctrl-C doesn't work, Ctr-Z doesn't work, etc...)

To prevent this, I monkey-patched the breakpoint() behavior with a function that raises a RuntimeError instead. This makes the issue explicit and avoids the confusing situation of an unresponsive UI.

This is specially useful in cases where a leftover breakpoint() call remains in code that runs within an "obscure and rarely used" part of the UI. Without this, the app would silently hang, making it hard to understand what went wrong.


- [x] Docstrings on all new or modified functions / classes 
- [x] Updated documentation
- [x] Updated CHANGELOG.md (where appropriate)
