### PR TITLE
Fix links inside dynamically updated markdown tables

### DIFF
--- a/src/textual/widgets/_markdown.py
+++ b/src/textual/widgets/_markdown.py
@@ -697,7 +697,7 @@ class MarkdownTableContent(Widget):
         for row_index, row in enumerate(updated_rows, self.last_row):
             for cell in row:
                 new_cells.append(
-                    Static(
+                    MarkdownTableCellContents(
                         cell,
                         classes=f"row{row_index} cell",
                     ).with_tooltip(cell)

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -217,3 +217,38 @@ async def test_markdown_quoting():
     async with app.run_test() as pilot:
         await pilot.click(Markdown, offset=(3, 0))
     assert links == ["tété"]
+
+
+async def test_link_in_markdown_table_posts_message_when_updated():
+    """A link inside a markdown table updated via update_rows should post a Markdown.LinkClicked
+    message when clicked.
+    
+    Regression test for https://github.com/Textualize/textual/issues/6597
+    """
+    
+    class MarkdownTableApp(App):
+        messages = []
+
+        def compose(self) -> ComposeResult:
+            yield Markdown()
+
+        @on(Markdown.LinkClicked)
+        def log_markdown_link_clicked(
+            self,
+            event: Markdown.LinkClicked,
+        ) -> None:
+            self.messages.append(event.__class__.__name__)
+
+    app = MarkdownTableApp()
+    async with app.run_test() as pilot:
+        md = app.query_one(Markdown)
+        
+        # update via append to trigger _update_rows
+        await md.append('| Textual Links |\n| --- |\n| [GitHub](https://github.com/textualize/textual/) |')
+        await pilot.pause()
+        
+        from textual.widgets._markdown import MarkdownTableCellContents
+        cell = list(md.query(MarkdownTableCellContents))[1] # second cell
+        await pilot.click(cell, offset=(1, 0)) # click on the text
+        
+        assert app.messages == ["LinkClicked"]


### PR DESCRIPTION
Thank you for contributing!

## Link to issue or discussion

https://github.com/Textualize/textual/issues/6597

## Summary

Fixes #6597.

When Markdown content is updated dynamically (for example via `Markdown.append()`), table cells are created using `Static` instead of `MarkdownTableCellContents`.

Because `Static` doesn't implement `action_link()`, links inside dynamically updated Markdown tables appear interactive but clicking them has no effect.

This change uses `MarkdownTableCellContents` consistently for dynamically created table cells so that link click events are handled correctly.

## Changes

* Replace `Static` with `MarkdownTableCellContents` in the dynamic table rendering path.
* Add a regression test covering dynamically updated Markdown tables.
* Verify existing Markdown tests continue to pass.

## Testing

* Added a regression test reproducing Issue #6597.
* Verified the regression test fails on the original implementation.
* Verified it passes with this change.
* Ran the Markdown test suite successfully.
