### PR TITLE
fix(masked input): fix selection

### DIFF
--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -572,12 +572,19 @@ class MaskedInput(Input, can_focus=True):
             if char == " ":
                 result.stylize(style, index, index + 1)
 
-        if self._cursor_visible and self.has_focus:
-            if self.cursor_at_end:
-                result.pad_right(1)
-            cursor_style = self.get_component_rich_style("input--cursor")
-            cursor = self.cursor_position
-            result.stylize(cursor_style, cursor, cursor + 1)
+        if self.has_focus:
+            if not self.selection.is_empty:
+                start, end = self.selection
+                start, end = sorted((start, end))
+                selection_style = self.get_component_rich_style("input--selection")
+                result.stylize_before(selection_style, start, end)
+
+            if self._cursor_visible:
+                cursor_style = self.get_component_rich_style("input--cursor")
+                cursor = self.cursor_position
+                if self.cursor_at_end:
+                    result.pad_right(1)
+                result.stylize(cursor_style, cursor, cursor + 1)
 
         segments = list(result.render(self.app.console))
         line_length = Segment.get_line_length(segments)

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -474,6 +474,7 @@ class MaskedInput(Input, can_focus=True):
                 which determine when to do input validation. The default is to do
                 validation for all messages.
             valid_empty: Empty values are valid.
+            select_on_focus: Whether to select all text on focus.
             name: Optional name for the masked input widget.
             id: Optional ID for the widget.
             classes: Optional initial classes for the widget.

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -279,6 +279,12 @@ class _Template(Validator):
                 new_value, cursor_position
             )
 
+        if (
+            new_value[cursor_position:]
+            == self.empty_mask[cursor_position : len(new_value)]
+        ):
+            new_value = new_value[:cursor_position]
+
         return new_value, cursor_position
 
     def insert(self, text: str, index: int) -> tuple[str, int] | None:

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -691,21 +691,37 @@ class MaskedInput(Input, can_focus=True):
         """Clear the masked input."""
         self.value, self.cursor_position = self._template.insert_separators("", 0)
 
-    def action_cursor_left(self) -> None:
-        """Move the cursor one position to the left; separators are skipped."""
+    def action_cursor_left(self, select: bool = False) -> None:
+        """Move the cursor one position to the left; separators are skipped.
+
+        Args:
+            select: If `True`, select the text to the left of the cursor.
+        """
         self._template.move_cursor(-1)
 
-    def action_cursor_right(self) -> None:
-        """Move the cursor one position to the right; separators are skipped."""
+    def action_cursor_right(self, select: bool = False) -> None:
+        """Move the cursor one position to the right; separators are skipped.
+
+        Args:
+            select: If `True`, select the text to the right of the cursor.
+        """
         self._template.move_cursor(1)
 
-    def action_home(self) -> None:
-        """Move the cursor to the start of the input."""
+    def action_home(self, select: bool = False) -> None:
+        """Move the cursor to the start of the input.
+
+        Args:
+            select: If `True`, select the text between the old and new cursor positions.
+        """
         self._template.move_cursor(-len(self.template))
 
-    def action_cursor_left_word(self) -> None:
+    def action_cursor_left_word(self, select: bool = False) -> None:
         """Move the cursor left next to the previous separator. If no previous
-        separator is found, moves the cursor to the start of the input."""
+        separator is found, moves the cursor to the start of the input.
+
+        Args:
+            select: If `True`, select the text between the old and new cursor positions.
+        """
         if self._template.at_separator(self.cursor_position - 1):
             position = self._template.prev_separator_position(self.cursor_position - 1)
         else:
@@ -714,9 +730,13 @@ class MaskedInput(Input, can_focus=True):
             position += 1
         self.cursor_position = position or 0
 
-    def action_cursor_right_word(self) -> None:
+    def action_cursor_right_word(self, select: bool = False) -> None:
         """Move the cursor right next to the next separator. If no next
-        separator is found, moves the cursor to the end of the input."""
+        separator is found, moves the cursor to the end of the input.
+
+        Args:
+            select: If `True`, select the text between the old and new cursor positions.
+        """
         position = self._template.next_separator_position()
         if position is None:
             self.cursor_position = len(self._template.mask)

