### PR TITLE
docs: fix missing colon in __main__ example in app.md

### DIFF
--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -249,7 +249,7 @@ To exit the app with a return code, you should call `sys.exit`.
 Here's how you might do that:
 
 ```python
-if __name__ == "__main__"
+if __name__ == "__main__":
     app = MyApp()
     app.run()
     import sys


### PR DESCRIPTION
## Summary

Fixes #6461 

The example code in the 'Exit Code' section of `docs/guide/app.md` was missing a colon at the end of the `if __name__ == "__main__"` line.

## Change

```diff
-if __name__ == "__main__"
+if __name__ == "__main__":
```

This is a simple syntax fix to ensure the documentation example is valid Python code.