### PR TITLE
Improve focus navigation performance by caching Screen.focus_chain between layout changes

### DIFF
--- a/src/textual/dom.py
+++ b/src/textual/dom.py
@@ -492,6 +492,10 @@ class DOMNode(MessagePump):
             trap_focus: `True` to trap focus. `False` to restore default behavior.
         """
         self._trap_focus = trap_focus
+        try:
+            self.screen._focus_chain_cache = None
+        except Exception:
+            pass
 
     def run_worker(
         self,
@@ -1328,6 +1332,10 @@ class DOMNode(MessagePump):
             node._attach(self)
             _append(node)
             node._add_children(*node._pending_children)
+        try:
+            self.screen._focus_chain_cache = None
+        except Exception:
+            pass
 
     WalkType = TypeVar("WalkType", bound="DOMNode")
 

--- a/src/textual/screen.py
+++ b/src/textual/screen.py
@@ -326,6 +326,9 @@ class Screen(Generic[ScreenResultType], Widget):
         self._css_update_count = -1
         """Track updates to CSS."""
 
+        self._focus_chain_cache: list[Widget] | None = None
+        """Cached focus chain, invalidated on layout or focus change."""
+
         self._layout_widgets: dict[DOMNode, set[Widget]] = {}
         """Widgets whose layout may have changed."""
 
@@ -771,8 +774,8 @@ class Screen(Generic[ScreenResultType], Widget):
     @property
     def focus_chain(self) -> list[Widget]:
         """A list of widgets that may receive focus, in focus order."""
-        # TODO: Calculating a focus chain is moderately expensive.
-        # Suspect we can move focus without calculating the entire thing again.
+        if self._focus_chain_cache is not None:
+            return self._focus_chain_cache
 
         widgets: list[Widget] = []
         add_widget = widgets.append
@@ -823,6 +826,7 @@ class Screen(Generic[ScreenResultType], Widget):
                 if node_is_visible and node.allow_focus():
                     add_widget(node)
 
+        self._focus_chain_cache = widgets
         return widgets
 
     def _move_focus(
@@ -1113,6 +1117,7 @@ class Screen(Generic[ScreenResultType], Widget):
             # Widget is already focused
             return
 
+        self._focus_chain_cache = None
         focused: Widget | None = None
         blurred: Widget | None = None
 
@@ -1423,6 +1428,7 @@ class Screen(Generic[ScreenResultType], Widget):
                 break
             widget = ancestor
 
+        self._focus_chain_cache = None
         if layout_required and not self._layout_required:
             self._layout_required = True
             self.check_idle()


### PR DESCRIPTION
**Link to issue or discussion**

Addresses the acknowledged TODO at `screen.py:774`:
> TODO: Calculating a focus chain is moderately expensive. Suspect we can move focus without calculating the entire thing again.

## What this PR does

`Screen.focus_chain` traverses the entire DOM on every call — sorting children by focus order, walking visibility, and checking disabled state. It's called on every Tab/Shift+Tab keypress and in several internal focus-management paths.

This PR caches the result in `_focus_chain_cache` and clears it in the three places that make it stale:

| Invalidation point | Why |
|---|---|
| `Screen._on_layout` | Covers mount, unmount, show/hide (`display: none`), and disabled state changes — all of which post a `Layout` message |
| `Screen.set_focus` | The root node of the traversal depends on `self.focused` when `_trap_focus` is active |
| `DOMNode.trap_focus` | Directly toggles `_trap_focus`, changing which node acts as the traversal root — no layout message is posted |

`_add_children` (test-only helper that bypasses the mount pipeline) also clears the cache so existing tests stay green.

## Testing

- All 53 existing focus/screen tests pass (`test_focus.py`, `test_app_focus_blur.py`, `test_screens.py`, `test_screen_modes.py`)
- Full non-snapshot suite: 1431 passed, 1 pre-existing failure in `test_features.py` unrelated to this change