### PR TITLE
Fix #4968: give every Button subclass its own Pressed message class

### DIFF
--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -44,6 +44,33 @@ class Button(Widget, can_focus=True):
 
     """
 
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        # Give each Button subclass its own Pressed message class so that
+        # `@on(MyButton.Pressed)` only matches MyButton click events, not
+        # generic Button clicks. Without this, all subclasses share the
+        # parent's nested Pressed class (Python does not inherit nested
+        # classes), so the message type distinction is lost.
+        # See https://github.com/Textualize/textual/issues/4968
+        parent_pressed = getattr(cls, "Pressed", None)
+        if parent_pressed is not None:
+            new_pressed = type(
+                "Pressed",
+                (parent_pressed,),
+                {
+                    "__qualname__": f"{cls.__name__}.Pressed",
+                    "__module__": cls.__module__,
+                },
+            )
+            new_pressed.__doc__ = parent_pressed.__doc__
+            # Keep the original handler_name so user code that wrote
+            # `def on_button_pressed(self, ...)` keeps matching. Without
+            # this, Message.__init_subclass__ would derive a new name from
+            # the qualname (e.g. "on_my_button_pressed") and silently break
+            # existing handlers.
+            new_pressed.handler_name = parent_pressed.handler_name
+            cls.Pressed = new_pressed
+
     ALLOW_SELECT = False
 
     DEFAULT_CSS = """
@@ -432,7 +459,7 @@ class Button(Widget, can_focus=True):
         self._start_active_affect()
         # ...and let other components know that we've just been clicked:
         if self.action is None:
-            self.post_message(Button.Pressed(self))
+            self.post_message(self.Pressed(self))
         else:
             self.call_later(
                 self.app.run_action, self.action, default_namespace=self._parent

--- a/tests/test_on_subclass.py
+++ b/tests/test_on_subclass.py
@@ -1,0 +1,112 @@
+"""Tests for Textualize/textual#4968: @on decorator should respect subclass
+boundaries when matching message types.
+
+In Textual, a Button subclass like MyButton(Button) inherits the parent's
+nested `Pressed` message class because Python does not inherit nested
+classes. This means `@on(MyButton.Pressed)` and `@on(Button.Pressed)` end
+up registering handlers against the same message class, so a regular
+Button click wrongly fires handlers written for MyButton.
+
+The fix (Button.__init_subclass__): every Button subclass gets its own
+Pressed message class, distinct from Button.Pressed. handler_name is
+preserved so existing on_button_pressed naming-convention handlers keep
+working.
+"""
+
+import pytest
+from textual import on
+from textual.app import App
+from textual.widgets import Button
+
+
+class MyButton(Button):
+    pass
+
+
+class _App_BaseClickFiresSubclassHandler(App[None]):
+    """@on(MyButton.Pressed) should NOT fire when a regular Button is clicked."""
+
+    def __init__(self):
+        super().__init__()
+        self.subclass_fired = 0
+        self.base_fired = 0
+
+    def compose(self):
+        yield Button("Normal Button")
+
+    @on(MyButton.Pressed)
+    def on_my_button_pressed(self) -> None:
+        self.subclass_fired += 1
+
+    @on(Button.Pressed)
+    def on_button_pressed(self) -> None:
+        self.base_fired += 1
+
+
+class _App_SubclassClickFiresBothHandlers(App[None]):
+    """When MyButton is clicked, both @on(MyButton.Pressed) and
+    @on(Button.Pressed) (since MyButton is-a Button) should fire."""
+
+    def __init__(self):
+        super().__init__()
+        self.subclass_fired = 0
+        self.base_fired = 0
+
+    def compose(self):
+        yield MyButton("My Button")
+
+    @on(MyButton.Pressed)
+    def on_my_button_pressed(self) -> None:
+        self.subclass_fired += 1
+
+    @on(Button.Pressed)
+    def on_button_pressed(self) -> None:
+        self.base_fired += 1
+
+
+@pytest.mark.asyncio
+async def test_4968_base_button_click_does_not_fire_subclass_on_handler():
+    app = _App_BaseClickFiresSubclassHandler()
+    async with app.run_test() as pilot:
+        btn = pilot.app.query_one(Button)
+        await pilot.click(btn)
+        await pilot.pause()
+        assert app.base_fired == 1, (
+            "regular Button click should fire @on(Button.Pressed)"
+        )
+        assert app.subclass_fired == 0, (
+            "@on(MyButton.Pressed) must not fire for a regular Button click (bug #4968)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_subclass_button_click_fires_subclass_on_handler():
+    app = _App_SubclassClickFiresBothHandlers()
+    async with app.run_test() as pilot:
+        btn = pilot.app.query_one(MyButton)
+        await pilot.click(btn)
+        await pilot.pause()
+        # Both should fire: MyButton IS-A Button, so @on(Button.Pressed)
+        # matches too via MRO walking.
+        assert app.subclass_fired == 1, (
+            "@on(MyButton.Pressed) should fire when MyButton is clicked"
+        )
+        assert app.base_fired == 1, (
+            "@on(Button.Pressed) should also fire (MyButton is-a Button)"
+        )
+
+
+def test_button_subclass_pressed_classes_are_distinct():
+    """Sanity: each Button subclass should get its own Pressed class."""
+    assert MyButton.Pressed is not Button.Pressed
+    assert issubclass(MyButton.Pressed, Button.Pressed)
+    # handler_name is preserved so on_button_pressed naming-convention still matches
+    assert (
+        MyButton.Pressed.handler_name
+        == Button.Pressed.handler_name
+        == "on_button_pressed"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes Textualize/textual#4968.

## Bug

`@on(MyButton.Pressed)` fires for regular `Button` clicks because Python does not inherit nested classes — `MyButton(Button).Pressed is Button.Pressed`. Both decorators end up registering handlers against the same message class, breaking the subclass distinction.

## Fix

Two parts in `src/textual/widgets/_button.py`:

1. `Button.__init_subclass__` now creates a fresh `Pressed` subclass for every Button subclass. The new class inherits from the parent's `Pressed` so all field/method shape is preserved, but has its own `__qualname__` (`MyButton.Pressed`) and identity.

2. `Button._on_click` posts `self.Pressed` instead of the hard-coded `Button.Pressed`, so the post uses the subclass-specific class.

`handler_name` is explicitly preserved (`on_button_pressed`), so existing on_button_pressed naming-convention handlers keep matching.

## Tests

`tests/test_on_subclass.py` — 3 cases:
- `test_4968_base_button_click_does_not_fire_subclass_on_handler` — original bug repro
- `test_subclass_button_click_fires_subclass_on_handler` — MyButton click fires both handlers (MRO walk)
- `test_button_subclass_pressed_classes_are_distinct` — sanity

Full test_on + test_message_pump + test_screens + test_widget + test_modal + test_app run: 111 passed, 1 pre-existing failure (test_hover_update_styles, unrelated — fails on the unmodified base too).

Refs: AI-2138