### PR TITLE
fix: prevent KeyError when clearing and re-rendering DataTable

### DIFF
--- a/src/textual/widgets/_data_table.py
+++ b/src/textual/widgets/_data_table.py
@@ -1592,6 +1592,8 @@ class DataTable(ScrollView, Generic[CellType], can_focus=True):
         self._y_offsets.clear()
         self._data.clear()
         self.rows.clear()
+        self._updated_cells.clear()
+        self._new_rows.clear()
         self._row_locations = TwoWayDict({})
         if columns:
             self.columns.clear()

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -1139,6 +1139,36 @@ async def test_reuse_row_key_after_clear():
         assert table.get_row("ROW2") == [7, 8]
 
 
+async def test_clear_clears_updated_cells_and_new_rows():
+    """Regression test for https://github.com/Textualize/textual/issues/4900
+
+    After clear(), _updated_cells and _new_rows should be empty to prevent
+    stale RowKey references from causing KeyError on re-render.
+    """
+    app = DataTableApp()
+    async with app.run_test():
+        table = app.query_one(DataTable)
+        cols = table.add_columns("A", "B")
+        row = table.add_row("hello", "world")
+        table.update_cell(row, cols[0], "updated", update_width=True)
+
+        # _updated_cells and _new_rows should have entries after adding/updating
+        assert len(table._updated_cells) > 0
+        assert len(table._new_rows) > 0
+
+        # clear() should remove stale references
+        table.clear()
+
+        assert len(table._updated_cells) == 0, (
+            f"_updated_cells should be empty after clear, "
+            f"got {table._updated_cells}"
+        )
+        assert len(table._new_rows) == 0, (
+            f"_new_rows should be empty after clear, "
+            f"got {table._new_rows}"
+        )
+
+
 async def test_reuse_column_key_after_clear():
     """Regression test for https://github.com/Textualize/textual/issues/1806"""
     app = DataTableApp()


### PR DESCRIPTION
## Summary

Fixes #4900

`DataTable.clear()` was not clearing `_updated_cells` and `_new_rows`, leaving stale `RowKey` references that could cause a `KeyError` when the table was re-rendered after clearing and adding new rows.

## Root Cause

When `DataTable.clear()` is called, it clears `self.rows`, `self._data`, and `self._row_locations`, but it does **not** clear `self._updated_cells` or `self._new_rows`. These sets retain stale `RowKey`/`CellKey` objects that reference rows which no longer exist in the table.

Since `RowKey(value=None)` uses `id(self)` as its hash, these stale key objects will never match any key in the rebuilt `self.rows` dict. When the `on_idle` handler processes these stale references, it can trigger a `KeyError` in code paths that access `self.rows[row_key]` directly (without `.get()`).

Notably, `remove_row()` already cleans up `_updated_cells` for the removed row — `clear()` should do the same for all rows.

## Fix

Add two lines to `DataTable.clear()` to clear the stale reference sets:

```python
self._updated_cells.clear()
self._new_rows.clear()
```

## Test

Added `test_clear_clears_updated_cells_and_new_rows` which verifies that both `_updated_cells` and `_new_rows` are empty after calling `clear()`.

## Checklist

- [x] Fix is minimal — only adds 2 lines
- [x] Tests pass (88/88)
- [x] Regression test added