### PR TITLE
fix: bounds-check start_line in Selection.extract()

### DIFF
--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -51,6 +51,7 @@ class Selection(NamedTuple):
         else:
             end_line, end_offset = self.end.transpose
         end_line = min(len(lines), end_line)
+        start_line = min(len(lines) - 1, start_line) if start_line < len(lines) else len(lines) - 1
 
         if start_line == end_line:
             return lines[start_line][start_offset:end_offset]


### PR DESCRIPTION
When Selection.extract() is called with coordinates that exceed the
text line count, it crashes with IndexError. This happens because
end_line is bounds-checked but start_line is not.

Fix: Add bounds check for start_line similar to end_line to prevent
IndexError when start_line exceeds the text line count.

Fixes #6428