### PR TITLE
fix(app): refresh after suspend

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -4594,6 +4594,7 @@ class App(Generic[ReturnType], DOMNode):
     def _resume_signal(self) -> None:
         """Signal that the application is being resumed from a suspension."""
         self.app_resume_signal.publish(self)
+        self.refresh(layout=True)
 
     @contextmanager
     def suspend(self) -> Iterator[None]:
@@ -4642,7 +4643,6 @@ class App(Generic[ReturnType], DOMNode):
             self._driver.resume_application_mode()
             # ...and publish a resume signal.
             self._resume_signal()
-            self.refresh(layout=True)
         else:
             raise SuspendNotSupported(
                 "App.suspend is not supported in this environment."


### PR DESCRIPTION
Fix the app display not refreshing after `action_suspend_process`.

A similar issue was reported in https://github.com/Textualize/textual/issues/5528 but specifically when using the `App.suspend` context manager. This was fixed in 81392ff by adding `refresh(layout=True)`, however this doesn't cover when the app was suspended with `action_suspend_process`. This simply moves that call to `refresh` to account for both suspend methods.

Related issue: https://github.com/Textualize/textual/issues/6298