### PR TITLE
ci: run tests when highlights `**.scm` file changed

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,6 +7,7 @@ on:
       - "**.py"
       - "**.pyi"
       - "**.css"
+      - "**.scm"
       - "**.ambr"
       - "**.lock"
       - "Makefile"


### PR DESCRIPTION
Syntax highlighting in the `TextArea` depends on the `**.scm` files.

Currently tests aren't run in CI after changing these files, as shown in https://github.com/Textualize/textual/pull/6275.

Add `**.scm` to workflow paths to ensure tests run after changes.