### PR TITLE
Fix KeyError and color blending crash on custom TextAreas

### DIFF
--- a/src/textual/_text_area_theme.py
+++ b/src/textual/_text_area_theme.py
@@ -85,7 +85,12 @@ class TextAreaTheme:
             text_area: The TextArea instance to retrieve fallback styling from.
         """
         self.base_style = text_area.rich_style or Style()
-        get_style = text_area.get_component_rich_style
+
+        def get_style(name: str) -> Style | None:
+            try:
+                return text_area.get_component_rich_style(name)
+            except KeyError:
+                return None
 
         if self.base_style.color is None:
             self.base_style = Style(color="#f3f3f3", bgcolor=self.base_style.bgcolor)
@@ -148,7 +153,7 @@ class TextAreaTheme:
                 self.selection_style = selection_style
             else:
                 selection_background_color = background_color.blend(
-                    app_theme.primary, factor=0.5
+                    Color.parse(app_theme.primary), factor=0.5
                 )
                 self.selection_style = Style.from_color(
                     bgcolor=selection_background_color.rich_color

--- a/tests/text_area/test_issue_6528.py
+++ b/tests/text_area/test_issue_6528.py
@@ -1,0 +1,50 @@
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import TextArea
+from textual.geometry import Region
+
+class CredsModal(ModalScreen[None]):
+    CSS = """
+    #box {
+        width: 80;
+        height: 20;
+        border: heavy white;
+    }
+    #ta {
+        height: 10;
+        border: solid white;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Container(id="box"):
+            yield TextArea("", id="ta", language=None, show_line_numbers=False)
+
+class Demo(App):
+    def on_mount(self) -> None:
+        self.push_screen(CredsModal())
+
+async def test_modal_textarea():
+    app = Demo()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+class CustomTextArea(TextArea):
+    COMPONENT_CLASSES = set()
+    _inherit_component_classes = False
+
+class CustomCredsModal(ModalScreen[None]):
+    def compose(self) -> ComposeResult:
+        yield CustomTextArea("", id="ta", language=None, show_line_numbers=False)
+
+class CustomDemo(App):
+    def on_mount(self) -> None:
+        self.push_screen(CustomCredsModal())
+
+async def test_custom_textarea_no_component_classes():
+    app = CustomDemo()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        text_area = app.screen.query_one(CustomTextArea)
+        text_area.render_lines(Region(0, 0, 80, 10))


### PR DESCRIPTION
This Pull Request resolves two crashes associated with the `TextArea` widget:
1. **KeyError in `apply_css`:** Mounting or rendering a custom `TextArea` subclass with overridden or empty `COMPONENT_CLASSES` raised `KeyError: "No 'text-area--gutter' key in COMPONENT_CLASSES"`. This happened because `TextAreaTheme.apply_css` called `get_component_rich_style()` directly without safety checks. This is resolved by wrapping style retrieval in a try-except block to return `None` on missing classes rather than crashing.
2. **AttributeError in color blending:** In the selection style fallback code, `app_theme.primary` (a string) was passed directly to `background_color.blend()`, which expects a `Color` object, raising `AttributeError: 'str' object has no attribute 'auto'`. This is fixed by wrapping the string in `Color.parse()`.
### Fixes
Fixes #6528
### Verification
Added a unit test under `tests/text_area/test_issue_6528.py` that verifies `TextArea` subclassing with overridden component classes mounts and resolves styles correctly without crashes.
