### PR TITLE
fix typos in docstrings and comments

### DIFF
--- a/src/textual/_xterm_parser.py
+++ b/src/textual/_xterm_parser.py
@@ -56,7 +56,7 @@ SPECIAL_KEY_TO_CHARACTER: Final = {
     "enter": "\r",
     "tab": "\t",
 }
-"""Explcit characters for keys, used in Kitty protocol parsing"""
+"""Explicit characters for keys, used in Kitty protocol parsing"""
 
 
 class XTermParser(Parser[Message]):

--- a/src/textual/content.py
+++ b/src/textual/content.py
@@ -558,7 +558,7 @@ class Content(Visual):
     def get_optimal_width(self, rules: RulesMap, container_width: int) -> int:
         """Get optimal width of the Visual to display its content.
 
-        The exact definition of "optimal width" is dependant on the Visual, but
+        The exact definition of "optimal width" is dependent on the Visual, but
         will typically be wide enough to display output without cropping or wrapping,
         and without superfluous space.
 

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -1321,7 +1321,7 @@ class Spacing(NamedTuple):
 class Shape:
     """An arbitrary shape defined by a sequence of regions.
 
-    This class currently exists to filter widgets within a shape defined when the user is slecting text.
+    This class currently exists to filter widgets within a shape defined when the user is selecting text.
 
     """
 

--- a/src/textual/selection.py
+++ b/src/textual/selection.py
@@ -258,10 +258,10 @@ class SelectState(NamedTuple):
         return start_offset, end_offset
 
     def update_end(self, pointer_offset: Offset, select_end: SelectEnd) -> SelectState:
-        """Update the state with the selction end.
+        """Update the state with the selection end.
 
         Args:
-            pointer_offset: Current mosue position.
+            pointer_offset: Current mouse position.
             select_end: Selection end.
 
         Returns:


### PR DESCRIPTION
Fix several spelling errors in source file docstrings and comments:

- `src/textual/selection.py`: "selction" -> "selection", "mosue" -> "mouse"
- `src/textual/geometry.py`: "slecting" -> "selecting"
- `src/textual/_xterm_parser.py`: "Explcit" -> "Explicit"
- `src/textual/content.py`: "dependant" -> "dependent"

These were found with `codespell`. No logic changes.