### PR TITLE
Add DataTable row multi-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added row multi-selection support to `DataTable`, including selected row state, range selection, toggle selection, and `RowSelectionChanged`.
 - Added support for Kitty key protocol "Report all keys as escape codes" which enabled alt+backspace on Warp https://github.com/Textualize/textual/pull/6544
 - Added support for detecting separate modifier keys for terminals that support the Kitty key protocol https://github.com/Textualize/textual/pull/6544
 - Added `TEXTUAL_DISABLE_KITTY_KEY` env var to disable Kitty key protocol support (debug aid). https://github.com/Textualize/textual/pull/6544

--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -42,13 +42,13 @@ from textual.strip import Strip
 from textual.widget import PseudoClasses
 
 CellCacheKey: TypeAlias = (
-    "tuple[RowKey, ColumnKey, Style, bool, bool, bool, int, PseudoClasses]"
+    "tuple[RowKey, ColumnKey, Style, bool, bool, bool, bool, int, PseudoClasses]"
 )
 LineCacheKey: TypeAlias = (
     "tuple[int, int, int, int, Coordinate, Coordinate, Style, CursorType, bool, int, PseudoClasses]"
 )
 RowCacheKey: TypeAlias = (
-    "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, int, PseudoClasses]"
+    "tuple[RowKey, int, Style, Coordinate, Coordinate, CursorType, bool, bool, bool, int, PseudoClasses]"
 )
 CursorType = Literal["cell", "row", "column", "none"]
 """The valid types of cursors for [`DataTable.cursor_type`][textual.widgets.DataTable.cursor_type]."""
@@ -272,6 +272,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("enter", "select_cursor", "Select", show=False),
+        Binding("space", "toggle_row", "Toggle row", show=False),
         Binding("up", "cursor_up", "Cursor up", show=False),
         Binding("down", "cursor_down", "Cursor down", show=False),
         Binding("right", "cursor_right", "Cursor right", show=False),
@@ -307,6 +308,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         "datatable--header",
         "datatable--header-cursor",
         "datatable--header-hover",
+        "datatable--selected",
         "datatable--odd-row",
         "datatable--even-row",
     }
@@ -320,6 +322,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
     | `datatable--header` | Target the header of the data table. |
     | `datatable--header-cursor` | Target cells highlighted by the cursor. |
     | `datatable--header-hover` | Target hovered header or row label cells. |
+    | `datatable--selected` | Target selected rows. |
     | `datatable--even-row` | Target even rows (row indices start at 0) if zebra_stripes. |
     | `datatable--odd-row` | Target odd rows (row indices start at 0) if zebra_stripes. |
     """
@@ -403,6 +406,10 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
         & > .datatable--hover {
             background: $block-hover-background;
+        }
+
+        & > .datatable--selected {
+            background: $accent 20%;
         }
     }
     """
@@ -556,6 +563,36 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         def __rich_repr__(self) -> rich.repr.Result:
             yield "cursor_row", self.cursor_row
             yield "row_key", self.row_key
+
+        @property
+        def control(self) -> DataTable:
+            """Alias for the data table."""
+            return self.data_table
+
+    class RowSelectionChanged(Message):
+        """Posted when the set of selected rows changes.
+
+        This message is independent from the cursor and from
+        [`DataTable.RowSelected`][textual.widgets.DataTable.RowSelected]. It is posted
+        when row selection is changed through methods such as
+        [`select_row`][textual.widgets.DataTable.select_row],
+        [`toggle_row`][textual.widgets.DataTable.toggle_row], or
+        [`select_range`][textual.widgets.DataTable.select_range].
+        """
+
+        def __init__(
+            self,
+            data_table: DataTable,
+            selected_rows: frozenset[RowKey],
+        ) -> None:
+            self.data_table = data_table
+            """The data table."""
+            self.selected_rows = selected_rows
+            """The selected row keys."""
+            super().__init__()
+
+        def __rich_repr__(self) -> rich.repr.Result:
+            yield "selected_rows", self.selected_rows
 
         @property
         def control(self) -> DataTable:
