### PR TITLE
fix(TabbedContent): prevent old tab re-activation on switch with focused widget

### DIFF
--- a/src/textual/widgets/_tabbed_content.py
+++ b/src/textual/widgets/_tabbed_content.py
@@ -13,6 +13,7 @@ from textual.app import ComposeResult
 from textual.await_complete import AwaitComplete
 from textual.content import ContentText, ContentType
 from textual.css.query import NoMatches
+from textual.dom import NoScreen
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
@@ -501,6 +502,31 @@ class TabbedContent(Widget):
         """
         self._tab_content.append(widget)
 
+    def _defocus_old_pane(self, switcher: ContentSwitcher) -> None:
+        """If the focused widget is inside the currently active pane, remove focus.
+
+        This prevents a re-activation cascade when hiding the old pane during a
+        tab switch. Without this, hiding the pane causes focus to move to a sibling
+        widget still within the (now-hidden) pane, which fires a DescendantFocus
+        event that re-activates the old tab.
+
+        See https://github.com/Textualize/textual/issues/4955
+        """
+        if switcher.current is None:
+            return
+        try:
+            focused = self.screen.focused
+        except NoScreen:
+            return
+        if focused is None:
+            return
+        try:
+            old_pane = switcher.get_child_by_id(switcher.current)
+        except NoMatches:
+            return
+        if old_pane in focused.ancestors_with_self:
+            self.screen.set_focus(None)
+
     def _on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
         """User clicked a tab."""
         if self._is_associated_tabs(event.tabs):
@@ -508,6 +534,7 @@ class TabbedContent(Widget):
             event.stop()
             assert event.tab.id is not None
             switcher = self.get_child_by_type(ContentSwitcher)
+            self._defocus_old_pane(switcher)
             switcher.current = ContentTab.sans_prefix(event.tab.id)
             with self.prevent(self.TabActivated):
                 # We prevent TabbedContent.TabActivated because it is also
@@ -558,7 +585,9 @@ class TabbedContent(Widget):
         """Switch tabs when the active attributes changes."""
         with self.prevent(Tabs.TabActivated, Tabs.Cleared):
             self.get_child_by_type(ContentTabs).active = ContentTab.add_prefix(active)
-        self.get_child_by_type(ContentSwitcher).current = active
+        switcher = self.get_child_by_type(ContentSwitcher)
+        self._defocus_old_pane(switcher)
+        switcher.current = active
         if active:
             self.post_message(
                 TabbedContent.TabActivated(

--- a/tests/test_tabbed_content.py
+++ b/tests/test_tabbed_content.py
@@ -4,7 +4,16 @@ import pytest
 
 from textual.app import App, ComposeResult
 from textual.reactive import var
-from textual.widgets import Label, Tab, TabbedContent, TabPane, Tabs
+from textual.widgets import (
+    Button,
+    Footer,
+    Input,
+    Label,
+    Tab,
+    TabbedContent,
+    TabPane,
+    Tabs,
+)
 from textual.widgets._tabbed_content import ContentTab
 
 
@@ -914,3 +923,116 @@ async def test_disabling_tab_within_tabbed_content_stays_isolated():
         await pilot.pause()
         assert app.query_one("Tab#duplicate").disabled is True
         assert app.query_one("TabPane#duplicate").disabled is False
+
+
+async def test_tab_switch_with_focused_input():
+    """Regression test for https://github.com/Textualize/textual/issues/4955.
+
+    When a widget with focus (e.g. Input) is inside a TabbedContent,
+    switching tabs via key binding should not re-activate the old tab.
+    """
+
+    class Bug4955App(App):
+        BINDINGS = [
+            ("ctrl+s", "switch_s", "S"),
+            ("ctrl+t", "switch_t", "T"),
+        ]
+
+        def action_switch_s(self) -> None:
+            self.query_one(TabbedContent).active = "s-tab"
+
+        def action_switch_t(self) -> None:
+            self.query_one(TabbedContent).active = "t-tab"
+
+        def compose(self) -> ComposeResult:
+            with TabbedContent(initial="s-tab"):
+                with TabPane("S Group", id="s-tab"):
+                    yield Input("sss", id="s-input")
+                    yield Button("S", id="s-btn")
+                with TabPane("T Group", id="t-tab"):
+                    yield Input("ttt", id="t-input")
+                    yield Button("T", id="t-btn")
+            yield Footer()
+
+    app = Bug4955App()
+    async with app.run_test() as pilot:
+        tabbed_content = app.query_one(TabbedContent)
+
+        # Focus the input in the first tab
+        app.query_one("#s-input", Input).focus()
+        await pilot.pause()
+        assert tabbed_content.active == "s-tab"
+
+        # Switch to the second tab via key binding
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        # The active tab should be "t-tab", not "s-tab"
+        assert tabbed_content.active == "t-tab"
+        assert tabbed_content.active_pane.id == "t-tab"
+
+
+async def test_tab_switch_with_focused_input_via_click():
+    """Switching tabs by clicking a tab while a widget has focus should work.
+
+    Related to https://github.com/Textualize/textual/issues/4955.
+    """
+
+    class ClickSwitchApp(App):
+        def compose(self) -> ComposeResult:
+            with TabbedContent(initial="first"):
+                with TabPane("First", id="first"):
+                    yield Input("hello", id="first-input")
+                with TabPane("Second", id="second"):
+                    yield Input("world", id="second-input")
+
+    app = ClickSwitchApp()
+    async with app.run_test() as pilot:
+        tabbed_content = app.query_one(TabbedContent)
+
+        # Focus input in first tab
+        app.query_one("#first-input", Input).focus()
+        await pilot.pause()
+        assert tabbed_content.active == "first"
+
+        # Click the second tab
+        await pilot.click(f"Tab#{ContentTab.add_prefix('second')}")
+        await pilot.pause()
+
+        # Should switch to second tab
+        assert tabbed_content.active == "second"
+        assert tabbed_content.active_pane.id == "second"
+
+
+async def test_auto_tab_switch_on_programmatic_focus():
+    """Programmatically focusing a widget in a hidden tab should auto-switch.
+
+    Ensures the fix for #4955 doesn't break the auto-tab-switch feature.
+    """
+
+    class AutoSwitchApp(App):
+        BINDINGS = [("space", "focus_btn2", "Focus btn2")]
+
+        def action_focus_btn2(self) -> None:
+            self.query_one("#btn-2", Button).focus()
+
+        def compose(self) -> ComposeResult:
+            with TabbedContent(initial="tab-1"):
+                with TabPane("Tab 1", id="tab-1"):
+                    yield Button("Button 1", id="btn-1")
+                with TabPane("Tab 2", id="tab-2"):
+                    yield Button("Button 2", id="btn-2")
+            yield Footer()
+
+    app = AutoSwitchApp()
+    async with app.run_test() as pilot:
+        tabbed_content = app.query_one(TabbedContent)
+        assert tabbed_content.active == "tab-1"
+
+        # Programmatically focus a widget in the hidden tab
+        await pilot.press("space")
+        await pilot.pause()
+
+        # Auto-switch should activate tab-2
+        assert tabbed_content.active == "tab-2"
+        assert tabbed_content.active_pane.id == "tab-2"


### PR DESCRIPTION
## Summary

Fixes #4955 — When a widget with focus (e.g. `Input`) is inside a `TabbedContent`, switching tabs via key binding or programmatic `active` assignment causes the old tab to briefly deactivate then immediately re-activate.

**Root cause:** Hiding the old tab pane moves focus to a sibling widget still within the same (now-hidden) pane. This triggers a `DescendantFocus` event that bubbles up to `TabPane._on_descendant_focus`, which posts `TabPane.Focused`, causing `TabbedContent._on_tab_pane_focused` to re-activate the old tab.

**Fix:** Added `_defocus_old_pane()` which removes focus from any widget inside the old pane *before* the `ContentSwitcher` hides it. This is called in both tab-switch paths (`_watch_active` and `_on_tabs_tab_activated`), preventing the `DescendantFocus` cascade entirely.

The auto-tab-switch feature (focusing a widget in a hidden pane switches to that tab) is preserved — it works because `_defocus_old_pane` only acts on the *currently displayed* pane, not the target pane.

- `src/textual/widgets/_tabbed_content.py` — added `_defocus_old_pane()`, called before `switcher.current` is changed
- `tests/test_tabbed_content.py` — 3 regression tests: key-binding switch, click switch, and auto-switch preservation

## Test plan

- [x] `test_tab_switch_with_focused_input` — reproduces the exact bug from #4955 (key binding with focused Input)
- [x] `test_tab_switch_with_focused_input_via_click` — verifies clicking a tab works when an Input has focus
- [x] `test_auto_tab_switch_on_programmatic_focus` — confirms the auto-tab-switch feature still works
- [x] All 44 existing `test_tabbed_content.py` tests pass
- [x] All `test_tabs.py`, `test_content_switcher.py`, `test_focus.py` tests pass

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)