### PR TITLE
Fix Tree.clear() to reset _tree_nodes and register new root

### DIFF
--- a/src/textual/widgets/_tree.py
+++ b/src/textual/widgets/_tree.py
@@ -928,16 +928,15 @@ class Tree(Generic[TreeDataType], ScrollView, can_focus=True):
         """
         self._clear_line_cache()
         self._current_id = 0
+        self._tree_nodes.clear()
         root_label = self.root._label
         root_data = self.root.data
         root_expanded = self.root.is_expanded
-        self.root = TreeNode(
-            self,
+        self.root = self._add_node(
             None,
-            self._new_id(),
             root_label,
             root_data,
-            expanded=root_expanded,
+            expand=root_expanded,
         )
         self._updates += 1
         self.refresh()


### PR DESCRIPTION
## Summary

Fix `Tree.clear()` to properly reset the internal `_tree_nodes` dictionary and register the new root node through `_add_node()`.

## Problem

`clear()` creates the new root node via `TreeNode(...)` directly, bypassing `_add_node()`. This causes two issues:

1. **`_tree_nodes` is never cleared** — all previously created nodes remain in the dict after `clear()`.
2. **The new root is not registered** — `_add_node()` is what adds nodes to `_tree_nodes`, but it's not called.

Compare with `__init__`:
```python
# __init__ - correct
self._tree_nodes: dict[NodeID, TreeNode[TreeDataType]] = {}
self.root = self._add_node(None, text_label, data)

# clear() - wrong
self._current_id = 0
self.root = TreeNode(self, None, self._new_id(), ...)  # Not registered!
```

After `clear()`:
- `get_node_by_id(0)` returns the **old** root node (stale, detached)
- `_current_id` resets, so new nodes silently overwrite old entries in `_tree_nodes`
- Old entries with IDs higher than new max persist as ghost nodes

## Fix

Clear `_tree_nodes` before recreating the root, and use `_add_node()` to create the new root node (consistent with `__init__`).
