### PR TITLE
fix: use errors='replace' in UTF-8 incremental decoder to prevent crashes on invalid bytes

### DIFF
--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -412,7 +412,7 @@ class LinuxDriver(Driver):
         feed = parser.feed
         tick = parser.tick
 
-        utf8_decoder = getincrementaldecoder("utf-8")().decode
+        utf8_decoder = getincrementaldecoder("utf-8")(errors="replace").decode
         decode = utf8_decoder
         read = os.read
 

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -130,7 +130,7 @@ class LinuxInlineDriver(Driver):
         feed = parser.feed
         tick = parser.tick
 
-        utf8_decoder = getincrementaldecoder("utf-8")().decode
+        utf8_decoder = getincrementaldecoder("utf-8")(errors="replace").decode
         decode = utf8_decoder
         read = os.read
 

--- a/src/textual/drivers/web_driver.py
+++ b/src/textual/drivers/web_driver.py
@@ -185,7 +185,7 @@ class WebDriver(Driver):
         """Wait for input and dispatch events."""
         input_reader = self._input_reader
         parser = XTermParser(debug=self._debug)
-        utf8_decoder = getincrementaldecoder("utf-8")().decode
+        utf8_decoder = getincrementaldecoder("utf-8")(errors="replace").decode
         decode = utf8_decoder
         # The server sends us a stream of bytes, which contains the equivalent of stdin, plus
         # in band data packets.


### PR DESCRIPTION
## Fix: UnicodeDecodeError crashes input thread on invalid UTF-8 bytes (#6456)

**Bug:** The LinuxDriver, LinuxInlineDriver, and WebDriver all create a strict UTF-8 incremental decoder with no `errors=` argument, defaulting to `"strict"`. When invalid UTF-8 bytes arrive (e.g. from a non-UTF-8 terminal locale, misbehaving pipe, or partial paste), the decoder raises `UnicodeDecodeError`, killing the input thread and making the application unresponsive.

**Fix:** Add `errors="replace"` to all three decoder instantiations. This substitutes invalid byte sequences with U+FFFD (the Unicode replacement character) instead of crashing.

**Affected files:**
- `src/textual/drivers/linux_driver.py` line 415
- `src/textual/drivers/linux_inline_driver.py` line 133
- `src/textual/drivers/web_driver.py` line 188

```python
# Before (strict — crashes on invalid bytes)
utf8_decoder = getincrementaldecoder("utf-8")().decode

# After (replace — substitutes U+FFFD for invalid bytes)
utf8_decoder = getincrementaldecoder("utf-8")(errors="replace").decode
```

Closes #6456