### PR TITLE
Fix escaping for uppercase markup tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed selection to the right of code fence blocks (may break some snapshots)
+- Fixed `textual.markup.escape()` so uppercase bracketed text like `[RED]` is escaped correctly
 
 ## [8.2.5] - 2026-04-30
 

--- a/src/textual/markup.py
+++ b/src/textual/markup.py
@@ -155,7 +155,7 @@ _EscapeSubMethod = Callable[[_ReSubCallable, str], str]  # Sub method of a compi
 
 def escape(
     markup: str,
-    _escape: _EscapeSubMethod = re.compile(r"(\\*)(\[[a-z#/@][^[]*?])").sub,
+    _escape: _EscapeSubMethod = re.compile(r"(\\*)(\[[a-zA-Z#/@][^[]*?])").sub,
 ) -> str:
     """Escapes text so that it won't be interpreted as markup.
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -5,6 +5,7 @@ from rich.text import Text
 
 from textual.color import Color
 from textual.content import Content, Span
+from textual.markup import escape
 from textual.style import Style
 from textual.visual import RenderOptions
 from textual.widget import Widget
@@ -243,6 +244,8 @@ def test_assemble():
         ("\\[", "["),
         ("\\[foo", "[foo"),
         ("\\[foo]", "[foo]"),
+        ("\\[FOO", "[FOO"),
+        ("\\[FOO]", "[FOO]"),
         ("\\[/foo", "[/foo"),
         ("\\[/foo]", "[/foo]"),
         ("\\[]", "[]"),
@@ -253,6 +256,14 @@ def test_escape(markup: str, plain: str) -> None:
     """Test that escaping the first square bracket."""
     content = Content.from_markup(markup)
     assert content.plain == plain
+    assert content.spans == []
+
+
+def test_escape_uppercase_markup_tag() -> None:
+    """Regression test for uppercase tags being treated as markup."""
+    escaped = escape("[RED] literal uppercase tag")
+    content = Content.from_markup(escaped)
+    assert content.plain == "[RED] literal uppercase tag"
     assert content.spans == []
 
 


### PR DESCRIPTION
Fixes #6525.

## Summary
- teach `textual.markup.escape()` to escape uppercase bracketed markup openings as well as lowercase ones
- add regression coverage for escaped uppercase tags like `[FOO]` and `[RED]`
- note the bugfix in the changelog

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_content.py -k escape -q`
- `PYTHONPATH=src python3 -m pytest tests/test_markup.py -q`