### PR TITLE
Add installation instructions for Textual with --dev flag clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Install Textual via pip:
 pip install textual textual-dev
 ```
 
+Install Textual via uv:
+
+```
+uv add textual
+uv add --dev textual-dev
+```
+
 See [getting started](https://textual.textualize.io/getting_started/) for details.
 
 


### PR DESCRIPTION
[uv](https://docs.astral.sh/uv/) is widely used, but `textual-dev` is often installed as a regular dependency due to missing guidance on the `--dev` flag for development packages.

Add uv installation instructions for Textual, explicitly using `--dev` flag for the `-dev` package.