### PR TITLE
fix: auto-width columns shrink when widest row is removed

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1362,6 +1362,44 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
             else 0
         )
 
+    def _recalculate_auto_width_columns(self) -> None:
+        """Recalculate content_width for all auto-width columns.
+
+        Called after removing a row, since the removed row may have contained
+        the widest cell in one or more columns. Without this, auto-width
+        columns never shrink back down when their widest content is removed.
+        """
+        console = self.app.console
+        for column_key, column in self.columns.items():
+            if not column.auto_width:
+                continue
+
+            label_width = measure(console, column.label, 1)
+
+            if not self.rows:
+                # No rows left — column width collapses to just the label
+                column.content_width = label_width
+                continue
+
+            max_cell_width = 0
+            for row_key in self.rows:
+                if column_key not in self._data.get(row_key, {}):
+                    continue
+                cell_value = self._data[row_key][column_key]
+                row = self.rows[row_key]
+                cell_width = measure(
+                    console,
+                    default_cell_formatter(
+                        cell_value,
+                        wrap=row.height != 1,
+                        height=row.height,
+                    ),
+                    1,
+                )
+                max_cell_width = max(max_cell_width, cell_width)
+
+            column.content_width = max(max_cell_width, label_width)
+
     def _update_column_widths(self, updated_cells: set[CellKey]) -> None:
         """Update the widths of the columns based on the newly updated cell widths."""
         for row_key, column_key in updated_cells:
@@ -1822,6 +1860,10 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
 
         del self.rows[row_key]
         del self._data[row_key]
+
+        # Recalculate content_width for auto-width columns, since removing
+        # the row may have removed the widest cell in a column.
+        self._recalculate_auto_width_columns()
 
         self.cursor_coordinate = self.cursor_coordinate
         self.hover_coordinate = self.hover_coordinate

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -341,6 +341,39 @@ async def test_remove_row():
         assert len(table.rows) == 2
 
 
+async def test_remove_row_auto_width_columns_shrink():
+    """Regression test for https://github.com/Textualize/textual/issues/3449 -
+    Auto-width columns should shrink when the widest row is removed."""
+    app = DataTableApp()
+    async with app.run_test() as pilot:
+        table: DataTable = app.query_one(DataTable)
+        col_key = table.add_column("A")
+        short_key = table.add_row("short", key="short")
+        long_key = table.add_row("a_very_long_string_that_is_the_widest", key="long")
+        await pilot.pause()
+
+        # After adding both rows, column width should accommodate the longer string
+        column = table.columns[col_key]
+        width_with_both = column.content_width
+        assert width_with_both > len("short")
+
+        # Remove the row with the widest content
+        table.remove_row(long_key)
+        await pilot.pause()
+
+        # Column should now shrink to fit only the remaining content
+        width_after_removal = column.content_width
+        assert width_after_removal < width_with_both, (
+            f"Expected column to shrink after removing widest row, "
+            f"but content_width stayed at {width_after_removal} "
+            f"(was {width_with_both} before removal)"
+        )
+        assert width_after_removal == len("short"), (
+            f"Expected content_width to be {len('short')}, "
+            f"but got {width_after_removal}"
+        )
+
+
 async def test_remove_row_and_update():
     """Regression test for https://github.com/Textualize/textual/issues/3470 -
     Crash when attempting to remove and update the same cell."""


### PR DESCRIPTION
## Summary

Fixes #3449 — DataTable auto-width columns do not shrink back down when the row containing the widest cell is removed.

## The Bug

When `remove_row()` is called on a DataTable with auto-width columns, the column widths are never recalculated. This means removing the row that contained the widest cell in a column leaves the column stuck at its old width, even though all remaining rows are narrower.

This is because `remove_row()` deletes the row data and updates row locations, but never triggers a column width recalculation. The existing `_update_column_widths()` method only handles cells that were explicitly updated (via the `updated_cells` set), so it cannot detect when a removed row was the one setting the maximum width.

## The Fix

Added `_recalculate_auto_width_columns()` which recomputes `content_width` for each auto-width column by measuring all remaining cells after row removal. Called from `remove_row()` after deleting the row data but before refreshing the layout.

### Key behaviors:
- If no rows remain, column width collapses to just the label width
- If rows remain, column width becomes `max(widest remaining cell, label width)`
- Fixed-width columns (auto_width=False) are unaffected

## Testing

- ✅ New test: `test_remove_row_auto_width_columns_shrink` — verifies that removing the widest row shrinks the column width
- ✅ All 88 existing DataTable tests pass
- ✅ Reproducible with the example app from the issue (press R to remove row, column now shrinks)

## Reproduction

The original issue includes a complete reproduction app. With this fix:

1. Run the example app — columns are sized to fit the widest content
2. Press R to remove the row with `"Aleksandr Sadovnikov ============="` (the widest cell)
3. **Before fix**: Column stays wide ✗
4. **After fix**: Column shrinks to fit remaining content ✓