### PR TITLE
enhanced kitty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for Kitty key protocl "Report all keys as escape codes" which enabled alt+backspace on Warp
 - Added support for detecting separate modifier keys for terminals that support the Kitty key protocol
+- Added `TEXTUAL_DISABLE_KITTY_KEY` env var to disable Kitty key protocol support (debug aid).
 
 ## [8.2.6] - 2026-04-13
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -343,20 +343,14 @@ class XTermParser(Parser[Message]):
 
         if (match := _re_extended_key.fullmatch(sequence)) is not None:
             codes, end = match.groups(default="")
-            number_ordinal, modifiers_ordinal, text_ordinal = (
-                codes.split(";") + [""] * 3
-            )[:3]
+            codepoint_str, modifiers_str, text_str, *_ = codes.split(";") + ["", "", ""]
 
-            number = int(number_ordinal or "1")
-            modifiers = int(modifiers_ordinal or "0")
-            text = chr(int(text_ordinal or "0")) if text_ordinal else None
+            codepoint = int(codepoint_str or "1")
+            modifiers = int(modifiers_str or "0")
+            text = chr(int(text_str)) if text_str else None
 
-            if key := FUNCTIONAL_KEYS.get(f"{number}{end}", ""):
-                text = None
-            else:
-                key = (
-                    _character_to_key(text) if text else _character_to_key(chr(number))
-                )
+            if not (key := FUNCTIONAL_KEYS.get(f"{codepoint}{end}", "")):
+                key = _character_to_key(text if text else chr(codepoint))
 
             key_tokens: list[str] = []
             # The modifier is redundant on a modifier key
@@ -365,7 +359,11 @@ class XTermParser(Parser[Message]):
                 # Not convinced of the utility in reporting caps_lock and num_lock
                 MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
                 # Ignore caps_lock and num_lock modifiers
-                if modifier_bits & 1:
+                # If the shift changes the case, then we want "shift+" in the key
+                # If the key does not simply change the case (i.e. shift+1) we do *not* want the modifier
+                if modifier_bits & 1 and (
+                    text is None or chr(codepoint).casefold() == text.casefold()
+                ):
                     key_tokens.append("shift")
                 for bit, modifier in enumerate(MODIFIERS, 1):
                     if modifier_bits & (1 << bit):

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -37,8 +37,11 @@ FOCUSOUT: Final[str] = "\x1b[O"
 SPECIAL_SEQUENCES = {BRACKETED_PASTE_START, BRACKETED_PASTE_END, FOCUSIN, FOCUSOUT}
 """Set of special sequences."""
 
