### PR TITLE
Support more key combinations in TextArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Undo/redo/copy/cut/paste in TextArea will now work with cmd+ on supported terminals
 - In TextArea, ctrl+u will now delete a newline if the cursor is at the start
+- in TextArea ctrl+delete is now bound to delete word right
 
 ## [8.2.6] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Undo/redo/copy/cut/paste in TextArea will now work with cmd+ on supported terminals
 - In TextArea, ctrl+u will now delete a newline if the cursor is at the start
-- in TextArea ctrl+delete is now bound to delete word right
+- in TextArea alt+delete is now bound to delete word right
 
 ## [8.2.6] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for Kitty key protocl "Report all keys as escape codes" which enabled alt+backspace on Warp
+- Added support for Kitty key protocol "Report all keys as escape codes" which enabled alt+backspace on Warp
 - Added support for detecting separate modifier keys for terminals that support the Kitty key protocol
 - Added `TEXTUAL_DISABLE_KITTY_KEY` env var to disable Kitty key protocol support (debug aid).
 
 ### Changed
 
-- Undo/redo/copy/cut/paste in TextAre will now work with cmd+ on supported terminals
+- Undo/redo/copy/cut/paste in TextArea will now work with cmd+ on supported terminals
 - In TextArea, ctrl+u will now delete a newline if the cursor is at the start
 
 ## [8.2.6] - 2026-04-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for detecting separate modifier keys for terminals that support the Kitty key protocol
 - Added `TEXTUAL_DISABLE_KITTY_KEY` env var to disable Kitty key protocol support (debug aid).
 
+### Changed
+
+- Undo/redo/copy/cut/paste in TextAre will now work with cmd+ on supported terminals
+- In TextArea, ctrl+u will now delete a newline if the cursor is at the start
+
 ## [8.2.6] - 2026-04-13
 
 ### Fixed

