### PR TITLE
fix: bounds-check start_line in Selection.extract()

### DIFF
--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -50,7 +50,10 @@ class Selection(NamedTuple):
             end_offset = len(lines[-1])
         else:
             end_line, end_offset = self.end.transpose
-        end_line = min(len(lines), end_line)
+        
+        # Bounds check both start_line and end_line
+        start_line = max(0, min(start_line, len(lines) - 1))
+        end_line = max(0, min(end_line, len(lines)))
 
         if start_line == end_line:
             return lines[start_line][start_offset:end_offset]


### PR DESCRIPTION
Selection.extract() bounds-checks end_line but not start_line, causing IndexError when start_line exceeds the text line count. This happens when selecting text in widgets positioned below row 0 on screen.

Fix: Add bounds checking for start_line to prevent IndexError.

Fixes #6428