+# _re_extended_key: Final[re.Pattern[str]] = re.compile(
+#     r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])"
+# )
 _re_extended_key: Final[re.Pattern[str]] = re.compile(
-    r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])"
+    r"\x1b\[((?:\d*;?){2,3})([u~ABCDEFHPQRS])"
 )
 _re_in_band_window_resize: Final[re.Pattern[str]] = re.compile(
     r"\x1b\[48;(\d+(?:\:.*?)?);(\d+(?:\:.*?)?);(\d+(?:\:.*?)?);(\d+(?:\:.*?)?)t"
@@ -339,35 +342,39 @@ class XTermParser(Parser[Message]):
         """
 
         if (match := _re_extended_key.fullmatch(sequence)) is not None:
-            number, modifiers, end = match.groups(default="")
-            number = number or "1"
+            codes, end = match.groups(default="")
+            number_ordinal, modifiers_ordinal, text_ordinal = (
+                codes.split(";") + [""] * 3
+            )[:3]
 
-            character_sequence = sequence
-            if (
-                not (key := FUNCTIONAL_KEYS.get(f"{number}{end}", ""))
-                and number.isalnum()
-            ):
-                ordinal = int(number)
-                character_sequence = chr(ordinal)
-                key = _character_to_key(character_sequence)
+            number = int(number_ordinal or "1")
+            modifiers = int(modifiers_ordinal or "0")
+            text = chr(int(text_ordinal or "0")) if text_ordinal else None
+
+            if key := FUNCTIONAL_KEYS.get(f"{number}{end}", ""):
+                text = None
+            else:
+                key = (
+                    _character_to_key(text) if text else _character_to_key(chr(number))
+                )
 
             key_tokens: list[str] = []
             # The modifier is redundant on a modifier key
             if modifiers and key not in MODIFIER_FUNCTIONAL_KEYS:
                 modifier_bits = int(modifiers) - 1
                 # Not convinced of the utility in reporting caps_lock and num_lock
-                MODIFIERS = ("shift", "alt", "ctrl", "super", "hyper", "meta")
+                MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
                 # Ignore caps_lock and num_lock modifiers
-                for bit, modifier in enumerate(MODIFIERS):
+                if modifier_bits & 1:
+                    key_tokens.append("shift")
+                for bit, modifier in enumerate(MODIFIERS, 1):
                     if modifier_bits & (1 << bit):
                         key_tokens.append(modifier)
 
             key_tokens.sort()
-            key_tokens.append(key.lower())
-            yield events.Key(
-                "+".join(key_tokens),
-                character_sequence if len(character_sequence) == 1 else None,
-            )
+            if key is not None:
+                key_tokens.append(key.lower())
+            yield events.Key("+".join(key_tokens), text)
             return
 
         keys = ANSI_SEQUENCES_KEYS.get(sequence)

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from functools import lru_cache
 from typing import Any, Generator, Iterable
 
 from typing_extensions import Final
@@ -53,6 +54,7 @@ IS_ITERM = (
 SPECIAL_KEY_TO_CHARACTER: Final = {
     "backspace": "\x7f",
     "enter": "\r",
+    "tab": "\t",
 }
 """Explcit characters for keys, used in Kitty protocol parsing"""
 
@@ -332,6 +334,53 @@ class XTermParser(Parser[Message]):
             self._debug_log_file.close()
             self._debug_log_file = None
 
+    @lru_cache(maxsize=1024)
+    def _parse_extended_key(self, sequence: str) -> events.Key | None:
+        """Parse a Kitty sequence.
+
+        Args:
+            sequence: Input sequence
+
+        Returns:
+            Key event, or `None` of none could be parsed.
+        """
+
+        if (match := _re_extended_key.fullmatch(sequence)) is None:
+            return None
+
+        codes, end = match.groups(default="")
+        codepoint_str, modifiers_str, text_str, *_ = codes.split(";") + ["", "", ""]
+
+        codepoint = int(codepoint_str or "1")
+        modifiers = int(modifiers_str or "0")
+        text = chr(int(text_str)) if text_str else None
+
+        if not (key := FUNCTIONAL_KEYS.get(f"{codepoint}{end}", "")):
+            key = _character_to_key(text if text else chr(codepoint))
+
+        key_tokens: list[str] = []
+        # The modifier is redundant on a modifier key
+        if modifiers and key not in MODIFIER_FUNCTIONAL_KEYS and text_str is not None:
+            modifier_bits = int(modifiers) - 1
+            # Not convinced of the utility in reporting caps_lock and num_lock
+            MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
+            # Ignore caps_lock and num_lock modifiers
+            if modifier_bits & 1 and (text is None or text.isspace()):
+                key_tokens.append("shift")
+            for bit, modifier in enumerate(MODIFIERS, 1):
+                if modifier == "alt" and text is not None:
+                    continue
+                if modifier_bits & (1 << bit):
+                    key_tokens.append(modifier)
+
+        key_tokens.sort()
+        if key is not None:
+            key_tokens.append(key)
+        return events.Key(
+            "+".join(key_tokens),
+            text or (None if modifiers else SPECIAL_KEY_TO_CHARACTER.get(key, None)),
+        )
+
     def _sequence_to_key_events(
         self, sequence: str, alt: bool = False
     ) -> Iterable[events.Key]:
@@ -344,44 +393,11 @@ class XTermParser(Parser[Message]):
             Iterable of key events.
         """
 
-        if (match := _re_extended_key.fullmatch(sequence)) is not None:
-            codes, end = match.groups(default="")
-            codepoint_str, modifiers_str, text_str, *_ = codes.split(";") + ["", "", ""]
-
-            codepoint = int(codepoint_str or "1")
-            modifiers = int(modifiers_str or "0")
-            text = chr(int(text_str)) if text_str else None
-
-            if not (key := FUNCTIONAL_KEYS.get(f"{codepoint}{end}", "")):
-                key = _character_to_key(text if text else chr(codepoint))
-
-            key_tokens: list[str] = []
-            # The modifier is redundant on a modifier key
-            if (
-                modifiers
-                and key not in MODIFIER_FUNCTIONAL_KEYS
-                and text_str is not None
-            ):
-                modifier_bits = int(modifiers) - 1
-                # Not convinced of the utility in reporting caps_lock and num_lock
-                MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
-                # Ignore caps_lock and num_lock modifiers
-                if modifier_bits & 1 and (text is None or text.isspace()):
-                    key_tokens.append("shift")
-                for bit, modifier in enumerate(MODIFIERS, 1):
-                    if modifier == "alt" and text is not None:
-                        continue
-                    if modifier_bits & (1 << bit):
-                        key_tokens.append(modifier)
-
-            key_tokens.sort()
-            if key is not None:
-                key_tokens.append(key)
-            yield events.Key(
-                "+".join(key_tokens),
-                text
-                or (None if modifiers else SPECIAL_KEY_TO_CHARACTER.get(key, None)),
-            )
+        if (
+            not constants.DISABLE_KITTY_KEY
+            and (key := self._parse_extended_key(sequence)) is not None
+        ):
+            yield key
             return
 
         keys = ANSI_SEQUENCES_KEYS.get(sequence)

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -397,7 +397,7 @@ class XTermParser(Parser[Message]):
             not constants.DISABLE_KITTY_KEY
             and (key := self._parse_extended_key(sequence)) is not None
         ):
