### PR TITLE
docs: clarify ANSI color generation behavior in FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -295,7 +295,7 @@ We recommend any of the following terminals:
 <a name="why-doesnt-textual-support-ansi-themes"></a>
 ## Why doesn't Textual support ANSI themes?
 
-Textual will not generate escape sequences for the 16 themeable *ANSI* colors.
+By default, Textual will not generate escape sequences for the 16 themeable *ANSI* colors.
 
 This is an intentional design decision we took for the following reasons:
 


### PR DESCRIPTION
### Description
The first paragraph under the "Why doesn't Textual support ANSI themes?" section states that Textual will never generate ANSI escape sequences. However, the tip box directly below it mentions the `ansi_color` boolean added in version 0.80.0. 

This PR adds "By default" to the opening sentence to resolve this small contradiction and make the FAQ completely accurate.