### PR TITLE
fix: remove `CollapsibleTitle` from `textual.widgets` exports

### DIFF
--- a/src/textual/widgets/__init__.py
+++ b/src/textual/widgets/__init__.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
     from textual.widget import Widget
     from textual.widgets._button import Button
     from textual.widgets._checkbox import Checkbox
-    from textual.widgets._collapsible import Collapsible, CollapsibleTitle
+    from textual.widgets._collapsible import Collapsible
     from textual.widgets._content_switcher import ContentSwitcher
     from textual.widgets._data_table import DataTable
     from textual.widgets._digits import Digits
@@ -54,7 +54,6 @@ __all__ = [
     "Button",
     "Checkbox",
     "Collapsible",
-    "CollapsibleTitle",
     "ContentSwitcher",
     "DataTable",
     "Digits",

--- a/src/textual/widgets/__init__.pyi
+++ b/src/textual/widgets/__init__.pyi
@@ -2,7 +2,6 @@
 from ._button import Button as Button
 from ._checkbox import Checkbox as Checkbox
 from ._collapsible import Collapsible as Collapsible
-from ._collapsible import CollapsibleTitle as CollapsibleTitle
 from ._content_switcher import ContentSwitcher as ContentSwitcher
 from ._data_table import DataTable as DataTable
 from ._digits import Digits as Digits


### PR DESCRIPTION
Fixes #6261

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
