### PR TITLE
feat: enhance fuzzy matcher to prioritize whole words (#3208)

### DIFF
--- a/src/textual/fuzzy.py
+++ b/src/textual/fuzzy.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from functools import lru_cache
 from operator import itemgetter
-from re import finditer
+from re import finditer, search
+import re
 from typing import Iterable, Sequence
 
 import rich.repr
@@ -101,6 +102,32 @@ class FuzzySearch:
             candidate = candidate.lower()
             query = query.lower()
         score = self.score
+
+        # Build regex flags based on case sensitivity
+        flags = 0 if self.case_sensitive else re.IGNORECASE
+
+        # Check for exact match first (HIGHEST PRIORITY - 4.0x boost)
+        if candidate == query:
+            offsets = list(range(len(query)))
+            yield (score(candidate, offsets) * 4.0, offsets)
+            return
+
+        # Check whole-word match (\bword\b) - HIGH PRIORITY
+        whole_word_pattern = rf"\b{re.escape(query)}\b"
+        if re.search(whole_word_pattern, candidate, flags):
+            query_location = candidate.find(query)
+            offsets = list(range(query_location, query_location + len(query)))
+            yield (score(candidate, offsets) * 3.5, offsets)
+            return
+
+        # Check word-start match (\bword) - MEDIUM PRIORITY
+        word_start_pattern = rf"\b{re.escape(query)}"
+        if re.search(word_start_pattern, candidate, flags):
+            query_location = candidate.find(query)
+            offsets = list(range(query_location, query_location + len(query)))
+            yield (score(candidate, offsets) * 2.5, offsets)
+            return
+
         if query in candidate:
             # Quick exit when the query exists as a substring
             query_location = candidate.find(query)
@@ -172,7 +199,7 @@ class Matcher:
         self._query = query
         self._match_style = Style(reverse=True) if match_style is None else match_style
         self._case_sensitive = case_sensitive
-        self.fuzzy_search = FuzzySearch()
+        self.fuzzy_search = FuzzySearch(case_sensitive=case_sensitive)
 
     @property
     def query(self) -> str:

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -37,3 +37,77 @@ def test_highlight():
         Span(9, 10, Style(reverse=True)),
         Span(10, 11, Style(reverse=True)),
     ]
+
+
+def test_whole_word_boost():
+    """Whole word matches should score higher than word-start matches."""
+    matcher = Matcher("cmd")
+    # Exact match (4.0x) should be highest
+    exact_score = matcher.match("cmd")
+    # Whole-word in multi-word string (3.5x) should be second
+    whole_word_score = matcher.match("cmd palette")
+    # Word-start (2.5x) should be third
+    word_start_score = matcher.match("cmd123")
+    # Regular substring (1.5x) should be fourth
+    substring_score = matcher.match("mycmd")
+    # Fuzzy match (1.0x) should be lowest
+    fuzzy_score = matcher.match("command")
+
+    assert exact_score > whole_word_score, "Exact match should beat whole-word in multi-word"
+    assert whole_word_score > word_start_score, "Whole-word should beat word-start"
+    assert word_start_score > substring_score, "Word-start should beat substring"
+    assert substring_score > fuzzy_score, "Substring should beat fuzzy"
+
+
+def test_word_start_vs_substring():
+    """Word-start matches should score higher than regular substring matches."""
+    matcher = Matcher("test")
+    # Word-start match (test in "test file")
+    word_start_score = matcher.match("test file")
+    # Substring match (test in "mytest")
+    substring_score = matcher.match("mytest")
+
+    assert word_start_score > substring_score
+
+
+def test_whole_word_with_numbers():
+    """Word boundaries should work with alphanumeric boundaries."""
+    matcher = Matcher("cmd")
+    # "cmd123" is a word-start match (cmd at start of "word")
+    assert matcher.match("cmd123") > matcher.match("mycmd")
+    # "123cmd" is NOT a word-start match (cmd not at word boundary)
+    assert matcher.match("cmd123") > matcher.match("123cmd")
+
+
+def test_case_sensitive_word_boundaries():
+    """Word boundary boosts should respect case_sensitive setting."""
+    matcher_cs = Matcher("Test", case_sensitive=True)
+    matcher_ci = Matcher("Test", case_sensitive=False)
+    # Case-sensitive: "Test" in "Test file" should boost
+    assert matcher_cs.match("Test file") > matcher_cs.match("test file")
+    # Case-insensitive: both should boost equally
+    assert matcher_ci.match("Test file") == matcher_ci.match("test file")
+
+
+def test_multi_word_query():
+    """Multi-word queries should get word boundary boosts."""
+    matcher = Matcher("save screen")
+    # Whole word match (save screen in "save screen") - highest
+    whole_word = matcher.match("save screen")
+    # Word-start match (save screen in "save screenshot") - medium
+    word_start = matcher.match("save screenshot")
+    # Regular match (save screen in "save my screen") - lower
+    regular = matcher.match("save my screen")
+
+    assert whole_word > word_start > regular
+
+
+def test_no_word_boundary_match():
+    """Queries without word boundaries should use normal fuzzy matching."""
+    matcher = Matcher("abc")
+    # "abc" should get whole-word boost
+    abc_score = matcher.match("abc")
+    # "a-b-c" has no word boundaries, should use fuzzy scoring
+    fuzzy_score = matcher.match("a-b-c")
+    # abc should score much higher due to whole-word boost
+    assert abc_score > fuzzy_score * 2


### PR DESCRIPTION
Fixes #3208

    **What Changed:**
    Added regex word boundary checks to `FuzzySearch._match()` to prioritize semantic matches:
    - **Exact match:** 4.0x score boost
    - **Whole-word match (`\bword\b`):** 3.5x score boost
    - **Word-start match (`\bword`):** 2.5x score boost

    Also fixed an existing bug where `FuzzySearch` instantiation was ignoring the `case_sensitive` parameter.

    Added comprehensive test coverage in `tests/test_fuzzy.py`.