### PR TITLE
fix: Add bounds check for start_line in Selection.extract()

### DIFF
--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -45,6 +45,10 @@ class Selection(NamedTuple):
         else:
             start_line, start_offset = self.start.transpose
 
+        # Bounds check: if start_line is beyond the text, return empty
+        if start_line >= len(lines):
+            return ""
+
         if self.end is None:
             end_line = len(lines)
             end_offset = len(lines[-1])

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -17,6 +17,10 @@ from textual.widgets import Static
         ("Foo", Selection(Offset(1, 0), Offset(2, 0)), "o"),
         ("Foo", Selection(Offset(0, 0), Offset(2, 0)), "Fo"),
         ("Foo", Selection(Offset(0, 0), None), "Foo"),
+        # Regression tests for issue #6428: start_line bounds checking
+        ("line1\nline2", Selection(Offset(0, 5), Offset(10, 5)), ""),  # start_line beyond text
+        ("single", Selection(Offset(0, 1), Offset(10, 1)), ""),  # start_line at boundary
+        ("", Selection(Offset(0, 0), Offset(10, 0)), ""),  # empty text
     ],
 )
 def test_extract(text: str, selection: Selection, expected: str) -> None:


### PR DESCRIPTION
## Summary

Fixes #6428

## Root Cause

The <code>Selection.extract()</code> method was missing bounds checking for <code>start_line</code>. When the selection's start y-coordinate exceeds the number of lines in the text, accessing <code>lines[start_line]</code> causes an <code>IndexError</code>.

## Fix

Added a bounds check after calculating <code>start_line</code>:
- If <code>start_line >= len(lines)</code>, return an empty string (nothing to extract)
- This mirrors the existing bounds check for <code>end_line</code>

## Test Evidence

Added regression tests in <code>tests/test_selection.py</code> covering:
1. Selection starting beyond text length (y=5 on 2-line text)
2. Selection at boundary (y=1 on 1-line text)  
3. Empty text handling

All tests pass:


## CLA Confirmation

I have read the CLA Document and I hereby sign the CLA.