--- a/src/textual/widgets/_input.py
+++ b/src/textual/widgets/_input.py
@@ -124,7 +124,10 @@ class Input(ScrollView):
         ),
         Binding("ctrl+u", "delete_left_all", "Delete all to the left", show=False),
         Binding(
-            "ctrl+f", "delete_right_word", "Delete right to start of word", show=False
+            "ctrl+backspace",
+            "delete_right_word",
+            "Delete right to start of word",
+            show=False,
         ),
         Binding("ctrl+k", "delete_right_all", "Delete all to the right", show=False),
         Binding("ctrl+x", "cut", "Cut selected text", show=False),

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -2668,9 +2668,19 @@ TextArea {
 
     def action_delete_to_start_of_line(self) -> None:
         """Deletes from the cursor location to the start of the line."""
-        from_location = self.selection.end
-        to_location = self.get_cursor_line_start_location()
-        self._delete_via_keyboard(from_location, to_location)
+        if self.read_only:
+            return
+
+        if self.cursor_at_start_of_line:
+            selection = self.selection
+            start, end = selection
+            if selection.is_empty:
+                end = self.get_cursor_left_location()
+            self._delete_via_keyboard(start, end)
+        else:
+            from_location = self.selection.end
+            to_location = self.get_cursor_line_start_location()
+            self._delete_via_keyboard(from_location, to_location)
 
     def action_delete_to_end_of_line(self) -> None:
         """Deletes from the cursor location to the end of the line."""

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -102,7 +102,7 @@ class TextAreaLanguage:
     name: str
     """The name of the language"""
 
-    language: "Language" | None
+    language: "Language | None"
     """The tree-sitter language object if that has been overridden, or None if it is a built-in language."""
 
     highlight_query: str

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -223,16 +223,66 @@ TextArea {
 
     BINDINGS = [
         # Cursor movement
-        Binding("up", "cursor_up", "Cursor up", show=False),
-        Binding("down", "cursor_down", "Cursor down", show=False),
-        Binding("left", "cursor_left", "Cursor left", show=False),
-        Binding("right", "cursor_right", "Cursor right", show=False),
-        Binding("ctrl+left", "cursor_word_left", "Cursor word left", show=False),
-        Binding("ctrl+right", "cursor_word_right", "Cursor word right", show=False),
-        Binding("home,ctrl+a", "cursor_line_start", "Cursor line start", show=False),
-        Binding("end,ctrl+e", "cursor_line_end", "Cursor line end", show=False),
-        Binding("pageup", "cursor_page_up", "Cursor page up", show=False),
-        Binding("pagedown", "cursor_page_down", "Cursor page down", show=False),
+        Binding(
+            "up",
+            "cursor_up",
+            "Cursor up",
+            show=False,
+        ),
+        Binding(
+            "down",
+            "cursor_down",
+            "Cursor down",
+            show=False,
+        ),
+        Binding(
+            "left",
+            "cursor_left",
+            "Cursor left",
+            show=False,
+        ),
+        Binding(
+            "right",
+            "cursor_right",
+            "Cursor right",
+            show=False,
+        ),
+        Binding(
+            "ctrl+left",
+            "cursor_word_left",
+            "Cursor word left",
+            show=False,
+        ),
+        Binding(
+            "ctrl+right",
+            "cursor_word_right",
+            "Cursor word right",
+            show=False,
+        ),
+        Binding(
+            "home,ctrl+a",
+            "cursor_line_start",
+            "Cursor line start",
+            show=False,
+        ),
+        Binding(
+            "end,ctrl+e",
+            "cursor_line_end",
+            "Cursor line end",
+            show=False,
+        ),
+        Binding(
+            "pageup",
+            "cursor_page_up",
+            "Cursor page up",
+            show=False,
+        ),
+        Binding(
+            "pagedown",
+            "cursor_page_down",
+            "Cursor page down",
+            show=False,
+        ),
         # Making selections (generally holding the shift key and moving cursor)
         Binding(
             "ctrl+shift+left",
@@ -253,30 +303,97 @@ TextArea {
             show=False,
         ),
         Binding(
-            "shift+end", "cursor_line_end(True)", "Cursor line end select", show=False
+            "shift+end",
+            "cursor_line_end(True)",
+            "Cursor line end select",
+            show=False,
         ),
-        Binding("shift+up", "cursor_up(True)", "Cursor up select", show=False),
-        Binding("shift+down", "cursor_down(True)", "Cursor down select", show=False),
-        Binding("shift+left", "cursor_left(True)", "Cursor left select", show=False),
-        Binding("shift+right", "cursor_right(True)", "Cursor right select", show=False),
+        Binding(
+            "shift+up",
+            "cursor_up(True)",
+            "Cursor up select",
+            show=False,
+        ),
+        Binding(
+            "shift+down",
+            "cursor_down(True)",
+            "Cursor down select",
+            show=False,
+        ),
+        Binding(
+            "shift+left",
+            "cursor_left(True)",
+            "Cursor left select",
+            show=False,
+        ),
+        Binding(
+            "shift+right",
+            "cursor_right(True)",
+            "Cursor right select",
+            show=False,
+        ),
         # Shortcut ways of making selections
         # Binding("f5", "select_word", "select word", show=False),
-        Binding("f6", "select_line", "Select line", show=False),
-        Binding("f7", "select_all", "Select all", show=False),
+        Binding(
+            "f6",
+            "select_line",
+            "Select line",
+            show=False,
+        ),
+        Binding(
+            "f7",
+            "select_all",
+            "Select all",
+            show=False,
+        ),
         # Deletion
-        Binding("backspace", "delete_left", "Delete character left", show=False),
         Binding(
-            "ctrl+w", "delete_word_left", "Delete left to start of word", show=False
+            "backspace",
+            "delete_left",
+            "Delete character left",
+            show=False,
         ),
-        Binding("delete,ctrl+d", "delete_right", "Delete character right", show=False),
         Binding(
-            "ctrl+f", "delete_word_right", "Delete right to start of word", show=False
+            "ctrl+w",
+            "delete_word_left",
+            "Delete left to start of word",
+            show=False,
         ),
-        Binding("ctrl+x", "cut", "Cut", show=False),
-        Binding("ctrl+c,super+c", "copy", "Copy", show=False),
-        Binding("ctrl+v", "paste", "Paste", show=False),
         Binding(
-            "ctrl+u", "delete_to_start_of_line", "Delete to line start", show=False
+            "delete,ctrl+d",
+            "delete_right",
+            "Delete character right",
+            show=False,
+        ),
+        Binding(
+            "ctrl+f",
+            "delete_word_right",
+            "Delete right to start of word",
+            show=False,
+        ),
+        Binding(
+            "ctrl+x,super+x",
+            "cut",
+            "Cut",
+            show=False,
+        ),
+        Binding(
+            "ctrl+c,super+c",
+            "copy",
+            "Copy",
+            show=False,
+        ),
+        Binding(
+            "ctrl+v",
+            "paste",
+            "Paste",
+            show=False,
+        ),
+        Binding(
+            "ctrl+u",
+            "delete_to_start_of_line",
+            "Delete to line start",
+            show=False,
         ),
         Binding(
             "ctrl+k",
@@ -290,8 +407,18 @@ TextArea {
             "Delete line",
             show=False,
         ),
-        Binding("ctrl+z", "undo", "Undo", show=False),
-        Binding("ctrl+y", "redo", "Redo", show=False),
+        Binding(
+            "ctrl+z,super+z",
+            "undo",
+            "Undo",
+            show=False,
+        ),
+        Binding(
+            "ctrl+y,super+y",
+            "redo",
+            "Redo",
+            show=False,
+        ),
     ]
     """
     | Key(s)                 | Description                                  |
@@ -323,11 +450,11 @@ TextArea {
     | ctrl+k                 | Delete from cursor to the end of the line.   |
     | f6                     | Select the current line.                     |
     | f7                     | Select all text in the document.             |
-    | ctrl+z                 | Undo.                                        |
-    | ctrl+y                 | Redo.                                        |
-    | ctrl+x                 | Cut selection or line if no selection.       |
-    | ctrl+c                 | Copy selection to clipboard.                 |
-    | ctrl+v                 | Paste from clipboard.                        |
+    | ctrl+z,super+z         | Undo.                                        |
+    | ctrl+y,super+y         | Redo.                                        |
+    | ctrl+x,super+x         | Cut selection or line if no selection.       |
+    | ctrl+c,super+c         | Copy selection to clipboard.                 |
+    | ctrl+v,super+v         | Paste from clipboard.                        |
     """
 
     language: Reactive[str | None] = reactive(None, always_update=True, init=False)

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -354,7 +354,7 @@ TextArea {
             show=False,
         ),
         Binding(
-            "ctrl+w",
+            "ctrl+w,ctrl+backspace",
             "delete_word_left",
             "Delete left to start of word",
             show=False,
@@ -442,7 +442,7 @@ TextArea {
     | shift+left             | Select while moving the cursor left.         |
     | shift+right            | Select while moving the cursor right.        |
     | backspace              | Delete character to the left of cursor.      |
-    | ctrl+w                 | Delete from cursor to start of the word.     |
+    | ctrl+w,ctrl+backspace  | Delete from cursor to start of the word.     |
     | delete,ctrl+d          | Delete character to the right of cursor.     |
     | ctrl+f                 | Delete from cursor to end of the word.       |
     | ctrl+shift+k           | Delete the current line.                     |

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -366,7 +366,7 @@ TextArea {
             show=False,
         ),
         Binding(
-            "ctrl+f",
+            "ctrl+delete",
             "delete_word_right",
             "Delete right to start of word",
             show=False,

--- a/src/textual/widgets/_text_area.py
+++ b/src/textual/widgets/_text_area.py
@@ -366,7 +366,7 @@ TextArea {
             show=False,
         ),
         Binding(
-            "ctrl+delete",
+            "alt+delete",
             "delete_word_right",
             "Delete right to start of word",
             show=False,
@@ -444,7 +444,7 @@ TextArea {
     | backspace              | Delete character to the left of cursor.      |
     | ctrl+w,ctrl+backspace  | Delete from cursor to start of the word.     |
     | delete,ctrl+d          | Delete character to the right of cursor.     |
-    | ctrl+f                 | Delete from cursor to end of the word.       |
+    | alt+delete             | Delete from cursor to end of the word.       |
     | ctrl+shift+k           | Delete the current line.                     |
     | ctrl+u                 | Delete from cursor to the start of the line. |
     | ctrl+k                 | Delete from cursor to the end of the line.   |
@@ -2742,7 +2742,7 @@ TextArea {
 
         # Check the current line for a word boundary
         line = self.document[cursor_row][cursor_column:]
-        matches = list(re.finditer(self._word_pattern, line))
+        matches = list(re.finditer(r"\s*\w+", line))
 
         current_row_length = len(self.document[cursor_row])
         if matches:

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -361,6 +361,17 @@ async def test_delete_word_left(selection, expected_result, final_selection):
         assert text_area.text == expected_result
         assert text_area.selection == final_selection
 
+    # Repeat with ctrl+backspace binding
+    async with app.run_test() as pilot:
+        text_area = app.query_one(TextArea)
+        text_area.load_text("  012 345 6789")
+        text_area.selection = selection
+
+        await pilot.press("ctrl+backspace")
+
+        assert text_area.text == expected_result
+        assert text_area.selection == final_selection
+
 
 @pytest.mark.parametrize(
     "selection,expected_result,final_selection",

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -362,6 +362,7 @@ async def test_delete_word_left(selection, expected_result, final_selection):
         assert text_area.selection == final_selection
 
     # Repeat with ctrl+backspace binding
+    app = TextAreaApp()
     async with app.run_test() as pilot:
         text_area = app.query_one(TextArea)
         text_area.load_text("  012 345 6789")
@@ -450,7 +451,7 @@ async def test_delete_word_right(selection, expected_result, final_selection):
         text_area.load_text("  012 345 6789")
         text_area.selection = selection
 
-        await pilot.press("ctrl+f")
+        await pilot.press("ctrl+delete")
 
         assert text_area.text == expected_result
         assert text_area.selection == final_selection
@@ -463,7 +464,7 @@ async def test_delete_word_right_delete_to_end_of_line():
         text_area.load_text("01234\n56789")
         text_area.selection = Selection.cursor((0, 3))
 
-        await pilot.press("ctrl+f")
+        await pilot.press("ctrl+delete")
 
         assert text_area.text == "012\n56789"
         assert text_area.selection == Selection.cursor((0, 3))
@@ -476,7 +477,7 @@ async def test_delete_word_right_at_end_of_line():
         text_area.load_text("01234\n56789")
         text_area.selection = Selection.cursor((0, 5))
 
-        await pilot.press("ctrl+f")
+        await pilot.press("ctrl+delete")
 
         assert text_area.text == "0123456789"
         assert text_area.selection == Selection.cursor((0, 5))
@@ -488,7 +489,7 @@ async def test_delete_word_right_at_end_of_line():
         "enter",
         "backspace",
         "ctrl+u",
-        "ctrl+f",
+        "ctrl+delete",
         "ctrl+w",
         "ctrl+k",
         "ctrl+x",

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -563,3 +563,37 @@ async def test_paste_read_only_does_nothing():
         await pilot.pause()
 
         assert text_area.text == TEXT  # No change
+
+
+async def test_delete_to_start_of_line_deletes_newline():
+    """Test that default ctrl+u deletes newline when the cursor is at the start"""
+
+    class TextAreaApp(App):
+        def compose(self) -> ComposeResult:
+            text_area = TextArea.code_editor()
+            text_area.insert("Hello\nWorld")
+
+            yield text_area
+
+    app = TextAreaApp()
+    async with app.run_test() as pilot:
+        text_area = app.query_one(TextArea)
+
+        # Two lines to start
+        assert text_area.text == "Hello\nWorld"
+
+        # Delete the line
+        await pilot.press("ctrl+u")
+        assert text_area.text == "Hello\n"
+
+        # Delete at start, deletes the \n
+        await pilot.press("ctrl+u")
+        assert text_area.text == "Hello"
+
+        # Delete the line
+        await pilot.press("ctrl+u")
+        assert text_area.text == ""
+
+        # Delete empty is a NOOP
+        await pilot.press("ctrl+u")
+        assert text_area.text == ""

--- a/tests/text_area/test_edit_via_bindings.py
+++ b/tests/text_area/test_edit_via_bindings.py
@@ -436,11 +436,11 @@ async def test_delete_word_left_at_line_start():
 @pytest.mark.parametrize(
     "selection,expected_result,final_selection",
     [
-        (Selection.cursor((0, 0)), "012 345 6789", Selection.cursor((0, 0))),
+        (Selection.cursor((0, 0)), " 345 6789", Selection.cursor((0, 0))),
         (Selection.cursor((0, 4)), "  01 345 6789", Selection.cursor((0, 4))),
-        (Selection.cursor((0, 5)), "  012345 6789", Selection.cursor((0, 5))),
+        (Selection.cursor((0, 5)), "  012 6789", Selection.cursor((0, 5))),
         (Selection.cursor((0, 14)), "  012 345 6789", Selection.cursor((0, 14))),
-        # When non-empty selection, "delete word right" just deletes the selection
+        # # When non-empty selection, "delete word right" just deletes the selection
         (Selection((0, 4), (0, 11)), "  01789", Selection.cursor((0, 4))),
     ],
 )
@@ -451,9 +451,10 @@ async def test_delete_word_right(selection, expected_result, final_selection):
         text_area.load_text("  012 345 6789")
         text_area.selection = selection
 
-        await pilot.press("ctrl+delete")
+        await pilot.press("alt+delete")
 
         assert text_area.text == expected_result
+        print(final_selection)
         assert text_area.selection == final_selection
 
 
@@ -464,7 +465,7 @@ async def test_delete_word_right_delete_to_end_of_line():
         text_area.load_text("01234\n56789")
         text_area.selection = Selection.cursor((0, 3))
 
-        await pilot.press("ctrl+delete")
+        await pilot.press("alt+delete")
 
         assert text_area.text == "012\n56789"
         assert text_area.selection == Selection.cursor((0, 3))
@@ -477,7 +478,7 @@ async def test_delete_word_right_at_end_of_line():
         text_area.load_text("01234\n56789")
         text_area.selection = Selection.cursor((0, 5))
 
-        await pilot.press("ctrl+delete")
+        await pilot.press("alt+delete")
 
         assert text_area.text == "0123456789"
         assert text_area.selection == Selection.cursor((0, 5))


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/6488

- [x] ctrl+u doesn't remove previous \n when cursor is at the beginning of the line (but ctrl+k actually has the good behavior regarding \n)
- [ ] ~ctrl+b: Move cursor backward (left)~
- [ ] ~ctrl+f: Move cursor forward (right) - instead, it currently deletes the next word~
- [x] ctrl+backspace: delete previous word (this one is probably also linked to kitty protocol support)
- [x] option+delete: Delete end of word
- [ ] ~ctrl+p: Move cursor to the previous line~
- [ ] ~ctrl+n: Move cursor to the next line~
- [x] Side note: would it make sense to support cmd+Z at the TextArea level?

ctrl+p conflicts with the command palette. Apps that need this can easily add bindings in a subclass. See note in comment

cmd+z is bound as an alternative to ctrl+z. Alas, not all terminals report this. Ghostty captures ctrl+z as undo for its own purposes. The cmd modifier doesn't work at all in iTerm. It does work in Kitty though.

There's not much I can do from the Textual side to improve things here. It is somewhat possible to deduce what bindings are available, then at least the app can not display bindings that don't work. But this typically relies on environment variables being set correctly, and it may fail over ssh, tmux etc.