### PR TITLE
Docs: Clarify CSS variable usage scope (Fixes #3951)

### DIFF
--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -465,6 +465,15 @@ If we decide we want to change some aspect of our design in the future, we only 
 
     Variables can only be used in the _values_ of a CSS declaration. You cannot, for example, refer to a variable inside a selector.
 
+!!! note "Variable Scope & Inheritance"
+
+    When you **use** a variable in a CSS rule (e.g., `color: $text-muted;`), it behaves like any other CSS property:
+    
+    1.  **Inheritance:** The value is applied to the widget and inherited by its children (descendants), unless the children override it.
+    2.  **Isolation:** The value does **not** affect siblings or parents.
+    
+    Variables themselves are global (defined by the Theme), but their *application* is scoped to the widget tree where they are used.
+
 Variables can refer to other variables.
 Let's say we define a variable `$success: lime;`.
 Our `$border` variable could then be updated to `$border: wide $success;`, which will


### PR DESCRIPTION
Fixes #3951

### Summary
Clarified the documentation regarding CSS variables. While variables are globally defined in the Theme, this update adds a note explaining that their **usage** follows standard CSS inheritance rules:
- Values are inherited by descendants (waterfall).
- Values are isolated from siblings.

*Note: Skipped `CHANGELOG.md` update as this is a documentation-only clarification.*