### PR TITLE
fix(syntax): remove aggressive python type inference rules

### DIFF
--- a/src/textual/tree-sitter/highlights/python.scm
+++ b/src/textual/tree-sitter/highlights/python.scm
@@ -10,14 +10,14 @@
 (interpolation) @none
 
 ;; Identifier naming conventions
-((identifier) @type
- (#match? @type "^[A-Z].*[a-z]"))
-((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
-
-((attribute
-    attribute: (identifier) @field)
- (#match? @field "^([A-Z])@!.*$"))
+;; ((identifier) @type
+;;  (#match? @type "^[A-Z].*[a-z]"))
+;; ((identifier) @constant
+;;  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+;;
+;; ((attribute
+;;     attribute: (identifier) @field)
+;;  (#match? @field "^([A-Z])@!.*$"))
 
 ((identifier) @type.builtin
  (#any-of? @type.builtin
@@ -57,14 +57,14 @@
   function: (attribute
               attribute: (identifier) @method.call))
 
-((call
-   function: (identifier) @constructor)
- (#match? @constructor "^[A-Z]"))
-
-((call
-  function: (attribute
-              attribute: (identifier) @constructor))
- (#match? @constructor "^[A-Z]"))
+;; ((call
+;;    function: (identifier) @constructor)
+;;  (#match? @constructor "^[A-Z]"))
+;;
+;; ((call
+;;   function: (attribute
+;;               attribute: (identifier) @constructor))
+;;  (#match? @constructor "^[A-Z]"))
 
 ;; Decorators
 


### PR DESCRIPTION
### Problem

The current python.scm syntax highlighting queries are too aggressive. They use broad regular expressions to match any identifier starting with a capital letter as a @type or @constructor.

This results in incorrect syntax highlighting behavior, such as:

Variables like Final_Score

Function calls

Even commented text

…being highlighted as Types or Constructors simply because they start with a capital letter.
This leads to inconsistent "rainbow coloring" and reduces readability for Python code displayed inside TextArea.

### Solution

The heuristic rules depending solely on regex matching for types and constructors have been disabled.
These were removed in:

File: src/textual/tree-sitter/highlights/python.scm

Removed queries:

((identifier) @type
  (#match? @type "^[A-Z].*[a-z]"))

((call
  function: (identifier) @constructor)
  (#match? @constructor "^[A-Z]"))


This ensures Tree-sitter relies more on proper semantic analysis instead of unreliable capitalization guessing.

The result:
✔ Cleaner syntax highlighting
✔ More accurate code representation
✔ No more distracting false-type coloring


- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