@@ -738,6 +775,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         where each cell currently resides in space."""
 
         self.columns: dict[ColumnKey, Column] = {}
+        self._selected_rows: set[RowKey] = set()
+        self._selection_anchor: RowKey | None = None
         """Metadata about the columns of the table, indexed by their key."""
         self.rows: dict[RowKey, Row] = {}
         """Metadata about the rows of the table, indexed by their key."""
@@ -1097,6 +1136,153 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             raise ColumnDoesNotExist(f"No column exists for column_key={column_key!r}")
         return self._column_locations.get(column_key)
 
+    @property
+    def selected_rows(self) -> frozenset[RowKey]:
+        """The currently selected row keys.
+
+        Selection is independent from the cursor. The cursor tracks the current
+        row/cell location; this set tracks the rows chosen by the user or app.
+        """
+        return frozenset(self._selected_rows)
+
+    @property
+    def selection_anchor(self) -> RowKey | None:
+        """The anchor row key used for range selection, if any."""
+        return self._selection_anchor
+
+    def _coerce_row_key(self, row_key: RowKey | str) -> RowKey:
+        """Validate and normalize a row key."""
+        if row_key not in self._row_locations:
+            raise RowDoesNotExist(f"No row exists for row_key={row_key!r}")
+        return self._row_locations.get_key(self._row_locations.get(row_key))
+
+    def _row_keys_in_range(
+        self, anchor: RowKey | str, target: RowKey | str
+    ) -> list[RowKey]:
+        """Return visible row keys between two rows, inclusive."""
+        anchor_key = self._coerce_row_key(anchor)
+        target_key = self._coerce_row_key(target)
+        anchor_index = self._row_locations.get(anchor_key)
+        target_index = self._row_locations.get(target_key)
+        first, last = sorted((anchor_index, target_index))
+        return [
+            self._row_locations.get_key(row_index)
+            for row_index in range(first, last + 1)
+        ]
+
+    def _set_selected_rows(
+        self, row_keys: Iterable[RowKey | str], *, anchor: RowKey | str | None = None
+    ) -> Self:
+        """Set row selection state and refresh affected rows."""
+        old_selection = self._selected_rows
+        new_selection = {self._coerce_row_key(row_key) for row_key in row_keys}
+        new_anchor = self._coerce_row_key(anchor) if anchor is not None else None
+
+        if old_selection == new_selection:
+            self._selection_anchor = new_anchor
+            return self
+
+        changed_rows = old_selection ^ new_selection
+        self._selected_rows = new_selection
+        self._selection_anchor = new_anchor
+        self._clear_caches()
+        for row_key in changed_rows:
+            if row_key in self._row_locations:
+                self.refresh_row(self._row_locations.get(row_key))
+        self.post_message(
+            DataTable.RowSelectionChanged(self, frozenset(self._selected_rows))
+        )
+        return self
+
+    def select_row(
+        self, row_key: RowKey | str, *, replace: bool = False, anchor: bool = True
+    ) -> Self:
+        """Select a row.
+
+        Args:
+            row_key: The key of the row to select.
+            replace: Replace the current selection with this row.
+            anchor: Set this row as the range-selection anchor.
+
+        Returns:
+            The `DataTable` instance.
+        """
+        normalized_key = self._coerce_row_key(row_key)
+        selected_rows = (
+            {normalized_key} if replace else self._selected_rows | {normalized_key}
+        )
+        selection_anchor = normalized_key if anchor else self._selection_anchor
+        return self._set_selected_rows(selected_rows, anchor=selection_anchor)
+
+    def deselect_row(self, row_key: RowKey | str) -> Self:
+        """Deselect a row.
+
+        Args:
+            row_key: The key of the row to deselect.
+
+        Returns:
+            The `DataTable` instance.
+        """
+        normalized_key = self._coerce_row_key(row_key)
+        selected_rows = self._selected_rows - {normalized_key}
+        selection_anchor = (
+            None if self._selection_anchor == normalized_key else self._selection_anchor
+        )
+        return self._set_selected_rows(selected_rows, anchor=selection_anchor)
+
+    def toggle_row(self, row_key: RowKey | str, *, anchor: bool = True) -> Self:
+        """Toggle the selection state of a row.
+
+        Args:
+            row_key: The key of the row to toggle.
+            anchor: Set this row as the range-selection anchor.
+
+        Returns:
+            The `DataTable` instance.
+        """
+        normalized_key = self._coerce_row_key(row_key)
+        if normalized_key in self._selected_rows:
+            return self.deselect_row(normalized_key)
+        return self.select_row(normalized_key, anchor=anchor)
+
+    def select_range(
+        self,
+        anchor: RowKey | str,
+        target: RowKey | str,
+        *,
+        replace: bool = False,
+    ) -> Self:
+        """Select all visible rows between two row keys, inclusive.
+
+        Args:
+            anchor: The first row key in the range.
+            target: The last row key in the range.
+            replace: Replace the current selection with this range.
+
+        Returns:
+            The `DataTable` instance.
+        """
+        anchor_key = self._coerce_row_key(anchor)
+        row_keys = set(self._row_keys_in_range(anchor_key, target))
+        selected_rows = row_keys if replace else self._selected_rows | row_keys
+        return self._set_selected_rows(selected_rows, anchor=anchor_key)
+
+    def clear_selection(self) -> Self:
+        """Clear row selection.
+
+        Returns:
+            The `DataTable` instance.
+        """
+        return self._set_selected_rows(())
+
+    def select_all_rows(self) -> Self:
+        """Select all rows.
+
+        Returns:
+            The `DataTable` instance.
+        """
+        return self._set_selected_rows(self.rows.keys())
+
     def _clear_caches(self) -> None:
         self._row_render_cache.clear()
         self._cell_render_cache.clear()
@@ -1452,6 +1638,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             cursor_type = self.cursor_type
             cursor_location = self.cursor_coordinate
             hover_location = self.hover_coordinate
+            selected_rows = self._selected_rows
             base_style = self.rich_style
             fixed_style = self.get_component_styles(
                 "datatable--fixed"
@@ -1475,6 +1662,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                         column_index,
                         style,
                         column.get_render_width(self),
+                        selected=row.key in selected_rows,
                         cursor=should_highlight(
                             cursor_location, cell_location, cursor_type
                         ),
@@ -1589,6 +1777,9 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             The `DataTable` instance.
         """
         self._clear_caches()
