### PR TITLE
Fix: make widget.loading thread-safe (closes #5108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `loading` reactive not being thread-safe when set from a worker thread https://github.com/Textualize/textual/issues/5108
+
 ## [8.2.8] - 2026-06-30
 
 ### Fixed

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -5,6 +5,8 @@ This module contains the `Widget` class, the base class for all widgets.
 
 from __future__ import annotations
 
+import threading
+
 from asyncio import create_task, gather, wait
 from collections import Counter
 from contextlib import asynccontextmanager
@@ -1074,7 +1076,12 @@ class Widget(DOMNode):
         if not self.is_mounted:
             self.call_later(self.set_loading, loading)
         else:
-            self.set_loading(loading)
+            if threading.get_ident() == self.app._thread_id:
+                self.set_loading(loading)
+            else:
+                # Setting `loading` from a worker thread: hop over to the
+                # app's thread instead of touching the UI directly.
+                self.app.call_from_thread(self.set_loading, loading)
 
     ExpectType = TypeVar("ExpectType", bound="Widget")
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -53,3 +53,25 @@ async def test_premature_loading():
     app = LoadingApp()
     async with app.run_test() as pilot:
         await pilot.pause()
+
+
+async def test_loading_set_from_worker_thread():
+    """Regression test for #5108: setting `loading` from a background
+    thread should not touch the DOM directly, and should not raise."""
+
+    class LoadingApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Label("hello")
+
+    app = LoadingApp()
+    async with app.run_test() as pilot:
+        label = app.query_one(Label)
+
+        def set_loading_from_thread() -> None:
+            label.loading = True
+
+        app.run_worker(set_loading_from_thread, thread=True)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert label.loading is True


### PR DESCRIPTION
Closes #5108.

`_watch_loading` now checks whether it's running on the app's own
thread before mutating the widget's DOM. If `loading` is set from a
worker thread, the update is routed through `App.call_from_thread`
instead of touching the UI directly.

## Testing
- Added `test_loading_set_from_worker_thread` in tests/test_loading.py,
  which sets `.loading = True` from a real background thread via
  `run_worker(thread=True)` and asserts it doesn't raise and updates
  the reactive correctly.
- `poetry run pytest tests/ -k loading -q` — 20 passed.
- `poetry run ruff check` — all checks passed.
- `poetry run mypy src/textual/widget.py` — confirmed 12 pre-existing
  errors are unrelated to this change (same errors present on `main`).