### PR TITLE
fix(work): parameterize Decorator return alias in @work

### DIFF
--- a/src/textual/_work_decorator.py
+++ b/src/textual/_work_decorator.py
@@ -84,7 +84,7 @@ def work(
     exclusive: bool = False,
     description: str | None = None,
     thread: bool = False,
-) -> Callable[FactoryParamSpec, Worker[ReturnType]] | Decorator:
+) -> Callable[FactoryParamSpec, Worker[ReturnType]] | Decorator[..., ReturnType]:
     """A decorator used to create [workers](/guide/workers).
 
     Args:

--- a/tests/workers/test_work_decorator.py
+++ b/tests/workers/test_work_decorator.py
@@ -184,3 +184,19 @@ async def test_calling_workers_from_within_workers(call_stack: Tuple[str]):
         for _ in range(len(call_stack)):
             await app.workers.wait_for_complete()
         assert app.call_stack == []
+
+
+def test_work_decorator_return_annotation_uses_parameterized_decorator():
+    """Regression test for https://github.com/Textualize/textual/issues/3510.
+
+    The return annotation of ``work`` must reference the ``Decorator`` type
+    alias with its type parameters supplied (``Decorator[..., ReturnType]``)
+    rather than as a bare generic, so that downstream type checkers can
+    propagate the worker's return type.
+    """
+    from textual._work_decorator import work
+
+    annotation = work.__annotations__["return"]
+    assert "Decorator[..., ReturnType]" in annotation
+    assert "| Decorator]" not in annotation
+    assert not annotation.rstrip().endswith("| Decorator")


### PR DESCRIPTION
Closes #3510

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
Textualize/textual

## Issue
https://github.com/Textualize/textual/issues/3510

## Root cause
In `src/textual/_work_decorator.py`, the runtime `work()` function's return
annotation used the bare alias `Decorator` (`Callable[..., Worker[ReturnType]] | Decorator`)
instead of supplying its `ParamSpec`/`TypeVar` arguments. When `@work(...)` is
called without a method, type checkers fall through to that branch and lose
the parameterization, leaving `ReturnType` unbound.

## Fix
Parameterize the alias as `Decorator[..., ReturnType]` in the return
annotation of `work()` so the worker's return type propagates through the
no-argument decorator overload path. One-line change.

## Regression test
`tests/workers/test_work_decorator.py::test_work_decorator_return_annotation_uses_parameterized_decorator`
asserts that `work.__annotations__["return"]` contains
`Decorator[..., ReturnType]` and does not end with the bare `Decorator`.

## Risk
trivial

## Verification
Verified the new test logic against the patched and pre-patch annotation
strings via direct `python -c` checks (test passes post-fix and would fail
pre-fix). Could not run the full pytest suite due to an unrelated `conftest`
import error (missing `click` from a third-party `dash` package in the
sandbox); the change is annotation-only, no runtime behavior altered.
