### PR TITLE
fix: preserve existing text when typing separator in MaskedInput

### DIFF
--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -231,14 +231,15 @@ class _Template(Validator):
                                 _CharFlags.SEPARATOR
                                 in self.template[cursor_position].flags
                             ):
-                                char = self.template[cursor_position].char
-                            else:
-                                char = " "
-                            value = (
-                                value[:cursor_position]
-                                + char
-                                + value[cursor_position + 1 :]
-                            )
+                                # Insert the separator character
+                                sep_char = self.template[cursor_position].char
+                                value = (
+                                    value[:cursor_position]
+                                    + sep_char
+                                    + value[cursor_position + 1 :]
+                                )
+                            # For non-separator positions, preserve existing text
+                            # (don't overwrite with spaces)
                             cursor_position += 1
                 continue
             if cursor_position >= len(self.template):


### PR DESCRIPTION
**Link to issue or discussion**

https://github.com/Textualize/textual/issues/6315

when typing a separator character in MaskedInput, the cursor should jump to the position after the next separator without overwriting any existing text. the code would fill non-separator positions with spaces, deleting any text that was already there.

the fix preserves existing text at non-separator positions by only inserting the separator characters themselves, not spaces.