### PR TITLE
fix: add bounds check for start_line in Selection.extract()

### DIFF
--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -51,7 +51,10 @@ class Selection(NamedTuple):
         else:
             end_line, end_offset = self.end.transpose
         end_line = min(len(lines), end_line)
-        start_line = min(len(lines) - 1, start_line) if start_line < len(lines) else len(lines) - 1
+        if start_line >= len(lines):
+            start_line = len(lines) - 1
+        if start_line < 0:
+            start_line = 0
 
         if start_line == end_line:
             return lines[start_line][start_offset:end_offset]


### PR DESCRIPTION
## Summary
Fixes IndexError when selection start_line exceeds text line count.

## Issue
This PR addresses issue #6428 where `Selection.extract()` crashes with `IndexError: list index out of range` when selecting text.

## Fix
Added bounds checking for `start_line` to ensure it stays within valid range, mirroring the existing check for `end_line`.