### PR TITLE
Fix alt modifier ignored in ANSI_SEQUENCES_KEYS tuple branch

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -374,7 +374,10 @@ class XTermParser(Parser[Message]):
             # If the sequence mapped to a tuple, then it's values from the
             # `Keys` enum. Raise key events from what we find in the tuple.
             for key in keys:
-                yield events.Key(key.value, sequence if len(sequence) == 1 else None)
+                key_name = key.value
+                if alt:
+                    key_name = f"alt+{key_name}"
+                yield events.Key(key_name, sequence if len(sequence) == 1 else None)
             return
         # If keys is a string, the intention is that it's a mapping to a
         # character, which should really be treated as the sequence for the

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -191,6 +191,8 @@ def test_double_escape(parser):
         ("\x1b[65;4u", "alt+shift+a"),
         ("\x1bA", "alt+shift+a"),
         ("\x1b[120;7u", "alt+ctrl+x"),
+        ("\x1b\r", "alt+enter"),
+        ("\x1b ", "alt+space"),
     ],
 )
 def test_keys(parser, sequence: str, key: str) -> None:


### PR DESCRIPTION
Fixes #6378

## Summary

The `_sequence_to_key_events` method's tuple branch (keys like Enter, Space, Backspace, Tab) ignored the `alt` parameter, silently dropping the alt modifier. The single-character branch handled it correctly — this applies the same pattern to the tuple branch.

- Apply `alt+` prefix in tuple branch when `alt=True`, matching existing single-character branch pattern
- Add `alt+enter` and `alt+space` test cases to existing `test_keys` parametrize block

## Test plan

- [x] New tests pass: `pytest tests/test_xterm_parser.py -k test_keys` (9/9 pass)
- [x] All existing `test_xterm_parser.py` tests still pass
- [x] Manual verification: Alt+Enter produces `key='alt+enter'` in GNOME Console + tmux
- [x] Formatted with black

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>