### PR TITLE
Fix DataTable page_up to iterate rows backward from cursor

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -2737,7 +2737,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             offset = 0
             rows_to_scroll = 0
             row_index, _ = self.cursor_coordinate
-            for ordered_row in self.ordered_rows[: row_index + 1]:
+            for ordered_row in reversed(self.ordered_rows[: row_index + 1]):
                 offset += ordered_row.height
                 rows_to_scroll += 1
                 if offset > height:


### PR DESCRIPTION
## Summary

Fix `DataTable.action_page_up` to iterate rows backward from the cursor position instead of forward from row 0.

## Problem

`action_page_up` calculates how many rows fit in a "page" to determine where the cursor should land:

```python
for ordered_row in self.ordered_rows[: row_index + 1]:  # Forward from row 0
    offset += ordered_row.height
    rows_to_scroll += 1
    if offset > height:
        break
```

This iterates **forward from row 0**. For page-up, it should iterate **backward from the cursor** — just as `action_page_down` correctly iterates forward from the cursor via `self.ordered_rows[row_index:]`.

### Why it matters

With uniform row heights, the iteration direction doesn't matter — the same count of rows fits in a page regardless of direction. But with **variable row heights**, the order matters:

| Row | Height |
|-----|--------|
| 0   | 1      |
| 1   | 1      |
| 2   | 1      |
| 3   | 1      |
| 4   | 10     |
| 5   | 10     |

Cursor at row 5, page height = 15:
- **Current (forward from 0):** 1+1+1+1+10+10 > 15 at 6 rows → target = 5 - 6 + 1 = 0 (jumps to top)
- **Correct (backward from 5):** 10+10 > 15 at 2 rows → target = 5 - 2 + 1 = 4 (moves up 1 row)

## Fix

Use `reversed(self.ordered_rows[: row_index + 1])` to iterate backward from the cursor.
