### PR TITLE
fix(parser): ignore malformed SGR mouse reports

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -19,7 +19,7 @@ from textual.message import Message
 # to be unsuccessful?
 _MAX_SEQUENCE_SEARCH_THRESHOLD = 32
 
-_re_mouse_event = re.compile("^" + re.escape("\x1b[") + r"(<?[-\d;]+[mM]|M...)\Z")
+_re_mouse_event = re.compile("^" + re.escape("\x1b[") + r"(<?[^;]*;[^;]*;[^;]*[mM]|M...)\Z")
 _re_terminal_mode_response = re.compile(
     "^" + re.escape("\x1b[") + r"\?(?P<mode_id>\d+);(?P<setting_parameter>\d)\$y"
 )

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -211,6 +211,11 @@ def test_keys(parser, sequence: str, key: str) -> None:
     assert event.key == key
 
 
+def test_malformed_sgr_mouse_report_is_ignored(parser):
+    """Malformed SGR mouse reports should not be reissued as key events."""
+    assert list(parser.feed("\x1b[<32;NaN;NaNM")) == []
+
+
 @pytest.mark.parametrize(
     "sequence, event_type, shift, meta",
     [


### PR DESCRIPTION
## Summary

Fixes #6573.

Malformed SGR mouse reports such as `\x1b[<32;NaN;NaNM` are now recognized as mouse reports and ignored instead of being reissued as key input.

## Test plan

- `python -m pytest tests/test_xterm_parser.py -q`
- `git diff --check`
