### PR TITLE
Fix cursor_coordinate going out of bounds into header for empty tables

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1317,8 +1317,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
     def _clamp_cursor_coordinate(self, coordinate: Coordinate) -> Coordinate:
         """Clamp a coordinate such that it falls within the boundaries of the table."""
         row, column = coordinate
-        row = clamp(row, 0, self.row_count - 1)
-        column = clamp(column, 0, len(self.columns) - 1)
+        row = clamp(row, 0, max(0, self.row_count - 1))
+        column = clamp(column, 0, max(0, len(self.columns) - 1))
         return Coordinate(row, column)
 
     def watch_cursor_type(self, old: str, new: str) -> None:


### PR DESCRIPTION
When a `DataTable` is empty (no rows or columns), pressing arrow keys could cause `cursor_coordinate` to become `(-1, 0)`, which corresponds to the header row. This caused the header cell to be highlighted as if it were a selected data cell.

The issue was in `_clamp_cursor_coordinate`:
```python
row = clamp(row, 0, self.row_count - 1)
```

When `row_count = 0`, this becomes `clamp(-1, 0, -1)`, which returns `-1`, causing the issue.

**Fix:** Ensure the maximum bound is never negative:
```python
row = clamp(row, 0, max(0, self.row_count - 1))
column = clamp(column, 0, max(0, len(self.columns) - 1))
```

Fixes #6411