### PR TITLE
Fix MaskedInput separator jump deleting existing text

### DIFF
--- a/src/textual/widgets/_masked_input.py
+++ b/src/textual/widgets/_masked_input.py
@@ -231,14 +231,12 @@ class _Template(Validator):
                                 _CharFlags.SEPARATOR
                                 in self.template[cursor_position].flags
                             ):
-                                char = self.template[cursor_position].char
-                            else:
-                                char = " "
-                            value = (
-                                value[:cursor_position]
-                                + char
-                                + value[cursor_position + 1 :]
-                            )
+                                sep_char = self.template[cursor_position].char
+                                value = (
+                                    value[:cursor_position]
+                                    + sep_char
+                                    + value[cursor_position + 1 :]
+                                )
                             cursor_position += 1
                 continue
             if cursor_position >= len(self.template):

--- a/tests/test_masked_input.py
+++ b/tests/test_masked_input.py
@@ -221,3 +221,27 @@ async def test_digits_required():
         await pilot.press("a", "1")
         assert input.value == "1"
         assert not input.is_valid
+
+
+async def test_separator_jump_preserves_existing_text():
+    """Regression test for https://github.com/Textualize/textual/issues/6315
+
+    Typing a separator character should jump the cursor to after the next
+    separator, but must not delete any existing text in between.
+    """
+    app = InputApp("9999-9999-9999-9999;_")
+    async with app.run_test() as pilot:
+        input = app.query_one(MaskedInput)
+        # Fill in the full value first
+        input.value = "1234-5678-9012-3456"
+        # Move cursor to the start of the second group (position 5)
+        input.cursor_position = 5
+        # Move one to the right, landing on position 6
+        input.action_cursor_right()
+        assert input.cursor_position == 6
+        # Now type a separator "-" to jump to the next group
+        await pilot.press("-")
+        # Cursor should be just past the separator at position 10
+        assert input.cursor_position == 10
+        # The existing text should still be intact
+        assert input.value == "1234-5678-9012-3456"


### PR DESCRIPTION
## Summary
- Fixes #6315
- When a separator character is typed in `MaskedInput`, the cursor jumps to the next group. The loop that advances the cursor was replacing all non-separator positions with spaces, wiping out any text already entered in those slots.
- Changed the jump logic to only write separator characters at their positions and skip over non-separator positions without modifying them.
- Added a regression test that fills in a full value, positions the cursor mid-group, types a separator to jump, and verifies the existing text is preserved.

## Test plan
- [x] All 14 existing `test_masked_input.py` tests still pass
- [x] New `test_separator_jump_preserves_existing_text` test passes