### PR TITLE
Fix @on decorator matching widget subclass unexpectedly

### DIFF
--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -432,7 +432,7 @@ class Button(Widget, can_focus=True):
         self._start_active_affect()
         # ...and let other components know that we've just been clicked:
         if self.action is None:
-            self.post_message(Button.Pressed(self))
+            self.post_message(type(self).Pressed(self))
         else:
             self.call_later(
                 self.app.run_action, self.action, default_namespace=self._parent


### PR DESCRIPTION
## Summary

Fix `@on(MyButton.Pressed)` handler firing for all `Button` presses, not just `MyButton` instances.

## Root Cause

`MyButton(Button)` inherits `Pressed` from `Button`, so `MyButton.Pressed == Button.Pressed`. When a `Button` is clicked, `post_message(Button.Pressed(self))` sends the same message class regardless of the actual widget type. The `@on` decorator has no way to distinguish which subclass was intended.

## Fix

Change `self.post_message(Button.Pressed(self))` to `self.post_message(type(self).Pressed(self))`. This way:
- `Button` instances still post `Button.Pressed`
- Subclasses that define their own `Pressed` (unique per subclass) will post their specific type
- Handlers decorated with `@on(MyButton.Pressed)` will only fire when `MyButton.Pressed` is posted

Subclasses should define their own `Pressed` for unique handling:
```python
class MyButton(Button):
    class Pressed(Button.Pressed):
        pass
```

Fixes #4968