### PR TITLE
fixed ListView (src/textual/widgets/_list_view.py): clear stuck hover state during scrollbar drag

### DIFF
--- a/src/textual/widgets/_list_item.py
+++ b/src/textual/widgets/_list_item.py
@@ -35,5 +35,7 @@ class ListItem(Widget, can_focus=False):
     @on(events.Enter)
     @on(events.Leave)
     def on_enter_or_leave(self, event: events.Enter | events.Leave) -> None:
+        """Remove mouse hover when dragging the scrollbar"""
         event.stop()
-        self.set_class(self.is_mouse_over, "-hovered")
+        mouse_captured = self.app.mouse_captured is not None
+        self.set_class(self.is_mouse_over and not mouse_captured, "-hovered")

--- a/src/textual/widgets/_list_view.py
+++ b/src/textual/widgets/_list_view.py
@@ -394,12 +394,3 @@ class ListView(VerticalScroll, can_focus=True, can_focus_children=False):
     def __len__(self) -> int:
         """Compute the length (in number of items) of the list view."""
         return len(self._nodes)
-
-    def _on_scroll_to(self, message) -> None:
-        """Clear any stuck hovered items that the mouse is no longer over"""
-        hovered = self.query(".-hovered")
-        if hovered:
-            for item in hovered:
-                if not item.is_mouse_over:
-                    item.set_class(False, "-hovered")
-        super()._on_scroll_to(message)


### PR DESCRIPTION
Fixes #6259 

## Cause
When dragging the scrollbar, it'd call capture_mouse() which prevented Leave events from firing on ListItem widgets. This causes 
items to remain in the -hovered state even after the mouse moves away.

## Fix
Override _on_scroll_to in ListView to clear the -hovered class from 
any items the mouse is no longer over whenever a scrollbar drag causes a scroll.

## Reproduction
Run the MRE from the issue and drag the scrollbar sideways into the list.

Before this fix, items would remain highlighted after the mouse moved away.
After this fix, highlighted items return to their normal state when not hovered.