### PR TITLE
Fix @on decorator firing for parent widget events when subclass is specified

### DIFF
--- a/src/textual/_on.py
+++ b/src/textual/_on.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from textual.css.model import SelectorSet
 from textual.css.parse import parse_selectors
 from textual.css.tokenizer import TokenError
 from textual.message import Message
+
+if TYPE_CHECKING:
+    pass
 
 DecoratedType = TypeVar("DecoratedType")
 
@@ -21,8 +24,73 @@ class OnNoWidget(Exception):
     """A selector was applied to an attribute that isn't a widget."""
 
 
+class _NamespacedMessage:
+    """Wrapper returned when an inherited message class is accessed via a widget subclass.
+
+    This allows ``@on(MyButton.Pressed)`` to implicitly constrain the handler
+    to fire only when the event's control is an instance of ``MyButton``, rather
+    than matching *any* ``Button.Pressed`` event (which is the same class object).
+    """
+
+    def __init__(self, message_class: type[Message], widget_class: type) -> None:
+        self._message_class = message_class
+        self._widget_class = widget_class
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._message_class, name)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Message:
+        return self._message_class(*args, **kwargs)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _NamespacedMessage):
+            return (
+                self._message_class is other._message_class
+                and self._widget_class is other._widget_class
+            )
+        return self._message_class is other
+
+    def __hash__(self) -> int:
+        return hash(self._message_class)
+
+    def __repr__(self) -> str:
+        return f"<NamespacedMessage {self._widget_class.__name__}.{self._message_class.__name__}>"
+
+
+class _MessageClassDescriptor:
+    """Descriptor installed on a widget subclass for an inherited message class.
+
+    When ``MyButton.Pressed`` is accessed (where ``Pressed`` is inherited from
+    ``Button`` and not overridden), this descriptor returns a
+    :class:`_NamespacedMessage` that carries ``MyButton`` as the implicit
+    widget-type constraint for the ``@on`` decorator.
+    """
+
+    def __init__(self, message_class: type[Message], widget_class: type) -> None:
+        self._message_class = message_class
+        self._widget_class = widget_class
+
+    def __get__(
+        self, obj: object, objtype: type | None = None
+    ) -> _NamespacedMessage:
+        # If accessed via a further subclass, use that subclass as the namespace.
+        namespace = objtype if (objtype is not None) else self._widget_class
+        return _NamespacedMessage(self._message_class, namespace)
+
+    def __set__(self, obj: object, value: object) -> None:
+        raise AttributeError("Cannot set a message class attribute")
+
+    def __repr__(self) -> str:
+        return (
+            f"<_MessageClassDescriptor "
+            f"{self._widget_class.__name__}.{self._message_class.__name__}>"
+        )
+
+
 def on(
-    message_type: type[Message], selector: str | None = None, **kwargs: str
+    message_type: type[Message] | _NamespacedMessage,
+    selector: str | None = None,
+    **kwargs: str,
 ) -> Callable[[DecoratedType], DecoratedType]:
     """Decorator to declare that the method is a message handler.
 
@@ -56,6 +124,14 @@ def on(
         **kwargs: Additional selectors for other attributes of the message.
     """
 
+    # If the message type was accessed via a widget subclass (e.g. MyButton.Pressed
+    # where MyButton inherits Pressed from Button), capture the widget class so the
+    # handler will only fire when the event's control is an instance of that subclass.
+    namespace_widget: type | None = None
+    if isinstance(message_type, _NamespacedMessage):
+        namespace_widget = message_type._widget_class
+        message_type = message_type._message_class
+
     selectors: dict[str, str] = {}
     if selector is not None:
         selectors["control"] = selector
