### PR TITLE
Fix TextArea scrollbar initial wrap flicker (#5103)

### DIFF
--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -1101,9 +1101,18 @@ TextArea {
         return 0
 
     def _rewrap_and_refresh_virtual_size(self) -> None:
-        self.wrapped_document.wrap(self.wrap_width, tab_width=self.indent_width)
+        width_before = self.wrap_width
+        self.wrapped_document.wrap(width_before, tab_width=self.indent_width)
         self._line_cache.clear()
         self._refresh_size()
+
+        # If a scrollbar appeared or disappeared as a result of the wrap,
+        # the wrap_width will have changed. We must wrap again to prevent a flicker.
+        width_after = self.wrap_width
+        if width_after != width_before:
+            self.wrapped_document.wrap(width_after, tab_width=self.indent_width)
+            self._line_cache.clear()
+            self._refresh_size()
 
     @property
     def is_syntax_aware(self) -> bool:


### PR DESCRIPTION
# Fix TextArea scrollbar initial wrap flicker (#5103)

This commit forces an internal geometry double-pass exclusively during `_rewrap_and_refresh_virtual_size` if the wrap calculation triggers an appearance/disappearance of the scrollbar dynamically. This mathematically sets the width *before* flushing the virtual DOM to the visual layer, preventing the flicker loop reported in #5103.

## The Epistemic Before vs After Logs

**Input Command:**
```bash
$ python3 scratch/test_layout.py
```

**Before Logs:**
Notice how the layout unpredictably triggers events during `resize` pushing to an async queue and bouncing between `15` and `13`.
```text
=== HEADLESS RENDER OUTCOME ===
REWRAP: width=0, v_scroll=False, size=Size(width=0, height=0), scroll_region=Size(width=0, height=0)
REWRAP: width=15, v_scroll=False, size=Size(width=16, height=3), scroll_region=Size(width=16, height=3)
  File "/Users/<user>/textual/src/textual/widgets/_text_area.py", line 1085, in _on_resize
    self._rewrap_and_refresh_virtual_size()

REWRAP: width=13, v_scroll=True, size=Size(width=16, height=3), scroll_region=Size(width=14, height=3)
  File "/Users/<user>/textual/src/textual/reactive.py", line 355, in _set
  File "/Users/<user>/textual/src/textual/widgets/_text_area.py", line 861, in _watch_show_vertical_scrollbar
    self._rewrap_and_refresh_virtual_size()
```

**After Logs:**
The geometry natively stabilizes in memory perfectly inside the bounding box before being rendered.
```text
=== HEADLESS RENDER OUTCOME ===
Container Size: Size(width=16, height=3)
Scrollable Content Region Size: Size(width=14, height=3)
Computed wrap_width: 13
Scrollables: vertical=True, horizontal=False
Wrapped lines total: 12
  Line 0: length=13 'XXXXXXXXXXXXX'
```

*302 Pytest assertions passed locally in 33.49s ensuring no downstream caching regressions.*
