### PR TITLE
docs: fix miscellaneous typos

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -297,7 +297,7 @@ We recommend any of the following terminals:
 
 Textual will not generate escape sequences for the 16 themeable *ANSI* colors.
 
-This is an intentional design decision we took for for the following reasons:
+This is an intentional design decision we took for the following reasons:
 
 - Not everyone has a carefully chosen ANSI color theme. Color combinations which may look fine on your system, may be unreadable on another machine. There is very little an app author or Textual can do to resolve this. Asking users to simply pick a better theme is not a good solution, since not all users will know how.
 - ANSI colors can't be manipulated in the way Textual can do with other colors. Textual can blend colors and produce light and dark shades from an original color, which is used to create more readable text and user interfaces. Color blending will also be used to power future accessibility features.

--- a/docs/css_types/position.md
+++ b/docs/css_types/position.md
@@ -1,6 +1,6 @@
 # &lt;position&gt;
 
-The `<position>` CSS type defines how the the `offset` rule is applied..
+The `<position>` CSS type defines how the `offset` rule is applied.
 
 
 ## Syntax

--- a/docs/guide/styles.md
+++ b/docs/guide/styles.md
@@ -62,7 +62,7 @@ In addition to color names, you can also use any of the following ways of expres
 
 - RGB hex colors starts with a `#` followed by three pairs of one or two hex digits; one for the red, green, and blue color components. For example, `#f00` is an intense red color, and `#9932CC` is *dark orchid*.
 - RGB decimal color start with `rgb` followed by a tuple of three numbers in the range 0 to 255. For example `rgb(255,0,0)` is intense red, and `rgb(153,50,204)` is *dark orchid*.
-- HSL colors start with `hsl` followed by a angle between 0 and 360 and two percentage values, representing Hue, Saturation and Lightness. For example `hsl(0,100%,50%)` is intense red and `hsl(280,60%,49%)` is *dark orchid*.
+- HSL colors start with `hsl` followed by an angle between 0 and 360 and two percentage values, representing Hue, Saturation and Lightness. For example `hsl(0,100%,50%)` is intense red and `hsl(280,60%,49%)` is *dark orchid*.
 
 
 The background and color styles also accept a [Color][textual.color.Color] object which can be used to create colors dynamically.

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -165,7 +165,7 @@ Setting `border_title` will display text within the top border, and setting `bor
 The default value for these attributes is empty string, which disables the title.
 You can change the default value for the title attributes with the [`BORDER_TITLE`][textual.widget.Widget.BORDER_TITLE] and [`BORDER_SUBTITLE`][textual.widget.Widget.BORDER_SUBTITLE] class variables.
 
-Let's demonstrate setting a title, both as a class variable and a instance variable:
+Let's demonstrate setting a title, both as a class variable and an instance variable:
 
 
 === "hello06.py"

--- a/docs/how-to/style-inline-apps.md
+++ b/docs/how-to/style-inline-apps.md
@@ -9,7 +9,7 @@ Your apps will typically run inline without modification, but you may want to ma
 This How-To will explain how.
 
 Let's look at an inline app.
-The following app displays the the current time (and keeps it up to date).
+The following app displays the current time (and keeps it up to date).
 
 ```python hl_lines="31"
 --8<-- "docs/examples/how-to/inline01.py"

--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -561,7 +561,7 @@ class App(Generic[ReturnType], DOMNode):
                 will be loaded in order.
             watch_css: Reload CSS if the files changed. This is set automatically if
                 you are using `textual run` with the `dev` switch.
-            ansi_color: Allow ANSI colors if `True`, or convert ANSI colors to to RGB if `False`.
+            ansi_color: Allow ANSI colors if `True`, or convert ANSI colors to RGB if `False`.
 
         Raises:
             CssPathError: When the supplied CSS path(s) are an unexpected type.
@@ -1824,7 +1824,7 @@ class App(Generic[ReturnType], DOMNode):
     ) -> str | None:
         """Deliver a screenshot of the app.
 
-        This with save the screenshot when running locally, or serve it when the app
+        This will save the screenshot when running locally, or serve it when the app
         is running in a web browser.
 
         Args:
@@ -3438,7 +3438,6 @@ class App(Generic[ReturnType], DOMNode):
         Args:
             parent: Parent node.
             child: The child widget to register.
-            widgets: The widget to register.
             before: A location to mount before.
             after: A location to mount after.
         """

--- a/src/textual/css/styles.py
+++ b/src/textual/css/styles.py
@@ -283,7 +283,7 @@ class StylesBase:
     """
 
     layout = LayoutProperty()
-    """Set the layout of the widget, defining how it's children are laid out.
+    """Set the layout of the widget, defining how its children are laid out.
     
     Valid values are "grid", "stream", "horizontal", or "vertical" or None to clear any layout
     that was set at runtime.
@@ -395,7 +395,7 @@ class StylesBase:
     transitions = TransitionsProperty()
 
     tint = ColorProperty("transparent")
-    """Set the tint of the widget. This allows you apply a opaque color above the widget.
+    """Set the tint of the widget. This allows you apply an opaque color above the widget.
 
     You can specify an opacity after a color e.g. "blue 10%"
     """

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -1134,7 +1134,7 @@ class DOMNode(MessagePump):
     def _get_title_style_information(
         self, background: Color
     ) -> tuple[Color, Color, VisualStyle]:
