### PR TITLE
Fix parsing multiple keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed parsing Kitty extended keys with multiple codepoints
+
 ## [8.2.7] - 2026-05-19 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed parsing Kitty extended keys with multiple codepoints
+- Fixed parsing Kitty extended keys with multiple codepoints https://github.com/Textualize/textual/pull/6592
 
 ## [8.2.7] - 2026-05-19 
 

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -39,7 +39,7 @@ SPECIAL_SEQUENCES = {BRACKETED_PASTE_START, BRACKETED_PASTE_END, FOCUSIN, FOCUSO
 """Set of special sequences."""
 
 _re_extended_key: Final[re.Pattern[str]] = re.compile(
-    r"\x1b\[((?:\d*;?){2,3})([u~ABCDEFHPQRS])"
+    r"\x1b\[((?:[\d:]*;?){2,3})([u~ABCDEFHPQRS])"
 )
 _re_in_band_window_resize: Final[re.Pattern[str]] = re.compile(
     r"\x1b\[48;(\d+(?:\:.*?)?);(\d+(?:\:.*?)?);(\d+(?:\:.*?)?);(\d+(?:\:.*?)?)t"
@@ -334,8 +334,26 @@ class XTermParser(Parser[Message]):
             self._debug_log_file.close()
             self._debug_log_file = None
 
+    @classmethod
+    def _parse_colon_codepoints(cls, text_str: str) -> list[str | None]:
+        """Convert codepoints split on colons in to a list of characters.
+
+        Args:
+            text_str: String with groups of digits, separated by one or more colons.
+
+        Returns:
+            A list of characters.
+        """
+        if not text_str:
+            return [None]
+        characters: list[str | None] = [
+            chr(int(part)) if part.isdecimal() else chr(1)
+            for part in text_str.split(":")
+        ]
+        return characters
+
     @lru_cache(maxsize=1024)
-    def _parse_extended_key(self, sequence: str) -> events.Key | None:
+    def _parse_extended_key(self, sequence: str) -> list[events.Key] | None:
         """Parse a Kitty sequence.
 
         Args:
@@ -348,38 +366,50 @@ class XTermParser(Parser[Message]):
         if (match := _re_extended_key.fullmatch(sequence)) is None:
             return None
 
+        key_events: list[events.Key] = []
+
         codes, end = match.groups(default="")
         codepoint_str, modifiers_str, text_str, *_ = codes.split(";") + ["", "", ""]
 
-        codepoint = int(codepoint_str or "1")
-        modifiers = int(modifiers_str or "0")
-        text = chr(int(text_str)) if text_str else None
+        # text_codepoints = self._parse_colon_codepoints(text_str)
+        for text in self._parse_colon_codepoints(text_str):
 
-        if not (key := FUNCTIONAL_KEYS.get(f"{codepoint}{end}", "")):
-            key = _character_to_key(text if text else chr(codepoint))
+            codepoint = int(codepoint_str or "1")
+            modifiers = int(modifiers_str or "0")
 
-        key_tokens: list[str] = []
-        # The modifier is redundant on a modifier key
-        if modifiers and key not in MODIFIER_FUNCTIONAL_KEYS and text_str is not None:
-            modifier_bits = int(modifiers) - 1
-            # Not convinced of the utility in reporting caps_lock and num_lock
-            MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
-            # Ignore caps_lock and num_lock modifiers
-            if modifier_bits & 1 and (text is None or text.isspace()):
-                key_tokens.append("shift")
-            for bit, modifier in enumerate(MODIFIERS, 1):
-                if modifier == "alt" and text is not None:
-                    continue
-                if modifier_bits & (1 << bit):
-                    key_tokens.append(modifier)
+            if not (key := FUNCTIONAL_KEYS.get(f"{codepoint}{end}", "")):
+                key = _character_to_key(text if text else chr(codepoint))
 
-        key_tokens.sort()
-        if key is not None:
-            key_tokens.append(key)
-        return events.Key(
-            "+".join(key_tokens),
-            text or (None if modifiers else SPECIAL_KEY_TO_CHARACTER.get(key, None)),
-        )
+            key_tokens: list[str] = []
+            # The modifier is redundant on a modifier key
+            if (
+                modifiers
+                and key not in MODIFIER_FUNCTIONAL_KEYS
+                and text_str is not None
+            ):
+                modifier_bits = int(modifiers) - 1
+                # Not convinced of the utility in reporting caps_lock and num_lock
+                MODIFIERS = ("alt", "ctrl", "super", "hyper", "meta")
+                # Ignore caps_lock and num_lock modifiers
+                if modifier_bits & 1 and (text is None or text.isspace()):
+                    key_tokens.append("shift")
+                for bit, modifier in enumerate(MODIFIERS, 1):
+                    if modifier == "alt" and text is not None:
+                        continue
+                    if modifier_bits & (1 << bit):
+                        key_tokens.append(modifier)
+
+            key_tokens.sort()
+            if key is not None:
+                key_tokens.append(key)
+            key_events.append(
+                events.Key(
+                    "+".join(key_tokens),
+                    text
+                    or (None if modifiers else SPECIAL_KEY_TO_CHARACTER.get(key, None)),
+                )
+            )
+        return key_events
 
     def _sequence_to_key_events(
         self, sequence: str, alt: bool = False
@@ -395,9 +425,10 @@ class XTermParser(Parser[Message]):
 
         if (
             not constants.DISABLE_KITTY_KEY
-            and (key := self._parse_extended_key(sequence)) is not None
+            and (keys := self._parse_extended_key(sequence)) is not None
         ):
-            yield key.copy()
+            for key in keys:
+                yield key.copy()
             return
 
         keys = ANSI_SEQUENCES_KEYS.get(sequence)

--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -370,13 +370,10 @@ class XTermParser(Parser[Message]):
 
         codes, end = match.groups(default="")
         codepoint_str, modifiers_str, text_str, *_ = codes.split(";") + ["", "", ""]
+        codepoint = int(codepoint_str or "1")
+        modifiers = int(modifiers_str or "0")
 
-        # text_codepoints = self._parse_colon_codepoints(text_str)
         for text in self._parse_colon_codepoints(text_str):
-
-            codepoint = int(codepoint_str or "1")
-            modifiers = int(modifiers_str or "0")
-
             if not (key := FUNCTIONAL_KEYS.get(f"{codepoint}{end}", "")):
                 key = _character_to_key(text if text else chr(codepoint))
 

--- a/tests/test_xterm_parser.py
+++ b/tests/test_xterm_parser.py
@@ -212,6 +212,26 @@ def test_keys(parser, sequence: str, key: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "sequence,keys",
+    [
+        ("a", "a"),  # Sanity check
+        (
+            "\x1b[58;2;126:47u",
+            "~/",
+        ),  # press option+n folloed by forwards slash, emits ~/ on international keyboards
+    ],
+)
+def test_extended_keys(parser, sequence: str, keys: str) -> None:
+    """Test kitty key sequences that produce multiple keys."""
+    events = []
+    for event in parser.feed(sequence):
+        assert isinstance(event, Key)
+        events.append(event)
+    parsed_keys = "".join([event.character for event in events])
+    assert parsed_keys == keys
+
+
+@pytest.mark.parametrize(
     "sequence, event_type, shift, meta",
     [
         # Mouse down, with and without modifiers


### PR DESCRIPTION
The kitty key protocol provide multiple characters in the text field for a single keypress, which Textual wasn't parsing.

When you hit option+n followed by a forward slash, the terminal sends a single sequence containing two text characters. Textual translates this into 2 key events, which results in apps doing the right thing.

Fixes https://github.com/Textualize/textual/issues/6562