--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -200,7 +200,7 @@ class _Template(Validator):
             cursor_position += 1
         return value, cursor_position
 
-    def insert_text_at_cursor(self, text: str) -> str | None:
+    def insert_text_at_cursor(self, text: str) -> tuple[str, int] | None:
         """Inserts `text` at current cursor position. If not present in `text`, any expected separator is automatically
         inserted at the correct position.
 

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_masked_input_highlights_selection.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_masked_input_highlights_selection.svg
@@ -1,0 +1,153 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #121212 }
+.terminal-r2 { fill: #b93c5b }
+.terminal-r3 { fill: #c5c8c6 }
+.terminal-r4 { fill: #e0e0e0 }
+.terminal-r5 { fill: #797979 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">MaskedInputApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#b93c5b" x="0" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="12.2" y="1.5" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#b93c5b" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="12.2" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d4e74" x="36.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="73.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="85.4" y="25.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="268.4" y="25.9" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="939.4" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#b93c5b" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="12.2" y="50.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▊</text><text class="terminal-r2" x="12.2" y="20" textLength="951.6" clip-path="url(#terminal-line-0)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-r2" x="963.8" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▎</text><text class="terminal-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▊</text><text class="terminal-r4" x="36.6" y="44.4" textLength="36.6" clip-path="url(#terminal-line-1)">123</text><text class="terminal-r1" x="73.2" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">0</text><text class="terminal-r5" x="85.4" y="44.4" textLength="183" clip-path="url(#terminal-line-1)">-0000-0000-0000</text><text class="terminal-r2" x="963.8" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▎</text><text class="terminal-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▊</text><text class="terminal-r2" x="12.2" y="68.8" textLength="951.6" clip-path="url(#terminal-line-2)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-r2" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▎</text><text class="terminal-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -41,6 +41,7 @@ from textual.widgets import (
     ListView,
     Log,
     Markdown,
+    MaskedInput,
     OptionList,
     Placeholder,
     ProgressBar,
@@ -4800,3 +4801,22 @@ def test_text_area_paste(snap_compare) -> None:
         await pilot.press("ctrl+v")
 
     assert snap_compare(TextAreaApp(), run_before=run_before)
+
+
+def test_masked_input_highlights_selection(snap_compare) -> None:
+    """Regression test for https://github.com/Textualize/textual/issues/5495
+
+    You should see a MaskedInput where the selection is highlighted.
+    """
+
+    class MaskedInputApp(App):
+        def compose(self) -> ComposeResult:
+            yield MaskedInput(
+                template="9999-9999-9999-9999;0",
+                value="123"
+            )
+
+    async def run_before(pilot):
+        pilot.app.query_one(MaskedInput).cursor_blink = False
+
+    assert snap_compare(MaskedInputApp(), run_before=run_before)

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -323,3 +323,41 @@ async def test_replace_selection_with_invalid_value():
         assert input.selection == (0, len(input.value))  # Sanity check
         await pilot.press("a")
         assert input.value == "2025-12"
+
+
+async def test_movement_actions_with_select():
+    app = MaskedInputApp(
+        template=">NNNNN-NNNNN-NNNNN-NNNNN;_",
+        value="ABCDE-FGHIJ-KLMNO-PQRST",
+        select_on_focus=False,
+    )
+    async with app.run_test():
+        input = app.query_one(MaskedInput)
+
+        input.action_home(select=True)
+        assert input.selection == (len(input.value), 0)
+
+        input.action_cursor_left()
+        assert input.selection.is_empty
+        assert input.cursor_position == 0
+
+        input.action_cursor_right_word(select=True)
+        assert input.selection == (0, 6)
+
+        input.action_cursor_right()
+        assert input.selection.is_empty
+        assert input.cursor_position == 6
+
+        input.action_cursor_left(select=True)
+        assert input.selection == (6, 4)
+
+        input.action_cursor_left()
+        input.action_cursor_right(select=True)
+        assert input.selection == (4, 6)
+
+        input.action_end(select=True)
+        assert input.selection == (6, len(input.value))
+
+        input.action_cursor_right()
+        input.action_cursor_left_word(select=True)
+        assert input.selection == (len(input.value), 18)

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union
 
 import pytest

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -94,6 +94,39 @@ async def test_editing():
         assert input.cursor_position == len(serial)
 
 
+async def test_overwrite_typing():
+    app = InputApp("9999-9999-9999-9999;0")
+    async with app.run_test() as pilot:
+        input = app.query_one(MaskedInput)
+        input.value = "0000-99"
+        input.action_home()
+
+        await pilot.press("1", "2", "3")
+        assert input.cursor_position == 3
+        assert input.value == "1230-99"
+
+        await pilot.press("4")
+        assert input.cursor_position == 5
+        assert input.value == "1234-99"
+
+        await pilot.press("0", "0")
+        assert input.cursor_position == 7
+        assert input.value == "1234-00"
+
+        await pilot.press("7", "8")
+        assert input.cursor_position == 10
+        assert input.value == "1234-0078-"
+
+        await pilot.press("left", "left")
+        await pilot.press("backspace", "backspace")
+        assert input.cursor_position == 5
+        assert input.value == "1234-  78"
+
+        await pilot.press("5", "6")
+        assert input.cursor_position == 7
+        assert input.value == "1234-5678"
+
+
 async def test_key_movement_actions():
     serial = "ABCDE-FGHIJ-KLMNO-PQRST"
     app = InputApp(">NNNNN-NNNNN-NNNNN-NNNNN;_")

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -413,3 +413,16 @@ async def test_replace_selection():
         assert input.value == "a    -   IJ-KLMx -PQRST"
         assert input.selection.is_empty
         assert input.cursor_position == 1
+
+        input.cursor_position = 13
+        input.action_end(select=True)
+        await pilot.press("x")
+        assert input.value == "a    -   IJ-Kx"
+        assert input.selection.is_empty
+        assert input.cursor_position == 14
+
+        input.action_home(select=True)
+        await pilot.press("x")
+        assert input.value == "x"
+        assert input.selection.is_empty
+        assert input.cursor_position == 1

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -254,3 +254,21 @@ async def test_digits_required():
         await pilot.press("a", "1")
         assert input.value == "1"
         assert not input.is_valid
+
+
+async def test_replace_selection_with_invalid_value():
+    """Regression test for https://github.com/Textualize/textual/issues/5493"""
+
+    class MaskedInputApp(App):
+        def compose(self) -> ComposeResult:
+            yield MaskedInput(
+                template="9999-99-99",
+                value="2025-12",
+            )
+
+    app = MaskedInputApp()
+    async with app.run_test() as pilot:
+        input = app.query_one(MaskedInput)
+        assert input.selection == (0, len(input.value))  # Sanity check
+        await pilot.press("a")
+        assert input.value == "2025-12"

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -152,6 +152,33 @@ async def test_overwrite_typing():
         assert input.value == "1234-5678"
 
 
