### PR TITLE
Fix run_worker typing to support async def callables under mypy stric…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed typing of run_worker to support async def callables under mypy strict checking (https://github.com/Textualize/textual/issues/6386)
 - Fixed parsing Kitty extended keys with multiple codepoints https://github.com/Textualize/textual/pull/6592
 
 ### Changed

--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -54,6 +54,7 @@ from textual.walk import walk_breadth_first, walk_breadth_search_id, walk_depth_
 from textual.worker_manager import WorkerManager
 
 if TYPE_CHECKING:
+    from typing import Awaitable, Coroutine
     from typing_extensions import Self, TypeAlias
     from _typeshed import SupportsRichComparison
 
@@ -493,9 +494,10 @@ class DOMNode(MessagePump):
         """
         self._trap_focus = trap_focus
 
+    @overload
     def run_worker(
         self,
-        work: WorkType[ResultType],
+        work: Callable[[], Coroutine[Any, Any, ResultType]],
         name: str | None = "",
         group: str = "default",
         description: str = "",
@@ -503,7 +505,45 @@ class DOMNode(MessagePump):
         start: bool = True,
         exclusive: bool = False,
         thread: bool = False,
-    ) -> Worker[ResultType]:
+    ) -> Worker[ResultType]: ...
+
+    @overload
+    def run_worker(
+        self,
+        work: Callable[[], ResultType],
+        name: str | None = "",
+        group: str = "default",
+        description: str = "",
+        exit_on_error: bool = True,
+        start: bool = True,
+        exclusive: bool = False,
+        thread: bool = False,
+    ) -> Worker[ResultType]: ...
+
+    @overload
+    def run_worker(
+        self,
+        work: Awaitable[ResultType],
+        name: str | None = "",
+        group: str = "default",
+        description: str = "",
+        exit_on_error: bool = True,
+        start: bool = True,
+        exclusive: bool = False,
+        thread: bool = False,
+    ) -> Worker[ResultType]: ...
+
+    def run_worker(
+        self,
+        work: WorkType[Any],
+        name: str | None = "",
+        group: str = "default",
+        description: str = "",
+        exit_on_error: bool = True,
+        start: bool = True,
+        exclusive: bool = False,
+        thread: bool = False,
+    ) -> Worker[Any]:
         """Run work in a worker.
 
         A worker runs a function, coroutine, or awaitable, in the *background* as an async task or as a thread.
@@ -525,10 +565,10 @@ class DOMNode(MessagePump):
         # If we're running a worker from inside a secondary thread,
         # do so in a thread-safe way.
         if self.app._thread_id != threading.get_ident():
-            creator = partial(self.app.call_from_thread, self.workers._new_worker)
+            creator: Any = partial(self.app.call_from_thread, self.workers._new_worker)
         else:
             creator = self.workers._new_worker
-        worker: Worker[ResultType] = creator(
+        worker: Worker[Any] = creator(
             work,
             self,
             name=name,

--- a/src/textual/worker.py
+++ b/src/textual/worker.py
@@ -15,6 +15,7 @@ from threading import Event
 from time import monotonic
 from typing import (
     TYPE_CHECKING,
+    Any,
     Awaitable,
     Callable,
     Coroutine,
@@ -98,7 +99,7 @@ ResultType = TypeVar("ResultType")
 
 
 WorkType: TypeAlias = Union[
-    Callable[[], Coroutine[None, None, ResultType]],
+    Callable[[], Coroutine[Any, Any, ResultType]],
     Callable[[], ResultType],
     Awaitable[ResultType],
 ]


### PR DESCRIPTION
### Description
This PR resolves issue #6386 by updating the `WorkType` type alias and overloading `run_worker` on `DOMNode` to prevent `mypy` type-inference failures when passing `async def` callables.

**Root Cause**:
In strict mode, `mypy` type-checks `async def` functions as returning `Coroutine[Any, Any, ReturnType]`. Since `WorkType` originally required `Coroutine[None, None, ReturnType]`, it failed. Simply widening `WorkType` to `Coroutine[Any, Any, ResultType]` is insufficient because `mypy`'s generic type inference conflicts when matching a callable return type against both `Callable[[], Coroutine[Any, Any, ResultType]]` and `Callable[[], ResultType]`, causing it to infer `ResultType` as `Never`.

**Fix**:
1. Updated `WorkType` to accept `Coroutine[Any, Any, ResultType]` instead of `Coroutine[None, None, ResultType]`.
2. Added three `@overload` signatures for `run_worker` in `DOMNode` to evaluate the callable/awaitable structures independently.
3. Updated the `run_worker` implementation signature to accept `WorkType[Any]` and return `Worker[Any]` to allow the overloads to drive the external type-checking.

### Link to issue or discussion
Fixes https://github.com/Textualize/textual/issues/6386

### Testing
- Verified that strict `mypy` checking passes on user reproduction files.
- Ran all existing worker unit tests via `pytest tests/workers/` and verified they pass successfully.