### PR TITLE
fix: add set_options to SelectionList

### DIFF
--- a/src/textual/widgets/_selection_list.py
+++ b/src/textual/widgets/_selection_list.py
@@ -713,3 +713,16 @@ class SelectionList(Generic[SelectionType], OptionList):
         self._selected.clear()
         self._values.clear()
         return super().clear_options()
+
+    def set_options(self, options: Iterable[SelectionType]) -> Self:
+        """Set options, potentially clearing existing options.
+
+        Args:
+            options: Options to set.
+
+        Returns:
+            The `SelectionList` instance
+        """
+        self._selected.clear()
+        self._values.clear()
+        return super().set_options(options)


### PR DESCRIPTION
threw me off when this happened to rovr, because the self._selected never got cleared when `set_options` was used instead of `clear_options` + `add_options`


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
