### PR TITLE
docs: fix blog post wording in anatomy of a TUI

### DIFF
--- a/docs/blog/posts/anatomy-of-a-textual-user-interface.md
+++ b/docs/blog/posts/anatomy-of-a-textual-user-interface.md
@@ -125,7 +125,7 @@ self.styles.color = "red"
 self.styles.margin = 8
 ```
 
-Which is fine, but CSS shines when the UI get's more complex.
+Which is fine, but CSS shines when the UI gets more complex.
 
 ## Look, man. I only need to know one thing: where they are.
 


### PR DESCRIPTION
Thank you for contributing!

This project requires all PRs to link to an issue or discussion. Ideally signed off by @willmcgugan

**Link to issue or discussion**

N/A (trivial docs typo fix)

## Summary
- fix the "gets" spelling in the anatomy-of-a-textual-user-interface blog post

## Validation
- Ran `git diff --check`
