### PR TITLE
Fix Select widget border not rendering due to BLANK name collision

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -4206,7 +4206,7 @@ class Widget(DOMNode):
         Returns:
             A rendered line.
         """
-        if self.BLANK:
+        if self.BLANK is True:
             return Strip.blank(self.size.width, self.visual_style.rich_style)
 
         if self._dirty_regions:
@@ -4227,7 +4227,7 @@ class Widget(DOMNode):
         Returns:
             A list of list of segments.
         """
-        if self.BLANK:
+        if self.BLANK is True:
             strips = [
                 Strip.blank(crop.width, self.visual_style.rich_style)
             ] * crop.height


### PR DESCRIPTION
## Summary

- `Widget.BLANK` (a `ClassVar[bool]` defaulting to `False`) was added in v7.1.0 to allow widgets to opt into blank rendering
- `Select.BLANK` is a pre-existing `NoSelection` sentinel object used to represent "no value selected"
- In v7.2.0, `render_line` and `render_lines` were optimized to check `if self.BLANK:` and skip normal rendering — but `NoSelection()` is truthy, so `Select` inadvertently enters the blank rendering path, causing its border (and all visual chrome) to disappear
- Fix: use `if self.BLANK is True:` to match only the boolean `True`, not arbitrary truthy objects

## Reproduction

```python
from textual.app import App, ComposeResult
from textual.widgets import Select

class TestApp(App):
    CSS = """
    Select { border: heavy #252e49; }
    SelectCurrent { border: none; }
    """
    def compose(self) -> ComposeResult:
        yield Select([("Option 1", 1)], prompt="Test")

TestApp().run()
```

**Expected:** Select has a heavy border  
**Actual (7.2.0+):** Select renders with no border

## Test plan

- [x] Verified border renders correctly on 6.11.0 through 7.1.0
- [x] Verified border disappears on 7.2.0 through 7.5.0
- [x] Verified fix restores border rendering on 7.5.0
- [x] Verified `Widget.BLANK = True` still produces blank rendering for widgets that use it