### PR TITLE
docs: fix miscellaneous typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed selection to the right of code fence blocks (may break some snapshots)
+- Fixed typos in docs, docstrings, and code comments
 
 ## [8.2.5] - 2026-04-30
 

--- a/docs/examples/widgets/progress_bar_isolated.py
+++ b/docs/examples/widgets/progress_bar_isolated.py
@@ -17,7 +17,7 @@ class IndeterminateProgressBar(App[None]):
         yield Footer()
 
     def on_mount(self) -> None:
-        """Set up a timer to simulate progess happening."""
+        """Set up a timer to simulate progress happening."""
         self.progress_timer = self.set_interval(1 / 10, self.make_progress, pause=True)
 
     def make_progress(self) -> None:

--- a/docs/guide/CSS.md
+++ b/docs/guide/CSS.md
@@ -297,7 +297,7 @@ Unlike the `id` attribute, a widget's classes can be changed after the widget wa
 - [remove_class()][textual.dom.DOMNode.remove_class] Removes class name(s) from a widget.
 - [toggle_class()][textual.dom.DOMNode.toggle_class] Removes a class name if it is present, or adds the name if it's not already present.
 - [has_class()][textual.dom.DOMNode.has_class] Checks if one or more classes are set on a widget.
-- [set_class()][textual.css.query.DOMQuery.set_class] Sets or removes a class dependant on a boolean.
+- [set_class()][textual.css.query.DOMQuery.set_class] Sets or removes a class dependent on a boolean.
 - [classes][textual.dom.DOMNode.classes] Is a frozen set of the class(es) set on a widget.
 
 

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -230,7 +230,7 @@ When you exit a Textual app with [`App.exit()`][textual.app.App.exit], you can o
     Returns codes are a standard feature provided by your operating system.
     When any application exits it can return an integer to indicate if it was successful or not.
     A return code of `0` indicates success, any other value indicates that an error occurred.
-    The exact meaning of a non-zero return code is application-dependant.
+    The exact meaning of a non-zero return code is application-dependent.
 
 When a Textual app exits normally, the return code will be `0`. If there is an unhandled exception, Textual will set a return code of `1`.
 You may want to set a different value for the return code if there is error condition that you want to differentiate from an unhandled exception.

--- a/docs/guide/reactivity.md
+++ b/docs/guide/reactivity.md
@@ -94,7 +94,7 @@ The `Name` widget has a reactive `who` attribute. When the app modifies that att
 
 !!! information
 
-    Textual will check if a value has really changed, so assigning the same value wont prompt an unnecessary refresh.
+    Textual will check if a value has really changed, so assigning the same value won't prompt an unnecessary refresh.
 
 ### Disabling refresh
 
@@ -107,7 +107,7 @@ class MyWidget(Widget):
     count = var(0)  # (1)!
 ```
 
-1. Changing `self.count` wont cause a refresh or layout.
+1. Changing `self.count` won't cause a refresh or layout.
 
 ### Layout
 

--- a/docs/guide/styles.md
+++ b/docs/guide/styles.md
@@ -198,7 +198,7 @@ Let's look at an example. We will create two widgets, one with a height of `"2fr
 ```
 
 The total `fr` units for height is 3.
-The first widget has a height ot `2fr`, which results in the height being two thirds of the total height.
+The first widget has a height of `2fr`, which results in the height being two thirds of the total height.
 The second widget has a height of `1fr` which makes it take up the remaining third of the height.
 Here's what that looks like.
 

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -612,7 +612,7 @@ The `InputWithLabel` class bundles an [Input](../widgets/input.md) with a [Label
 ## Coordinating widgets
 
 Widgets rarely exist in isolation, and often need to communicate or exchange data with other parts of your app.
-This is not difficult to do, but there is a risk that widgets can become dependant on each other, making it impossible to reuse a widget without copying a lot of dependant code.
+This is not difficult to do, but there is a risk that widgets can become dependent on each other, making it impossible to reuse a widget without copying a lot of dependent code.
 
 In this section we will show how to design and build a fully-working app, while keeping widgets reusable.
 

--- a/docs/widgets/toast.md
+++ b/docs/widgets/toast.md
@@ -54,7 +54,7 @@ Toast.-error {
 }
 ```
 
-You can customize just the title wih the `toast--title` class.
+You can customize just the title with the `toast--title` class.
 The following would make the title italic for an information toast:
 
 ```scss

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -558,7 +558,7 @@ class Content(Visual):
     def get_optimal_width(self, rules: RulesMap, container_width: int) -> int:
         """Get optimal width of the Visual to display its content.
 
-        The exact definition of "optimal width" is dependant on the Visual, but
+        The exact definition of "optimal width" is dependent on the Visual, but
         will typically be wide enough to display output without cropping or wrapping,
         and without superfluous space.
 
@@ -1721,7 +1721,7 @@ class Content(Visual):
 class _FormattedLine:
     """A line of content with additional formatting information.
 
-    This class is used internally within Content, and you are unlikely to need it an an app.
+    This class is used internally within Content, and you are unlikely to need it in an app.
     """
 
     def __init__(

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -1321,7 +1321,7 @@ class Spacing(NamedTuple):
 class Shape:
     """An arbitrary shape defined by a sequence of regions.
 
-    This class currently exists to filter widgets within a shape defined when the user is slecting text.
+    This class currently exists to filter widgets within a shape defined when the user is selecting text.
 
     """
 

--- a/src/textual/visual.py
+++ b/src/textual/visual.py
@@ -147,7 +147,7 @@ class Visual(ABC):
     def get_optimal_width(self, rules: RulesMap, container_width: int) -> int:
         """Get optimal width of the Visual to display its content.
 
-        The exact definition of "optimal width" is dependant on the Visual, but
+        The exact definition of "optimal width" is dependent on the Visual, but
         will typically be wide enough to display output without cropping or wrapping,
         and without superfluous space.
 
@@ -236,7 +236,7 @@ class Visual(ABC):
             ),
         )
         if widget.auto_links and not widget.is_container:
-            # TODO: This is suprisingly expensive (why?)
+            # TODO: This is surprisingly expensive (why?)
             link_style = widget.link_style
             strips = [strip._apply_link_style(link_style) for strip in strips]
 


### PR DESCRIPTION
**Link to issue or discussion**

N/A — purely documentation/comment typo fixes, no behavior change.

## Summary

Spotted a handful of typos while reading the codebase and grepped for similar ones. Batched into a single PR rather than several:

- `slecting` → `selecting` (`geometry.py` docstring)
- `suprisingly` → `surprisingly` (`visual.py` comment)
- `dependant` → `dependent` (`visual.py`, `content.py`, `CSS.md`, `widgets.md`, `app.md`)
- `an an app` → `in an app` (`content.py` docstring)
- `wih` → `with` (`toast.md`)
- `ot` → `of` (`styles.md`)
- `wont` → `won't` (`reactivity.md`, two occurrences)
- `progess` → `progress` (`progress_bar_isolated.py` docstring)

## Validation

- Only comments, docstrings, and prose touched — no behaviour change.
- `black --check` clean on the modified `.py` files.
- Python files still parse (`ast.parse`).