+        selection_changed = bool(self._selected_rows)
+        self._selected_rows = set()
+        self._selection_anchor = None
         self._y_offsets.clear()
         self._data.clear()
         self.rows.clear()
@@ -1606,6 +1797,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self.scroll_y = 0
         self.scroll_target_x = 0
         self.scroll_target_y = 0
+        if selection_changed:
+            self.post_message(DataTable.RowSelectionChanged(self, frozenset()))
         return self
 
     def add_column(
@@ -1801,11 +1994,12 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         """
         if row_key not in self._row_locations:
             raise RowDoesNotExist(f"Row key {row_key!r} is not valid.")
+        removed_row_key = self._coerce_row_key(row_key)
 
         self._require_update_dimensions = True
         self.check_idle()
 
-        index_to_delete = self._row_locations.get(row_key)
+        index_to_delete = self._row_locations.get(removed_row_key)
         new_row_locations = TwoWayDict({})
         for row_location_key in self._row_locations:
             row_index = self._row_locations.get(row_location_key)
@@ -1817,17 +2011,26 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._row_locations = new_row_locations
 
         # Prevent the removed cells from triggering dimension updates
-        for column_key in self._data.get(row_key):
-            self._updated_cells.discard(CellKey(row_key, column_key))
+        for column_key in self._data.get(removed_row_key):
+            self._updated_cells.discard(CellKey(removed_row_key, column_key))
 
-        del self.rows[row_key]
-        del self._data[row_key]
+        selection_changed = removed_row_key in self._selected_rows
+        self._selected_rows.discard(removed_row_key)
+        if self._selection_anchor == removed_row_key:
+            self._selection_anchor = None
+
+        del self.rows[removed_row_key]
+        del self._data[removed_row_key]
 
         self.cursor_coordinate = self.cursor_coordinate
         self.hover_coordinate = self.hover_coordinate
 
         self._update_count += 1
         self.refresh(layout=True)
+        if selection_changed:
+            self.post_message(
+                DataTable.RowSelectionChanged(self, frozenset(self._selected_rows))
+            )
 
     def remove_column(self, column_key: ColumnKey | str) -> None:
         """Remove a column (identified by a key) from the DataTable.
@@ -2090,6 +2293,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         column_index: int,
         base_style: Style,
         width: int,
+        selected: bool = False,
         cursor: bool = False,
         hover: bool = False,
     ) -> SegmentLines:
@@ -2100,6 +2304,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             column_index: Index of the column.
             base_style: Style to apply.
             width: Width of the cell.
+            selected: Is this cell part of a selected row?
             cursor: Is this cell affected by cursor highlighting?
             hover: Is this cell affected by hover cursor highlighting?
 
@@ -2125,6 +2330,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             row_key,
             column_key,
             base_style,
+            selected,
             cursor,
             hover,
             self._show_hover_cursor,
@@ -2145,6 +2351,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                 is_header_cell,
                 is_row_label_cell,
                 is_fixed_style_cell,
+                selected,
                 hover,
                 cursor,
                 self.show_cursor,
@@ -2192,6 +2399,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         is_header_cell: bool,
         is_row_label_cell: bool,
         is_fixed_style_cell: bool,
+        selected: bool,
         hover: bool,
         cursor: bool,
         show_cursor: bool,
@@ -2205,6 +2413,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             is_header_cell: Is this a cell from a header?
             is_row_label_cell: Is this the label of any given row?
             is_fixed_style_cell: Should this cell be styled like a fixed cell?
+            selected: Does this cell belong to a selected row?
             hover: Does this cell have the hover pseudo class?
             cursor: Is this cell covered by the cursor?
             show_cursor: Do we want to show the cursor in the data table?
@@ -2215,6 +2424,9 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         """
         get_component = self.get_component_rich_style
         component_style = Style()
+
+        if selected:
+            component_style += get_component("datatable--selected")
 
         if hover and show_cursor and show_hover_cursor:
             component_style += get_component("datatable--hover")
@@ -2268,6 +2480,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         """
         cursor_type = self.cursor_type
         show_cursor = self.show_cursor
+        selected = row_key in self._selected_rows
 
         cache_key = (
             row_key,
@@ -2278,6 +2491,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             cursor_type,
             show_cursor,
             self._show_hover_cursor,
+            selected,
             self._update_count,
             self._pseudo_class_state,
         )
@@ -2305,6 +2519,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                 -1,
                 header_style,
                 width=self._row_label_column_width,
+                selected=selected,
                 cursor=should_highlight(cursor_location, cell_location, cursor_type),
                 hover=should_highlight(hover_location, cell_location, cursor_type),
             )[line_no]
@@ -2325,6 +2540,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                     column_index,
                     fixed_style,
                     column.get_render_width(self),
+                    selected=selected,
                     cursor=should_highlight(
                         cursor_location, cell_location, cursor_type
                     ),
@@ -2342,6 +2558,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                 column_index,
                 row_style,
                 column.get_render_width(self),
+                selected=selected,
                 cursor=should_highlight(cursor_location, cell_location, cursor_type),
                 hover=should_highlight(hover_location, cell_location, cursor_type),
             )[line_no]
@@ -2363,6 +2580,7 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
                 row_index == -1,
                 False,
                 False,
+                selected,
                 should_highlight(
                     hover_location, Coordinate(row_index or 0, 0), cursor_type
                 ),
