### PR TITLE
docs: fix textual UI blog typo

### DIFF
--- a/docs/blog/posts/anatomy-of-a-textual-user-interface.md
+++ b/docs/blog/posts/anatomy-of-a-textual-user-interface.md
@@ -125,7 +125,7 @@ self.styles.color = "red"
 self.styles.margin = 8
 ```
 
-Which is fine, but CSS shines when the UI get's more complex.
+Which is fine, but CSS shines when the UI gets more complex.
 
 ## Look, man. I only need to know one thing: where they are.
 


### PR DESCRIPTION
## Summary
- fix a typo in the textual UI blog post

## Related issue
- N/A (trivial docs typo)

## Validation
- `git diff --check`
