### PR TITLE
Fix ANSI Footer key description text to be visible

### DIFF
--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -203,7 +203,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
             }
             .footer-key--description {
                 background: ansi_default;
-                color: ansi_default;
+                color: ansi_magenta;
             }
             FooterKey:hover {
                 text-style: underline;


### PR DESCRIPTION
Hey I think there is a small issue in ansi config Footer component  description text  is not visible (background and color are the same).
