### PR TITLE
fix: enable extended key reporting in Kitty keyboard protocol

### DIFF
--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -275,6 +275,7 @@ class LinuxDriver(Driver):
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
         self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 
+        self.write("\x1b[=8;u")  # Enable extended key reporting for space and other keys
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread, name="textual-input")
         send_size_event()

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -212,6 +212,7 @@ class LinuxInlineDriver(Driver):
         self.flush()
 
         self._enable_mouse_support()
+        self.write("\x1b[=8;u")  # Enable extended key reporting for space and other keys
         self.write("\n" * self._app.INLINE_PADDING)
         self.flush()
         try:

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -98,6 +98,7 @@ class WindowsDriver(Driver):
         self.write("\033[?1004h")  # Enable FocusIn/FocusOut.
         self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
         self.flush()
+        self.write("\x1b[=8;u")  # Enable extended key reporting for space and other keys
         self._enable_bracketed_paste()
 
         self._event_thread = win32.EventMonitor(


### PR DESCRIPTION
Fixes space character not appearing in VS Code integrated terminal (issue #6408)

VS Code 1.110 enabled additional Kitty keyboard protocol extensions that require enabling extended key reporting mode. Without this, the space key and other keys may not be properly detected.

Added `self.write("\x1b[=8;u")` after the Kitty protocol initialization in all three driver files:
- `src/textual/drivers/linux_driver.py`
- `src/textual/drivers/linux_inline_driver.py`
- `src/textual/drivers/windows_driver.py`

Reference: https://github.com/Textualize/textual/issues/6074