-            yield key
+            yield key.copy()
             return
 
         keys = ANSI_SEQUENCES_KEYS.get(sequence)

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -37,9 +37,6 @@ FOCUSOUT: Final[str] = "\x1b[O"
 SPECIAL_SEQUENCES = {BRACKETED_PASTE_START, BRACKETED_PASTE_END, FOCUSIN, FOCUSOUT}
 """Set of special sequences."""
 
-# _re_extended_key: Final[re.Pattern[str]] = re.compile(
-#     r"\x1b\[(?:(\d+)(?:;(\d+))?)?([u~ABCDEFHPQRS])"
-# )
 _re_extended_key: Final[re.Pattern[str]] = re.compile(
     r"\x1b\[((?:\d*;?){2,3})([u~ABCDEFHPQRS])"
 )
@@ -52,6 +49,12 @@ IS_ITERM = (
     os.environ.get("LC_TERMINAL", "") == "iTerm2"
     or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
 )
+
+SPECIAL_KEY_TO_CHARACTER: Final = {
+    "backspace": "\x7f",
+    "enter": "\r",
+}
+"""Explcit characters for keys, used in Kitty protocol parsing"""
 
 
 class XTermParser(Parser[Message]):
@@ -354,25 +357,31 @@ class XTermParser(Parser[Message]):
 
             key_tokens: list[str] = []
             # The modifier is redundant on a modifier key
-            if modifiers and key not in MODIFIER_FUNCTIONAL_KEYS:
+            if (
+                modifiers
+                and key not in MODIFIER_FUNCTIONAL_KEYS
+                and text_str is not None
+            ):
                 modifier_bits = int(modifiers) - 1
                 # Not convinced of the utility in reporting caps_lock and num_lock
                 MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
                 # Ignore caps_lock and num_lock modifiers
-                # If the shift changes the case, then we want "shift+" in the key
-                # If the key does not simply change the case (i.e. shift+1) we do *not* want the modifier
-                if modifier_bits & 1 and (
-                    text is None or chr(codepoint).casefold() == text.casefold()
-                ):
+                if modifier_bits & 1 and (text is None or text.isspace()):
                     key_tokens.append("shift")
                 for bit, modifier in enumerate(MODIFIERS, 1):
+                    if modifier == "alt" and text is not None:
+                        continue
                     if modifier_bits & (1 << bit):
                         key_tokens.append(modifier)
 
             key_tokens.sort()
             if key is not None:
-                key_tokens.append(key.lower())
-            yield events.Key("+".join(key_tokens), text)
+                key_tokens.append(
+                    key if (text is not None and len(text) == 1) else key.lower()
+                )
+            yield events.Key(
+                "+".join(key_tokens), text or SPECIAL_KEY_TO_CHARACTER.get(key, None)
+            )
             return
 
         keys = ANSI_SEQUENCES_KEYS.get(sequence)

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -376,9 +376,7 @@ class XTermParser(Parser[Message]):
 
             key_tokens.sort()
             if key is not None:
-                key_tokens.append(
-                    key if (text is not None and len(text) == 1) else key.lower()
-                )
+                key_tokens.append(key)
             yield events.Key(
                 "+".join(key_tokens), text or SPECIAL_KEY_TO_CHARACTER.get(key, None)
             )

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -378,7 +378,9 @@ class XTermParser(Parser[Message]):
             if key is not None:
                 key_tokens.append(key)
             yield events.Key(
-                "+".join(key_tokens), text or SPECIAL_KEY_TO_CHARACTER.get(key, None)
+                "+".join(key_tokens),
+                text
+                or (None if modifiers else SPECIAL_KEY_TO_CHARACTER.get(key, None)),
             )
             return
 

--- a/src/textual/constants.py
+++ b/src/textual/constants.py
@@ -113,6 +113,9 @@ DEBUG: Final[bool] = _get_environ_bool("TEXTUAL_DEBUG")
 DRIVER: Final[str | None] = get_environ("TEXTUAL_DRIVER", None)
 """Import for replacement driver."""
 
+DISABLE_KITTY_KEY: Final[bool] = _get_environ_bool("TEXTUAL_DISABLE_KITTY_KEY")
+"""Disable kitty key protocol."""
+
 FILTERS: Final[str] = get_environ("TEXTUAL_FILTERS", "")
 """A list of filters to apply to renderables."""
 

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -283,7 +283,11 @@ class LinuxDriver(Driver):
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
 
         # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
