### PR TITLE
Add missing docstrings to _loop.py and _two_way_dict.py

### DIFF
--- a/src/textual/_loop.py
+++ b/src/textual/_loop.py
@@ -1,3 +1,5 @@
+"""Utility functions for iterating with positional awareness (first/last flags)."""
+
 from __future__ import annotations
 
 from typing import Iterable, Literal, Sequence, TypeVar
@@ -6,7 +8,15 @@ T = TypeVar("T")
 
 
 def loop_first(values: Iterable[T]) -> Iterable[tuple[bool, T]]:
-    """Iterate and generate a tuple with a flag for first value."""
+    """Iterate and generate a tuple with a flag for first value.
+
+    Args:
+        values: An iterable of values to loop over.
+
+    Yields:
+        A tuple of (is_first, value) where is_first is True only for the
+            first item yielded.
+    """
     iter_values = iter(values)
     try:
         value = next(iter_values)
@@ -18,7 +28,15 @@ def loop_first(values: Iterable[T]) -> Iterable[tuple[bool, T]]:
 
 
 def loop_last(values: Iterable[T]) -> Iterable[tuple[bool, T]]:
-    """Iterate and generate a tuple with a flag for last value."""
+    """Iterate and generate a tuple with a flag for last value.
+
+    Args:
+        values: An iterable of values to loop over.
+
+    Yields:
+        A tuple of (is_last, value) where is_last is True only for the
+            last item yielded.
+    """
     iter_values = iter(values)
     try:
         previous_value = next(iter_values)
@@ -31,7 +49,15 @@ def loop_last(values: Iterable[T]) -> Iterable[tuple[bool, T]]:
 
 
 def loop_first_last(values: Iterable[T]) -> Iterable[tuple[bool, bool, T]]:
-    """Iterate and generate a tuple with a flag for first and last value."""
+    """Iterate and generate a tuple with a flag for first and last value.
+
+    Args:
+        values: An iterable of values to loop over.
+
+    Yields:
+        A tuple of (is_first, is_last, value) where is_first is True only
+            for the first item and is_last is True only for the last item.
+    """
     iter_values = iter(values)
     try:
         previous_value = next(iter_values)

--- a/src/textual/_two_way_dict.py
+++ b/src/textual/_two_way_dict.py
@@ -15,21 +15,46 @@ class TwoWayDict(Generic[Key, Value]):
     """
 
     def __init__(self, initial: dict[Key, Value]) -> None:
+        """Initialise the TwoWayDict from an existing dictionary.
+
+        Args:
+            initial: A dictionary whose key-value pairs populate both the
+                forward and reverse mappings.
+        """
         self._forward: dict[Key, Value] = initial
         self._reverse: dict[Value, Key] = {value: key for key, value in initial.items()}
 
     def __setitem__(self, key: Key, value: Value) -> None:
+        """Set a key-value pair in both the forward and reverse mappings.
+
+        Args:
+            key: The key to set.
+            value: The value to associate with the key.
+        """
         # TODO: Duplicate values need to be managed to ensure consistency,
         #  decide on best approach.
         self._forward.__setitem__(key, value)
         self._reverse.__setitem__(value, key)
 
     def __delitem__(self, key: Key) -> None:
+        """Delete a key and its associated value from both mappings.
+
+        Args:
+            key: The key to delete.
+
+        Raises:
+            KeyError: If the key is not present in the mapping.
+        """
         value = self._forward[key]
         self._forward.__delitem__(key)
         self._reverse.__delitem__(value)
 
     def __iter__(self):
+        """Iterate over keys in the forward mapping.
+
+        Yields:
+            Each key in insertion order.
+        """
         return iter(self._forward)
 
     def get(self, key: Key) -> Value | None:
@@ -66,7 +91,20 @@ class TwoWayDict(Generic[Key, Value]):
         return value in self._reverse
 
     def __len__(self):
+        """Return the number of key-value pairs in the mapping.
+
+        Returns:
+            The number of entries.
+        """
         return len(self._forward)
 
     def __contains__(self, item: Key) -> bool:
+        """Check if a key is present in the forward mapping.
+
+        Args:
+            item: The key to check.
+
+        Returns:
+            True if the key exists in the mapping.
+        """
         return item in self._forward


### PR DESCRIPTION
**Link to issue or discussion**

https://github.com/Textualize/textual/issues/6474

## Summary

- Added a module-level docstring to `_loop.py`.
- Expanded the terse one-liner docstrings on `loop_first`, `loop_last`, and `loop_first_last` with `Args` and `Yields` sections matching the style already used on `loop_from_index`.
- Added missing docstrings to `TwoWayDict.__init__`, `__setitem__`, `__delitem__`, `__iter__`, `__len__`, and `__contains__` in `_two_way_dict.py`, matching the style of the existing `get`, `get_key`, and `contains_value` methods.

No logic, behaviour, or tests were changed.