### PR TITLE
docs: Fix ToastRack location example in documentation

### DIFF
--- a/docs/widgets/toast.md
+++ b/docs/widgets/toast.md
@@ -25,9 +25,13 @@ For example:
 
 ```scss
 ToastRack {
-        align: right top;
+    dock: none;
+    align: right top;
 }
 ```
+
+!!! note
+    You must set `dock: none;` to override the default `dock: bottom;` before the `align` property will take effect.
 
 The three severity levels also have corresponding
 [classes](../guide/CSS.md#class-name-selector), allowing you to target the


### PR DESCRIPTION
The documentation showed `align` property but failed to mention that `dock: none` must be set to override the default `dock: bottom`.

Closes #6389