### PR TITLE
Fix tooltip clearing when popup overlaps cursor

### DIFF
--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -1591,7 +1591,8 @@ class Screen(Generic[ScreenResultType], Widget):
     def _maybe_clear_tooltip(self, _) -> None:
         """Check if the widget under the mouse cursor still pertains to the tooltip.
 
-        If they differ, the tooltip will be removed.
+        If they differ, the tooltip will be removed. Hit-testing may return the Tooltip
+        overlay when it covers the cursor; that must not count as leaving the source widget.
         """
         # If there's a widget associated with the tooltip at all...
         if self._tooltip_widget is not None:
@@ -1601,9 +1602,10 @@ class Screen(Generic[ScreenResultType], Widget):
             except NoWidget:
                 pass
             else:
-                # If it's not the same widget...
-                if under_mouse is not self._tooltip_widget:
-                    # ...clear the tooltip.
+                if (
+                    under_mouse is not self._tooltip_widget
+                    and not isinstance(under_mouse, Tooltip)
+                ):
                     self._clear_tooltip()
 
     def _handle_tooltip_timer(self, widget: Widget) -> None:
@@ -1669,18 +1671,19 @@ class Screen(Generic[ScreenResultType], Widget):
                 except NoMatches:
                     pass
                 else:
-                    if self._tooltip_widget != widget or not tooltip.display:
-                        self._tooltip_widget = widget
-                        if self._tooltip_timer is not None:
-                            self._tooltip_timer.stop()
+                    if not isinstance(widget, Tooltip):
+                        if self._tooltip_widget != widget or not tooltip.display:
+                            self._tooltip_widget = widget
+                            if self._tooltip_timer is not None:
+                                self._tooltip_timer.stop()
 
-                        self._tooltip_timer = self.set_timer(
-                            self.app.TOOLTIP_DELAY,
-                            partial(self._handle_tooltip_timer, widget),
-                            name="tooltip-timer",
-                        )
-                    else:
-                        tooltip.display = False
+                            self._tooltip_timer = self.set_timer(
+                                self.app.TOOLTIP_DELAY,
+                                partial(self._handle_tooltip_timer, widget),
+                                name="tooltip-timer",
+                            )
+                        else:
+                            tooltip.display = False
         self.screen.update_pointer_shape()
 
     @staticmethod

--- a/tests/test_tooltips.py
+++ b/tests/test_tooltips.py
@@ -3,7 +3,7 @@
 from typing_extensions import Final
 
 from textual.app import App, ComposeResult
-from textual.widgets import Static
+from textual.widgets import Static, TextArea
 
 
 class TooltipApp(App[None]):
@@ -116,3 +116,32 @@ async def test_making_tipper_shuffle_away_should_remove_tooltip() -> None:
         await pilot.app.mount(Static(id="mr-brown"), before="#mr-blue")
         await pilot.pause()
         assert pilot.app.query_one("#textual-tooltip").display is False
+
+
+async def test_large_tooltip_survives_layout_when_popup_covers_cursor() -> None:
+    """Regression for #6296: tooltip must not clear when the popup overlaps the cursor.
+
+    In a small terminal a large tooltip may be constrained such that it covers the
+    mouse cell; hit-testing then returns the Tooltip overlay and must not be
+    treated as leaving the source widget.
+    """
+    TOOLTIP_PAUSE = TOOLTIP_TIMEOUT + 0.15
+
+    class LargeTipSmallScreenApp(App[None]):
+        TOOLTIP_DELAY = 0.4
+        CSS = """
+        TextArea {
+            width: 1fr;
+            height: 1fr;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            yield TextArea().with_tooltip("Line\n\n" * 50)
+
+    async with LargeTipSmallScreenApp().run_test(tooltips=True, size=(36, 10)) as pilot:
+        await pilot.hover("TextArea")
+        await pilot.pause(TOOLTIP_PAUSE)
+        assert pilot.app.query_one("#textual-tooltip").display is True
+        await pilot.pause(0.2)
+        assert pilot.app.query_one("#textual-tooltip").display is True


### PR DESCRIPTION
## Summary

Fixes tooltip clearing when a large tooltip overlaps the mouse cursor in a constrained terminal layout.

When hit-testing returned the Tooltip overlay itself, tooltip ownership checks incorrectly treated this as leaving the source widget, causing the tooltip to disappear immediately.

This change:

* avoids clearing the tooltip when the cursor is over the Tooltip overlay itself
* avoids retargeting tooltip ownership to the Tooltip widget during mouse move handling
* adds a regression test covering large tooltips in a small terminal window

## Testing

python -m pytest tests/test_tooltips.py -v

All tooltip tests pass, including the new regression test.

