### PR TITLE
fix: footer margin handling (Closes #6616 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed Footer's width calculation when docked to correctly respect margins https://github.com/Textualize/textual/issues/6616
+
 ## [8.2.8] - 2026-06-30
 
 ### Fixed

--- a/src/textual/widgets/_footer.py
+++ b/src/textual/widgets/_footer.py
@@ -154,6 +154,7 @@ class Footer(ScrollableContainer, can_focus=False, can_focus_children=False):
         background: $footer-background;
         dock: bottom;
         height: 1;
+        width: 100%;
         scrollbar-size: 0 0;
         &.-compact {
             FooterLabel {

--- a/tests/snapshot_tests/__snapshots__/test_snapshots/test_footer_margin.svg
+++ b/tests/snapshot_tests/__snapshots__/test_snapshots/test_footer_margin.svg
@@ -1,0 +1,152 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #ffa62b;font-weight: bold }
+.terminal-r3 { fill: #e0e0e0 }
+.terminal-r4 { fill: #495259 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">FooterMarginApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#0000ff" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="440.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="61" y="440.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="440.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="440.7" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="768.6" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="780.8" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="805.2" y="440.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="902.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="915" y="440.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0000ff" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r2" x="61" y="459.2" textLength="36.6" clip-path="url(#terminal-line-18)">&#160;q&#160;</text><text class="terminal-r3" x="97.6" y="459.2" textLength="61" clip-path="url(#terminal-line-18)">Quit&#160;</text><text class="terminal-r4" x="768.6" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▏</text><text class="terminal-r2" x="780.8" y="459.2" textLength="24.4" clip-path="url(#terminal-line-18)">^p</text><text class="terminal-r3" x="805.2" y="459.2" textLength="97.6" clip-path="url(#terminal-line-18)">&#160;palette</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshot_tests/snapshot_apps/footer_margin.py
+++ b/tests/snapshot_tests/snapshot_apps/footer_margin.py
@@ -1,0 +1,29 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Footer
+
+
+class FooterMarginApp(App):
+    """Regression test for https://github.com/Textualize/textual/issues/6616
+
+    Setting a margin on the Footer should shrink it on all sides. Previously
+    the Footer kept a fixed width, so the left/top margin created a gap but
+    the right margin had nowhere to go and was invisible."""
+
+    CSS = """
+    Screen {
+        background: blue;
+    }
+    """
+
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def compose(self) -> ComposeResult:
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one(Footer).styles.margin = 5
+
+
+if __name__ == "__main__":
+    app = FooterMarginApp()
+    app.run()

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -391,7 +391,11 @@ def test_datatable_change_cell_padding(snap_compare):
 def test_footer_render(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "footer.py")
 
+def test_footer_margin(snap_compare):
+    """Regression test for https://github.com/Textualize/textual/issues/6616"""
+    assert snap_compare(SNAPSHOT_APPS_DIR / "footer_margin.py")
 
+    
 def test_header_render(snap_compare):
     assert snap_compare(WIDGET_EXAMPLES_DIR / "header.py")
 


### PR DESCRIPTION
### Description
This PR resolves the issue where setting a margin on a docked `Footer` would not shrink the footer correctly on both sides, causing the right margin to clip off-screen.

#### Root Cause
The `Footer` widget inherits from `ScrollableContainer`, which defaults to `width: 1fr;`. For docked widgets, the layout resolver evaluates fractional widths (`1fr`) relative to the full container size (e.g. `120` cells) without subtracting the margins. It then adds the margins on top of this width (e.g. `120 + 10 = 130` cells), which causes the widget to exceed the screen width and clip the right margin off-screen when translated by the left margin.

####  Solution
Adding `width: 100%;` to the `Footer` widget's `DEFAULT_CSS` overrides the inherited `1fr`. Percentage-based widths in the box model resolver are calculated relative to the container width **minus** the margins. This allows the footer to resolve to the correct size (`110` cells) and shrink properly to respect both the left and right margins (matching how `Header` works).

---

###  Testing
- **New Snapshot Test App**: Created `tests/snapshot_tests/snapshot_apps/footer_margin.py` to render the `Footer` with a margin of 5 on all sides over a blue background.
- **Test Case**: Added `test_footer_margin` to `tests/snapshot_tests/test_snapshots.py` and generated the baseline SVG (`test_footer_margin.svg`).

---

Related Issues
Closes https://github.com/Textualize/textual/issues/6616

---
This Pull Request was generated with the assistance of Windsurf, an AI-powered code editor.