+async def test_insert_jump_to_next_separator():
+    app = MaskedInputApp(
+        template="9999-9999-9999-9999;0",
+        select_on_focus=False,
+    )
+    async with app.run_test() as pilot:
+        input = app.query_one(MaskedInput)
+
+        # If cursor is at the start, input should not jump to next separator
+        await pilot.press("-")
+        assert input.value == ""
+        assert input.cursor_position == 0
+
+        await pilot.press("1", "-")
+        assert input.value == "1   -"
+        assert input.cursor_position == 5
+
+        # If previous character is a separator, input should not jump to next separator
+        await pilot.press("-")
+        assert input.value == "1   -"
+        assert input.cursor_position == 5
+
+        await pilot.press("2", "-")
+        assert input.value == "1   -2   -"
+        assert input.cursor_position == 10
+
+
 async def test_key_movement_actions():
     serial = "ABCDE-FGHIJ-KLMNO-PQRST"
     app = MaskedInputApp(


### PR DESCRIPTION
When text selection was added to the `Input` widget in #5340, it was unfortunately overlooked that `MaskedInput` inherits from this widget.

- Fixes #5495
- Fixes #5493
- Fixes bindings to move and select

**Please review the following checklist.**

- [ ] Docstrings on all new or modified functions / classes 
- [ ] Updated documentation
- [ ] Updated CHANGELOG.md (where appropriate)
