### PR TITLE
perf: use deque for lazy widget reveal queue

### DIFF
--- a/src/textual/lazy.py
+++ b/src/textual/lazy.py
@@ -3,6 +3,7 @@ Tools for lazy loading widgets.
 """
 
 from __future__ import annotations
+from collections import deque
 
 from textual.widget import Widget
 
@@ -98,11 +99,11 @@ class Reveal(Widget):
             widget: A widget to mount.
         """
         self._replace_widget = widget
-        self._widgets: list[Widget] = []
+        self._widgets: deque[Widget] = deque()
         super().__init__()
 
     @classmethod
-    def _reveal(cls, parent: Widget, widgets: list[Widget]) -> None:
+    def _reveal(cls, parent: Widget, widgets: deque[Widget]) -> None:
         """Reveal children lazily.
 
         Args:
@@ -114,7 +115,7 @@ class Reveal(Widget):
             """Check for pending children"""
             if not widgets:
                 return
-            widget = widgets.pop(0)
+            widget = widgets.popleft()
             try:
                 await parent.mount(widget)
             except Exception:


### PR DESCRIPTION
## Summary

Replace `list.pop(0)` with `collections.deque.popleft()` in the lazy-widget reveal timer callback.

## Problem

`Lazy._reveal()` drains the pending-widgets list one element at a time via a recurring timer. Each `list.pop(0)` call is **O(n)** because CPython must shift all remaining elements left.

## Solution

Switch `_widgets` from `list[Widget]` to `collections.deque[Widget]` and use `.popleft()` for **O(1)** front removal.

## Compatibility

- `.append()`, `.copy()`, `.clear()`, truthiness, and iteration are identical on `deque`
- No API surface changes; this is an internal-only optimisation
- Zero behaviour change

## Complexity

| Operation | Before | After |
|-----------|--------|-------|
| pop front | O(n) | O(1) |