### PR TITLE
ci: add `anti-slop` workflow for PRs

### DIFF
--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -1,0 +1,69 @@
+name: PR Quality
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  pr-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peakoss/anti-slop@v0.2.1
+        with:
+          # General Settings
+          max-failures: 2
+
+          # User Checks
+          min-account-age: 30
+          max-daily-forks: 7
+
+          # PR Description Checks
+          require-linked-issue: true
+
+          # PR Template Checks
+          # require-pr-template: false
+          # strict-pr-template-sections: ""
+          # optional-pr-template-sections: ""
+          # max-additional-pr-template-sections: 0
+
+          # PR Failure Actions
+          failure-pr-message: "https://github.com/Textualize/textual/blob/main/AI_POLICY.md"
+          close-pr: true
+
+          #########################
+          # DISABLE OTHER DEFAULTS
+          #########################
+
+          # PR Branch Checks
+          blocked-source-branches: ""
+
+          # PR Quality Checks
+          require-maintainer-can-modify: false
+
+          # PR Description Checks
+          require-description: false
+          max-description-length: 0
+          max-emoji-count: 0
+          max-code-references: 0
+
+          # Commit Message Checks
+          max-commit-message-length: 0
+          require-commit-author-match: false
+          blocked-commit-authors: ""
+
+          # File Checks
+          blocked-paths: ""
+          require-final-newline: false
+          max-added-comments: 0
+
+          # User Checks
+          detect-spam-usernames: false
+          min-profile-completeness: 0
+
+          # Merge Checks
+          min-global-merge-ratio: 0

--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -22,6 +22,9 @@ jobs:
           min-account-age: 30
           max-daily-forks: 7
 
+          # Merge Checks
+          min-global-merge-ratio: 30
+
           # PR Description Checks
           require-linked-issue: true
 
@@ -64,6 +67,3 @@ jobs:
           # User Checks
           detect-spam-usernames: false
           min-profile-completeness: 0
-
-          # Merge Checks
-          min-global-merge-ratio: 0


### PR DESCRIPTION
Textual is starting to drown in AI-generated slop PRs.

This adds the `anti-slop` Github Action to automatically close slop PRs: https://github.com/peakoss/anti-slop

Despite this workflow claiming "sensible defaults", I've erred on the side of caution with the check rules.
