### PR TITLE
fix: on-decorator-control-type-filter

### DIFF
--- a/src/textual/_on.py
+++ b/src/textual/_on.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 from textual.css.model import SelectorSet
 from textual.css.parse import parse_selectors
 from textual.css.tokenizer import TokenError
 from textual.message import Message
+
+if TYPE_CHECKING:
+    from textual.widget import Widget
 
 DecoratedType = TypeVar("DecoratedType")
 
@@ -22,7 +25,11 @@ class OnNoWidget(Exception):
 
 
 def on(
-    message_type: type[Message], selector: str | None = None, **kwargs: str
+    message_type: type[Message],
+    selector: str | None = None,
+    *,
+    control_type: type["Widget"] | None = None,
+    **kwargs: str,
 ) -> Callable[[DecoratedType], DecoratedType]:
     """Decorator to declare that the method is a message handler.
 
@@ -49,10 +56,28 @@ def on(
             ...
         ```
 
+    The `control_type` parameter can be used to filter by widget class. This is useful
+    when a widget subclass inherits message types from its parent but you want to handle
+    only events from the specific subclass.
+
+    Example:
+        ```python
+        class MyButton(Button):
+            pass
+
+        class MyApp(App):
+            @on(Button.Pressed, control_type=MyButton)
+            def handle_my_button_only(self) -> None:
+                # Only handles Button.Pressed from MyButton instances
+                ...
+        ```
+
     Args:
         message_type: The message type (i.e. the class).
         selector: An optional [selector](/guide/CSS#selectors). If supplied, the handler will only be called if `selector`
             matches the widget from the `control` attribute of the message.
+        control_type: An optional widget class. If supplied, the handler will only be called if
+            the message's `control` is an instance of this class (or a subclass).
         **kwargs: Additional selectors for other attributes of the message.
     """
 
@@ -81,12 +106,19 @@ def on(
                 f"Unable to parse selector {css_selector!r} for {attribute}; check for syntax errors"
             ) from None
 
+    # Validate control_type if specified
+    if control_type is not None:
+        if message_type.control == Message.control:
+            raise OnDecoratorError(
+                "The message class must have a 'control' to use control_type with the on decorator"
+            )
+
     def decorator(method: DecoratedType) -> DecoratedType:
         """Store message and selector in function attribute, return callable unaltered."""
 
         if not hasattr(method, "_textual_on"):
             setattr(method, "_textual_on", [])
-        getattr(method, "_textual_on").append((message_type, parsed_selectors))
+        getattr(method, "_textual_on").append((message_type, parsed_selectors, control_type))
 
         return method
 


### PR DESCRIPTION
**Link to issue or discussion**

(https://github.com/Textualize/textual/issues/4968)

## Summary

adds a `control_type` parameter to the `@on` decorator that allows filtering message handlers by the widget class of the message's `control` property.

```
class MyButton(Button):
    pass

class MyApp(App):
    @on(Button.Pressed, control_type=MyButton)
    def handle_my_button_only(self) -> None:
        # Only fires for MyButton instances, not regular Button
```

tests:
- test_on_control_type_filters_widget_class
- test_on_control_type_with_selector
- test_on_control_type_no_control_raises