### PR TITLE
Fix unused imports, dead variables, and f-strings (F401, F541, F841)

### DIFF
--- a/src/textual/_markup_playground.py
+++ b/src/textual/_markup_playground.py
@@ -128,7 +128,7 @@ class MarkupPlayground(App):
         variables_text_area = self.query_one("#variables", TextArea)
         try:
             variables = json.loads(variables_text_area.text)
-        except Exception as error:
+        except Exception:
             variables_text_area.add_class("-bad-json")
             self.variables = {}
         else:

--- a/src/textual/drivers/linux_inline_driver.py
+++ b/src/textual/drivers/linux_inline_driver.py
@@ -298,7 +298,7 @@ class LinuxInlineDriver(Driver):
                 except termios.error:
                     pass
 
-        except Exception as error:
+        except Exception:
             # TODO: log this
             pass
 

--- a/src/textual/drivers/windows_driver.py
+++ b/src/textual/drivers/windows_driver.py
@@ -115,7 +115,7 @@ class WindowsDriver(Driver):
                     self._event_thread.join()
                     self._event_thread = None
                 self.exit_event.clear()
-        except Exception as error:
+        except Exception:
             # TODO: log this
             pass
 

--- a/src/textual/validation.py
+++ b/src/textual/validation.py
@@ -361,7 +361,7 @@ class Integer(Number):
 
         # We know it's a number, but is that number an integer?
         try:
-            int_value = int(value)
+            int(value)
         except ValueError:
             return ValidationResult.failure([Integer.NotAnInteger(self, value)])
         return self.success()

--- a/src/textual/widgets/_log.py
+++ b/src/textual/widgets/_log.py
@@ -173,7 +173,6 @@ class Log(ScrollView, can_focus=True):
         Returns:
             The `Log` instance.
         """
-        is_vertical_scroll_end = self.is_vertical_scroll_end
         if data:
             if not self._lines:
                 self._lines.append("")

--- a/tests/css/test_inheritance.py
+++ b/tests/css/test_inheritance.py
@@ -33,7 +33,7 @@ async def test_inheritance():
 
     app = InheritanceApp()
     async with app.run_test():
-        widget1 = app.query_one("#widget1", Widget1)
+        app.query_one("#widget1", Widget1)
         widget2 = app.query_one("#widget2", Widget2)
 
         assert widget2.styles.background == Color.parse("green")

--- a/tests/css/test_parse.py
+++ b/tests/css/test_parse.py
@@ -1106,7 +1106,7 @@ class TestParseTransition:
         }
 
     def test_no_delay_specified(self):
-        css = f"#some-widget {{ transition: offset-x 1 in_out_cubic; }}"
+        css = "#some-widget { transition: offset-x 1 in_out_cubic; }"
         stylesheet = Stylesheet()
         stylesheet.add_source(css)
 

--- a/tests/snapshot_tests/snapshot_apps/data_table_add_column.py
+++ b/tests/snapshot_tests/snapshot_apps/data_table_add_column.py
@@ -1,6 +1,6 @@
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.widgets import DataTable, Footer
+from textual.widgets import DataTable
 
 MOVIES = [
     "Severance",

--- a/tests/snapshot_tests/snapshot_apps/directory_tree_reload.py
+++ b/tests/snapshot_tests/snapshot_apps/directory_tree_reload.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from textual.app import App, ComposeResult
+from textual.app import App
 from textual.widgets import DirectoryTree
 
 

--- a/tests/snapshot_tests/snapshot_apps/log_write.py
+++ b/tests/snapshot_tests/snapshot_apps/log_write.py
@@ -1,6 +1,5 @@
 from textual.app import App, ComposeResult
 from textual.widgets import Log
-from textual.containers import Horizontal
 
 
 class LogApp(App):

--- a/tests/snapshot_tests/snapshot_apps/mount_style_fix.py
+++ b/tests/snapshot_tests/snapshot_apps/mount_style_fix.py
@@ -1,4 +1,3 @@
-from textual import __version__
 from textual.app import App, ComposeResult
 from textual.widgets import Static
 

--- a/tests/snapshot_tests/snapshot_apps/scroll_page.py
+++ b/tests/snapshot_tests/snapshot_apps/scroll_page.py
@@ -1,4 +1,3 @@
-import os
 from textual.app import App
 from textual.widgets import RichLog
 

--- a/tests/snapshot_tests/snapshot_apps/text_selection.py
+++ b/tests/snapshot_tests/snapshot_apps/text_selection.py
@@ -3,7 +3,6 @@ from textual.app import App, ComposeResult
 from textual.widgets import Label
 
 from textual.containers import VerticalGroup
-from textual.content import Content
 
 TEXT = """I must not fear.
 Fear is the mind-killer.

