### PR TITLE
fix(markdown): sync code and _highlighted_code in MarkdownFence._update_from_block

### DIFF
--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -929,6 +929,8 @@ class MarkdownFence(MarkdownBlock):
 
     async def _update_from_block(self, block: MarkdownBlock):
         if isinstance(block, MarkdownFence):
+            self.code = block.code
+            self._highlighted_code = block._highlighted_code
             self.set_content(block._highlighted_code)
             self._copy_context(block)
         else:


### PR DESCRIPTION
## The bug

When a fenced code block is streamed via `MarkdownStream`, `_update_from_block` updates the visible `Label` via `set_content(block._highlighted_code)` but does not sync `self.code` or `self._highlighted_code` from the source block. 

After a recompose, style update, or theme change, `notify_style_update` (or `compose`) rebuilds the `Label` from `self._highlighted_code`, which is still empty from the initial construction. The code body disappears.

This affects LLM-streaming TUIs where code fences render correctly during generation but go blank after a click, focus change, or style refresh.

## Root cause

`_update_from_block` at line 930 only calls `set_content` and `_copy_context`. It copies `lexer` and `_token` but not `code` or `_highlighted_code`. When the fence recomposes, it rebuilds from the stale empty fields.

## Fix

Copy `code` and `_highlighted_code` from the source block before calling `set_content`:

```python
self.code = block.code
self._highlighted_code = block._highlighted_code
self.set_content(block._highlighted_code)
```

This ensures `notify_style_update` and recompose find the correct state.

Fixes #6518