### PR TITLE
fix: prevent KeyError on TextArea theme initialization (#6528)

### DIFF
--- a/src/textual/_text_area_theme.py
+++ b/src/textual/_text_area_theme.py
@@ -85,7 +85,11 @@ class TextAreaTheme:
             text_area: The TextArea instance to retrieve fallback styling from.
         """
         self.base_style = text_area.rich_style or Style()
-        get_style = text_area.get_component_rich_style
+        def get_style(name: str) -> Style | None:
+            try:
+                return text_area.get_component_rich_style(name)
+            except KeyError:
+                return None
 
         if self.base_style.color is None:
             self.base_style = Style(color="#f3f3f3", bgcolor=self.base_style.bgcolor)

--- a/tests/text_area/test_issue_6528.py
+++ b/tests/text_area/test_issue_6528.py
@@ -1,0 +1,41 @@
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import TextArea
+
+
+class CredsModal(ModalScreen[None]):
+    CSS = """
+    #box {
+        width: 80;
+        height: 20;
+        border: heavy white;
+    }
+    #ta {
+        height: 10;
+        border: solid white;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Container(id="box"):
+            yield TextArea("", id="ta", language=None, show_line_numbers=False)
+
+
+class Demo(App):
+    def on_mount(self) -> None:
+        self.push_screen(CredsModal())
+
+
+@pytest.mark.asyncio
+async def test_issue_6528_modal_textarea_no_crash():
+    app = Demo()
+    async with app.run_test() as pilot:
+        # Pushing a ModalScreen and rendering the TextArea inside should not crash
+        await pilot.pause()
+        ta = app.screen.query_one(TextArea)
+        assert ta is not None
+        # Call render_lines explicitly to ensure apply_css is executed
+        from textual.geometry import Region
+        ta.render_lines(Region(0, 0, 80, 10))


### PR DESCRIPTION
Thank you for contributing!

This project requires all PRs to link to an issue or discussion. Ideally signed off by @willmcgugan

**Link to issue or discussion**
Closes #6528

---

Hey folks! Ran into a crash when throwing a `TextArea` inside a `ModalScreen`. It throws a `KeyError` looking for `text-area--gutter` in the component styles because it tries to render before the DOM has fully resolved the initial component classes.

To fix this without breaking the render cycle, I just wrapped the `get_component_rich_style` call inside `apply_css` with a try/except. If the key isn't there yet, it safely falls back to `None` and continues smoothly. 

I also dropped a quick regression test in `test_issue_6528.py` to make sure we don't catch this crash again in the future.

Let me know if you need any adjustments to this approach. Thanks!
