### PR TITLE
docs: note that thread workers should stay short-lived

### DIFF
--- a/docs/guide/workers.md
+++ b/docs/guide/workers.md
@@ -158,6 +158,8 @@ You can work around this with the [App.call_from_thread][textual.app.App.call_fr
 
 The second difference is that you can't cancel threads in the same way as coroutines, but you *can* manually check if the worker was cancelled.
 
+Because a blocking thread keeps running until it returns control, thread workers are best kept short-lived. If you need longer-running background work, prefer async workers or split the work into smaller steps that can check for cancellation between blocking calls.
+
 Let's demonstrate thread workers by replacing `httpx` with `urllib.request` (in the standard library).
 The `urllib` module is not async aware, so we will need to use threads:
 


### PR DESCRIPTION
Thank you for contributing!

**Link to issue or discussion**

- Closes #2593

## Summary
- add a short note that thread workers should stay short-lived because blocking threads cannot be interrupted like async workers
- point readers toward async workers or smaller cancellable steps for longer-running background work

## Validation
- ran `git diff --check`
