### PR TITLE
Fix TwoWayDict reverse map going stale on key reassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `TwoWayDict` leaving a stale entry in its reverse map when a key was reassigned https://github.com/Textualize/textual/pull/6551
+
 ## [8.2.7] - 2026-05-19 
 
 ### Added

--- a/src/textual/_two_way_dict.py
+++ b/src/textual/_two_way_dict.py
@@ -21,6 +21,10 @@ class TwoWayDict(Generic[Key, Value]):
     def __setitem__(self, key: Key, value: Value) -> None:
         # TODO: Duplicate values need to be managed to ensure consistency,
         #  decide on best approach.
+        if key in self._forward:
+            # Reassigning an existing key: drop its old value from the
+            # reverse map, otherwise that value keeps pointing back here.
+            self._reverse.__delitem__(self._forward[key])
         self._forward.__setitem__(key, value)
         self._reverse.__setitem__(value, key)
 

--- a/tests/test_two_way_dict.py
+++ b/tests/test_two_way_dict.py
@@ -28,6 +28,18 @@ def test_set_item(two_way_dict):
     assert two_way_dict.get_key(400) == 40
 
 
+def test_set_item_reassigning_key_clears_old_reverse_entry(two_way_dict):
+    # Reassigning an existing key must not leave its old value behind in the
+    # reverse mapping.
+    assert two_way_dict.get_key(10) == 1
+    two_way_dict[1] = 999
+    assert two_way_dict.get(1) == 999
+    assert two_way_dict.get_key(999) == 1
+    assert two_way_dict.get_key(10) is None
+    assert not two_way_dict.contains_value(10)
+    assert len(two_way_dict) == 3
+
+
 def test_len(two_way_dict):
     assert len(two_way_dict) == 3
 


### PR DESCRIPTION
`TwoWayDict.__setitem__` writes the new value into `_forward` and `_reverse`, but never removes the *old* value from `_reverse` when a key is reassigned:

```python
d = TwoWayDict({})
d[1] = 10
d[1] = 20
d.get(1)               # 20  ✓
d.get_key(20)          # 1   ✓
d.get_key(10)          # 1   ✗ should be None
d.contains_value(10)   # True ✗ should be False
```

So `_reverse` stops being a true inverse of `_forward` — `get_key` and `contains_value` keep reporting a value the key no longer maps to.

The fix drops the old value's reverse entry when the key already exists. The pre-existing `TODO` about duplicate *values* (two keys → one value) is a separate design question and is left untouched.

Added `test_set_item_reassigning_key_clears_old_reverse_entry` alongside the existing `test_set_item`.

Worth noting on scope: `DataTable` (the in-tree user of `TwoWayDict`) currently rebuilds these dicts rather than reassigning keys, so this isn't a user-visible bug today — it's a correctness hole in the utility class itself, which has an explicit two-way invariant and its own test file.