@@ -86,7 +162,9 @@ def on(
 
         if not hasattr(method, "_textual_on"):
             setattr(method, "_textual_on", [])
-        getattr(method, "_textual_on").append((message_type, parsed_selectors))
+        getattr(method, "_textual_on").append(
+            (message_type, parsed_selectors, namespace_widget)
+        )
 
         return method
 

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -175,7 +175,7 @@ class DOMNode(MessagePump):
 
     _reactives: ClassVar[dict[str, Reactive]]
 
-    _decorated_handlers: dict[type[Message], list[tuple[Callable, str | None]]]
+    _decorated_handlers: dict[type[Message], list[tuple[Callable, str | None, type | None]]]
 
     # Names of potential computed reactives
     _computes: ClassVar[frozenset[str]]

--- a/src/textual/message_pump.py
+++ b/src/textual/message_pump.py
@@ -80,7 +80,8 @@ class _MessagePumpMeta(type):
         **kwargs: Any,
     ) -> _MessagePumpMetaSub:
         handlers: dict[
-            type[Message], list[tuple[Callable, dict[str, tuple[SelectorSet, ...]]]]
+            type[Message],
+            list[tuple[Callable, dict[str, tuple[SelectorSet, ...]], type | None]],
         ] = class_dict.get("_decorated_handlers", {})
 
         class_dict["_decorated_handlers"] = handlers
@@ -88,10 +89,16 @@ class _MessagePumpMeta(type):
         for value in class_dict.values():
             if callable(value) and hasattr(value, "_textual_on"):
                 textual_on: list[
-                    tuple[type[Message], dict[str, tuple[SelectorSet, ...]]]
+                    tuple[
+                        type[Message],
+                        dict[str, tuple[SelectorSet, ...]],
+                        type | None,
+                    ]
                 ] = getattr(value, "_textual_on")
-                for message_type, selectors in textual_on:
-                    handlers.setdefault(message_type, []).append((value, selectors))
+                for message_type, selectors, namespace_widget in textual_on:
+                    handlers.setdefault(message_type, []).append(
+                        (value, selectors, namespace_widget)
+                    )
 
         # Look for reactives with public AND private compute methods.
         prefix = "compute_"
@@ -760,7 +767,7 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 break
             # Try decorated handlers first
             decorated_handlers = cast(
-                "dict[type[Message], list[tuple[Callable, dict[str, tuple[SelectorSet, ...]]]]] | None",
+                "dict[type[Message], list[tuple[Callable, dict[str, tuple[SelectorSet, ...]], type | None]]] | None",
                 cls.__dict__.get("_decorated_handlers"),
             )
 
@@ -768,9 +775,19 @@ class MessagePump(metaclass=_MessagePumpMeta):
                 for message_class in message_mro:
                     handlers = decorated_handlers.get(message_class, [])
 
-                    for method, selectors in handlers:
+                    for method, selectors, namespace_widget in handlers:
                         if method in methods_dispatched:
                             continue
+                        # If the handler was registered via a widget subclass
+                        # (e.g. @on(MyButton.Pressed)), only fire when the event's
+                        # control (or sender) is an instance of that subclass.
+                        if namespace_widget is not None:
+                            control = message.control
+                            if control is not None:
+                                if not isinstance(control, namespace_widget):
+                                    continue
+                            elif not isinstance(message._sender, namespace_widget):
+                                continue
                         if not selectors:
                             yield cls, method.__get__(self, cls)
                             methods_dispatched.add(method)

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -278,6 +278,42 @@ class BadWidgetName(Exception):
     """Raised when widget class names do not satisfy the required restrictions."""
 
 
