### PR TITLE
Fix double mention of `DeliveryComplete`

### DIFF
--- a/src/textual/driver.py
+++ b/src/textual/driver.py
@@ -235,7 +235,7 @@ class Driver(ABC):
             mime_type: *web only* The MIME type of the file. This will be used to
                 set the `Content-Type` header in the HTTP response.
             name: A user-defined name which will be returned in [`DeliveryComplete`][textual.events.DeliveryComplete]
-                and [`DeliveryComplete`][textual.events.DeliveryComplete].
+                and [`DeliveryFailed`][textual.events.DeliveryFailed].
 
         """
 


### PR DESCRIPTION
I should have noticed this when quickly doing #6225. The documentation for `name` in `Driver.deliver_binary` calls out `DeliveryComplete` twice; I would imagine this is really meant to be a call out to `DeliveryComplete` and `DeliveryFailed`.
