### PR TITLE
Fix IndexError in Selection.extract() when start_line exceeds text lines

### DIFF
--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -51,6 +51,7 @@ class Selection(NamedTuple):
         else:
             end_line, end_offset = self.end.transpose
         end_line = min(len(lines), end_line)
+        start_line = min(len(lines) - 1, max(0, start_line))
 
         if start_line == end_line:
             return lines[start_line][start_offset:end_offset]


### PR DESCRIPTION
## Summary

When selecting text in a single-line widget positioned below row 0 on screen, `Selection.extract()` crashes with `IndexError: list index out of range` because `start_line` is not bounds-checked before indexing into the lines array.

## Fix

This fix adds a bounds check for `start_line` similar to the existing check for `end_line`, ensuring the index stays within valid range.

```python
# Before:
end_line = min(len(lines), end_line)

# After:
end_line = min(len(lines), end_line)
start_line = min(len(lines) - 1, max(0, start_line))
```

## Test

```python
from textual.selection import Selection
from textual.geometry import Offset

# This previously crashed with IndexError
sel = Selection(start=Offset(x=140, y=13), end=None)
result = sel.extract("▶ Loaded: 40 skills")  # Now returns "" instead of crashing
```

Fixes #6428