### PR TITLE
Reuse link_id if link is split across lines

### DIFF
--- a/src/textual/style.py
+++ b/src/textual/style.py
@@ -492,7 +492,7 @@ class Style:
             _meta,
         ) = _get_simple_attributes(self)
         color = None if foreground is None else background + foreground
-        return RichStyle(
+        rich_style = RichStyle(
             color=None if color is None else color.rich_color,
             bgcolor=None if background is None else background.rich_color,
             bold=bold,
@@ -506,6 +506,9 @@ class Style:
             link=link,
             meta={**self.meta, "offset": (x, y)},
         )
+        if link is not None or _meta is not None:
+            rich_style._link_id = f"L{id(self)}"
+        return rich_style
 
     @cached_property
     def without_color(self) -> Style:

--- a/tests/test_style_parse.py
+++ b/tests/test_style_parse.py
@@ -54,3 +54,18 @@ def test_parse_style(markup: str, style: Style) -> None:
     print(parsed_style._meta)
     print(style._meta)
     assert parsed_style == style
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        Style(link="https://textual.textualize.io"),
+        Style.from_meta({"@click": "app.bell"}),
+    ],
+)
+def test_rich_style_with_offset_reuses_link_id(style: Style) -> None:
+
+    assert (
+        style.rich_style_with_offset(0, 0)._link_id
+        == style.rich_style_with_offset(0, 1)._link_id
+    )


### PR DESCRIPTION
This PR fixes a problem with links that are split up over several lines because each segment regenerates a link ID. The patch reuses the link ID for each part of a link. Different links get their own ID, still. It fixes a problem that _Battery Acid & Bubblegum_ was encountering: when a link wraps to the next line and you hover the mouse cursor only the _part_ of the link on the current line is highlighted. With the fix in this PR, the _complete_ link is highlighted, even if it extends over multiple lines.

Previously discussed on Discord: https://discord.com/channels/1026214085173461072/1026214085865504861/1540021386913775797.