@@ -2696,6 +2914,12 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             new_coordinate = Coordinate(row_index, column_index)
             highlight_click = new_coordinate == self.cursor_coordinate
             self.cursor_coordinate = new_coordinate
+            if self.cursor_type == "row":
+                row_key = self._row_locations.get_key(row_index)
+                if event.shift and self._selection_anchor is not None:
+                    self.select_range(self._selection_anchor, row_key)
+                elif event.ctrl or event.meta:
+                    self.toggle_row(row_key)
             if highlight_click:
                 self._post_selected_message()
             self._scroll_cursor_into_view(animate=True)
@@ -2837,6 +3061,13 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._set_hover_cursor(False)
         if self.show_cursor and self.cursor_type != "none":
             self._post_selected_message()
+
+    def action_toggle_row(self) -> None:
+        """Toggle selection for the row under the cursor."""
+        self._set_hover_cursor(False)
+        if self.show_cursor and self.cursor_type == "row" and self.row_count:
+            row_key = self._row_locations.get_key(self.cursor_row)
+            self.toggle_row(row_key)
 
     def _post_selected_message(self):
         """Post the appropriate message for a selection based on the `cursor_type`."""

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_datatable_row_selection_render.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_datatable_row_selection_render.svg
@@ -1,0 +1,152 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #e0e0e0;font-weight: bold }
+.terminal-r2 { fill: #c5c8c6 }
+.terminal-r3 { fill: #eaeaea;font-weight: bold }
+.terminal-r4 { fill: #e0e0e0 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">TableApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#363636" x="0" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#363636" x="134.2" y="1.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#363636" x="317.2" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#363636" x="414.8" y="1.5" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#656565" x="0" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#656565" x="134.2" y="25.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#656565" x="317.2" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#656565" x="414.8" y="25.9" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="134.2" y="50.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="317.2" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="414.8" y="50.3" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#424242" x="0" y="74.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#424242" x="134.2" y="74.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#424242" x="317.2" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#424242" x="414.8" y="74.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="99.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="134.2" y="99.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="317.2" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="414.8" y="99.1" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="134.2" clip-path="url(#terminal-line-0)">&#160;Name&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r1" x="134.2" y="20" textLength="183" clip-path="url(#terminal-line-0)">&#160;Role&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r1" x="317.2" y="20" textLength="97.6" clip-path="url(#terminal-line-0)">&#160;Status&#160;</text><text class="terminal-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r3" x="0" y="44.4" textLength="134.2" clip-path="url(#terminal-line-1)">&#160;Ada&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r3" x="134.2" y="44.4" textLength="183" clip-path="url(#terminal-line-1)">&#160;Engineer&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r3" x="317.2" y="44.4" textLength="97.6" clip-path="url(#terminal-line-1)">&#160;Active&#160;</text><text class="terminal-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r4" x="0" y="68.8" textLength="134.2" clip-path="url(#terminal-line-2)">&#160;Grace&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r4" x="134.2" y="68.8" textLength="183" clip-path="url(#terminal-line-2)">&#160;Admiral&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r4" x="317.2" y="68.8" textLength="97.6" clip-path="url(#terminal-line-2)">&#160;Active&#160;</text><text class="terminal-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r4" x="0" y="93.2" textLength="134.2" clip-path="url(#terminal-line-3)">&#160;Katherine&#160;</text><text class="terminal-r4" x="134.2" y="93.2" textLength="183" clip-path="url(#terminal-line-3)">&#160;Mathematician&#160;</text><text class="terminal-r4" x="317.2" y="93.2" textLength="97.6" clip-path="url(#terminal-line-3)">&#160;Active&#160;</text><text class="terminal-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r4" x="0" y="117.6" textLength="134.2" clip-path="url(#terminal-line-4)">&#160;Margaret&#160;&#160;</text><text class="terminal-r4" x="134.2" y="117.6" textLength="183" clip-path="url(#terminal-line-4)">&#160;Programmer&#160;&#160;&#160;&#160;</text><text class="terminal-r4" x="317.2" y="117.6" textLength="97.6" clip-path="url(#terminal-line-4)">&#160;Active&#160;</text><text class="terminal-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/snapshot_apps/data_table_row_selection.py
+++ b/tests/snapshot_tests/snapshot_apps/data_table_row_selection.py
@@ -1,0 +1,30 @@
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+ROWS = [
+    ("Name", "Role", "Status"),
+    ("Ada", "Engineer", "Active"),
+    ("Grace", "Admiral", "Active"),
+    ("Katherine", "Mathematician", "Active"),
+    ("Margaret", "Programmer", "Active"),
+]
+
+
+class TableApp(App):
+    def compose(self) -> ComposeResult:
+        table = DataTable(cursor_type="row")
+        table.focus()
+        yield table
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        rows = iter(ROWS)
+        table.add_columns(*next(rows))
+        row_keys = table.add_rows(rows)
+        table.select_row(row_keys[0])
+        table.select_row(row_keys[2])
+
+
+if __name__ == "__main__":
+    app = TableApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -292,6 +292,10 @@ def test_datatable_row_cursor_render(snap_compare):
     assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_row_cursor.py", press=press)
 
 
+def test_datatable_row_selection_render(snap_compare):
+    assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_row_selection.py")
+
+
 def test_datatable_column_cursor_render(snap_compare):
     press = ["left", "up", "down", "right", "right"]
     assert snap_compare(SNAPSHOT_APPS_DIR / "data_table_column_cursor.py", press=press)

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -35,6 +35,7 @@ class DataTableApp(App):
         "CellSelected",
         "RowHighlighted",
         "RowSelected",
+        "RowSelectionChanged",
         "ColumnHighlighted",
         "ColumnSelected",
         "HeaderSelected",
@@ -845,6 +846,120 @@ async def test_click_row_cursor():
         row_selected: DataTable.RowSelected = app.messages[0]
         assert row_selected.row_key == row_key
         assert row_highlighted.cursor_row == 1
+
+
+async def test_row_selection_methods():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        table.add_column("ABC")
+        row_keys = [table.add_row(str(index)) for index in range(5)]
+
+        table.select_row(row_keys[1])
+        assert table.selected_rows == frozenset({row_keys[1]})
+        assert table.selection_anchor == row_keys[1]
+
+        table.toggle_row(row_keys[3])
+        assert table.selected_rows == frozenset({row_keys[1], row_keys[3]})
+        assert table.selection_anchor == row_keys[3]
+
+        table.select_range(row_keys[1], row_keys[3], replace=True)
+        assert table.selected_rows == frozenset(row_keys[1:4])
+        assert table.selection_anchor == row_keys[1]
+
+        table.deselect_row(row_keys[2])
+        assert table.selected_rows == frozenset({row_keys[1], row_keys[3]})
+        assert table.selection_anchor == row_keys[1]
+
+        table.clear_selection()
+        assert table.selected_rows == frozenset()
+        assert table.selection_anchor is None
+
+        table.select_all_rows()
+        assert table.selected_rows == frozenset(row_keys)
+
+
+async def test_row_selection_changed_message():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        table.add_column("ABC")
+        row_keys = [table.add_row(str(index)) for index in range(3)]
+        await wait_for_idle()
+        app.messages.clear()
+
+        table.select_row(row_keys[1])
+        await wait_for_idle()
+        assert app.message_names == ["RowSelectionChanged"]
+
+        selection_changed: DataTable.RowSelectionChanged = app.messages[0]
+        assert selection_changed.selected_rows == frozenset({row_keys[1]})
+
+
+async def test_row_selection_space_toggles_cursor_row():
+    app = DataTableApp()
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        table.cursor_type = "row"
+        table.add_column("ABC")
+        row_keys = [table.add_row(str(index)) for index in range(3)]
+        table.move_cursor(row=1)
+        await wait_for_idle()
+        app.messages.clear()
+
+        await pilot.press("space")
+        assert table.selected_rows == frozenset({row_keys[1]})
+        assert table.selection_anchor == row_keys[1]
+        assert app.message_names == ["RowSelectionChanged"]
+
+        await pilot.press("space")
+        assert table.selected_rows == frozenset()
+        assert table.selection_anchor is None
+
+
+async def test_row_selection_click_modifiers():
+    app = DataTableApp()
+    async with app.run_test() as pilot:
+        table = app.query_one(DataTable)
+        table.cursor_type = "row"
+        table.add_column("ABC")
+        row_keys = [table.add_row(str(index)) for index in range(6)]
+
+        # Click offsets are +1 because the header occupies the first line.
+        await pilot.click(offset=(1, 2), control=True)
+        assert table.selected_rows == frozenset({row_keys[1]})
+        assert table.selection_anchor == row_keys[1]
+
+        await pilot.click(offset=(1, 5), shift=True)
+        assert table.selected_rows == frozenset(row_keys[1:5])
+        assert table.selection_anchor == row_keys[1]
+
+        await pilot.click(offset=(1, 6), control=True)
+        assert table.selected_rows == frozenset(row_keys[1:6])
+        assert table.selection_anchor == row_keys[5]
+
+
+async def test_row_selection_updates_when_rows_are_removed_or_cleared():
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        table.add_column("ABC")
+        row_keys = [table.add_row(str(index)) for index in range(4)]
+        table.select_all_rows()
+        await wait_for_idle()
+        app.messages.clear()
+
+        table.remove_row(row_keys[1])
+        await wait_for_idle()
+        assert table.selected_rows == frozenset({row_keys[0], row_keys[2], row_keys[3]})
+        assert app.message_names == ["RowSelectionChanged"]
+
+        app.messages.clear()
+        table.clear()
+        await wait_for_idle()
+        assert table.selected_rows == frozenset()
+        assert table.selection_anchor is None
+        assert app.message_names == ["RowSelectionChanged"]
 
 
 async def test_click_column_cursor():


### PR DESCRIPTION
## Summary

This PR adds native row multi-selection support to `DataTable`.

The main design choice is to keep selection separate from the cursor. The cursor still means "where the user is focused"; selection means "which rows the user has chosen". Those often overlap, but they are different pieces of state. Keeping them separate makes the feature support both range selection and discontiguous selection without changing the existing meaning of `cursor_coordinate` or making `move_cursor` accept non-cursor concepts.

## Approach

The new selection state is represented by row keys rather than row indexes:

- `selected_rows` exposes the selected row keys as a `frozenset[RowKey]`
- `selection_anchor` stores the row used as the anchor for range selection
- `select_row`, `deselect_row`, `toggle_row`, `select_range`, `clear_selection`, and `select_all_rows` provide explicit APIs for apps
- `RowSelectionChanged` is posted when the selected row set changes
- selected rows get a dedicated `datatable--selected` component class

For interaction:

- `space` toggles the current row when `cursor_type == "row"`
- `ctrl`/`meta` click toggles a row
- shift-click extends selection from the current anchor

This means apps can use a common table-selection model:

- toggle individual rows
- select contiguous ranges
- keep selected rows outside the current range
- select all or clear selection
- style selected rows independently from cursor/hover styling

## Why this shape

There is an older PR, #3821, that models range selection as cursor-range state. That works for contiguous ranges, but it makes selection an extension of cursor/highlight state. In practice, tables usually need both contiguous and discontiguous row selection, and the focused row should remain independent from the selected row set.

This PR tries to be easier to merge by:

- avoiding a change to `move_cursor`
- avoiding a change to the meaning of `cursor_coordinate`
- preserving the existing cursor and hover highlight path
- adding a small, explicit selection API instead of overloading cursor state
- using row keys so selection survives visual row ordering better than raw row indexes
- covering the behavior with unit tests and a focused snapshot test

## Tests

- `uv run pytest tests/test_data_table.py -q`
- `uv run pytest tests/snapshot_tests/test_snapshots.py::test_datatable_row_selection_render -q`