### PR TITLE
Fix Timer._timer_count to increment the class variable, not instance

### DIFF
--- a/src/textual/timer.py
+++ b/src/textual/timer.py
@@ -59,7 +59,7 @@ class Timer:
         self._target = weakref.ref(event_target)
         self._interval = interval
         self.name = f"Timer#{self._timer_count}" if name is None else name
-        self._timer_count += 1
+        Timer._timer_count += 1
         self._callback = callback
         self._repeat = repeat
         self._skip = skip


### PR DESCRIPTION
## Summary

Fix `Timer._timer_count` to actually increment the class variable instead of creating a shadowing instance attribute.

## Problem

```python
class Timer:
    _timer_count: int = 1  # Class variable

    def __init__(self, ...):
        self.name = f"Timer#{self._timer_count}" if name is None else name
        self._timer_count += 1  # Bug: creates instance attribute, class var stays 1
```

In Python, `self._timer_count += 1` reads the class variable (1), adds 1 (2), and stores the result as an **instance attribute** on `self`. The class variable `Timer._timer_count` is never modified — it stays at 1 forever.

Every auto-named timer gets the name `"Timer#1"`.

## Fix

Use `Timer._timer_count += 1` (explicit class reference) to modify the class variable directly.
