### PR TITLE
fix(widget): fix visual not updated after style changes

### DIFF
--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_visual_updates_after_style_changes.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_visual_updates_after_style_changes.svg
@@ -1,0 +1,150 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #ffff00 }
+.terminal-r2 { fill: #c5c8c6 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">UpdateStylesApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#ff0000" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="269.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="402.6" y="269.9" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="561.2" y="269.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#ff0000" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="402.6" y="288.4" textLength="158.6" clip-path="url(#terminal-line-11)">yellow&#160;on&#160;red</text><text class="terminal-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -4804,3 +4804,28 @@ def test_text_area_paste(snap_compare) -> None:
         await pilot.press("ctrl+v")
 
     assert snap_compare(TextAreaApp(), run_before=run_before)
+
+
+def test_visual_updates_after_style_changes(snap_compare) -> None:
+    """Regression test for https://github.com/Textualize/textual/issues/6289
+
+    You should see a widget with a red background and yellow text.
+    """
+
+    class UpdateStylesApp(App):
+        CSS = """
+        Static {
+            height: 1fr;
+            content-align: center middle;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            yield Static("yellow on red")
+
+        def key_s(self) -> None:
+            widget = self.query_one(Static)
+            widget.styles.color = "yellow"
+            widget.styles.background = "red"
+
+    assert snap_compare(UpdateStylesApp(), press=["s"])


### PR DESCRIPTION
Fix a significant regression in Textual v6.0.0 where the widget visual is not updated after style changes.

This effectively reverts the changes in dca9439, which intended to optimize styles caching but clearly had unintended consequences.

Fixes https://github.com/Textualize/textual/issues/6235 
Fixes https://github.com/Textualize/textual/issues/6289 
Fixes https://github.com/Textualize/textual/issues/6322