### PR TITLE
Fix Selection.extract() IndexError when start_line exceeds text lines

### DIFF
--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -51,6 +51,7 @@ class Selection(NamedTuple):
         else:
             end_line, end_offset = self.end.transpose
         end_line = min(len(lines), end_line)
+        start_line = min(len(lines) - 1, max(0, start_line))
 
         if start_line == end_line:
             return lines[start_line][start_offset:end_offset]


### PR DESCRIPTION
## Fix

Add bounds checking for `start_line` in `Selection.extract()` method.

Previously only `end_line` was bounds-checked, causing `IndexError` when `start_line` exceeded the number of lines in the text.

### Before:
```python
end_line = min(len(lines), end_line)
# No bounds check for start_line - crash!
```

### After:
```python
end_line = min(len(lines), end_line)
start_line = min(len(lines) - 1, max(0, start_line))
```

## Test

```python
from textual.selection import Selection
from textual.geometry import Offset

sel = Selection(start=Offset(x=140, y=13), end=None)
sel.extract("▶ Loaded: 40 skills")  # Previously IndexError, now returns empty string
```

Fixes #6428