-        KITTY_PROTOCOL_FLAG = KITTY_DISAMBIGUATE_ESCAPE_CODES | KITTY_REPORT_ALL_KEYS
+        KITTY_PROTOCOL_FLAG = (
+            KITTY_DISAMBIGUATE_ESCAPE_CODES
+            | KITTY_REPORT_ALL_KEYS
+            | KITTY_REPORT_ASSOCIATED_TEXT
+        )
         self.write(f"\x1b[>{KITTY_PROTOCOL_FLAG}u")
 
         self.flush()

--- a/src/textual/drivers/linux_driver.py
+++ b/src/textual/drivers/linux_driver.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 import rich.repr
 
-from textual import events
+from textual import constants, events
 from textual._loop import loop_last
 from textual._parser import ParseError
 from textual._xterm_parser import XTermParser
@@ -282,13 +282,14 @@ class LinuxDriver(Driver):
         self.write("\x1b[?25l")  # Hide cursor
         self.write("\x1b[?1004h")  # Enable FocusIn/FocusOut.
 
-        # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
-        KITTY_PROTOCOL_FLAG = (
-            KITTY_DISAMBIGUATE_ESCAPE_CODES
-            | KITTY_REPORT_ALL_KEYS
-            | KITTY_REPORT_ASSOCIATED_TEXT
-        )
-        self.write(f"\x1b[>{KITTY_PROTOCOL_FLAG}u")
+        if not constants.DISABLE_KITTY_KEY:
+            # https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+            KITTY_PROTOCOL_FLAG = (
+                KITTY_DISAMBIGUATE_ESCAPE_CODES
+                | KITTY_REPORT_ALL_KEYS
+                | KITTY_REPORT_ASSOCIATED_TEXT
+            )
+            self.write(f"\x1b[>{KITTY_PROTOCOL_FLAG}u")
 
         self.flush()
         self._key_thread = Thread(target=self._run_input_thread, name="textual-input")

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -269,7 +269,7 @@ class Key(InputEvent):
         character: A printable character or `None` if it is not printable.
     """
 
-    __slots__ = ["key", "character", "aliases"]
+    __slots__ = ["key", "character"]
 
     def __init__(self, key: str, character: str | None) -> None:
         super().__init__()
@@ -279,8 +279,6 @@ class Key(InputEvent):
             (key if len(key) == 1 else None) if character is None else character
         )
         """A printable character or ``None`` if it is not printable."""
-        self.aliases: list[str] = _get_key_aliases(key)
-        """The aliases for the key, including the key itself."""
 
     def __rich_repr__(self) -> rich.repr.Result:
         yield "key", self.key
@@ -288,6 +286,10 @@ class Key(InputEvent):
         yield "name", self.name
         yield "is_printable", self.is_printable
         yield "aliases", self.aliases, [self.key]
+
+    def copy(self) -> Key:
+        """Get a copy of this key event."""
+        return Key(self.key, self.character)
 
     @property
     def name(self) -> str:
@@ -307,6 +309,11 @@ class Key(InputEvent):
             `True` if the key is printable.
         """
         return False if self.character is None else self.character.isprintable()
+
+    @property
+    def aliases(self) -> list[str]:
+        """The aliases for the key, including the key itself."""
+        return _get_key_aliases(self.key)
 
 
 def _key_to_identifier(key: str) -> str:

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -186,6 +186,8 @@ def test_double_escape(parser):
     [
         ("a", "a"),
         ("B", "B"),
+        ("\x1b[97;;97u", "a"),
+        ("\x1b[97;2;65u", "A"),
         ("\x1ba", "alt+a"),
         ("\x1b[97;3u", "alt+a"),
         ("\x1b[65;4u", "alt+shift+a"),
@@ -194,6 +196,8 @@ def test_double_escape(parser):
         ("\x1b[57443;3u", "left_alt"),
         ("\x1b[127;3u", "alt+backspace"),
         ("\x1b[27u", "escape"),
+        ("\x1b[32;;32u", "space"),
+        ("\x1b[32;2;32u", "shift+space"),
     ],
 )
 def test_keys(parser, sequence: str, key: str) -> None:

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -190,7 +190,7 @@ def test_double_escape(parser):
         ("\x1b[97;2;65u", "A"),
         ("\x1ba", "alt+a"),
         ("\x1b[97;3u", "alt+a"),
-        ("\x1b[65;4u", "alt+shift+a"),
+        ("\x1b[97;4u", "alt+shift+a"),
         ("\x1bA", "alt+shift+a"),
         ("\x1b[120;7u", "alt+ctrl+x"),
         ("\x1b[57443;3u", "left_alt"),


### PR DESCRIPTION
Further to https://github.com/Textualize/textual/pull/6542

Added support for `KITTY_REPORT_ASSOCIATED_TEXT` which sends the character in addition to ordinal+modifiers. This is required to know that shift+1 == "!" (for example).