+def _install_message_class_descriptors(widget_class: type) -> None:
+    """Install :class:`~textual._on._MessageClassDescriptor` descriptors on a widget
+    subclass for every message class it inherits but does not directly define.
+
+    This makes ``MyButton.Pressed`` return a
+    :class:`~textual._on._NamespacedMessage` wrapper rather than the raw
+    ``Button.Pressed`` class, which lets the ``@on`` decorator add an implicit
+    widget-type constraint to the handler.
+    """
+    from textual._on import _MessageClassDescriptor
+    from textual.message import Message
+
+    # Walk base classes (skip the class itself) and collect message classes that
+    # are not already present in the new subclass's own __dict__.
+    seen_names: set[str] = set()
+    for base in widget_class.__mro__[1:]:
+        for name, value in base.__dict__.items():
+            if name in seen_names or name in widget_class.__dict__:
+                seen_names.add(name)
+                continue
+            message_class: type[Message] | None = None
+            if isinstance(value, type) and issubclass(value, Message):
+                message_class = value
+            elif isinstance(value, _MessageClassDescriptor):
+                # Already a descriptor installed by a parent's __init_subclass__;
+                # carry the underlying message class forward.
+                message_class = value._message_class
+            if message_class is not None:
+                setattr(
+                    widget_class,
+                    name,
+                    _MessageClassDescriptor(message_class, widget_class),
+                )
+                seen_names.add(name)
+
+
 @rich.repr.auto
 class Widget(DOMNode):
     """
@@ -3897,6 +3933,12 @@ class Widget(DOMNode):
                 if can_focus_children is None
                 else can_focus_children
             )
+
+        # Install descriptors for inherited message classes so that accessing
+        # e.g. ``MyButton.Pressed`` returns a _NamespacedMessage wrapper that
+        # causes ``@on(MyButton.Pressed)`` to implicitly constrain the handler
+        # to events whose control is an instance of ``MyButton``.
+        _install_message_class_descriptors(cls)
 
     def __rich_repr__(self) -> rich.repr.Result:
         try:

--- a/tests/test_on.py
+++ b/tests/test_on.py
@@ -378,3 +378,42 @@ async def test_on_with_enter_and_leave_events():
         await pilot.hover(Button, offset=(0, 20))
         expected_messages.append("Leave")
         assert app.messages == expected_messages
+
+
+async def test_on_widget_subclass_does_not_match_parent() -> None:
+    """@on(MyButton.Pressed) must NOT fire when a plain Button is pressed.
+
+    Regression test for https://github.com/Textualize/textual/issues/4968.
+    """
+    pressed: list[str] = []
+
+    class MyButton(Button):
+        pass
+
+    class SubclassOnApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Button("Base", id="base")
+            yield MyButton("Sub", id="sub")
+
+        @on(MyButton.Pressed)
+        def only_my_button(self) -> None:
+            pressed.append("my_button")
+
+        @on(Button.Pressed)
+        def any_button(self) -> None:
+            pressed.append("any_button")
+
+    app = SubclassOnApp()
+    async with app.run_test() as pilot:
+        # Press the plain Button — only the @on(Button.Pressed) handler should fire.
+        await pilot.click("#base")
+        assert pressed == ["any_button"], (
+            "@on(MyButton.Pressed) should not fire for a plain Button press"
+        )
+
+        pressed.clear()
+        # Press MyButton — both handlers should fire.
+        await pilot.click("#sub")
+        assert pressed == ["my_button", "any_button"], (
+            "Both @on(MyButton.Pressed) and @on(Button.Pressed) should fire for a MyButton press"
+        )


### PR DESCRIPTION
Fixes #4968.

## Problem

When a widget subclass does not define its own message class, `MyButton.Pressed` and `Button.Pressed` are **the same class object**:

```python
>>> MyButton.Pressed is Button.Pressed
True
```

This caused `@on(MyButton.Pressed)` to fire for *any* `Button.Pressed` event — including presses from plain `Button` instances — which is unintuitive and a significant footgun.

## Fix

`Widget.__init_subclass__` now installs a `_MessageClassDescriptor` on each widget subclass for every **inherited** message class. Accessing `MyButton.Pressed` via the descriptor returns a lightweight `_NamespacedMessage(Button.Pressed, MyButton)` wrapper instead of the raw class.

The `@on` decorator detects this wrapper and records `MyButton` as an implicit `namespace_widget` constraint alongside the handler. At dispatch time `_get_dispatch_methods` only invokes the handler when `isinstance(message.control, MyButton)` is `True`.

Message classes that are **directly defined** on a widget (e.g. `Button.Pressed` accessed via `Button`) continue to return the real class unchanged, so `@on(Button.Pressed)` remains unconstrained and fires for all subclasses as before.

## Behaviour after this fix

```python
class MyButton(Button):
    pass

class MyApp(App):
    def compose(self):
        yield Button("Base")   # plain Button
        yield MyButton("Sub")  # subclass

    @on(MyButton.Pressed)        # only MyButton
    def only_my_button(self): ...

    @on(Button.Pressed)          # any Button (incl. MyButton)
    def any_button(self): ...
```

| Event source | `@on(MyButton.Pressed)` fires? | `@on(Button.Pressed)` fires? |
|---|---|---|
| `Button` pressed | **No** (was Yes — the bug) | Yes |
| `MyButton` pressed | Yes | Yes |

## Test

`tests/test_on.py::test_on_widget_subclass_does_not_match_parent` covers both directions.