### PR TITLE
Improve caching of strips

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -4576,9 +4576,11 @@ class App(Generic[ReturnType], DOMNode):
             # app, and we don't want to have the driver auto-restart
             # application mode when the application comes back to the
             # foreground, in this context.
-            with self._driver.no_automatic_restart(), redirect_stdout(
-                sys.__stdout__
-            ), redirect_stderr(sys.__stderr__):
+            with (
+                self._driver.no_automatic_restart(),
+                redirect_stdout(sys.__stdout__),
+                redirect_stderr(sys.__stderr__),
+            ):
                 yield
             # We're done with the dev's code so resume application mode.
             self._driver.resume_application_mode()

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -395,8 +395,8 @@ class Content(Visual):
     def simplify(self) -> Content:
         """Simplify spans by joining contiguous spans together.
 
-        This can produce faster renders but typically only worth it if you have appended a
-        large number of Content instances together.
+        This may produce faster renders if you have concatenated a large number of small pieces
+        of content with repeating styles.
 
         Note that this modifies the Content instance in-place, which might appear
         to violate the immutability constraints, but it will not change the rendered output,

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1485,7 +1485,10 @@ TextArea {
             line_style = theme.base_style if theme else None
 
         text_strip = text_strip.extend_cell_length(target_width, line_style)
-        strip = Strip.join([Strip(gutter, cell_length=gutter_width), text_strip])
+        if gutter:
+            strip = Strip.join([Strip(gutter, cell_length=gutter_width), text_strip])
+        else:
+            strip = text_strip
 
         return strip.apply_style(base_style)
 
@@ -2343,6 +2346,8 @@ TextArea {
         Returns:
             An `EditResult` containing information about the edit.
         """
+        if len(text) > 1:
+            self._restart_blink()
         if location is None:
             location = self.cursor_location
         return self.edit(Edit(text, location, location, maintain_selection_offset))


### PR DESCRIPTION
Improve caching of strips.

In the last phase of the render Textual was doing Strip.join, which isn't cacheable. With this update the strips aren't joined, which allows previous renders to be re-used. The result is faster scrolling.