### PR TITLE
feat(link): update empty link with url

### DIFF
--- a/src/textual/widgets/_link.py
+++ b/src/textual/widgets/_link.py
@@ -62,6 +62,12 @@ class Link(Static, can_focus=True):
 
     def watch_text(self, text: str) -> None:
         self.update(text)
+        if not self.url:
+            self.url = text
+
+    def watch_url(self, url: str) -> None:
+        if not self.text:
+            self.text = url
 
     def on_click(self) -> None:
         self.action_open_link()

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,20 @@
+from textual.widgets import Link
+
+TEST_URL = "http://example.com"
+
+
+async def test_link_url_defaults_to_text():
+    link = Link(TEST_URL)
+    assert link.url == TEST_URL
+
+
+async def test_empty_link_updates_url_with_text():
+    link = Link("")
+    link.text = TEST_URL
+    assert link.url == TEST_URL
+
+
+async def test_empty_link_updates_text_with_url():
+    link = Link("")
+    link.url = TEST_URL
+    assert link.text == TEST_URL


### PR DESCRIPTION
Creating an 'empty' link with `Link("")` is often useful when you still need to fetch the data.

But currently you can't just update the `url` or the `text` for the link to work.

Resolves https://github.com/Textualize/textual/discussions/6310