-        """Get a Visual Style object for for titles.
+        """Get a Visual Style object for titles.
 
         Args:
             background: The background color.
@@ -1157,7 +1157,7 @@ class DOMNode(MessagePump):
     def _get_subtitle_style_information(
         self, background: Color
     ) -> tuple[Color, Color, VisualStyle]:
-        """Get a Rich Style object for for titles.
+        """Get a Rich Style object for subtitles.
 
         Args:
             background: The background color.

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -730,7 +730,7 @@ class Screen(Generic[ScreenResultType], Widget):
         self._select_end = None
 
     def _select_all_in_widget(self, widget: Widget) -> None:
-        """Select a widget and all it's children.
+        """Select a widget and all its children.
 
         Args:
             widget: Widget to select.

--- a/src/textual/scroll_view.py
+++ b/src/textual/scroll_view.py
@@ -19,7 +19,7 @@ class ScrollView(ScrollableContainer):
 
     !!! note
 
-        This is the typically wrong class for making something scrollable. If you want to make something scroll, set it's
+        This is the typically wrong class for making something scrollable. If you want to make something scroll, set its
         `overflow` style to auto or scroll. Or use one of the pre-defined scrolling containers such as [VerticalScroll][textual.containers.VerticalScroll].
     """
 

--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -36,7 +36,7 @@ class Timer:
         event_target: The object which will receive the timer events.
         interval: The time between timer events, in seconds.
         name: A name to assign the event (for debugging).
-        callback: A optional callback to invoke when the event is handled.
+        callback: An optional callback to invoke when the event is handled.
         repeat: The number of times to repeat the timer, or None to repeat forever.
         skip: Enable skipping of scheduled events that couldn't be sent in time.
         pause: Start the timer paused.

--- a/src/textual/visual.py
+++ b/src/textual/visual.py
@@ -57,7 +57,7 @@ class SupportsVisual(Protocol):
 
         Args:
             widget: The widget that generated the render.
-            obj: The result of the the render.
+            obj: The result of the render.
 
         Returns:
             A Visual instance, or `None` if it wasn't possible.

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -492,7 +492,7 @@ class Input(ScrollView):
             character: A character associated with the key, or `None` if there isn't one.
 
         Returns:
-            `True` if the widget may capture the key in it's `Key` message, or `False` if it won't.
+            `True` if the widget may capture the key in its `Key` message, or `False` if it won't.
         """
         return character is not None and character.isprintable()
 

--- a/src/textual/widgets/_option_list.py
+++ b/src/textual/widgets/_option_list.py
@@ -283,7 +283,7 @@ class OptionList(ScrollView, can_focus=True):
         self._id_to_option: dict[str, Option] = {}
         """Maps an Options's ID on to the option itself."""
         self._option_to_index: dict[Option, int] = {}
-        """Maps an Option to it's index in self._options."""
+        """Maps an Option to its index in self._options."""
 
         self._option_render_cache: LRUCache[tuple[Option, Style, Spacing], list[Strip]]
         self._option_render_cache = LRUCache(maxsize=1024 * 2)

--- a/src/textual/widgets/_selection_list.py
+++ b/src/textual/widgets/_selection_list.py
@@ -193,7 +193,7 @@ class SelectionList(Generic[SelectionType], OptionList):
         """Message sent when the collection of selected values changes.
 
         This is sent regardless of whether the change occurred via user interaction
-        or programmatically the the `SelectionList` API.
+        or programmatically via the `SelectionList` API.
 
         When a bulk change occurs, such as through `select_all` or `deselect_all`,
         only a single `SelectedChanged` message will be sent (rather than one per

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -676,7 +676,7 @@ TextArea {
             character: A character associated with the key, or `None` if there isn't one.
 
         Returns:
-            `True` if the widget may capture the key in it's `Key` message, or `False` if it won't.
+            `True` if the widget may capture the key in its `Key` message, or `False` if it won't.
         """
         if self.read_only:
             # In read only mode we don't consume any key events
@@ -1035,7 +1035,7 @@ TextArea {
                 "Try `pip install 'textual[syntax]'` or '`poetry add textual[syntax]' to get started quickly.\n\n"
                 "Alternatively, install tree-sitter manually (`pip install tree-sitter`) and then\n"
                 "install the required language (e.g. `pip install tree-sitter-ruby`), then register it.\n"
-                "and it's highlight query using TextArea.register_language().\n\n"
+                "and its highlight query using TextArea.register_language().\n\n"
                 "Falling back to plain text for now."
             )
             document = Document(text)


### PR DESCRIPTION
I spotted a few typos in passing and grepped to check for similar ones.

(Sorry if this seems a bit pedantic, but I thought it better to address these typos all at once rather than potentially having multiple PRs when others might notice them.)