### PR TITLE
Kitty keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased 
+
+### Added
+
+- Added support for Kitty key protocl "Report all keys as escape codes" which enabled alt+backspace on Warp
+- Added support for detecting separate modifier keys for terminals that support the Kitty key protocol
+
 ## [8.2.6] - 2026-04-13
 
 ### Fixed

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -18,7 +18,7 @@ IGNORE_SEQUENCE: Final[IgnoredSequence] = IgnoredSequence()
 # Mapping of vt100 escape codes to Keys.
 ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...] | str | IgnoredSequence] = {
     # Control keys.
-    # " ": (Keys.Space,),
+    " ": (Keys.Space,),
     "\r": (Keys.Enter,),
     "\x00": (Keys.ControlAt,),  # Control-At (Also for Ctrl-Space)
     "\x01": (Keys.ControlA,),  # Control-A (home)

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -18,7 +18,7 @@ IGNORE_SEQUENCE: Final[IgnoredSequence] = IgnoredSequence()
 # Mapping of vt100 escape codes to Keys.
 ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...] | str | IgnoredSequence] = {
     # Control keys.
-    " ": (Keys.Space,),
+    # " ": (Keys.Space,),
     "\r": (Keys.Enter,),
     "\x00": (Keys.ControlAt,),  # Control-At (Also for Ctrl-Space)
     "\x01": (Keys.ControlA,),  # Control-A (home)

--- a/src/textual/_keyboard_protocol.py
+++ b/src/textual/_keyboard_protocol.py
@@ -1,5 +1,7 @@
+from typing import Final
+
 # https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions
-FUNCTIONAL_KEYS = {
+FUNCTIONAL_KEYS: Final = {
     "27u": "escape",
     "13u": "enter",
     "9u": "tab",
@@ -120,4 +122,22 @@ FUNCTIONAL_KEYS = {
     "57452u": "right_meta",
     "57453u": "iso_level3_shift",
     "57454u": "iso_level5_shift",
+}
+
+# A sub-set of modifier keys
+MODIFIER_FUNCTIONAL_KEYS: Final = {
+    "left_shift",
+    "left_control",
+    "left_alt",
+    "left_super",
+    "left_hyper",
+    "left_meta",
+    "right_shift",
+    "right_control",
+    "right_alt",
+    "right_super",
+    "right_hyper",
+    "right_meta",
+    "iso_level3_shift",
+    "iso_level5_shift",
 }

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -8,7 +8,7 @@ from typing_extensions import Final
 
 from textual import constants, events, messages
 from textual._ansi_sequences import ANSI_SEQUENCES_KEYS, IGNORE_SEQUENCE
-from textual._keyboard_protocol import FUNCTIONAL_KEYS
+from textual._keyboard_protocol import FUNCTIONAL_KEYS, MODIFIER_FUNCTIONAL_KEYS
 from textual._parser import ParseEOF, Parser, ParseTimeout, Peek1, Read1, TokenCallback
 from textual.keys import KEY_NAME_REPLACEMENTS, Keys, _character_to_key
 from textual.message import Message
@@ -344,8 +344,9 @@ class XTermParser(Parser[Message]):
                     key = _character_to_key(chr(int(number)))
                 except Exception:
                     key = chr(int(number))
+
             key_tokens: list[str] = []
-            if modifiers:
+            if modifiers and key not in MODIFIER_FUNCTIONAL_KEYS:
                 modifier_bits = int(modifiers) - 1
                 # Not convinced of the utility in reporting caps_lock and num_lock
                 MODIFIERS = ("shift", "alt", "ctrl", "super", "hyper", "meta")

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -37,8 +37,10 @@ FOCUSOUT: Final[str] = "\x1b[O"
 SPECIAL_SEQUENCES = {BRACKETED_PASTE_START, BRACKETED_PASTE_END, FOCUSIN, FOCUSOUT}
 """Set of special sequences."""
 
-_re_extended_key: Final = re.compile(r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])")
-_re_in_band_window_resize: Final = re.compile(
+_re_extended_key: Final[re.Pattern[str]] = re.compile(
+    r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])"
+)
+_re_in_band_window_resize: Final[re.Pattern[str]] = re.compile(
     r"\x1b\[48;(\d+(?:\:.*?)?);(\d+(?:\:.*?)?);(\d+(?:\:.*?)?);(\d+(?:\:.*?)?)t"
 )
 
@@ -337,15 +339,18 @@ class XTermParser(Parser[Message]):
         """
 
         if (match := _re_extended_key.fullmatch(sequence)) is not None:
-            number, modifiers, end = match.groups()
-            number = number or 1
+            number, modifiers, end = match.groups(default="")
+            number = number or "1"
+
+            character_sequence = sequence
             if not (key := FUNCTIONAL_KEYS.get(f"{number}{end}", "")):
-                try:
-                    key = _character_to_key(chr(int(number)))
-                except Exception:
-                    key = chr(int(number))
+                if number.isalnum():
+                    ordinal = int(number)
+                    character_sequence = chr(ordinal)
+                    key = _character_to_key(character_sequence)
 
             key_tokens: list[str] = []
+            # The modifier is redundant on a modifier key
             if modifiers and key not in MODIFIER_FUNCTIONAL_KEYS:
                 modifier_bits = int(modifiers) - 1
                 # Not convinced of the utility in reporting caps_lock and num_lock
@@ -358,7 +363,8 @@ class XTermParser(Parser[Message]):
             key_tokens.sort()
             key_tokens.append(key.lower())
             yield events.Key(
-                "+".join(key_tokens), sequence if len(sequence) == 1 else None
+                "+".join(key_tokens),
+                character_sequence if len(character_sequence) == 1 else None,
             )
             return
 
@@ -384,6 +390,7 @@ class XTermParser(Parser[Message]):
             sequence = keys
         # If the sequence is a single character, attempt to process it as a
         # key.
+
         if len(sequence) == 1:
             try:
                 if not sequence.isalnum():

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -335,7 +335,7 @@ class XTermParser(Parser[Message]):
             sequence: Sequence of code points.
 
         Returns:
-            Keys
+            Iterable of key events.
         """
 
         if (match := _re_extended_key.fullmatch(sequence)) is not None:
@@ -343,11 +343,13 @@ class XTermParser(Parser[Message]):
             number = number or "1"
 
             character_sequence = sequence
-            if not (key := FUNCTIONAL_KEYS.get(f"{number}{end}", "")):
-                if number.isalnum():
-                    ordinal = int(number)
-                    character_sequence = chr(ordinal)
-                    key = _character_to_key(character_sequence)
+            if (
+                not (key := FUNCTIONAL_KEYS.get(f"{number}{end}", ""))
+                and number.isalnum()
+            ):
+                ordinal = int(number)
+                character_sequence = chr(ordinal)
+                key = _character_to_key(character_sequence)
 
             key_tokens: list[str] = []
             # The modifier is redundant on a modifier key

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -274,7 +274,7 @@ class LinuxDriver(Driver):
 
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
-        self.write("\x1b[>1u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+        self.write("\x1b[>8u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread, name="textual-input")

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -9,7 +9,7 @@ import termios
 import tty
 from codecs import getincrementaldecoder
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import rich.repr
 
@@ -25,6 +25,13 @@ from textual.messages import InBandWindowResize
 
 if TYPE_CHECKING:
     from textual.app import App
+
+# https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
+KITTY_DISAMBIGUATE_ESCAPE_CODES: Final = 0b00000001
+KITTY_REPORT_EVENT_TYPES: Final = 0b00000010
+KITTY_REPORT_ALTERNATE_KEYS: Final = 0b00000100
+KITTY_REPORT_ALL_KEYS: Final = 0b00001000
+KITTY_REPORT_ASSOCIATED_TEXT: Final = 0b00010000
 
 
 @rich.repr.auto(angular=True)
@@ -274,7 +281,10 @@ class LinuxDriver(Driver):
 
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
-        self.write("\x1b[>8u")  # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+
+        # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+        KITTY_PROTOCOL_FLAG = KITTY_DISAMBIGUATE_ESCAPE_CODES | KITTY_REPORT_ALL_KEYS
+        self.write(f"\x1b[>{KITTY_PROTOCOL_FLAG}u")
 
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread, name="textual-input")

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -308,7 +308,7 @@ async def test_pilot_target_on_widget_that_is_not_visible_errors(method, target)
     """Make sure that clicking a widget that is not scrolled into view raises an error."""
     app = ManyLabelsApp()
     async with app.run_test(size=(80, 5)) as pilot:
-        app.query_one("#label50").scroll_visible(animate=False)
+        app.query_one("#label50").scroll_visible(immediate=True, animate=False)
         await pilot.pause()
 
         pilot_method = getattr(pilot, method)

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -191,6 +191,8 @@ def test_double_escape(parser):
         ("\x1b[65;4u", "alt+shift+a"),
         ("\x1bA", "alt+shift+a"),
         ("\x1b[120;7u", "alt+ctrl+x"),
+        ("\x1b[57443;3u", "left_alt"),
+        ("\x1b[127;3u", "alt+backspace"),
     ],
 )
 def test_keys(parser, sequence: str, key: str) -> None:

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -193,6 +193,7 @@ def test_double_escape(parser):
         ("\x1b[120;7u", "alt+ctrl+x"),
         ("\x1b[57443;3u", "left_alt"),
         ("\x1b[127;3u", "alt+backspace"),
+        ("\x1b[27u", "escape"),
     ],
 )
 def test_keys(parser, sequence: str, key: str) -> None:


### PR DESCRIPTION
Enable flag 8 on the Kitty key protocol.

This will report additional key combinations. It will also report modifier keys by themselves. So you can detect a press of a modifier without another key.

Test with `textual keys`

Fixes https://github.com/Textualize/textual/issues/6417