### PR TITLE
added alt+enter key binding as a replacement for shift+enter or ctrl+…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Addded a new key binding combination alt+enter as there is no possibility to use shift+enter or ctrl+enter https://github.com/Textualize/textual/discussions/4216
 - Added support for Kitty key protocol "Report all keys as escape codes" which enabled alt+backspace on Warp https://github.com/Textualize/textual/pull/6544
 - Added support for detecting separate modifier keys for terminals that support the Kitty key protocol https://github.com/Textualize/textual/pull/6544
 - Added `TEXTUAL_DISABLE_KITTY_KEY` env var to disable Kitty key protocol support (debug aid). https://github.com/Textualize/textual/pull/6544

--- a/src/textual/_ansi_sequences.py
+++ b/src/textual/_ansi_sequences.py
@@ -311,6 +311,8 @@ ANSI_SEQUENCES_KEYS: Mapping[str, Tuple[Keys, ...] | str | IgnoredSequence] = {
     "\x1b[1;8D": (Keys.Escape, Keys.ControlShiftLeft),
     "\x1b[1;8F": (Keys.Escape, Keys.ControlShiftEnd),
     "\x1b[1;8H": (Keys.Escape, Keys.ControlShiftHome),
+    # Alt + Enter
+    "\x1b\r": (Keys.AltEnter,),  # Left Alt key + Enter
     # Meta + arrow on (some?) Macs when using iTerm defaults (see issue #483).
     "\x1b[1;9A": (Keys.Escape, Keys.Up),
     "\x1b[1;9B": (Keys.Escape, Keys.Down),

--- a/src/textual/keys.py
+++ b/src/textual/keys.py
@@ -122,6 +122,8 @@ class Keys(str, Enum):  # type: ignore[no-redef]
     ControlShiftPageUp = "ctrl+shift+pageup"
     ControlShiftPageDown = "ctrl+shift+pagedown"
 
+    AltEnter = "alt+enter"  # alt + enter
+
     BackTab = "shift+tab"  # shift + tab
 
     F1 = "f1"


### PR DESCRIPTION
resolves https://github.com/Textualize/textual/discussions/4216 (A creative workaround )

Since there is not a default way to use the keys: shift+enter or ctrl+enter
I added alt+enter as a workaround

Added the VT100 code in the "_ansi_sequences.py" and added the string in "keys.py"
I placed it right above the Meta key definitions because as a default key on any keyboard I thought the best place is right below the well established categories but above the special keys 