### PR TITLE
Remove code_indent_guides attr use in markdown examples

### DIFF
--- a/docs/examples/widgets/markdown.py
+++ b/docs/examples/widgets/markdown.py
@@ -52,7 +52,6 @@ class MarkdownExampleApp(App):
 
     def compose(self) -> ComposeResult:
         markdown = Markdown(EXAMPLE_MARKDOWN)
-        markdown.code_indent_guides = False
         yield markdown
 
 

--- a/docs/examples/widgets/markdown_viewer.py
+++ b/docs/examples/widgets/markdown_viewer.py
@@ -61,7 +61,6 @@ Where the fear has gone there will be nothing. Only I will remain.
 class MarkdownExampleApp(App):
     def compose(self) -> ComposeResult:
         markdown_viewer = MarkdownViewer(EXAMPLE_MARKDOWN, show_table_of_contents=True)
-        markdown_viewer.code_indent_guides = False
         yield markdown_viewer
 
 


### PR DESCRIPTION
`code_indent_guides` attribute no longer does anything. Refer to #6451 for more context.

**Link to issue or discussion**

Fixes #6451 