--- a/tests/snapshot_tests/test_snapshots.py
+++ b/tests/snapshot_tests/test_snapshots.py
@@ -10,7 +10,6 @@ from rich.text import Text
 from tests.snapshot_tests.language_snippets import SNIPPETS
 from textual import events
 from textual._on import on
-from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.color import Color, ColorParseError
@@ -936,7 +935,7 @@ def test_richlog_write_at_specific_width(snap_compare):
             )
             yield rich_log
             width_marker = Label(
-                f"this label is width 50 (same as min_width)", id="width-marker"
+                "this label is width 50 (same as min_width)", id="width-marker"
             )
             yield width_marker
 
@@ -3796,7 +3795,7 @@ def test_auto_in_auto(snap_compare):
             Create the user interface
             """
 
-            self.last_updated = Label(f"Last Updated: NOW", id="last_updated")
+            self.last_updated = Label("Last Updated: NOW", id="last_updated")
 
             yield Header()
             yield Vertical(

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -497,7 +497,7 @@ async def test_get_cell_coordinate_invalid_row_key():
         table.add_row("TargetValue", key="R1")
 
         with pytest.raises(CellDoesNotExist):
-            coordinate = table.get_cell_coordinate("INVALID_ROW", "C1")
+            table.get_cell_coordinate("INVALID_ROW", "C1")
 
 
 async def test_get_cell_coordinate_invalid_column_key():
@@ -508,7 +508,7 @@ async def test_get_cell_coordinate_invalid_column_key():
         table.add_row("TargetValue", key="R1")
 
         with pytest.raises(CellDoesNotExist):
-            coordinate = table.get_cell_coordinate("R1", "INVALID_COLUMN")
+            table.get_cell_coordinate("R1", "INVALID_COLUMN")
 
 
 async def test_get_cell_at_returns_value_at_cell():
@@ -607,7 +607,7 @@ async def test_get_row_index_invalid_row_key():
         table.add_row("TargetValue", key="R1")
 
         with pytest.raises(RowDoesNotExist):
-            index = table.get_row_index("InvalidRow")
+            table.get_row_index("InvalidRow")
 
 
 async def test_get_column():
@@ -680,7 +680,7 @@ async def test_get_column_index_invalid_column_key():
         table.add_row("TargetValue1", "TargetValue2", "TargetValue3", key="R1")
 
         with pytest.raises(ColumnDoesNotExist):
-            index = table.get_column_index("InvalidCol")
+            table.get_column_index("InvalidCol")
 
 
 async def test_update_cell_cell_exists():
@@ -1397,7 +1397,7 @@ async def test_add_row_expands_column_widths():
 async def test_cell_padding_updates_virtual_size():
     app = DataTableApp()
 
-    async with app.run_test() as pilot:
+    async with app.run_test():
         table = app.query_one(DataTable)
         table.add_column("First")
         table.add_column("Second", width=10)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -331,7 +331,7 @@ async def test_query_refresh(args):
             yield MyWidget()
 
     app = MyApp()
-    async with app.run_test() as pilot:
+    async with app.run_test():
         app.query(MyWidget).refresh(repaint=args[0], layout=args[1])
         assert refreshes[-1] == args
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -297,7 +297,7 @@ async def test_premature_reactive_call():
             yield BrokenWidget()
 
     app = PrematureApp()
-    async with app.run_test() as pilot:
+    async with app.run_test():
         assert watcher_called
         app.exit()
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -626,10 +626,9 @@ def test_lazy_loading() -> None:
     """
 
     with pytest.raises(ImportError):
-        from textual.widgets import Foo  # nopycln: import
+        pass  # nopycln: import
 
     from textual import widgets
-    from textual.widgets import Label
 
     assert not hasattr(widgets, "foo")
     assert not hasattr(widgets, "bar")

--- a/tests/text_area/test_history.py
+++ b/tests/text_area/test_history.py
@@ -58,7 +58,7 @@ async def text_area(pilot):
 
 async def test_simple_undo_redo():
     app = TextAreaApp()
-    async with app.run_test() as pilot:
+    async with app.run_test():
         text_area = app.text_area
         text_area.insert("123", (0, 0))
 
@@ -188,7 +188,7 @@ async def test_undo_checkpoint_character_limit_reached():
 
 async def test_redo_with_no_undo_is_noop():
     app = TextAreaApp()
-    async with app.run_test() as pilot:
+    async with app.run_test():
         text_area = app.text_area
         text_area.text = SIMPLE_TEXT
         text_area.redo()
@@ -197,7 +197,7 @@ async def test_redo_with_no_undo_is_noop():
 
 async def test_undo_with_empty_undo_stack_is_noop():
     app = TextAreaApp()
-    async with app.run_test() as pilot:
+    async with app.run_test():
         text_area = app.text_area
         text_area.text = SIMPLE_TEXT
         text_area.undo()


### PR DESCRIPTION
Fix various lint issues flagged by Ruff:
- Remove unused imports
- Remove unused variable assignments
- Fix f-strings without placeholders