### PR TITLE
docs(widget): fix `Widget.region` docstring

### DIFF
--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -2249,10 +2249,6 @@ class Widget(DOMNode):
     def region(self) -> Region:
         """The region occupied by this widget, relative to the Screen.
 
-        Raises:
-            NoScreen: If there is no screen.
-            errors.NoWidget: If the widget is not on the screen.
-
         Returns:
             Region within screen occupied by widget.
         """


### PR DESCRIPTION
Remove the "raises" section from the `Widget.region` docstring, since these exceptions are handled in the try-except to return a null region.